### PR TITLE
add and act on TUN packet info

### DIFF
--- a/adapter/ph/src/classifier.rs
+++ b/adapter/ph/src/classifier.rs
@@ -117,7 +117,6 @@ fn classify_ipv4(
         return Err("Packet length error");
     }
 
-    metadata.set_ip_version(4);
     metadata.set_addresses(
         packet::IpAddress::new_from_v4(ipv4_header.src_address),
         packet::IpAddress::new_from_v4(ipv4_header.dst_address),
@@ -153,7 +152,6 @@ fn classify_ipv6(
     let header_bytes = &body[..size_of::<IPv6Header>()];
     let ipv6_header = IPv6Header::ref_from(header_bytes).unwrap();
 
-    metadata.set_ip_version(6);
     metadata.set_addresses(ipv6_header.src_address, ipv6_header.dst_address);
 
     classify_next_header(

--- a/adapter/ph/src/classifier.rs
+++ b/adapter/ph/src/classifier.rs
@@ -117,9 +117,10 @@ fn classify_ipv4(
         return Err("Packet length error");
     }
 
+    metadata.set_ip_version(4);
     metadata.set_addresses(
-        packet::v4_to_v6_address(ipv4_header.src_address),
-        packet::v4_to_v6_address(ipv4_header.dst_address),
+        packet::IpAddress::new_from_v4(ipv4_header.src_address),
+        packet::IpAddress::new_from_v4(ipv4_header.dst_address),
     );
 
     const FRAGMENT_OFFSET_MASK: u16 = 0x1FFF;
@@ -152,6 +153,7 @@ fn classify_ipv6(
     let header_bytes = &body[..size_of::<IPv6Header>()];
     let ipv6_header = IPv6Header::ref_from(header_bytes).unwrap();
 
+    metadata.set_ip_version(6);
     metadata.set_addresses(ipv6_header.src_address, ipv6_header.dst_address);
 
     classify_next_header(

--- a/adapter/ph/src/dtls_worker.rs
+++ b/adapter/ph/src/dtls_worker.rs
@@ -61,6 +61,7 @@ async fn worker<'pktbuf>(
                     match msg {
                         OutboundSendMessage::Packet(pkt) => {
                             ssl_write.write(pkt.body()).await.unwrap();  // TODO: error handling
+                            asm.counters[CounterType::OutPacksSent].increment();
                         },
 
                         OutboundSendMessage::TestPacket(_) => ()  /* handled below */

--- a/adapter/ph/src/ext/tokio_tun.rs
+++ b/adapter/ph/src/ext/tokio_tun.rs
@@ -40,10 +40,11 @@ impl TunExt for Tun {
 pub mod tun_pi {
     use bytes::buf;
 
+    // per-packet packet info
     #[derive(Clone, Copy)]
     pub struct TunPi {
-        pub strip: bool,
-        pub proto: u16,
+        pub strip: bool,  // the inbound packet was truncated (ignored outbound)
+        pub proto: u16,  // Ethertype of packet
     }
 
     #[cfg(target_os = "linux")]
@@ -89,6 +90,8 @@ pub mod tun_pi {
         }
         .into()
     }
+
+    pub const PI_SIZE: usize = std::mem::size_of::<os::TunPi>();
 
     pub fn write_pi<B: buf::BufMut>(buf: &mut B, pi: TunPi) {
         let os_pi: os::TunPi = pi.into();

--- a/adapter/ph/src/ext/tokio_tun.rs
+++ b/adapter/ph/src/ext/tokio_tun.rs
@@ -36,3 +36,68 @@ impl TunExt for Tun {
         Ok(size)
     }
 }
+
+pub mod tun_pi {
+    use bytes::buf;
+
+    #[derive(Clone, Copy)]
+    pub struct TunPi {
+        pub strip: bool,
+        pub proto: u16,
+    }
+
+    #[cfg(target_os = "linux")]
+    mod os {
+        const TUN_PKT_STRIP: u16 = 0x0001;
+
+        #[repr(C)]
+        #[derive(Clone, Copy)]
+        pub struct TunPi {
+            flags: u16,
+            proto: [u8; 2],
+        }
+
+        impl From<TunPi> for super::TunPi {
+            fn from(pi: TunPi) -> super::TunPi {
+                super::TunPi {
+                    strip: pi.flags & TUN_PKT_STRIP != 0,
+                    proto: u16::from_be_bytes(pi.proto),
+                }
+            }
+        }
+
+        impl From<super::TunPi> for TunPi {
+            fn from(pi: super::TunPi) -> TunPi {
+                TunPi {
+                    flags: 0,
+                    proto: pi.proto.to_be_bytes(),
+                }
+            }
+        }
+    }
+
+    pub fn read_pi<B: buf::Buf>(buf: &mut B) -> TunPi {
+        let mut os_pi = std::mem::MaybeUninit::<os::TunPi>::uninit();
+        let slice = os_pi.as_mut_ptr();
+        buf.copy_to_slice(unsafe {
+            /* SAFETY: we immediately initialize */
+            std::slice::from_raw_parts_mut(slice as *mut u8, std::mem::size_of::<os::TunPi>())
+        });
+        unsafe {
+            /* SAFETY: was just initialized */
+            os_pi.assume_init()
+        }
+        .into()
+    }
+
+    pub fn write_pi<B: buf::BufMut>(buf: &mut B, pi: TunPi) {
+        let os_pi: os::TunPi = pi.into();
+        buf.put(unsafe {
+            /* SAFETY: we are reading exactly the structure */
+            std::slice::from_raw_parts(
+                (&os_pi as *const _) as *const u8,
+                std::mem::size_of::<os::TunPi>(),
+            )
+        });
+    }
+}

--- a/adapter/ph/src/ext/tokio_tun.rs
+++ b/adapter/ph/src/ext/tokio_tun.rs
@@ -43,7 +43,7 @@ pub mod tun_pi {
     // per-packet packet info
     #[derive(Clone, Copy)]
     pub struct TunPi {
-        pub strip: bool,  // the inbound packet was truncated (ignored outbound)
+        pub strip: bool, // the inbound packet was truncated (ignored outbound)
         pub proto: u16,  // Ethertype of packet
     }
 

--- a/adapter/ph/src/inbound_send_worker.rs
+++ b/adapter/ph/src/inbound_send_worker.rs
@@ -1,5 +1,7 @@
 use crate::assembly::Assembly;
-use crate::InboundSendMessage;
+use crate::ext::tokio_tun::*;
+use crate::net_defs;
+use crate::queues::InboundSendMessage;
 use std::future::Future;
 use std::io::IoSlice;
 use tokio::sync::mpsc;
@@ -8,6 +10,14 @@ use tokio_tun::Tun;
 #[derive(Copy, Clone)]
 pub struct Config {
     pub batch_size: usize,
+}
+
+fn ip_ethertype(ip_version: u8) -> u16 {
+    match ip_version {
+        4 => net_defs::ETHERTYPE_IP,
+        6 => net_defs::ETHERTYPE_IPV6,
+        _ => 0,
+    }
 }
 
 async fn worker<'pktbuf>(
@@ -19,23 +29,30 @@ async fn worker<'pktbuf>(
     let mut messages = Vec::new();
 
     while let count @ 1.. = queue.recv_many(&mut messages, config.batch_size).await {
-        for msg in &messages {
+        for msg in &mut messages {
             match msg {
-                InboundSendMessage::Packet(msg) => {
-                    tun.send_vectored(&[IoSlice::new(msg.body())])
+                InboundSendMessage::Packet(pkt) => {
+                    tun_pi::write_pi(
+                        pkt,
+                        tun_pi::TunPi {
+                            strip: false,
+                            proto: ip_ethertype(pkt.metadata().get_ip_version()),
+                        },
+                    );
+                    tun.send_vectored(&[IoSlice::new(pkt.body())])
                         .await
                         .unwrap();
                 } // TODO: error handling
-                InboundSendMessage::TestPacket(_msg) => (),
+                InboundSendMessage::TestPacket(_pkt) => (),
             };
         }
         asm.buffer_stack
             .put_buffers(messages.drain(..).filter_map(|msg| match msg {
-                InboundSendMessage::Packet(msg) => Some(msg.destroy()),
+                InboundSendMessage::Packet(pkt) => Some(pkt.destroy()),
                 // acknowledge had to go here since it consumes the packet, it could not be in
                 // the previous match because the program still expected the packet to me in messages
-                InboundSendMessage::TestPacket(msg) => {
-                    msg.acknowledge(queue.len(), count);
+                InboundSendMessage::TestPacket(pkt) => {
+                    pkt.acknowledge(queue.len(), count);
                     None
                 }
             }));

--- a/adapter/ph/src/inbound_send_worker.rs
+++ b/adapter/ph/src/inbound_send_worker.rs
@@ -1,4 +1,5 @@
 use crate::assembly::Assembly;
+use crate::counters_enum::*;
 use crate::ext::tokio_tun::*;
 use crate::net_defs;
 use crate::queues::InboundSendMessage;
@@ -10,6 +11,10 @@ use tokio_tun::Tun;
 #[derive(Copy, Clone)]
 pub struct Config {
     pub batch_size: usize,
+}
+
+fn ip_version(pkt: &[u8]) -> u8 {
+    pkt[0] >> 4
 }
 
 fn ip_ethertype(ip_version: u8) -> u16 {
@@ -32,20 +37,27 @@ async fn worker<'pktbuf>(
         for msg in &mut messages {
             match msg {
                 InboundSendMessage::Packet(pkt) => {
+                    let proto = ip_ethertype(ip_version(pkt.body()));
+                    let mut hdr = pkt.alloc_zeroed_header::<[u8; tun_pi::PI_SIZE]>() as &mut [u8];
                     tun_pi::write_pi(
-                        pkt,
+                        &mut hdr,
                         tun_pi::TunPi {
                             strip: false,
-                            proto: ip_ethertype(pkt.metadata().get_ip_version()),
+                            proto,
                         },
                     );
+
                     tun.send_vectored(&[IoSlice::new(pkt.body())])
                         .await
                         .unwrap();
+
+                    asm.counters[CounterType::InPacksSent].increment();
                 } // TODO: error handling
+
                 InboundSendMessage::TestPacket(_pkt) => (),
             };
         }
+
         asm.buffer_stack
             .put_buffers(messages.drain(..).filter_map(|msg| match msg {
                 InboundSendMessage::Packet(pkt) => Some(pkt.destroy()),

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -34,6 +34,7 @@ mod ext;
 mod flow_control;
 mod inbound_processor_worker;
 mod inbound_send_worker;
+mod net_defs;
 mod options;
 mod outbound_processor_worker;
 mod outbound_recv_worker;
@@ -215,7 +216,6 @@ fn main() -> ExitCode {
 
             let tun_devs = TunBuilder::new()
                 .name(cmd_line.tun_if.unwrap_or(String::new()).as_str())
-                .packet_info(false)
                 .try_build_mq(tun_queue_count)
                 .expect("unable to open TUN device")
                 .leak();

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -1,0 +1,4 @@
+// Standard network constants.
+
+pub const ETHERTYPE_IP: u16 = 0x0800;
+pub const ETHERTYPE_IPV6: u16 = 0x86dd;

--- a/adapter/ph/src/outbound_recv_worker.rs
+++ b/adapter/ph/src/outbound_recv_worker.rs
@@ -1,5 +1,7 @@
 use crate::assembly::Assembly;
+use crate::counters_enum::*;
 use crate::ext::tokio_tun::*;
+use crate::net_defs;
 use crate::packet::Packet;
 use std::future::Future;
 use tokio_tun::Tun;
@@ -11,6 +13,10 @@ pub struct Config {
 
 // How much space to leave for the ZDP headers.
 const OUTBOUND_PACKET_HEADROOM: usize = 256;
+
+fn is_ip(pi: tun_pi::TunPi) -> bool {
+    pi.proto == net_defs::ETHERTYPE_IP || pi.proto == net_defs::ETHERTYPE_IPV6
+}
 
 async fn worker(config: &Config, asm: &Assembly<'_>, tun: &Tun) {
     let mut bufs = Vec::new();
@@ -25,7 +31,18 @@ async fn worker(config: &Config, asm: &Assembly<'_>, tun: &Tun) {
         // since neither `read_buf()` nor `enqueue()` support it
         for buf in bufs.drain(..) {
             let mut pkt = Packet::new(buf, OUTBOUND_PACKET_HEADROOM);
+
             tun_recv_buf(tun, &mut pkt).await.unwrap();
+
+            let pi = tun_pi::read_pi(&mut pkt);
+            if pi.strip || is_ip(pi) {
+                // packet was too large or non-IP; drop
+                asm.counters[CounterType::OutPacksDrop].increment();
+                asm.buffer_stack.put_buffer(pkt.destroy());
+                continue;
+            }
+
+            asm.counters[CounterType::OutPacksRec].increment();
             asm.outbound_processor.enqueue_packet(pkt).await;
         }
     }

--- a/adapter/ph/src/outbound_recv_worker.rs
+++ b/adapter/ph/src/outbound_recv_worker.rs
@@ -35,7 +35,7 @@ async fn worker(config: &Config, asm: &Assembly<'_>, tun: &Tun) {
             tun_recv_buf(tun, &mut pkt).await.unwrap();
 
             let pi = tun_pi::read_pi(&mut pkt);
-            if pi.strip || is_ip(pi) {
+            if pi.strip || !is_ip(pi) {
                 // packet was too large or non-IP; drop
                 asm.counters[CounterType::OutPacksDrop].increment();
                 asm.buffer_stack.put_buffer(pkt.destroy());

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -23,22 +23,18 @@ pub struct IpAddress {
 
 #[allow(dead_code)]
 impl IpAddress {
-    pub fn set_from_v4(&mut self, v4_address: [u8; 4]) {
-        self.v6[12..16].copy_from_slice(&v4_address);
-        self.v6[10] = 0xff;
-        self.v6[11] = 0xff
+    pub fn new_from_v4(v4_address: [u8; 4]) -> Self {
+        // Uses standard v4 to v6 conversion
+        let mut addr = Self::new_zeroed();
+        addr.v6[12..16].copy_from_slice(&v4_address);
+        addr.v6[10] = 0xff;
+        addr.v6[11] = 0xff;
+        addr
     }
 
-    pub fn read_as_v4(&self) -> &[u8] {
-        &self.v6[12..16]
+    pub fn read_as_v4(&self) -> [u8; 4] {
+        *array_ref!(self.v6, 12, 4)
     }
-}
-
-pub fn v4_to_v6_address(v4_address: [u8; 4]) -> IpAddress {
-    // Uses standard v4 to v6 conversion
-    let mut v6_address = IpAddress::new_zeroed();
-    v6_address.set_from_v4(v4_address);
-    v6_address
 }
 
 #[derive(AsBytes, FromZeroes, FromBytes)]
@@ -52,11 +48,17 @@ pub struct PacketMetadata {
     src_port: u16,
     dst_port: u16,
     protocol: u8,
-    _padding: [u8; 3],
+    ip_version: u8,
+    _padding: [u8; 2],
 }
 
 #[allow(dead_code)]
 impl PacketMetadata {
+    pub fn set_addresses(&mut self, src_addr: IpAddress, dst_addr: IpAddress) {
+        self.src_address = src_addr;
+        self.dst_address = dst_addr;
+    }
+
     pub fn set_src_port(&mut self, sport: [u8; 2]) {
         self.src_port = NetworkEndian::read_u16(&sport)
     }
@@ -69,9 +71,8 @@ impl PacketMetadata {
         self.protocol = proto
     }
 
-    pub fn set_addresses(&mut self, src_addr: IpAddress, dst_addr: IpAddress) {
-        self.src_address = src_addr;
-        self.dst_address = dst_addr;
+    pub fn set_ip_version(&mut self, ip_version: u8) {
+        self.ip_version = ip_version
     }
 
     pub fn get_src_address(&self) -> IpAddress {
@@ -92,6 +93,10 @@ impl PacketMetadata {
 
     pub fn get_protocol(&self) -> u8 {
         self.protocol
+    }
+
+    pub fn get_ip_version(&self) -> u8 {
+        self.ip_version
     }
 }
 

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -48,8 +48,7 @@ pub struct PacketMetadata {
     src_port: u16,
     dst_port: u16,
     protocol: u8,
-    ip_version: u8,
-    _padding: [u8; 2],
+    _padding: [u8; 3],
 }
 
 #[allow(dead_code)]
@@ -71,10 +70,6 @@ impl PacketMetadata {
         self.protocol = proto
     }
 
-    pub fn set_ip_version(&mut self, ip_version: u8) {
-        self.ip_version = ip_version
-    }
-
     pub fn get_src_address(&self) -> IpAddress {
         self.src_address
     }
@@ -93,10 +88,6 @@ impl PacketMetadata {
 
     pub fn get_protocol(&self) -> u8 {
         self.protocol
-    }
-
-    pub fn get_ip_version(&self) -> u8 {
-        self.ip_version
     }
 }
 


### PR DESCRIPTION
Read & write packet info from/to TUN device.

Also added an IP version field to the packet metadata since it isn't otherwise readily discernible.

Drive-by modification of `IpAddress` to enforce that IPv4 addresses are always correctly translated into IPv6 addresses.  (i.e. no possibility to stomp an already-written IPv6 address resulting in a mishmash.)

Addresses #190.