### PR TITLE
add documentation and tests to packet module

### DIFF
--- a/adapter/ph/src/classifier.rs
+++ b/adapter/ph/src/classifier.rs
@@ -1,5 +1,6 @@
 #[allow(unused_imports)]
 use crate::config;
+use crate::net_defs::*;
 use crate::packet;
 use std::mem::size_of;
 #[allow(unused_imports)]
@@ -42,8 +43,8 @@ struct IPv6Header {
     pub payload_length: [u8; 2],
     pub next_header: u8,
     pub hop_limit: u8,
-    pub src_address: packet::IpAddress,
-    pub dst_address: packet::IpAddress,
+    pub src_address: IpAddress,
+    pub dst_address: IpAddress,
 }
 
 const NO_NEXT_HEADER: u8 = 59;
@@ -72,7 +73,7 @@ struct UDPHeader {
 }
 
 pub fn classify(packet: &mut packet::Packet) -> Result<ClassifierResult, &'static str> {
-    let (metadata, body) = packet.metadata_mut_and_body();
+    let (metadata, body) = packet.metadata_mut_and_body_mut();
     classify_zdp(metadata, body)
 }
 
@@ -118,8 +119,8 @@ fn classify_ipv4(
     }
 
     metadata.set_addresses(
-        packet::IpAddress::new_from_v4(ipv4_header.src_address),
-        packet::IpAddress::new_from_v4(ipv4_header.dst_address),
+        IpAddress::new_from_v4(ipv4_header.src_address),
+        IpAddress::new_from_v4(ipv4_header.dst_address),
     );
 
     const FRAGMENT_OFFSET_MASK: u16 = 0x1FFF;
