### PR TITLE
Draft: Break builds if warnings are present

### DIFF
--- a/adapter/cd/src/main.rs
+++ b/adapter/cd/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use daemonize::Daemonize;
 use std::env;
 use std::fs::OpenOptions;

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use std::fs;
 use std::net::SocketAddr;
 use std::os::fd::{AsRawFd, BorrowedFd, RawFd};


### PR DESCRIPTION
cc @cpacejo i think you said you wanted this but now i'm doubting myself. Anyway, looked it up this seems like the simplest implementation. Seems to have "buyer beware" warnings around compatibility long term but i am not sure their first alternative (env variable) is different; we might want to consider listing the warning codes to deny though instead, that i'd be more on board with but it'll be uglier 😅 

https://github.com/rust-unofficial/patterns/blob/main/src/anti_patterns/deny-warnings.md