### PR TITLE
import outbound pipeline

### DIFF
--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -28,6 +28,8 @@ mod udp_stream;
 mod dtls_worker;
 mod inbound_processor_worker;
 mod inbound_send_worker;
+mod outbound_recv_worker;
+mod outbound_processor_worker;
 mod rpc_worker;
 
 use buffer_stack::BufferStack;
@@ -196,6 +198,18 @@ fn main() -> ExitCode {
                     &inbound_send_worker::Config{ batch_size: inbound_send_batch_size },
                     &*asm, is_outq, &*async_tun_fd));
             }
+
+            for async_tun_fd in async_tun_fds.iter() {
+                js.spawn(outbound_recv_worker::launch(
+                    &outbound_recv_worker::Config{ batch_size: outbound_recv_batch_size },
+                    &*asm, &*async_tun_fd));
+            }
+
+            js.spawn(outbound_processor_worker::launch(
+                    &outbound_processor_worker::Config{ batch_size: outbound_processor_batch_size },
+                    &*asm, op_outq));
+
+            js.spawn(rpc_worker::launch(&*asm, &*unix_socket));
 
             // TODO: initiate the DTLS connection asynchronously; for now, keep this at the end
             let socket = Box::leak(Box::new(UdpSocket::bind(self_addr).await.expect("unable to bind to self addr")));

--- a/adapter/ph/src/outbound_processor_worker.rs
+++ b/adapter/ph/src/outbound_processor_worker.rs
@@ -1,0 +1,31 @@
+use core::future::Future;
+use tokio::sync::mpsc;
+use crate::assembly::Assembly;
+use crate::packet::Packet;
+
+#[derive(Copy, Clone)]
+pub struct Config {
+    pub batch_size: usize
+}
+
+async fn worker<'pktbuf>(
+    config: &Config, asm: &Assembly<'pktbuf>, queue: &mut mpsc::Receiver<Packet<'pktbuf>>
+) {
+    let mut pkts = Vec::new();
+
+    while let _count @ 1.. = queue.recv_many(&mut pkts, config.batch_size).await {
+        for pkt in pkts.drain(..) {
+            asm.outbound_send.enqueue(pkt).await;
+        }
+    }
+}
+
+pub fn launch<'pktbuf, AsmRef: 'pktbuf>(
+    config: &Config, asm: AsmRef,
+    mut queue: mpsc::Receiver<Packet<'pktbuf>>)
+-> impl Future<Output = ()> + Send + 'pktbuf
+    where AsmRef: std::ops::Deref<Target = Assembly<'pktbuf>> + Send + Sync
+{
+    let cfg = *config;
+    async move { worker(&cfg, &*asm, &mut queue).await }
+}

--- a/adapter/ph/src/outbound_recv_worker.rs
+++ b/adapter/ph/src/outbound_recv_worker.rs
@@ -1,0 +1,58 @@
+use core::future::Future;
+use nix::errno::Errno;
+use std::os::fd::{AsFd, AsRawFd};
+use tokio::io::unix::AsyncFd;
+use crate::ext::std::vec::VecExt;
+use crate::ext::tokio::io::unix::*;
+use crate::assembly::Assembly;
+use crate::packet::{packet_body_buffer, Packet};
+
+#[derive(Copy, Clone)]
+pub struct Config {
+    pub batch_size: usize
+}
+
+async fn worker<Fd: AsFd + AsRawFd + Send + Sync>(
+    config: &Config, asm: &Assembly<'_>, tun_fd: &AsyncFd<Fd>
+) {
+    let mut bufs = Vec::new();
+    let mut recvd_outer = Vec::new();
+
+    loop {
+        // grab some buffers from the pool
+        asm.buffer_stack.get_buffers(config.batch_size, &mut bufs).await;
+
+        let mut recvd = recvd_outer;
+
+        // FIXME: how to detect truncated packet??
+        recvd.push(async_fd_read(tun_fd, packet_body_buffer(bufs[0])).await.unwrap());
+
+        for buf in &mut bufs[1..] {
+            match tun_fd.try_read(packet_body_buffer(buf)) {
+                Err(e) if e.raw_os_error().map(Errno::from_raw) == Some(Errno::EAGAIN) => break,
+                r => recvd.push(r.unwrap())
+            }
+        }
+
+        // return unused buffers
+        asm.buffer_stack.put_buffers(bufs.drain(recvd.len()..));
+
+        for (buf, &recvd) in bufs.drain(..).zip(&recvd) {
+            let mut pkt = Packet{ buf };
+            pkt.metadata_mut().len = recvd;
+            asm.outbound_processor.enqueue(pkt).await;
+        }
+
+        recvd_outer = recvd.recycle();
+    }
+}
+
+pub fn launch<'pktbuf, AsmRef: 'pktbuf, AfdRef: 'pktbuf, Fd: AsFd + AsRawFd + Send + Sync>(
+    config: &Config, asm: AsmRef, tun_fd: AfdRef
+) -> impl Future<Output = ()> + Send + 'pktbuf
+    where AsmRef: std::ops::Deref<Target = Assembly<'pktbuf>> + Send + Sync,
+        AfdRef: std::ops::Deref<Target = AsyncFd<Fd>> + Send + Sync
+{
+    let cfg = *config;
+    async move { worker(&cfg, &*asm, &*tun_fd).await }
+}


### PR DESCRIPTION
The rest of the PH from the "experimental" repo -- the remaining parts of the outbound pipeline.  `outbound_recv_worker` pulls packets off the TUN interface and forwards them to `outbound_processor_worker`, which "processes" them (nothing for now -- will encapsulate them).  That worker then forwards them on to the outbound queue of `dtls_worker` for egress to the node.