### PR TITLE
Simplify two pipeline stages

### DIFF
--- a/adapter/ph/src/dtls_worker.rs
+++ b/adapter/ph/src/dtls_worker.rs
@@ -33,16 +33,10 @@ impl<'pktbuf> InboundRecvState<'pktbuf> {
 
             InboundRecvState::ReadPacket{ buf } => {
                 let mut pkt = Packet::new(buf, 0);
-                match ssl_stream.read_buf(&mut pkt).await {
-                    Ok(_) => {
-                        asm.counters[CounterType::InPacksRec].increment();
-                        // NOTE: There is no way to detect a too-large packet.  See above.
-                        *self = InboundRecvState::EnqueuePacket{ pkt };
-                    },
-
-                    Err(_) =>  // TODO: count error
-                        *self = InboundRecvState::ReadPacket{ buf: pkt.buf }
-                }
+                ssl_stream.read_buf(&mut pkt).await.unwrap();
+                asm.counters[CounterType::InPacksRec].increment();
+                // NOTE: There is no way to detect a too-large packet.  See above.
+                *self = InboundRecvState::EnqueuePacket{ pkt };
             },
 
             InboundRecvState::EnqueuePacket{ pkt } => {

--- a/adapter/ph/src/outbound_recv_worker.rs
+++ b/adapter/ph/src/outbound_recv_worker.rs
@@ -1,8 +1,6 @@
 use core::future::Future;
-use nix::errno::Errno;
 use std::os::fd::{AsFd, AsRawFd};
 use tokio::io::unix::AsyncFd;
-use crate::ext::std::vec::VecExt;
 use crate::ext::tokio::io::unix::*;
 use crate::assembly::Assembly;
 use crate::packet::Packet;
@@ -19,37 +17,18 @@ async fn worker<Fd: AsFd + AsRawFd + Send + Sync>(
     config: &Config, asm: &Assembly<'_>, tun_fd: &AsyncFd<Fd>
 ) {
     let mut bufs = Vec::new();
-    let mut recvd_outer = Vec::new();
 
     loop {
         // grab some buffers from the pool
         asm.buffer_stack.get_buffers(config.batch_size, &mut bufs).await;
-        let mut bufs_iter = bufs.drain(..);
 
-        let mut recvd = recvd_outer;
-
-        let buf = bufs_iter.next().unwrap();
-        let mut pkt = Packet::new(buf, OUTBOUND_PACKET_HEADROOM);
-        // FIXME: how to detect truncated packet??
-        async_fd_read_buf(tun_fd, &mut pkt).await.unwrap();
-        recvd.push(pkt);
-
-        while let Some(buf) = bufs_iter.next() {
+        // read & forward packets one at a time, no sense to batch really
+        // since neither `read_buf()` nor `enqueue()` support it
+        for buf in bufs.drain(..) {
             let mut pkt = Packet::new(buf, OUTBOUND_PACKET_HEADROOM);
-            match tun_fd.try_read_buf(&mut pkt) {
-                Err(e) if e.raw_os_error().map(Errno::from_raw) == Some(Errno::EAGAIN) => break,
-                r => { r.unwrap(); recvd.push(pkt); }
-            }
-        }
-
-        // return unused buffers
-        asm.buffer_stack.put_buffers(bufs_iter);
-
-        for pkt in recvd.drain(..) {
+            async_fd_read_buf(tun_fd, &mut pkt).await.unwrap();
             asm.outbound_processor.enqueue(pkt).await;
         }
-
-        recvd_outer = recvd.recycle();
     }
 }
 


### PR DESCRIPTION
The inbound receive path was detecting errors and then mostly ignoring them.  This isn't right (likely, the error state may continue indefinitely, e.g. the socket was closed).  I changed it to simply panic if an error is detected.  It's still not great, but at least we will recover from error states when the PH is restarted.  Also this matches what I was doing in the outbound receive path.

The outbound receive path was overcomplicated.  For some reason I was "simulating" a batch read by performing one blocking read, then performing as many nonblocking reads as possible, but then (due to how Tokio queues work) just enqueuing each packet individually anyway.  So now – we just do the simple thing of alternating reads & writes.