### PR TITLE
Cpacejo develop ph

### DIFF
--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -1,13 +1,34 @@
-// Interface to full assembly of all stages.
-
 use crate::config;
 use crate::buffer_stack::BufferStack;
 use crate::queues::*;
 
+// Interface to full assembly of all stages.
+
+// This is the "public interface" that all stages of the system use to talk
+// to each other (via queues), and to shared resources (e.g. the buffer stack).
+
+// All queues and shared resources here should be bounded, so that
+// backpressure can flow from any processing stage all the way back to the
+// kernel network ingest queues, and that service time of any packet
+// transiting the system is not permitted to grow indefinitely under
+// pressure.
+
+// The intention is that there are no hidden unbounded queues in the system
+// (such as a mutex held over a blocking operation).  If a resource is
+// highly contended resulting in a bottleneck, that should result in some
+// visible queue becoming full.
+
 pub struct Assembly<'pktbuf> {
+    // Shared resources.  These may be accessed by any part of the system.
     pub buffer_stack: BufferStack<'pktbuf, { config::PACKET_BUFFER_SIZE }>,
+
+    // Inbound (dock->adapter) agent packet path.  Keep these topologically
+    // sorted according to expected packet flow.
     pub inbound_processor: InboundProcessor<'pktbuf>,
     pub inbound_send: InboundSend<'pktbuf>,
+
+    // Outbound (adapter->dock) agent packet path.  Keep these topologically
+    // sorted according to expected packet flow.
     pub outbound_processor: OutboundProcessor<'pktbuf>,
     pub outbound_send: OutboundSend<'pktbuf>
 }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -1,0 +1,13 @@
+// Interface to full assembly of all stages.
+
+use crate::config;
+use crate::buffer_stack::BufferStack;
+use crate::queues::*;
+
+pub struct Assembly<'pktbuf> {
+    pub buffer_stack: BufferStack<'pktbuf, { config::PACKET_BUFFER_SIZE }>,
+    pub inbound_processor: InboundProcessor<'pktbuf>,
+    pub inbound_send: InboundSend<'pktbuf>,
+    pub outbound_processor: OutboundProcessor<'pktbuf>,
+    pub outbound_send: OutboundSend<'pktbuf>
+}

--- a/adapter/ph/src/buffer_stack.rs
+++ b/adapter/ph/src/buffer_stack.rs
@@ -1,0 +1,69 @@
+use std::sync::Mutex;
+use tokio::sync::Notify;
+
+// This is used by the ingress stage to allocate buffers for incoming
+// packets.  Buffers are reused in a LIFO manner to promote cache reuse.
+
+pub struct BufferStack<'buf, const BUFSIZ: usize> {
+    buffers: Mutex<Vec<&'buf mut [u8; BUFSIZ]>>,
+    notify: Notify
+}
+
+impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
+    pub const BUFFER_SIZE: usize = BUFSIZ;
+
+    pub fn new<I>(bufs: I) -> Self where I: IntoIterator<Item = &'buf mut [u8; BUFSIZ]> {
+        Self{buffers: Mutex::new(bufs.into_iter().collect()), notify: Notify::new()}
+    }
+
+    // Blocks until at least 1 buffer can be returned.
+    // Returns up to n buffers.
+    // Exception: if n is 0, returns immediately with no buffers.
+    pub async fn get_buffers(
+        &self, n: usize, bufs_out: &mut Vec<&'buf mut [u8; BUFSIZ]>
+    ) -> usize {
+        if n == 0 { return 0; }
+
+        loop {
+            {
+                // `bufs` this needs to be lexically scoped as
+                // Rust's non-lexical scope logic isn't smart enough yet
+                // to figure out we don't need to hold the mutex over
+                // the `await`, even with `drop(bufs)`!
+                // hence the contorted logic here
+                let mut bufs = self.buffers.lock().unwrap();
+                let to_get = std::cmp::min(n, bufs.len());
+                for _ in 0..to_get {
+                    // note: intentional reversing!  keep bufs on top of stack hot
+                    bufs_out.push(bufs.pop().unwrap());
+                }
+                if to_get > 0 { return to_get; }
+            }
+
+            self.notify.notified().await;
+        }
+    }
+
+    pub fn put_buffers<I>(
+        &self, bufs_in: I
+    ) where I: IntoIterator<Item = &'buf mut [u8; BUFSIZ]> {
+        let mut it = bufs_in.into_iter();
+        match it.next() {
+            Some(first_buf) => {
+                let mut bufs = self.buffers.lock().unwrap();
+                let was_empty = bufs.is_empty();
+                bufs.push(first_buf);
+                bufs.extend(it);
+                /*for buf in it {
+                    bufs.push(buf);
+                }*/
+                drop(bufs);
+                if was_empty {
+                    self.notify.notify_waiters();
+                }
+            },
+
+            None => ()  // avoid taking the lock
+        }
+    }
+}

--- a/adapter/ph/src/buffer_stack.rs
+++ b/adapter/ph/src/buffer_stack.rs
@@ -54,9 +54,6 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
                 let was_empty = bufs.is_empty();
                 bufs.push(first_buf);
                 bufs.extend(it);
