### PR TITLE
import inbound_recv_worker

### DIFF
--- a/adapter/ph/src/inbound_recv_worker.rs
+++ b/adapter/ph/src/inbound_recv_worker.rs
@@ -1,0 +1,68 @@
+use core::future::Future;
+use std::io::IoSliceMut;
+use tokio::net::UdpSocket;
+use crate::ext::std::vec::VecExt;
+use crate::ext::tokio::net::*;
+use crate::assembly::Assembly;
+use crate::packet::Packet;
+
+#[derive(Copy, Clone)]
+pub struct Config {
+    pub batch_size: usize
+}
+
+async fn worker(
+    config: &Config, asm: &Assembly<'_>, socket: &UdpSocket
+) {
+    let mut bufs = Vec::new();
+    let mut iovs_outer = Vec::new();
+    //let mut iovs_slices_outer = Vec::new();  // TODO; see below
+    let mut msgs_outer = Vec::new();
+
+    loop {
+        // grab some buffers from the pool
+        asm.buffer_stack.get_buffers(config.batch_size, &mut bufs).await;
+
+        // construct iovecs
+        let mut iovs = iovs_outer;
+        for buf in &mut bufs {
+            iovs.push([IoSliceMut::new(*buf)])
+        }
+
+        // TODO: reuse Vec -- why doesn't the recycle trick work here?
+        let mut iovs_slices = Vec::new(); //iovs_slices_outer;
+        for iov in &mut iovs {
+            iovs_slices.push(&mut iov[..]);
+        }
+
+        // make space for msgs
+        let mut msgs = msgs_outer;
+
+        // grab at least one packet off the network
+        let n_recvd = udp_socket_recv_multiple_vectored_from(socket, &mut iovs_slices[..], &mut msgs).await.unwrap();
+
+        //iovs_slices_outer = iovs_slices.recycle();
+        iovs_outer = iovs.recycle();
+
+        // return unused buffers
+        asm.buffer_stack.put_buffers(bufs.drain(n_recvd..));
+
+        // enqueue received packets with packet processor
+        for (buf, msg) in bufs.drain(..).zip(&msgs) {
+            if msg.1 { asm.buffer_stack.put_buffers([buf]); }  // packet was too large; drop TODO: count somewhere
+            else { asm.inbound_processor.enqueue(Packet{ len: msg.0, buf }).await; }
+        }
+
+        msgs_outer = msgs.recycle();
+    }
+}
+
+pub fn launch<'pktbuf, AsmRef: 'pktbuf, UdpSocketRef: 'pktbuf>(
+    config: &Config, asm: AsmRef, socket: UdpSocketRef)
+-> impl Future<Output = ()> + Send + 'pktbuf
+    where AsmRef: std::ops::Deref<Target = Assembly<'pktbuf>> + Send + Sync,
+        UdpSocketRef: std::ops::Deref<Target = UdpSocket> + Send + Sync
+{
+    let cfg = *config;
+    async move { worker(&cfg, &*asm, &*socket).await }
+}

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -2,7 +2,9 @@ use std::net::SocketAddr;
 use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 use std::process::ExitCode;
 use tokio::io;
+use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 
 // TODO: make these all non-pub once everything is used
 pub mod ext;
@@ -11,6 +13,7 @@ pub mod buffer_stack;
 mod packet;
 mod queues;
 mod assembly;
+mod inbound_recv_worker;
 
 use buffer_stack::BufferStack;
 use queues::*;
@@ -113,6 +116,25 @@ fn main() -> ExitCode {
             buffer_stack, inbound_processor, inbound_send,
             outbound_processor, outbound_send
         }));
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let socket = Box::leak(Box::new(UdpSocket::bind(self_addr).await.expect("unable to bind to self addr")));
+            socket.connect(peer_addr).await.expect("unable to connect to peer addr");
+
+            let mut js = JoinSet::new();
+
+            js.spawn(inbound_recv_worker::launch(
+                    &inbound_recv_worker::Config{ batch_size: inbound_recv_batch_size },
+                    &*asm, &*socket));
+
+            while let Some(res) = js.join_next().await {
+                res.unwrap();
+            }
+        });
 
     ExitCode::SUCCESS
 }


### PR DESCRIPTION
The inbound receive worker has one task: it reserves buffers from the buffer pool, pulls batches of packets out of the tether socket into these buffers, and enqueues them into the packet processing stage.  There is necessarily one inbound receive worker, to ensure packets remain ordered when entering the system.  Fanout occurs during enqueue to the packet processing stage.

Future work: @svjaffer has suggested we may want to consider explicitly head-dropping (or otherwise managing the packet drop behavior) from the socket when the processing queue is full.  This would be a simple change to try to enqueue each packet (and drop if failed), rather than block to enqueue it.  (Or ideally the kernel lets us configure UDP socket drop behavior but I couldn't find anything in a cursory search.)