### PR TITLE
Packet handler encap + decap

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -241,6 +241,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "open-enum"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e88e2e4e7b332f23a96ece6261bae7cc7446b8a38439c0bae6fce02168cf16f"
+dependencies = [
+ "open-enum-derive",
+]
+
+[[package]]
+name = "open-enum-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f51a157e01c7343a7c31f540309b3b8b2c9751f3adb6d040373e3139aa2e2e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +331,7 @@ dependencies = [
  "foreign-types",
  "libc",
  "nix",
+ "open-enum",
  "openssl",
  "openssl-sys",
  "tokio",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -6,16 +6,17 @@ edition = "2021"
 [dependencies]
 arrayref = { version = "0.3.7" }
 bytes = { version = "1.6.0" }
+enum-map = { version = "2.7.3" }
 foreign-types = { version = "0.3.2" }
 libc = { version = "0.2.155" }
 nix = { version = "0.28.0", features = ["fs", "net", "socket", "uio"] }
-openssl = { version = "0.10.64" }
+open-enum = { version = "0.5.1" }
 openssl-sys = { version = "0.9.102" }
-tokio = { version = "1.37.0", features = ["full"] }
+openssl = { version = "0.10.64" }
 tokio-openssl = { version = "0.6.4" }
-zerocopy = { version = "0.7.34", features = ["byteorder"] }
+tokio = { version = "1.37.0", features = ["full"] }
 zerocopy-derive = { version = "0.7.34" }
-enum-map = { version = "2.7.3" }
+zerocopy = { version = "0.7.34", features = ["byteorder"] }
 
 [features]
 ci = []

--- a/adapter/ph/src/buffer_stack.rs
+++ b/adapter/ph/src/buffer_stack.rs
@@ -9,6 +9,7 @@ pub struct BufferStack<'buf, const BUFSIZ: usize> {
     notify: Notify
 }
 
+#[allow(dead_code)]
 impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
     pub const BUFFER_SIZE: usize = BUFSIZ;
 