-                /*for buf in it {
-                    bufs.push(buf);
-                }*/
                 drop(bufs);
                 if was_empty {
                     self.notify.notify_waiters();

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -1,0 +1,4 @@
+// Static system configuration.
+
+// Size of a packet buffer.
+pub const PACKET_BUFFER_SIZE: usize = 16384;

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -3,6 +3,13 @@ use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 use std::process::ExitCode;
 use tokio::io;
 
+// TODO: make these all non-pub once everything is used
+mod config;
+pub mod buffer_stack;
+
+use buffer_stack::BufferStack;
+
+
 fn is_std_fd(rfd: RawFd) -> bool {
     rfd == std::io::stdin().as_raw_fd() ||
     rfd == std::io::stdout().as_raw_fd() ||
@@ -61,6 +68,9 @@ fn main() -> ExitCode {
         set_fd_nonblocking(rfd).expect("unable to set FD nonblocking");
         tun_fds.push(unsafe { BorrowedFd::borrow_raw(rfd) });
     }
+
+    let buf_storage = vec![[0u8; config::PACKET_BUFFER_SIZE]; 256];
+    let buffer_stack = BufferStack::new(buf_storage.leak::<'static>());
 
     ExitCode::SUCCESS
 }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -2,12 +2,18 @@ use std::net::SocketAddr;
 use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 use std::process::ExitCode;
 use tokio::io;
+use tokio::sync::mpsc;
 
 // TODO: make these all non-pub once everything is used
 mod config;
 pub mod buffer_stack;
+mod packet;
+mod queues;
+mod assembly;
 
 use buffer_stack::BufferStack;
+use queues::*;
+use assembly::Assembly;
 
 
 fn is_std_fd(rfd: RawFd) -> bool {
@@ -69,8 +75,39 @@ fn main() -> ExitCode {
         tun_fds.push(unsafe { BorrowedFd::borrow_raw(rfd) });
     }
 
+    let inbound_recv_batch_size = 16;
+    let inbound_processor_batch_size = 16;
+    let inbound_send_batch_size = 4;
+    let outbound_recv_batch_size = 4;
+    let outbound_processor_batch_size = 16;
+    let outbound_send_batch_size = 16;
+
     let buf_storage = vec![[0u8; config::PACKET_BUFFER_SIZE]; 256];
     let buffer_stack = BufferStack::new(buf_storage.leak::<'static>());
+
+    let (ip_inq, ip_outq) = mpsc::channel(inbound_processor_batch_size * 2);
+    let inbound_processor = InboundProcessor::new(ip_inq);
+
+    let mut is_inqs = Vec::new();
+    let mut is_outqs = Vec::new();
+    for _ in 0..tun_fds.len() {
+        let (is_inq, is_outq) = mpsc::channel(inbound_send_batch_size * 2);
+        // FIXME: maybe a way to do this with unzip but Rust couldn't infer types
+        is_inqs.push(is_inq);
+        is_outqs.push(is_outq);
+    }
+    let inbound_send = InboundSend::new(is_inqs.into_boxed_slice());
+
+    let (op_inq, op_outq) = mpsc::channel(outbound_processor_batch_size * 2);
+    let outbound_processor = OutboundProcessor::new(op_inq);
+
+    let (os_inq, os_outq) = mpsc::channel(outbound_send_batch_size * 2);
+    let outbound_send = OutboundSend::new(os_inq);
+
+    let asm = Box::leak(Box::new(Assembly{
+            buffer_stack, inbound_processor, inbound_send,
+            outbound_processor, outbound_send
+        }));
 
     ExitCode::SUCCESS
 }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -75,6 +75,10 @@ fn main() -> ExitCode {
         tun_fds.push(unsafe { BorrowedFd::borrow_raw(rfd) });
     }
 
+    // TODO: These batch sizes are placeholders for now.  So are the queue
+    // sizes below which are all just double the batch size.  Performance
+    // testing will inform us the correct values for these, which balance
+    // throughput with service time.
     let inbound_recv_batch_size = 16;
     let inbound_processor_batch_size = 16;
     let inbound_send_batch_size = 4;

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -1,0 +1,16 @@
+use crate::config;
+
+// This contains all state of a packet which is moving through the system.
+// TODO: possible we want to keep this stuff on the heap
+
+pub struct Packet<'buf> {
+    pub len: usize,
+    pub buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE]
+}
+
+impl<'buf> Packet<'buf> {
+    // flowhash is different for different flows, but not necessarily vice-versa.
+    // Ideally this is a high-entropy value useful for load balancing.
+    // Must be cheap to query.
+    pub fn flowhash(&self) -> u32 { 0 /* TODO */ }
+}

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -1,0 +1,68 @@
+use tokio::sync::mpsc;
+use crate::packet::Packet;
+
+// Queues (i.e., frontend interface) for each stage of the system.
+
+
+pub struct InboundProcessor<'pktbuf> {
+    sender: mpsc::Sender<Packet<'pktbuf>>
+}
+
+impl<'pktbuf> InboundProcessor<'pktbuf> {
+    // TODO: this will almost certainly morph into multiple queues
+
+    pub(crate) fn new(sender: mpsc::Sender<Packet<'pktbuf>>) -> Self {
+        Self{ sender }
+    }
+
+    pub async fn enqueue(&self, packet: Packet<'pktbuf>) {
+        self.sender.send(packet).await.unwrap();
+    }
+}
+
+
+pub struct InboundSend<'pktbuf> {
+    senders: Box<[mpsc::Sender<Packet<'pktbuf>>]>
+}
+
+impl<'pktbuf> InboundSend<'pktbuf> {
+    pub(crate) fn new(senders: Box<[mpsc::Sender<Packet<'pktbuf>>]>) -> Self {
+        Self{ senders }
+    }
+
+    pub async fn enqueue(&self, packet: Packet<'pktbuf>) {
+        self.senders[packet.flowhash() as usize % self.senders.len()].send(packet).await.unwrap();
+    }
+}
+
+
+pub struct OutboundProcessor<'pktbuf> {
+    sender: mpsc::Sender<Packet<'pktbuf>>
+}
+
+impl<'pktbuf> OutboundProcessor<'pktbuf> {
+    // TODO: this will almost certainly morph into multiple queues
+
+    pub(crate) fn new(sender: mpsc::Sender<Packet<'pktbuf>>) -> Self {
+        Self{ sender }
+    }
+
+    pub async fn enqueue(&self, packet: Packet<'pktbuf>) {
+        self.sender.send(packet).await.unwrap();
+    }
+}
+
+
+pub struct OutboundSend<'pktbuf> {
+    sender: mpsc::Sender<Packet<'pktbuf>>
+}
+
+impl<'pktbuf> OutboundSend<'pktbuf> {
+    pub(crate) fn new(sender: mpsc::Sender<Packet<'pktbuf>>) -> Self {
+        Self{ sender }
+    }
+
+    pub async fn enqueue(&self, packet: Packet<'pktbuf>) {
+        self.sender.send(packet).await.unwrap();
+    }
+}

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -3,6 +3,15 @@ use crate::packet::Packet;
 
 // Queues (i.e., frontend interface) for each stage of the system.
 
