### PR TITLE
Slightly restructure inbound processor flow

### DIFF
--- a/adapter/ph/src/inbound_processor_worker.rs
+++ b/adapter/ph/src/inbound_processor_worker.rs
@@ -63,7 +63,7 @@ async fn handle_packet<'pktbuf>(
 ) {
     let hdr = ZdpPerFlowHeader::ref_from_prefix(pkt.body()).expect("too-short inbound packet");
 
-    match hdr.abbreviated_header.packet_type {
+    match hdr.base_header.packet_type {
         ZdpPacketType::TransitPacket => {
             // copy out relevant header info
             pkt.metadata_mut().flow_id = hdr.stream_id;

--- a/adapter/ph/src/inbound_processor_worker.rs
+++ b/adapter/ph/src/inbound_processor_worker.rs
@@ -61,26 +61,45 @@ async fn handle_packet<'pktbuf>(
     mut pkt: Packet<'pktbuf>,
     asm: &Assembly<'pktbuf>,
 ) {
-    let hdr = ZdpPerFlowHeader::ref_from_prefix(pkt.body()).expect("too-short inbound packet");
+    let base_hdr = ZdpBaseHeader::ref_from_prefix(pkt.body()).expect("too-short inbound packet");
 
-    match hdr.base_header.packet_type {
-        ZdpPacketType::TransitPacket => {
-            // copy out relevant header info
-            pkt.metadata_mut().flow_id = hdr.stream_id;
+    if base_hdr.packet_type.is_per_flow() {
+        let hdr = ZdpPerFlowHeader::ref_from_prefix(pkt.body()).expect("too-short inbound packet");
 
-            // strip packet header
-            pkt.advance(std::mem::size_of::<ZdpPerFlowHeader>());
+        // copy out relevant header info
+        let packet_type = hdr.base_header.packet_type;
+        let _sequence_number = hdr.base_header.sequence_number;
+        let stream_id = hdr.stream_id;
 
-            if config.mode == PhMode::Server {
-                // TODO: drop error packets
-                let _ = classify(&mut pkt);
+        // strip packet header
+        pkt.advance(std::mem::size_of::<ZdpPerFlowHeader>());
+
+        match packet_type {
+            ZdpPacketType::TransitPacket => {
+                pkt.metadata_mut().flow_id = stream_id;
+
+                if config.mode == PhMode::Server {
+                    // TODO: drop error packets
+                    let _ = classify(&mut pkt);
+                }
+
+                // send out decapsulated packet
+                asm.inbound_send.enqueue_packet(pkt).await;
             }
 
-            // send out decapsulated packet
-            asm.inbound_send.enqueue_packet(pkt).await;
+            packet_type => panic!("unhandled inbound packet type {}", packet_type.0),
         }
+    } else {
+        // copy out relevant header info
+        let packet_type = base_hdr.packet_type;
+        let _sequence_number = base_hdr.sequence_number;
 
-        packet_type => panic!("unhandled inbound packet type {}", packet_type.0),
+        // strip packet header
+        pkt.advance(std::mem::size_of::<ZdpBaseHeader>());
+
+        match packet_type {
+            packet_type => panic!("unhandled inbound packet type {}", packet_type.0),
+        }
     }
 }
 

--- a/adapter/ph/src/outbound_processor_worker.rs
+++ b/adapter/ph/src/outbound_processor_worker.rs
@@ -49,7 +49,7 @@ where
 async fn handle_packet<'pktbuf>(mut pkt: Packet<'pktbuf>, asm: &Assembly<'pktbuf>) {
     // allocate and fill in the header
     let hdr = pkt.alloc_zeroed_header::<ZdpPerFlowHeader>();
-    hdr.abbreviated_header.packet_type = ZdpPacketType::TransitPacket;
+    hdr.base_header.packet_type = ZdpPacketType::TransitPacket;
 
     // fill in metadata
     pkt.metadata_mut().flow_id = 0; // TODO: fill from IP header

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -46,6 +46,12 @@ pub enum ZdpPacketType {
     Report = 145,
 }
 
+impl ZdpPacketType {
+    pub fn is_per_flow(self) -> bool {
+        self.0 < 128
+    }
+}
+
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(packed)]
 pub struct ZdpBaseHeader {

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -57,14 +57,14 @@ pub struct ZdpBaseHeader {
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(packed)]
 pub struct ZdpPerFlowHeader {
-    pub abbreviated_header: ZdpBaseHeader,
+    pub base_header: ZdpBaseHeader,
     pub stream_id: u32,
 }
 
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(packed)]
 pub struct ZdpEchoHeader {
-    pub abbreviated_header: ZdpBaseHeader,
+    pub base_header: ZdpBaseHeader,
     pub sequence_number: u16, // Only used for the response
     pub additional_length: u16,
 }


### PR DESCRIPTION
I was writing this as a task and realized it was both a tangent, and also more complex to explain than just to do so I just did it!  This just splits inbound processing to have two branches, one for processing per-flow mgmt packets, the other for non-flow mgmt packets.