### PR TITLE
add `ci` feature which builds with warnings treated as errors

### DIFF
--- a/adapter/cd/Cargo.toml
+++ b/adapter/cd/Cargo.toml
@@ -23,3 +23,5 @@ toml = "0.8.12"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 
+[features]
+ci = []

--- a/adapter/cd/src/main.rs
+++ b/adapter/cd/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "ci", deny(warnings))]
 use daemonize::Daemonize;
 use std::env;
 use std::fs::OpenOptions;

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -16,3 +16,6 @@ tokio-openssl = { version = "0.6.4" }
 zerocopy = { version = "0.7.34", features = ["byteorder"] }
 zerocopy-derive = { version = "0.7.34" }
 enum-map = { version = "2.7.3" }
+
+[features]
+ci = []

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "ci", deny(warnings))]
 use std::fs;
 use std::io::ErrorKind;
 use std::net::SocketAddr;


### PR DESCRIPTION
With this, `cargo build -F ci` errors out if warnings are present; `cargo build` does not (existing behavior).