@@ -298,8 +299,8 @@ mod tests {
         assert_eq!(ClassifierResult::NonIP, classify(&mut packet).unwrap());
 
         let metadata = packet.metadata();
-        assert_eq!(packet::IpAddress::new_zeroed(), metadata.get_src_address());
-        assert_eq!(packet::IpAddress::new_zeroed(), metadata.get_dst_address());
+        assert_eq!(IpAddress::new_zeroed(), metadata.get_src_address());
+        assert_eq!(IpAddress::new_zeroed(), metadata.get_dst_address());
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
         assert_eq!(0u8, metadata.get_protocol());
@@ -425,8 +426,8 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
-        assert_eq!(packet::IpAddress::new_zeroed(), metadata.get_src_address());
-        assert_eq!(packet::IpAddress::new_zeroed(), metadata.get_dst_address());
+        assert_eq!(IpAddress::new_zeroed(), metadata.get_src_address());
+        assert_eq!(IpAddress::new_zeroed(), metadata.get_dst_address());
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
         assert_eq!(0u8, metadata.get_protocol());
@@ -451,8 +452,8 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
-        assert_eq!(packet::IpAddress::new_zeroed(), metadata.get_src_address());
-        assert_eq!(packet::IpAddress::new_zeroed(), metadata.get_dst_address());
+        assert_eq!(IpAddress::new_zeroed(), metadata.get_src_address());
+        assert_eq!(IpAddress::new_zeroed(), metadata.get_dst_address());
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
         assert_eq!(0u8, metadata.get_protocol());
@@ -477,8 +478,8 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
-        assert_eq!(packet::IpAddress::new_zeroed(), metadata.get_src_address());
-        assert_eq!(packet::IpAddress::new_zeroed(), metadata.get_dst_address());
+        assert_eq!(IpAddress::new_zeroed(), metadata.get_src_address());
+        assert_eq!(IpAddress::new_zeroed(), metadata.get_dst_address());
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
         assert_eq!(0u8, metadata.get_protocol());
@@ -510,7 +511,7 @@ mod tests {
 
         let metadata = packet.metadata();
         assert_eq!(
-            packet::IpAddress {
+            IpAddress {
                 v6: [
                     0xfc, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x01
@@ -519,7 +520,7 @@ mod tests {
             metadata.get_src_address()
         );
         assert_eq!(
-            packet::IpAddress {
+            IpAddress {
                 v6: [
                     0xfc, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x01
@@ -564,7 +565,7 @@ mod tests {
 
         let metadata = packet.metadata();
         assert_eq!(
-            packet::IpAddress {
+            IpAddress {
                 v6: [
                     0x26, 0x07, 0xf0, 0x10, 0x03, 0xf9, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x11, 0x00, 0x00
@@ -573,7 +574,7 @@ mod tests {
             metadata.get_dst_address()
         );
         assert_eq!(
-            packet::IpAddress {
+            IpAddress {
                 v6: [
                     0x26, 0x07, 0xf0, 0x10, 0x03, 0xf9, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x10, 0x01
@@ -611,7 +612,7 @@ mod tests {
 
         let metadata = packet.metadata();
         assert_eq!(
-            packet::IpAddress {
+            IpAddress {
                 v6: [
                     0x26, 0x07, 0xf0, 0x10, 0x03, 0xf9, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x11, 0x00, 0x00
@@ -620,7 +621,7 @@ mod tests {
             metadata.get_dst_address()
         );
         assert_eq!(
-            packet::IpAddress {
+            IpAddress {
                 v6: [
                     0x26, 0x07, 0xf0, 0x10, 0x03, 0xf9, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x10, 0x01
@@ -668,7 +669,7 @@ mod tests {
 
         let metadata = packet.metadata();
         assert_eq!(
-            packet::IpAddress {
+            IpAddress {
                 v6: [
                     0xfc, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x01
@@ -677,7 +678,7 @@ mod tests {
             metadata.get_dst_address()
         );
         assert_eq!(
-            packet::IpAddress {
+            IpAddress {
                 v6: [
                     0xfc, 0x00, 0x00, 0x42, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x02
@@ -717,7 +718,7 @@ mod tests {
 
         let metadata = packet.metadata();
         assert_eq!(
-            packet::IpAddress {
+            IpAddress {
                 v6: [
                     0xfc, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x01
@@ -726,7 +727,7 @@ mod tests {
             metadata.get_dst_address()
         );
         assert_eq!(
-            packet::IpAddress {
+            IpAddress {
                 v6: [
                     0xfc, 0x00, 0x00, 0x42, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
                     0x00, 0x00, 0x02
@@ -750,8 +751,8 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
-        assert_eq!(packet::IpAddress::new_zeroed(), metadata.get_src_address());
-        assert_eq!(packet::IpAddress::new_zeroed(), metadata.get_dst_address());
+        assert_eq!(IpAddress::new_zeroed(), metadata.get_src_address());
+        assert_eq!(IpAddress::new_zeroed(), metadata.get_dst_address());
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
         assert_eq!(0u8, metadata.get_protocol());

--- a/adapter/ph/src/dtls_worker.rs
+++ b/adapter/ph/src/dtls_worker.rs
@@ -20,7 +20,7 @@ pub struct Config {
 // full record.  So to ensure correct behavior we must be prepared to accept
 // the maximum size record.
 const _: () = assert!(
-    packet::PACKET_BODY_BUFFER_MAX_SIZE >= 16384,
+    packet::PACKET_BUFFER_MAX_BODY_SIZE >= 16384,
     "packet buffers too small for OpenSSL DTLS"
 );
 

--- a/adapter/ph/src/inbound_send_worker.rs
+++ b/adapter/ph/src/inbound_send_worker.rs
@@ -19,8 +19,8 @@ fn ip_version(pkt: &[u8]) -> u8 {
 
 fn ip_ethertype(ip_version: u8) -> u16 {
     match ip_version {
-        4 => net_defs::ETHERTYPE_IP,
-        6 => net_defs::ETHERTYPE_IPV6,
+        4 => net_defs::ethertype::IP,
+        6 => net_defs::ethertype::IPV6,
         _ => 0,
     }
 }
@@ -38,7 +38,7 @@ async fn worker<'pktbuf>(
             match msg {
                 InboundSendMessage::Packet(pkt) => {
                     let proto = ip_ethertype(ip_version(pkt.body()));
-                    let mut hdr = pkt.alloc_zeroed_header::<[u8; tun_pi::PI_SIZE]>() as &mut [u8];
+                    let mut hdr = pkt.alloc_zeroed_headroom(tun_pi::PI_SIZE);
                     tun_pi::write_pi(
                         &mut hdr,
                         tun_pi::TunPi {

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -1,4 +1,37 @@
-// Standard network constants.
+//! Standard network constants.
 
-pub const ETHERTYPE_IP: u16 = 0x0800;
-pub const ETHERTYPE_IPV6: u16 = 0x86dd;
+use zerocopy::FromZeroes;
+use zerocopy_derive::{AsBytes, FromBytes, FromZeroes, KnownLayout, Unaligned};
+
+pub mod ethertype {
+    //! Ethertype / IEEE 802 numbers
+
+    pub const IP: u16 = 0x0800;
+    pub const IPV6: u16 = 0x86dd;
+}
+
+pub const IPV6_ADDRESS_SIZE: usize = 16;
+
+#[derive(
+    AsBytes, FromZeroes, FromBytes, KnownLayout, Unaligned, Copy, Clone, Hash, Debug, PartialEq,
+)]
+#[repr(transparent)]
+pub struct IpAddress {
+    pub v6: [u8; IPV6_ADDRESS_SIZE],
+}
+
+#[allow(dead_code)]
+impl IpAddress {
+    pub fn new_from_v4(v4_address: [u8; 4]) -> Self {
+        // Uses standard v4 to v6 conversion
+        let mut addr = Self::new_zeroed();
+        addr.v6[12..16].copy_from_slice(&v4_address);
+        addr.v6[10] = 0xff;
+        addr.v6[11] = 0xff;
+        addr
+    }
+
+    pub fn read_as_v4(&self) -> [u8; 4] {
+        *array_ref!(self.v6, 12, 4)
+    }
+}

--- a/adapter/ph/src/outbound_recv_worker.rs
+++ b/adapter/ph/src/outbound_recv_worker.rs
@@ -15,7 +15,7 @@ pub struct Config {
 const OUTBOUND_PACKET_HEADROOM: usize = 256;
 
 fn is_ip(pi: tun_pi::TunPi) -> bool {
-    pi.proto == net_defs::ETHERTYPE_IP || pi.proto == net_defs::ETHERTYPE_IPV6
+    pi.proto == net_defs::ethertype::IP || pi.proto == net_defs::ethertype::IPV6
 }
 
 async fn worker(config: &Config, asm: &Assembly<'_>, tun: &Tun) {

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -1,44 +1,35 @@
+//! This module contains all state of a packet which is moving through the system.
+
 use crate::config;
+use crate::net_defs::*;
 use bytes::buf;
 use std::mem::{size_of, size_of_val};
 use zerocopy::{AsBytes, ByteOrder, FromBytes, FromZeroes, NetworkEndian};
-use zerocopy_derive::{AsBytes, FromBytes, FromZeroes, KnownLayout, Unaligned};
+use zerocopy_derive::{AsBytes, FromBytes, FromZeroes};
 
-// This contains all state of a packet which is moving through the system.
-// TODO: possible we want to keep this stuff on the heap
+/** Exclusive handle to an in-use packet buffer.
+ *
+ * Via this handle, a buffer is divided into four sections in this order:
+ *
+ * - metadata
+ * - headroom
+ * - packet body
+ * - tailroom
+ *
+ * Metadata is of a fixed size and contains information about the
+ * buffer layout itself, as well as packet classification data.
+ *
+ * The packet body resides between headroom and tailroom.  It can be
+ * extended into either of these, but not beyond.  The size of these
+ * is defined when the `Packet` handle is created.
+ */
 
 pub struct Packet<'buf> {
     buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE],
 }
 
-pub const IPV6_ADDRESS_SIZE: usize = 16;
-
-#[derive(
-    AsBytes, FromZeroes, FromBytes, KnownLayout, Unaligned, Copy, Clone, Hash, Debug, PartialEq,
-)]
-#[repr(transparent)]
-pub struct IpAddress {
-    pub v6: [u8; IPV6_ADDRESS_SIZE],
-}
-
-#[allow(dead_code)]
-impl IpAddress {
-    pub fn new_from_v4(v4_address: [u8; 4]) -> Self {
-        // Uses standard v4 to v6 conversion
-        let mut addr = Self::new_zeroed();
-        addr.v6[12..16].copy_from_slice(&v4_address);
-        addr.v6[10] = 0xff;
-        addr.v6[11] = 0xff;
-        addr
-    }
-
-    pub fn read_as_v4(&self) -> [u8; 4] {
-        *array_ref!(self.v6, 12, 4)
-    }
-}
-
 #[derive(AsBytes, FromZeroes, FromBytes)]
-#[repr(packed)]
+#[repr(C)]
 pub struct PacketMetadata {
     offset: usize,    // packet offset (must be >= PACKET_BODY_BUFFER_MIN_OFFSET)
     len: usize,       // packet length
@@ -48,7 +39,7 @@ pub struct PacketMetadata {
     src_port: u16,
     dst_port: u16,
     protocol: u8,
-    _padding: [u8; 3],
+    _padding: [u8; 7],
 }
 
 #[allow(dead_code)]
@@ -98,33 +89,36 @@ const _: () = assert!(
 
 pub const PACKET_BUFFER_MIN_BODY_OFFSET: usize = size_of::<PacketMetadata>();
 
+/// The maximum size packet body which can be referenced by a `Packet`.
 #[allow(dead_code)]
-pub const PACKET_BODY_BUFFER_MAX_SIZE: usize =
+pub const PACKET_BUFFER_MAX_BODY_SIZE: usize =
     config::PACKET_BUFFER_SIZE - PACKET_BUFFER_MIN_BODY_OFFSET;
 
 #[allow(dead_code)]
 impl<'buf> Packet<'buf> {
-    // Initialize a buffer as a packet buffer.
-    // `headroom` indicates room to keep free at packet start for possible extension.
+    /// Initialize a buffer as a packet buffer, returning an exclusive handle to it.
+    /// `headroom` indicates room to keep free at packet start for possible extension.
     pub fn new(buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE], headroom: usize) -> Self {
         Self::new_with_existing_data(buf, PACKET_BUFFER_MIN_BODY_OFFSET + headroom, 0)
     }
 
+    /// Consumes a packet handle, returning the underlying buffer.
     #[must_use]
     pub fn destroy(self) -> &'buf mut [u8; config::PACKET_BUFFER_SIZE] {
         self.buf
     }
 
-    // Initialize a buffer with existing packet data as a packet buffer.
-    // `offset` is offset of data within buffer.
-    // It must be at least equal to PACKET_BODY_BUFFER_MIN_OFFSET.
+    /// Initialize a buffer with existing packet data as a packet buffer.
+    /// `offset` is offset of data within buffer.
+    /// It must be at least equal to `PACKET_BUFFER_MIN_BODY_OFFSET`.
     pub fn new_with_existing_data(
         buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE],
         offset: usize,
         len: usize,
     ) -> Self {
         assert!(offset >= PACKET_BUFFER_MIN_BODY_OFFSET);
-        assert!(offset + len < size_of_val(buf));
+        assert!(len <= size_of_val(buf));
+        assert!(offset <= size_of_val(buf) - len);
         let mut pkt = Packet { buf };
         let md = pkt.metadata_mut();
         md.offset = offset;
@@ -133,6 +127,7 @@ impl<'buf> Packet<'buf> {
         pkt
     }
 
+    /// Copy this packet's metadata, data and layout into a new buffer, returning a handle for it.
     pub fn clone_into<'other>(
         &self,
         buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
@@ -140,6 +135,8 @@ impl<'buf> Packet<'buf> {
         self.clone_into_with_headroom(buf, self.headroom_available())
     }
 
+    /// Copy this packet's metadata and data into a new buffer, returning a handle for it.
+    /// The packet body will be positioned to leave the specified amount of headroom in the new buffer.
     pub fn clone_into_with_headroom<'other>(
         &self,
         buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
@@ -156,7 +153,7 @@ impl<'buf> Packet<'buf> {
         pkt
     }
 
-    // packet metadata
+    /// Returns a reference to the packet metadata.
     pub fn metadata(&self) -> &PacketMetadata {
         let opt = PacketMetadata::ref_from(&self.buf[..size_of::<PacketMetadata>()]);
         unsafe {
@@ -165,6 +162,7 @@ impl<'buf> Packet<'buf> {
         }
     }
 
+    /// Returns a mutable reference to the packet metadata.
     pub fn metadata_mut(&mut self) -> &mut PacketMetadata {
         let opt = PacketMetadata::mut_from(&mut self.buf[..size_of::<PacketMetadata>()]);
         unsafe {
@@ -173,28 +171,21 @@ impl<'buf> Packet<'buf> {
         }
     }
 
+    /// Returns a reference to the packet body.
     pub fn body(&self) -> &[u8] {
         let offset = self.metadata().offset;
         let len = self.metadata().len;
         &self.buf[offset..offset + len]
     }
 
+    /// Returns a mutable reference to the packet body.
     pub fn body_mut(&mut self) -> &mut [u8] {
         let offset = self.metadata().offset;
         let len = self.metadata().len;
         &mut self.buf[offset..offset + len]
     }
 
-    pub fn metadata_and_body_mut(&mut self) -> (&PacketMetadata, &mut [u8]) {
-        let (md, bd) = self.metadata_mut_and_body_mut();
-        (md as &_, bd)
-    }
-
-    pub fn metadata_mut_and_body(&mut self) -> (&mut PacketMetadata, &[u8]) {
-        let (md, bd) = self.metadata_mut_and_body_mut();
-        (md, bd as &_)
-    }
-
+    /// Returns mutable references to both the packet metadata and body.
     pub fn metadata_mut_and_body_mut(&mut self) -> (&mut PacketMetadata, &mut [u8]) {
         let (md, bd) = self.buf.split_at_mut(size_of::<PacketMetadata>());
         let opt = PacketMetadata::mut_from(md);
@@ -207,46 +198,56 @@ impl<'buf> Packet<'buf> {
         (md, &mut bd[offset..offset + len])
     }
 
-    // Space available for extension of the start of the packet.
+    /// Returns the amount of space available for extension of the start of the packet.
     pub fn headroom_available(&self) -> usize {
         self.metadata().offset - PACKET_BUFFER_MIN_BODY_OFFSET
     }
 
-    // Extend the start of the packet into available headroom.
-    pub fn alloc_zeroed_headroom(&mut self, cnt: usize) {
+    /// Extend the start of the packet into available headroom by the given amount,
+    /// and return a reference to that space.  The space allocated will be zeroed.
+    pub fn alloc_zeroed_headroom(&mut self, cnt: usize) -> &mut [u8] {
         assert!(cnt <= self.headroom_available());
         let md = self.metadata_mut();
         md.offset -= cnt;
         md.len += cnt;
-        let offset = md.offset;
-        self.buf[offset..offset + cnt].fill(0);
+        let hdr = &mut self.body_mut()[..cnt];
+        hdr.fill(0);
+        hdr
     }
 
+    /// Extend the start of the packet into available headroom enough to
+    /// hold a structure of the given type, and return a reference to the space.
+    /// The structure allocated will be zeroed.
     pub fn alloc_zeroed_header<T: AsBytes + FromBytes + FromZeroes>(&mut self) -> &mut T {
-        self.alloc_zeroed_headroom(size_of::<T>());
-        T::mut_from_prefix(self.body_mut()).unwrap()
+        T::mut_from(self.alloc_zeroed_headroom(size_of::<T>())).unwrap()
     }
 
-    // flowhash is different for different flows, but not necessarily vice-versa.
-    // Ideally this is a high-entropy value useful for load balancing.
-    // Must be cheap to query.
+    /// `flowhash()` is different for different flows, but not necessarily vice-versa.
+    /// Ideally this is a high-entropy value useful for load balancing.
+    /// Must be cheap to query.
     pub fn flowhash(&self) -> u32 {
         self.metadata().flow_id
     }
 }
 
 impl<'buf> buf::Buf for Packet<'buf> {
+    //! Reading from a `Packet` using the `Buf` interface consumes data
+    //! from the front of the packet.
+
+    /// This is simply the packet size.
     fn remaining(&self) -> usize {
         self.metadata().len
     }
 
-    // NOTE: This isn't super useful for us, as the contract of `chunk()`
-    // permits returning less than what's available (even though we do not).
-    // Most internal users should use `body()` instead.
+    /// Provides a reference to a portion of the remaining packet.
+    /// NOTE: This isn't super useful for us, as the contract of `chunk()`
+    /// permits returning less than what's available (even though we do not).
+    /// Most internal users should use `body()` instead.
     fn chunk(&self) -> &[u8] {
         self.body()
     }
 
+    /// Discards the indicated number of bytes from the start of the packet.
     fn advance(&mut self, cnt: usize) {
         assert!(cnt <= self.remaining());
         self.metadata_mut().offset += cnt;
@@ -255,19 +256,227 @@ impl<'buf> buf::Buf for Packet<'buf> {
 }
 
 unsafe impl<'buf> buf::BufMut for Packet<'buf> {
+    //! Writing to a `Packet` using the `BufMut` interface appends data
+    //! into the tailroom and the end of the packet.
+
+    /// This indicates how much tailroom is remaining.
     fn remaining_mut(&self) -> usize {
         let md = self.metadata();
         size_of_val(self.buf) - (md.offset + md.len)
     }
 
+    /// Provides a reference to a portion of the remaining tailroom.
     fn chunk_mut(&mut self) -> &mut buf::UninitSlice {
         let offset = self.metadata().offset;
         let len = self.metadata().len;
         buf::UninitSlice::new(&mut self.buf[offset + len..])
     }
 
+    /// Asserts that the indicated amount of tailroom has been initialized,
+    /// and grows the packet to include it as part of the body.
     unsafe fn advance_mut(&mut self, cnt: usize) {
         assert!(cnt <= self.remaining_mut());
         self.metadata_mut().len += cnt;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::{Buf, BufMut};
+
+    #[test]
+    fn lifetime_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let pkt = Packet::new(&mut buf, 0);
+        let ptr_buf = pkt.destroy().as_ptr();
+        assert_eq!(ptr_buf, (&buf).as_ptr());
+    }
+
+    #[test]
+    fn basic_headroom_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let pkt = Packet::new(&mut buf, 123);
+        assert_eq!(pkt.headroom_available(), 123);
+    }
+
+    #[test]
+    fn max_headroom_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let new_coke = Packet::new(&mut buf, PACKET_BUFFER_MAX_BODY_SIZE);
+        assert_eq!(new_coke.headroom_available(), PACKET_BUFFER_MAX_BODY_SIZE);
+    }
+
+    #[test]
+    #[should_panic]
+    fn too_much_headroom_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        Packet::new(&mut buf, PACKET_BUFFER_MAX_BODY_SIZE + 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn way_too_much_headroom_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        Packet::new(&mut buf, usize::MAX);
+    }
+
+    #[test]
+    #[should_panic]
+    fn existing_data_way_too_large_offset() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        Packet::new_with_existing_data(&mut buf, usize::MAX, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn existing_data_way_too_large_len() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET, usize::MAX);
+    }
+
+    #[test]
+    #[should_panic]
+    fn existing_data_too_small_offset() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        Packet::new_with_existing_data(&mut buf, std::mem::size_of::<PacketMetadata>() - 1, 0);
+    }
+
+    #[test]
+    fn existing_data() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let offset = PACKET_BUFFER_MIN_BODY_OFFSET + 123;
+        let data = [1, 2, 3, 4, 5, 6, 7, 8].as_slice();
+        buf[offset..offset + 8].copy_from_slice(data);
+        let pkt = Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET + 123, 8);
+        assert_eq!(pkt.body(), data);
+    }
+
+    #[test]
+    fn clone_headroom_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let pkt = Packet::new(&mut buf, 123);
+        let mut buf2 = [0u8; config::PACKET_BUFFER_SIZE];
+        let pkt2 = pkt.clone_into(&mut buf2);
+        assert_eq!(pkt2.headroom_available(), 123);
+    }
+
+    #[test]
+    fn clone_adjusted_headroom_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let pkt = Packet::new(&mut buf, 123);
+        let mut buf2 = [0u8; config::PACKET_BUFFER_SIZE];
+        let pkt2 = pkt.clone_into_with_headroom(&mut buf2, 456);
+        assert_eq!(pkt2.headroom_available(), 456);
+    }
+
+    #[test]
+    fn clone_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let offset = PACKET_BUFFER_MIN_BODY_OFFSET + 123;
+        let data = [1, 2, 3, 4, 5, 6, 7, 8].as_slice();
+        buf[offset..offset + 8].copy_from_slice(data);
+        let mut pkt =
+            Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET + 123, 8);
+        pkt.metadata_mut().flow_id = 100;
+        let mut buf2 = [0u8; config::PACKET_BUFFER_SIZE];
+        let pkt2 = pkt.clone_into_with_headroom(&mut buf2, 456);
+        assert_eq!(pkt.metadata().flow_id, pkt2.metadata().flow_id);
+        assert_eq!(*pkt.body(), *pkt2.body());
+    }
+
+    #[test]
+    fn alloc_headroom_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let mut pkt = Packet::new(&mut buf, 123);
+        let hdr = pkt.alloc_zeroed_headroom(123);
+        for &mut x in hdr {
+            assert_eq!(x, 0);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn alloc_too_much_headroom_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let mut pkt = Packet::new(&mut buf, 123);
+        pkt.alloc_zeroed_headroom(124);
+    }
+
+    #[test]
+    #[should_panic]
+    fn alloc_way_too_much_headroom_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let mut pkt = Packet::new(&mut buf, 0);
+        pkt.alloc_zeroed_headroom(usize::MAX);
+    }
+
+    #[test]
+    fn write_header_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let mut pkt = Packet::new(&mut buf, 4);
+        let data: [u8; 4] = [1, 2, 3, 4];
+        *pkt.alloc_zeroed_header() = data;
+        assert_eq!(pkt.body()[..4], data);
+    }
+
+    #[test]
+    fn buf_read_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let offset = PACKET_BUFFER_MIN_BODY_OFFSET + 123;
+        let data = [1, 2, 3, 4, 5, 6, 7, 8].as_slice();
+        buf[offset..offset + 8].copy_from_slice(data);
+        let mut pkt =
+            Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET + 123, 8);
+        assert_eq!(pkt.get_u64(), 0x0102030405060708u64);
+    }
+
+    #[test]
+    fn buf_read_twice_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let offset = PACKET_BUFFER_MIN_BODY_OFFSET + 123;
+        let data = [1, 2, 3, 4, 5, 6, 7, 8].as_slice();
+        buf[offset..offset + 8].copy_from_slice(data);
+        let mut pkt =
+            Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET + 123, 8);
+        assert_eq!(pkt.get_u32(), 0x01020304u32);
+        assert_eq!(pkt.get_u32(), 0x05060708u32);
+    }
+
+    #[test]
+    #[should_panic]
+    fn buf_read_too_much_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let offset = PACKET_BUFFER_MIN_BODY_OFFSET + 123;
+        let data = [1, 2, 3, 4, 5, 6, 7].as_slice();
+        buf[offset..offset + 8].copy_from_slice(data);
+        let mut pkt =
+            Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET + 123, 8);
+        let _ = pkt.get_u64();
+    }
+
+    #[test]
+    fn buf_write_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let mut pkt = Packet::new(&mut buf, 0);
+        pkt.put_u64(0x0102030405060708u64);
+        assert_eq!(pkt.body()[..8], [1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn buf_write_twice_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let mut pkt = Packet::new(&mut buf, 0);
+        pkt.put_u32(0x01020304u32);
+        pkt.put_u32(0x05060708u32);
+        assert_eq!(pkt.body()[..8], [1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn buf_write_no_tail_room_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let mut pkt = Packet::new(&mut buf, PACKET_BUFFER_MAX_BODY_SIZE);
+        pkt.put_u8(1);
     }
 }


### PR DESCRIPTION
This changeset only moves stuff, documents stuff, and adds tests.  Also, I deleted two unnecessary methods from `Packet`, and changed the representation of `PacketMetadata` to fix some access alignment issue.