### PR TITLE
Fix startup order

### DIFF
--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -165,12 +165,7 @@ fn main() -> ExitCode {
         .unwrap()
         .block_on(async {
             // TODO signal handler goes here
-            
-            let socket = Box::leak(Box::new(UdpSocket::bind(self_addr).await.expect("unable to bind to self addr")));
-            socket.connect(peer_addr).await.expect("unable to connect to peer addr");
-            let mut ssl_stream = tokio_openssl::SslStream::new(ssl, udp_stream::UdpStream::new(socket)).unwrap();
-            Pin::new(&mut ssl_stream).connect().await.expect("unable to establish DTLS connection");
-            
+
             fs::remove_file(&sock_path);
             let unix_socket =  Box::leak(Box::new(UnixListener::bind(sock_path).unwrap())); //TODO not sure if this needs the Box leak wrapper
 
@@ -178,12 +173,10 @@ fn main() -> ExitCode {
 
             let mut js = JoinSet::new();
 
-            js.spawn(dtls_worker::launch(&*asm, ssl_stream, os_outq));
-            
             // Launches RPC worker program
 
             js.spawn(rpc_worker::launch(&*asm, &*unix_socket));
-          
+
             let mut usr1_stream = Box::leak(Box::new(signal(SignalKind::user_defined1()).unwrap()));
             let mut term_stream = Box::leak(Box::new(signal(SignalKind::terminate()).unwrap()));
 
@@ -206,7 +199,13 @@ fn main() -> ExitCode {
                     &*asm, is_outq, &*async_tun_fd));
             }
 
-            js.spawn(rpc_worker::launch(&*asm, &*unix_socket));
+            // TODO: initiate the DTLS connection asynchronously; for now, keep this at the end
+            let socket = Box::leak(Box::new(UdpSocket::bind(self_addr).await.expect("unable to bind to self addr")));
+            socket.connect(peer_addr).await.expect("unable to connect to peer addr");
+            let mut ssl_stream = tokio_openssl::SslStream::new(ssl, udp_stream::UdpStream::new(socket)).unwrap();
+            Pin::new(&mut ssl_stream).connect().await.expect("unable to establish DTLS connection");
+
+            js.spawn(dtls_worker::launch(&*asm, ssl_stream, os_outq));
 
             while let Some(res) = js.join_next().await {
                 res.unwrap();


### PR DESCRIPTION
DTLS startup was blocking other workers from starting.

Ideally DTLS startup is made asynchronous; for now, move it to the end.

Also, remove a duplicate `rpc_worker` launch.