### PR TITLE
make Packet::buf private

### DIFF
--- a/adapter/ph/src/dtls_worker.rs
+++ b/adapter/ph/src/dtls_worker.rs
@@ -41,7 +41,7 @@ impl<'pktbuf> InboundRecvState<'pktbuf> {
                     },
 
                     Err(_) =>  // TODO: count error
-                        *self = InboundRecvState::ReadPacket{ buf: pkt.buf }
+                        *self = InboundRecvState::ReadPacket{ buf: pkt.destroy() }
                 }
             },
 
@@ -60,7 +60,7 @@ impl<'pktbuf> InboundRecvState<'pktbuf> {
                 asm.buffer_stack.put_buffer(buf),
 
             InboundRecvState::EnqueuePacket{ pkt } =>
-                asm.buffer_stack.put_buffer(pkt.buf)
+                asm.buffer_stack.put_buffer(pkt.destroy())
         }
     }
 }
@@ -90,7 +90,7 @@ async fn worker<'pktbuf>(
                 // writes can only block on the L2 network queue, not the
                 // path through the node.
                 ssl_stream.write(out_pkt.body()).await.unwrap();  // TODO: error handling
-                asm.buffer_stack.put_buffer(out_pkt.buf);
+                asm.buffer_stack.put_buffer(out_pkt.destroy());
             }
         };
     }

--- a/adapter/ph/src/inbound_send_worker.rs
+++ b/adapter/ph/src/inbound_send_worker.rs
@@ -23,7 +23,7 @@ async fn worker<'pktbuf, Fd: AsFd + AsRawFd + Send + Sync>(
         for pkt in &pkts {
             async_fd_write_vectored(tun_fd, &[IoSlice::new(pkt.body())]).await.unwrap();  // TODO: error handling
         }
-        asm.buffer_stack.put_buffers(pkts.drain(..).map(|pktbuf| pktbuf.buf));
+        asm.buffer_stack.put_buffers(pkts.drain(..).map(|pktbuf| pktbuf.destroy()));
     }
 }
 

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -8,7 +8,7 @@ use crate::config;
 // TODO: possible we want to keep this stuff on the heap
 
 pub struct Packet<'buf> {
-    pub buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE]
+    buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE]
 }
 
 #[derive(AsBytes, FromZeroes, FromBytes)]
@@ -30,6 +30,11 @@ impl<'buf> Packet<'buf> {
     // `headroom` indicates room to keep free at packet start for possible extension.
     pub fn new(buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE], headroom: usize) -> Self {
         Self::new_with_existing_data(buf, PACKET_BUFFER_MIN_BODY_OFFSET + headroom, 0)
+    }
+
+    #[must_use]
+    pub fn destroy(self) -> &'buf mut [u8; config::PACKET_BUFFER_SIZE] {
+        self.buf
     }
 
     // Initialize a buffer with existing packet data as a packet buffer.


### PR DESCRIPTION
The only code left which accesses `Packet::buf` directly does so to take the buffer _out_ of the `Packet` structure, to return it to the buffer pool.  So let's make `buf` private and add a method which destroys a `Packet` (by accepting it by value, instead of by reference) and returns the buffer.

(Note that, because `Packet` doesn't implement the `Copy` trait – nor can it, because it contains a mutable reference to `buf` – `Packet::destroy()` is guaranteed to destroy the only existing copy of the `Packet` structure it's passed.)