--- a/adapter/ph/src/counters_enum.rs
+++ b/adapter/ph/src/counters_enum.rs
@@ -4,6 +4,7 @@ use enum_map::Enum;
 pub enum CounterType {
     InPacksRec,
     InPacksDrop,
+    InPacksErr,
     InPacksSent,
     OutPacksRec,
     OutPacksDrop,
@@ -19,6 +20,7 @@ pub fn name_counters(count_num: CounterType) -> String {
     match count_num {
         CounterType::InPacksRec   => s = "Inbound Packets Recieved",
         CounterType::InPacksDrop  => s = "Inbound Packets Dropped",
+        CounterType::InPacksErr   => s = "Inbound Packet Errors",
         CounterType::InPacksSent  => s = "Inbound Packets Sent",
         CounterType::OutPacksRec  => s = "Outbound Packets Recieved",
         CounterType::OutPacksDrop => s = "Outbound Packets Dropped",

--- a/adapter/ph/src/counters_enum.rs
+++ b/adapter/ph/src/counters_enum.rs
@@ -4,7 +4,6 @@ use enum_map::Enum;
 pub enum CounterType {
     InPacksRec,
     InPacksDrop,
-    InPacksErr,
     InPacksSent,
     OutPacksRec,
     OutPacksDrop,
@@ -20,7 +19,6 @@ pub fn name_counters(count_num: CounterType) -> String {
     match count_num {
         CounterType::InPacksRec   => s = "Inbound Packets Recieved",
         CounterType::InPacksDrop  => s = "Inbound Packets Dropped",
-        CounterType::InPacksErr   => s = "Inbound Packet Errors",
         CounterType::InPacksSent  => s = "Inbound Packets Sent",
         CounterType::OutPacksRec  => s = "Outbound Packets Recieved",
         CounterType::OutPacksDrop => s = "Outbound Packets Dropped",

--- a/adapter/ph/src/ext/tokio.rs
+++ b/adapter/ph/src/ext/tokio.rs
@@ -1,4 +1,5 @@
-#[allow(dead_code)]
+#![allow(dead_code)]
+
 pub mod io {
     pub mod unix {
         use std::io::{IoSlice, IoSliceMut};

--- a/adapter/ph/src/ext/tokio.rs
+++ b/adapter/ph/src/ext/tokio.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 pub mod io {
     pub mod unix {
         use std::io::{IoSlice, IoSliceMut};

--- a/adapter/ph/src/inbound_processor_worker.rs
+++ b/adapter/ph/src/inbound_processor_worker.rs
@@ -23,10 +23,12 @@ async fn worker<'pktbuf>(
             match hdr.abbreviated_header.packet_type {
                 ZdpPacketType::UncompressedAgentPacket => {
                     // copy out relevant header info
-                    pkt.metadata_mut().stream_id = hdr.abbreviated_header.stream_id;
+                    pkt.metadata_mut().flow_id = hdr.abbreviated_header.stream_id;
+
                     // strip packet header
                     pkt.advance(std::mem::size_of::<ZdpHeader>());
-                    // send out packet
+
+                    // send out decapsulated packet
                     asm.inbound_send.enqueue(pkt).await;
                 },
 

--- a/adapter/ph/src/inbound_processor_worker.rs
+++ b/adapter/ph/src/inbound_processor_worker.rs
@@ -1,7 +1,10 @@
-use core::future::Future;
+use std::future::Future;
+use bytes::Buf;
 use tokio::sync::mpsc;
+use zerocopy::FromBytes;
 use crate::assembly::Assembly;
 use crate::packet::Packet;
+use crate::zdp::*;
 
 #[derive(Copy, Clone)]
 pub struct Config {
@@ -14,9 +17,22 @@ async fn worker<'pktbuf>(
     let mut pkts = Vec::new();
 
     while let _count @ 1.. = queue.recv_many(&mut pkts, config.batch_size).await {
-        for pkt in pkts.drain(..) {
-            // TODO: consider enqueueing in parallel to avoid blocking all if one Q is full
-            asm.inbound_send.enqueue(pkt).await;
+        for mut pkt in pkts.drain(..) {
+            let hdr = ZdpHeader::ref_from_prefix(pkt.body()).expect("too-short inbound packet");
+
+            match hdr.abbreviated_header.packet_type {
+                ZdpPacketType::UncompressedAgentPacket => {
+                    // copy out relevant header info
+                    pkt.metadata_mut().stream_id = hdr.abbreviated_header.stream_id;
+                    // strip packet header
+                    pkt.advance(std::mem::size_of::<ZdpHeader>());
+                    // send out packet
+                    asm.inbound_send.enqueue(pkt).await;
+                },
+
+                packet_type =>
+                    panic!("unhandled inbound packet type {}", packet_type.0)
+            }
         }
     }
 }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -20,21 +20,22 @@ use enum_map::{enum_map, EnumMap};
 extern crate arrayref;
 
 // TODO: make these all non-pub once everything is used
-pub mod ext;
-mod config;
-pub mod buffer_stack;
-mod packet;
-mod queues;
 mod assembly;
+mod buffer_stack;
+mod config;
 mod counter;
-mod udp_stream;
+mod counters_enum;
 mod dtls_worker;
+mod ext;
 mod inbound_processor_worker;
 mod inbound_send_worker;
-mod outbound_recv_worker;
 mod outbound_processor_worker;
+mod outbound_recv_worker;
+mod packet;
+mod queues;
 mod rpc_worker;
-mod counters_enum;
+mod udp_stream;
+mod zdp;
 
 use buffer_stack::BufferStack;
 use queues::*;

--- a/adapter/ph/src/outbound_processor_worker.rs
+++ b/adapter/ph/src/outbound_processor_worker.rs
@@ -2,6 +2,7 @@ use core::future::Future;
 use tokio::sync::mpsc;
 use crate::assembly::Assembly;
 use crate::packet::Packet;
+use crate::zdp::*;
 
 #[derive(Copy, Clone)]
 pub struct Config {
@@ -14,7 +15,15 @@ async fn worker<'pktbuf>(
     let mut pkts = Vec::new();
 
     while let _count @ 1.. = queue.recv_many(&mut pkts, config.batch_size).await {
-        for pkt in pkts.drain(..) {
+        for mut pkt in pkts.drain(..) {
+            // allocate and fill in the header
+            let hdr = pkt.alloc_zeroed_header::<ZdpHeader>();
+            hdr.abbreviated_header.packet_type = ZdpPacketType::UncompressedAgentPacket;
+
+            // fill in metadata
+            pkt.metadata_mut().flow_id = 0;  // TODO: fill from IP header
+
+            // forward encapsulated packet on
             asm.outbound_send.enqueue(pkt).await;
         }
     }

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -12,10 +12,11 @@ pub struct Packet<'buf> {
 }
 
 #[derive(AsBytes, FromZeroes, FromBytes)]
-#[repr(C)]
+#[repr(packed)]
 pub struct PacketMetadata {
     offset: usize,  // packet offset (must be >= PACKET_BODY_BUFFER_MIN_OFFSET)
-    len: usize  // packet length
+    len: usize,  // packet length
+    pub stream_id: u32  // ZPR stream ID; 0 is unknown
 }
 
 pub const PACKET_BUFFER_MIN_BODY_OFFSET: usize = size_of::<PacketMetadata>();
@@ -42,6 +43,7 @@ impl<'buf> Packet<'buf> {
         let md = pkt.metadata_mut();
         md.offset = offset;
         md.len = len;
+        md.stream_id = 0;
         pkt
     }
 
@@ -89,7 +91,26 @@ impl<'buf> Packet<'buf> {
     // flowhash is different for different flows, but not necessarily vice-versa.
     // Ideally this is a high-entropy value useful for load balancing.
     // Must be cheap to query.
-    pub fn flowhash(&self) -> u32 { 0 /* TODO */ }
+    pub fn flowhash(&self) -> u32 { self.metadata().stream_id }
+}
+
+impl<'buf> buf::Buf for Packet<'buf> {
+    fn remaining(&self) -> usize {
+        self.metadata().len
+    }
+
+    // NOTE: This isn't super useful for us, as the contract of `chunk()`
+    // permits returning less than what's available (even though we do not).
+    // Most internal users should use `body()` instead.
+    fn chunk(&self) -> &[u8] {
+        self.body()
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        assert!(cnt <= self.remaining());
+        self.metadata_mut().offset += cnt;
+        self.metadata_mut().len -= cnt;
+    }
 }
 
 unsafe impl<'buf> buf::BufMut for Packet<'buf> {
@@ -98,14 +119,14 @@ unsafe impl<'buf> buf::BufMut for Packet<'buf> {
         size_of_val(self.buf) - (md.offset + md.len)
     }
 
-    unsafe fn advance_mut(&mut self, cnt: usize) {
-        assert!(cnt <= self.remaining_mut());
-        self.metadata_mut().len += cnt;
-    }
-
     fn chunk_mut(&mut self) -> &mut buf::UninitSlice {
         let offset = self.metadata().offset;
         let len = self.metadata().len;
         buf::UninitSlice::new(&mut self.buf[offset+len..])
+    }
+
+    unsafe fn advance_mut(&mut self, cnt: usize) {
+        assert!(cnt <= self.remaining_mut());
+        self.metadata_mut().len += cnt;
     }
 }

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -1,6 +1,6 @@
 use std::mem::{size_of, size_of_val};
 use bytes::buf;
-use zerocopy::FromBytes;
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
 use crate::config;
 
@@ -16,7 +16,7 @@ pub struct Packet<'buf> {
 pub struct PacketMetadata {
     offset: usize,  // packet offset (must be >= PACKET_BODY_BUFFER_MIN_OFFSET)
     len: usize,  // packet length
-    pub stream_id: u32  // ZPR stream ID; 0 is unknown
+    pub flow_id: u32  // flow ID for load-balancing purposes; not otherwise meaningful
 }
 
 pub const PACKET_BUFFER_MIN_BODY_OFFSET: usize = size_of::<PacketMetadata>();
@@ -43,7 +43,7 @@ impl<'buf> Packet<'buf> {
         let md = pkt.metadata_mut();
         md.offset = offset;
         md.len = len;
-        md.stream_id = 0;
+        md.flow_id = 0;
         pkt
     }
 
@@ -82,16 +82,24 @@ impl<'buf> Packet<'buf> {
     }
 
     // Extend the start of the packet into available headroom.
-    pub fn alloc_headroom(&mut self, cnt: usize) {
+    pub fn alloc_zeroed_headroom(&mut self, cnt: usize) {
         assert!(cnt <= self.headroom_available());
-        self.metadata_mut().offset -= cnt;
-        self.metadata_mut().len += cnt;
+        let md = self.metadata_mut();
+        md.offset -= cnt;
+        md.len += cnt;
+        let offset = md.offset;
+        self.buf[offset..offset+cnt].fill(0);
+    }
+
+    pub fn alloc_zeroed_header<T: AsBytes + FromBytes + FromZeroes>(&mut self) -> &mut T {
+        self.alloc_zeroed_headroom(size_of::<T>());
+        T::mut_from_prefix(self.body_mut()).unwrap()
     }
 
     // flowhash is different for different flows, but not necessarily vice-versa.
     // Ideally this is a high-entropy value useful for load balancing.
     // Must be cheap to query.
-    pub fn flowhash(&self) -> u32 { self.metadata().stream_id }
+    pub fn flowhash(&self) -> u32 { self.metadata().flow_id }
 }
 
 impl<'buf> buf::Buf for Packet<'buf> {

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -1,9 +1,11 @@
+#![allow(dead_code)]
+
 use open_enum::open_enum;
-use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+use zerocopy_derive::{AsBytes, FromBytes, FromZeroes, Unaligned};
 
 
 #[open_enum]
-#[derive(FromZeroes, FromBytes, AsBytes)]
+#[derive(Copy, Clone, FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(u8)]
 pub enum ZdpPacketType {
     CompressedAgentPacket = 0,
@@ -11,27 +13,27 @@ pub enum ZdpPacketType {
 }
 
 #[open_enum]
-#[derive(FromZeroes, FromBytes, AsBytes)]
+#[derive(Copy, Clone, FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(u8)]
 pub enum ZdpD2DAlgorithm {
     NOP = 0,
     Blake2b256 = 1
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes)]
-#[repr(C, packed)]
+#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[repr(packed)]
 pub struct ZdpAbbreviatedHeader {
-    packet_type: ZdpPacketType,
-    sequence_number: u16,
-    stream_id: u32
+    pub packet_type: ZdpPacketType,
+    pub sequence_number: u16,
+    pub stream_id: u32
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes)]
-#[repr(C, packed)]
+#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[repr(packed)]
 pub struct ZdpHeader {
-    abbreviated_header: ZdpAbbreviatedHeader,
-    d2d_algorithm: ZdpD2DAlgorithm,
-    mac: [u8; 16]
+    pub abbreviated_header: ZdpAbbreviatedHeader,
+    pub d2d_algorithm: ZdpD2DAlgorithm,
+    pub mac: [u8; 16]
 }
 
 const _: () = assert!(core::mem::size_of::<ZdpHeader>() == 24);

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -1,0 +1,37 @@
+use open_enum::open_enum;
+use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
+
+
+#[open_enum]
+#[derive(FromZeroes, FromBytes, AsBytes)]
+#[repr(u8)]
+pub enum ZdpPacketType {
+    CompressedAgentPacket = 0,
+    UncompressedAgentPacket = 1
+}
+
+#[open_enum]
+#[derive(FromZeroes, FromBytes, AsBytes)]
+#[repr(u8)]
+pub enum ZdpD2DAlgorithm {
+    NOP = 0,
+    Blake2b256 = 1
+}
+
+#[derive(FromZeroes, FromBytes, AsBytes)]
+#[repr(C, packed)]
+pub struct ZdpAbbreviatedHeader {
+    packet_type: ZdpPacketType,
+    sequence_number: u16,
+    stream_id: u32
+}
+
+#[derive(FromZeroes, FromBytes, AsBytes)]
+#[repr(C, packed)]
+pub struct ZdpHeader {
+    abbreviated_header: ZdpAbbreviatedHeader,
+    d2d_algorithm: ZdpD2DAlgorithm,
+    mac: [u8; 16]
+}
+
+const _: () = assert!(core::mem::size_of::<ZdpHeader>() == 24);


### PR DESCRIPTION
Very basic -- we handle only agent data packets -- and basically do nothing with the headers.  But that's about all the CA PH will do anyway for agent data packets.  We'll only need to dress this up for the Node PH which actually cares about what's in the headers.

Testing: actually got a ping request and reply to go through!  (Had to store the received encapsulated ping in a file, then replay it back out from the file… but still, it worked!)