### PR TITLE
Change ZDP header definition to more closely resemble the spec

### DIFF
--- a/adapter/ph/src/inbound_processor_worker.rs
+++ b/adapter/ph/src/inbound_processor_worker.rs
@@ -61,15 +61,15 @@ async fn handle_packet<'pktbuf>(
     mut pkt: Packet<'pktbuf>,
     asm: &Assembly<'pktbuf>,
 ) {
-    let hdr = ZdpHeader::ref_from_prefix(pkt.body()).expect("too-short inbound packet");
+    let hdr = ZdpPerFlowHeader::ref_from_prefix(pkt.body()).expect("too-short inbound packet");
 
     match hdr.abbreviated_header.packet_type {
-        ZdpPacketType::UncompressedAgentPacket => {
+        ZdpPacketType::TransitPacket => {
             // copy out relevant header info
-            pkt.metadata_mut().flow_id = hdr.abbreviated_header.stream_id;
+            pkt.metadata_mut().flow_id = hdr.stream_id;
 
             // strip packet header
-            pkt.advance(std::mem::size_of::<ZdpHeader>());
+            pkt.advance(std::mem::size_of::<ZdpPerFlowHeader>());
 
             if config.mode == PhMode::Server {
                 // TODO: drop error packets

--- a/adapter/ph/src/outbound_processor_worker.rs
+++ b/adapter/ph/src/outbound_processor_worker.rs
@@ -48,8 +48,8 @@ where
 
 async fn handle_packet<'pktbuf>(mut pkt: Packet<'pktbuf>, asm: &Assembly<'pktbuf>) {
     // allocate and fill in the header
-    let hdr = pkt.alloc_zeroed_header::<ZdpHeader>();
-    hdr.abbreviated_header.packet_type = ZdpPacketType::UncompressedAgentPacket;
+    let hdr = pkt.alloc_zeroed_header::<ZdpPerFlowHeader>();
+    hdr.abbreviated_header.packet_type = ZdpPacketType::TransitPacket;
 
     // fill in metadata
     pkt.metadata_mut().flow_id = 0; // TODO: fill from IP header

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -48,7 +48,7 @@ pub enum ZdpPacketType {
 
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(packed)]
-pub struct ZdpAbbreviatedHeader {
+pub struct ZdpBaseHeader {
     pub packet_type: ZdpPacketType,
     pub excess_length: u8,
     pub sequence_number: u16,
@@ -57,12 +57,14 @@ pub struct ZdpAbbreviatedHeader {
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(packed)]
 pub struct ZdpPerFlowHeader {
-    pub abbreviated_header: ZdpAbbreviatedHeader,
+    pub abbreviated_header: ZdpBaseHeader,
     pub stream_id: u32,
 }
 
+#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[repr(packed)]
 pub struct ZdpEchoHeader {
-    pub abbreviated_header: ZdpAbbreviatedHeader,
+    pub abbreviated_header: ZdpBaseHeader,
     pub sequence_number: u16, // Only used for the response
     pub additional_length: u16,
 }

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -7,32 +7,64 @@ use zerocopy_derive::{AsBytes, FromBytes, FromZeroes, Unaligned};
 #[derive(Copy, Clone, FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(u8)]
 pub enum ZdpPacketType {
-    CompressedAgentPacket = 0,
-    UncompressedAgentPacket = 1,
-}
-
-#[open_enum]
-#[derive(Copy, Clone, FromZeroes, FromBytes, AsBytes, Unaligned)]
-#[repr(u8)]
-pub enum ZdpD2DAlgorithm {
-    NOP = 0,
-    Blake2b256 = 1,
+    // Flow-based
+    TransitPacket = 0,
+    Unused = 1,
+    DestinationUnreachable = 2,
+    VisaHeraldRequest = 3,
+    VisaHeraldResponse = 4,
+    VisaUpdateRequest = 5,
+    VisaUpdateResponse = 6,
+    VisaRetractRequest = 7,
+    VisaRetractResponse = 8,
+    VisaDeacceptIndication = 9,
+    VisaDeacceptAcknowledgement = 10,
+    BindAgentAddressRequest = 11,
+    BindAgentAddressResponse = 12,
+    UnbindAgentAddressRequest = 13,
+    UnbindAgentAddressResponse = 14,
+    AuthenticationRequest = 15,
+    SetPathMtu = 16,
+    AuthenticationResponse = 17,
+    // Not flow-based
+    ZprArp = 128,
+    KeyManagement = 129,
+    Discard = 130,
+    EchoRequest = 131,
+    EchoResponse = 132,
+    TerminateLinkRequest = 133,
+    TerminateLinkResponse = 134,
+    TerminateLinkIndication = 135,
+    HelloRequest = 136,
+    HelloResponse = 137,
+    ConfigurationRequest = 138,
+    ConfigurationResponse = 139,
+    RegisterAgentAddressRequest = 140,
+    RegisterAgentAddressResponse = 142,
+    UnregisterAgentAddressRequest = 143,
+    UnregisterAgentAddressResponse = 144,
+    Report = 145,
 }
 
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(packed)]
 pub struct ZdpAbbreviatedHeader {
     pub packet_type: ZdpPacketType,
+    pub excess_length: u8,
     pub sequence_number: u16,
-    pub stream_id: u32,
 }
 
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(packed)]
-pub struct ZdpHeader {
+pub struct ZdpPerFlowHeader {
     pub abbreviated_header: ZdpAbbreviatedHeader,
-    pub d2d_algorithm: ZdpD2DAlgorithm,
-    pub mac: [u8; 16],
+    pub stream_id: u32,
 }
 
-const _: () = assert!(core::mem::size_of::<ZdpHeader>() == 24);
+pub struct ZdpEchoHeader {
+    pub abbreviated_header: ZdpAbbreviatedHeader,
+    pub sequence_number: u16, // Only used for the response
+    pub additional_length: u16,
+}
+
+const _: () = assert!(core::mem::size_of::<ZdpPerFlowHeader>() == 8);


### PR DESCRIPTION
This specific chunk of code is a bit wonky because it's just casting everything to the PerFlow base ZDP header, which is not correct.