+// "Inbound" refers to the dock->adapter direction (i.e., inbound to this host).
+// "Outbound" refers to the adapter->dock direction (i.e., outbound from this host).
+
+
+
+// InboundProcessor is responsible for all "processing" of packets in the inbound direction.
+// All agent packets from the dock are sent here for decapsulation, and any
+// CPU-intensive postprocessing (e.g. signature verification).
+// This may morph into more or fewer (i.e. zero) stages depending on future requirements.
 
 pub struct InboundProcessor<'pktbuf> {
     sender: mpsc::Sender<Packet<'pktbuf>>
@@ -21,11 +30,16 @@ impl<'pktbuf> InboundProcessor<'pktbuf> {
 }
 
 
+// InboundSend is responsible for emitting decapsulated agent packets on the
+// host's TUN interface.
+
 pub struct InboundSend<'pktbuf> {
     senders: Box<[mpsc::Sender<Packet<'pktbuf>>]>
 }
 
 impl<'pktbuf> InboundSend<'pktbuf> {
+    // We necessarily have multiple queues, corresponding to the multiple
+    // FDs of a multiqueue-enabled TUN interface.
     pub(crate) fn new(senders: Box<[mpsc::Sender<Packet<'pktbuf>>]>) -> Self {
         Self{ senders }
     }
@@ -35,6 +49,11 @@ impl<'pktbuf> InboundSend<'pktbuf> {
     }
 }
 
+
+// OutboundProcessor is responsible for all "processing" of packets in the outbound direction.
+// All packets from the host are sent here for encapsulation, and any
+// CPU-intensive preprocessing (e.g. signature generation).
+// This may morph into more or fewer (i.e. zero) stages depending on future requirements.
 
 pub struct OutboundProcessor<'pktbuf> {
     sender: mpsc::Sender<Packet<'pktbuf>>
@@ -53,11 +72,15 @@ impl<'pktbuf> OutboundProcessor<'pktbuf> {
 }
 
 
+// OutboundSend is responsible for sending encapsulated agent packets to the dock.
+
 pub struct OutboundSend<'pktbuf> {
     sender: mpsc::Sender<Packet<'pktbuf>>
 }
 
 impl<'pktbuf> OutboundSend<'pktbuf> {
+    // Only one outbound socket, only one queue for now.  (To be determined
+    // whether `sendmmsg` via multiple threads provides any needed performance gain.)
     pub(crate) fn new(sender: mpsc::Sender<Packet<'pktbuf>>) -> Self {
         Self{ sender }
     }


### PR DESCRIPTION
Here I'm pulling in the "Assembly" code which structures the flow of packets in the system.  (Also removed some dead code from BufferStack which I noticed.)

The "Assembly" defines the inter-stage interface used for shuttling packets through the packet handler.  All inter-stage and shared-resource communication and access is mediated through the assembly.

The "Packet" is the primary means of referencing a packet traveling through the packet handler.

This commit doesn't actually include any of the processes which service the inter-stage queues.