### PR TITLE
buffer pool/stack implementation

### DIFF
--- a/adapter/ph/src/buffer_stack.rs
+++ b/adapter/ph/src/buffer_stack.rs
@@ -1,0 +1,69 @@
+use std::sync::Mutex;
+use tokio::sync::Notify;
+
+// This is used by the ingress stage to allocate buffers for incoming
+// packets.  Buffers are reused in a LIFO manner to promote cache reuse.
+
+pub struct BufferStack<'buf, const BUFSIZ: usize> {
+    buffers: Mutex<Vec<&'buf mut [u8; BUFSIZ]>>,
+    notify: Notify
+}
+
+impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
+    pub const BUFFER_SIZE: usize = BUFSIZ;
+
+    pub fn new<I>(bufs: I) -> Self where I: IntoIterator<Item = &'buf mut [u8; BUFSIZ]> {
+        Self{buffers: Mutex::new(bufs.into_iter().collect()), notify: Notify::new()}
+    }
+
+    // Blocks until at least 1 buffer can be returned.
+    // Returns up to n buffers.
+    // Exception: if n is 0, returns immediately with no buffers.
+    pub async fn get_buffers(
+        &self, n: usize, bufs_out: &mut Vec<&'buf mut [u8; BUFSIZ]>
+    ) -> usize {
+        if n == 0 { return 0; }
+
+        loop {
+            {
+                // `bufs` this needs to be lexically scoped as
+                // Rust's non-lexical scope logic isn't smart enough yet
+                // to figure out we don't need to hold the mutex over
+                // the `await`, even with `drop(bufs)`!
+                // hence the contorted logic here
+                let mut bufs = self.buffers.lock().unwrap();
+                let to_get = std::cmp::min(n, bufs.len());
+                for _ in 0..to_get {
+                    // note: intentional reversing!  keep bufs on top of stack hot
+                    bufs_out.push(bufs.pop().unwrap());
+                }
+                if to_get > 0 { return to_get; }
+            }
+
+            self.notify.notified().await;
+        }
+    }
+
+    pub fn put_buffers<I>(
+        &self, bufs_in: I
+    ) where I: IntoIterator<Item = &'buf mut [u8; BUFSIZ]> {
+        let mut it = bufs_in.into_iter();
+        match it.next() {
+            Some(first_buf) => {
+                let mut bufs = self.buffers.lock().unwrap();
+                let was_empty = bufs.is_empty();
+                bufs.push(first_buf);
+                bufs.extend(it);
+                /*for buf in it {
+                    bufs.push(buf);
+                }*/
+                drop(bufs);
+                if was_empty {
+                    self.notify.notify_waiters();
+                }
+            },
+
+            None => ()  // avoid taking the lock
+        }
+    }
+}

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -1,0 +1,4 @@
+// Static system configuration.
+
+// Size of a packet buffer.
+pub const PACKET_BUFFER_SIZE: usize = 16384;

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -3,6 +3,13 @@ use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 use std::process::ExitCode;
 use tokio::io;
 
+// TODO: make these all non-pub once everything is used
+mod config;
+pub mod buffer_stack;
+
+use buffer_stack::BufferStack;
+
+
 fn is_std_fd(rfd: RawFd) -> bool {
     rfd == std::io::stdin().as_raw_fd() ||
     rfd == std::io::stdout().as_raw_fd() ||
@@ -61,6 +68,9 @@ fn main() -> ExitCode {
         set_fd_nonblocking(rfd).expect("unable to set FD nonblocking");
         tun_fds.push(unsafe { BorrowedFd::borrow_raw(rfd) });
     }
+
+    let buf_storage = vec![[0u8; config::PACKET_BUFFER_SIZE]; 256];
+    let buffer_stack = BufferStack::new(buf_storage.leak::<'static>());
 
     ExitCode::SUCCESS
 }


### PR DESCRIPTION
Simple buffer pool/stack implementation.  Future work could include caching these at the OS thread level to reduce contention, and maintaining pools of different sizes (e.g. tiny, normal, jumbo) to allow for better memory usage.