### PR TITLE
implement BufMut variants of async FD read extension methods

### DIFF
--- a/adapter/ph/src/ext/std.rs
+++ b/adapter/ph/src/ext/std.rs
@@ -1,3 +1,9 @@
+pub mod mem {
+    pub unsafe fn slice_assume_init_mut<T>(slice: &mut [std::mem::MaybeUninit<T>]) -> &mut [T] {
+        unsafe { &mut *(slice as *mut _ as *mut [T]) }
+    }
+}
+
 pub mod vec {
     pub trait VecExt<T> {
         fn recycle<U>(self) -> Vec<U>;

--- a/adapter/ph/src/ext/tokio.rs
+++ b/adapter/ph/src/ext/tokio.rs
@@ -2,8 +2,10 @@ pub mod io {
     pub mod unix {
         use std::io::{IoSlice, IoSliceMut};
         use std::os::fd::{AsFd, AsRawFd};
+        use bytes::buf;
         use tokio::io::{self, Interest};
         use tokio::io::unix::AsyncFd;
+        use crate::ext::std::mem::slice_assume_init_mut;
 
         // Asynchronous read/write operations on raw FDs,
         // following the model in `std::io::{Read, Write}`.
@@ -12,6 +14,9 @@ pub mod io {
             // no support yet in Rust for async trait fns
             //async fn read(&self, buf: &mut [u8]) -> io::Result<usize>;
             fn try_read(&self, buf: &mut [u8]) -> io::Result<usize>;
+
+            //async fn read_buf<B: buf::BufMut>(&self, buf: &mut B) -> io::Result<usize>;
+            fn try_read_buf<B: buf::BufMut>(&self, buf: &mut B) -> io::Result<usize>;
 
             //async fn write(&self, buf: &[u8]) -> io::Result<usize>;
             fn try_write(&self, buf: &[u8]) -> io::Result<usize>;
@@ -26,6 +31,16 @@ pub mod io {
         pub async fn async_fd_read<T: AsFd + AsRawFd>(afd: &AsyncFd<T>, buf: &mut [u8]) -> io::Result<usize> {
             afd.async_io(Interest::READABLE,
                 |fd| nix::unistd::read(fd.as_raw_fd(), buf).map_err(std::io::Error::from)).await
+        }
+
+        pub async fn async_fd_read_buf<T: AsFd + AsRawFd, B: buf::BufMut>(afd: &AsyncFd<T>, buf: &mut B) -> io::Result<usize> {
+            let uninit_slice = buf.chunk_mut();
+            // SAFETY: we are only writing to this uninitialized slice
+            let slice = unsafe { slice_assume_init_mut(uninit_slice.as_uninit_slice_mut()) };
+            let size = async_fd_read(afd, slice).await?;
+            // SAFETY: we've now initialized this much of the slize
+            unsafe { buf.advance_mut(size); }
+            Ok(size)
         }
 
         pub async fn async_fd_write<T: AsFd + AsRawFd>(afd: &AsyncFd<T>, buf: &[u8]) -> io::Result<usize> {
@@ -46,6 +61,16 @@ pub mod io {
         impl<T: AsFd + AsRawFd> AsyncFdExt for AsyncFd<T> {
             fn try_read(&self, buf: &mut [u8]) -> io::Result<usize> {
                 nix::unistd::read(self.get_ref().as_raw_fd(), buf).map_err(std::io::Error::from)
+            }
+
+            fn try_read_buf<B: buf::BufMut>(&self, buf: &mut B) -> io::Result<usize> {
+                let uninit_slice = buf.chunk_mut();
+                // SAFETY: we are only writing to this uninitialized slice
+                let slice = unsafe { slice_assume_init_mut(uninit_slice.as_uninit_slice_mut()) };
+                let size = self.try_read(slice)?;
+                // SAFETY: we've now initialized this much of the slize
+                unsafe { buf.advance_mut(size); }
+                Ok(size)
             }
 
             fn try_write(&self, buf: &[u8]) -> io::Result<usize> {


### PR DESCRIPTION
These I will use in the outbound recv worker and the DTLS inbound path, to eliminate/simplify the logic of populating a packet with this data.