### PR TITLE
add DropGuard, use for get_buffer

### DIFF
--- a/adapter/ph/src/buffer_stack.rs
+++ b/adapter/ph/src/buffer_stack.rs
@@ -1,3 +1,4 @@
+use crate::ext::std::mem::{drop_guard, DropGuard};
 use std::sync::Mutex;
 use tokio::sync::Notify;
 
@@ -23,23 +24,30 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
         }
     }
 
+    /// Blocks until a single buffer can be returned.
     pub async fn get_buffer(&self) -> &'buf mut [u8; BUFSIZ] {
         loop {
-            {
-                let mut bufs = self.buffers.lock().unwrap();
-                match bufs.pop() {
-                    Some(buf) => return buf,
-                    None => (),
-                }
+            let mut bufs = self.buffers.lock().unwrap();
+            match bufs.pop() {
+                Some(buf) => break buf,
+                None => (),
             }
+            std::mem::drop(bufs);
 
             self.notify.notified().await;
         }
     }
 
-    // Blocks until at least 1 buffer can be returned.
-    // Returns up to n buffers.
-    // Exception: if n is 0, returns immediately with no buffers.
+    /// Same as `get_buffer()`, but returns the buffer in a `DropGuard`
+    /// which will automatically return the buffer to the pool if it goes
+    /// out of scope.
+    pub async fn get_buffer_guarded(&'buf self) -> impl DropGuard<&'buf mut [u8; BUFSIZ]> {
+        drop_guard(self.get_buffer().await, |buf| self.put_buffer(buf))
+    }
+
+    /// Blocks until at least 1 buffer can be returned.
+    /// Returns up to n buffers.
+    /// Exception: if n is 0, returns immediately with no buffers.
     pub async fn get_buffers(&self, n: usize, bufs_out: &mut Vec<&'buf mut [u8; BUFSIZ]>) -> usize {
         if n == 0 {
             return 0;
@@ -55,8 +63,8 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
         }
     }
 
-    // Does not block.  May return 0 if no buffers could be returned.
-    // Returns up to n buffers.
+    /// Does not block.  May return 0 if no buffers could be returned.
+    /// Returns up to n buffers.
     pub fn try_get_buffers(&self, n: usize, bufs_out: &mut Vec<&'buf mut [u8; BUFSIZ]>) -> usize {
         if n == 0 {
             return 0;
@@ -74,6 +82,7 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
         to_get
     }
 
+    /// Returns a single buffer.  Does not block.
     pub fn put_buffer(&self, buf: &'buf mut [u8; BUFSIZ]) {
         let mut bufs = self.buffers.lock().unwrap();
         let was_empty = bufs.is_empty();
@@ -84,6 +93,7 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
         }
     }
 
+    /// Returns all buffers in the given collection.  Does not block.
     pub fn put_buffers<I>(&self, bufs_in: I)
     where
         I: IntoIterator<Item = &'buf mut [u8; BUFSIZ]>,

--- a/adapter/ph/src/ext/std.rs
+++ b/adapter/ph/src/ext/std.rs
@@ -1,8 +1,87 @@
 #![allow(dead_code)]
 
 pub mod mem {
+    use std::ops::{Deref, DerefMut, Drop};
+
     pub unsafe fn slice_assume_init_mut<T>(slice: &mut [std::mem::MaybeUninit<T>]) -> &mut [T] {
         unsafe { &mut *(slice as *mut _ as *mut [T]) }
+    }
+
+    struct DropGuardImplInner<T, F: FnOnce(T)> {
+        item: T,
+        destructor: F,
+    }
+
+    // TODO: switch to ManuallyDrop
+    struct DropGuardImpl<T, F: FnOnce(T)>(Option<DropGuardImplInner<T, F>>);
+
+    impl<T, F: FnOnce(T)> Deref for DropGuardImpl<T, F> {
+        type Target = T;
+
+        fn deref(&self) -> &T {
+            &self.0.as_ref().unwrap().item
+        }
+    }
+
+    impl<T, F: FnOnce(T)> DerefMut for DropGuardImpl<T, F> {
+        fn deref_mut(&mut self) -> &mut T {
+            &mut self.0.as_mut().unwrap().item
+        }
+    }
+
+    impl<T, F: FnOnce(T)> Drop for DropGuardImpl<T, F> {
+        fn drop(&mut self) {
+            let inner = self.0.take().unwrap();
+            (inner.destructor)(inner.item);
+        }
+    }
+
+    #[allow(drop_bounds)]
+    pub trait DropGuard<T>: Deref<Target = T> + DerefMut<Target = T> + Drop {
+        //! A `DropGuard` is a wrapper for a value which calls a specified
+        //! destructor on the value when the guard is dropped.  This is
+        //! useful for specifying a "temporary" destructor, e.g.  across a
+        //! cancellation point.
+
+        /// Destroy the wrapper and return the wrapped value.  The destructor
+        /// will no longer be called.
+        fn into_inner(self) -> T;
+
+        /// Convert the wrapped value into another type, using `into_fn`.
+        /// The new value will be converted back to the original type using
+        /// `from_fn` in order to be destructed.
+        fn map<U, IntoFn: FnOnce(T) -> U, FromFn: FnOnce(U) -> T>(
+            self,
+            into_fn: IntoFn,
+            from_fn: FromFn,
+        ) -> impl DropGuard<U>;
+    }
+
+    impl<T, F: FnOnce(T)> DropGuard<T> for DropGuardImpl<T, F> {
+        fn into_inner(mut self) -> T {
+            let item = self.0.take().unwrap().item;
+            std::mem::forget(self);
+            item
+        }
+
+        fn map<U, IntoFn: FnOnce(T) -> U, FromFn: FnOnce(U) -> T>(
+            mut self,
+            into_fn: IntoFn,
+            from_fn: FromFn,
+        ) -> impl DropGuard<U> {
+            let inner = self.0.take().unwrap();
+            let inner_item = inner.item;
+            let inner_destructor = inner.destructor;
+            std::mem::forget(self);
+            drop_guard(into_fn(inner_item), |outer| {
+                inner_destructor(from_fn(outer))
+            })
+        }
+    }
+
+    /// Construct a `DropGuard`, wrapping the specified item, with the specified destructor.
+    pub fn drop_guard<T, F: FnOnce(T)>(item: T, destructor: F) -> impl DropGuard<T> {
+        DropGuardImpl(Some(DropGuardImplInner { item, destructor }))
     }
 }
 

--- a/adapter/ph/src/ext/std.rs
+++ b/adapter/ph/src/ext/std.rs
@@ -97,7 +97,10 @@ pub mod mem {
         fn drop_guard_drop_test() {
             let dropped = RefCell::new(false);
             {
-                let _guard = drop_guard(123, |x| { assert_eq!(x, 123); *dropped.borrow_mut() = true });
+                let _guard = drop_guard(123, |x| {
+                    assert_eq!(x, 123);
+                    *dropped.borrow_mut() = true
+                });
                 assert!(!*dropped.borrow());
             }
             assert!(dropped.take());
@@ -125,7 +128,10 @@ pub mod mem {
         fn drop_guard_map_test() {
             let dropped = RefCell::new(false);
             {
-                let guard_outer = drop_guard(123, |x| { assert_eq!(x, 123); *dropped.borrow_mut() = true });
+                let guard_outer = drop_guard(123, |x| {
+                    assert_eq!(x, 123);
+                    *dropped.borrow_mut() = true
+                });
                 let guard_inner = guard_outer.map(|x| x + 333, |x| x - 333);
                 assert!(!*dropped.borrow());
                 assert_eq!(*guard_inner, 456);

--- a/adapter/ph/src/ext/std.rs
+++ b/adapter/ph/src/ext/std.rs
@@ -87,6 +87,52 @@ pub mod mem {
     pub fn drop_guard<T, F: FnOnce(T)>(item: T, destructor: F) -> impl DropGuard<T> {
         DropGuardImpl(ManuallyDrop::new(DropGuardImplInner { item, destructor }))
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::cell::RefCell;
+
+        #[test]
+        fn drop_guard_drop_test() {
+            let dropped = RefCell::new(false);
+            {
+                let _guard = drop_guard(123, |x| { assert_eq!(x, 123); *dropped.borrow_mut() = true });
+                assert!(!*dropped.borrow());
+            }
+            assert!(dropped.take());
+        }
+
+        #[test]
+        fn drop_guard_into_inner_test() {
+            let mut dropped = false;
+            {
+                let guard = drop_guard(123, |_| dropped = true);
+                assert_eq!(guard.into_inner(), 123);
+            }
+            assert!(!dropped);
+        }
+
+        #[test]
+        fn drop_guard_deref_test() {
+            let mut guard = drop_guard(123, |_| ());
+            assert_eq!(*guard, 123);
+            *guard = 456;
+            assert_eq!(*guard, 456);
+        }
+
+        #[test]
+        fn drop_guard_map_test() {
+            let dropped = RefCell::new(false);
+            {
+                let guard_outer = drop_guard(123, |x| { assert_eq!(x, 123); *dropped.borrow_mut() = true });
+                let guard_inner = guard_outer.map(|x| x + 333, |x| x - 333);
+                assert!(!*dropped.borrow());
+                assert_eq!(*guard_inner, 456);
+            }
+            assert!(dropped.take());
+        }
+    }
 }
 
 pub mod vec {

--- a/adapter/ph/src/ext/std.rs
+++ b/adapter/ph/src/ext/std.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 pub mod mem {
+    use std::mem::ManuallyDrop;
     use std::ops::{Deref, DerefMut, Drop};
 
     pub unsafe fn slice_assume_init_mut<T>(slice: &mut [std::mem::MaybeUninit<T>]) -> &mut [T] {
@@ -12,26 +13,27 @@ pub mod mem {
         destructor: F,
     }
 
-    // TODO: switch to ManuallyDrop
-    struct DropGuardImpl<T, F: FnOnce(T)>(Option<DropGuardImplInner<T, F>>);
+    struct DropGuardImpl<T, F: FnOnce(T)>(ManuallyDrop<DropGuardImplInner<T, F>>);
 
     impl<T, F: FnOnce(T)> Deref for DropGuardImpl<T, F> {
         type Target = T;
 
         fn deref(&self) -> &T {
-            &self.0.as_ref().unwrap().item
+            &self.0.deref().item
         }
     }
 
     impl<T, F: FnOnce(T)> DerefMut for DropGuardImpl<T, F> {
         fn deref_mut(&mut self) -> &mut T {
-            &mut self.0.as_mut().unwrap().item
+            &mut self.0.deref_mut().item
         }
     }
 
     impl<T, F: FnOnce(T)> Drop for DropGuardImpl<T, F> {
         fn drop(&mut self) {
-            let inner = self.0.take().unwrap();
+            // SAFETY: we are calling this in the drop handler, and
+            // do not ourselves reuse `inner`
+            let inner = unsafe { ManuallyDrop::take(&mut self.0) };
             (inner.destructor)(inner.item);
         }
     }
@@ -59,9 +61,10 @@ pub mod mem {
 
     impl<T, F: FnOnce(T)> DropGuard<T> for DropGuardImpl<T, F> {
         fn into_inner(mut self) -> T {
-            let item = self.0.take().unwrap().item;
+            // SAFETY: we are consuming `self`, and forget it immediately after
+            let inner = unsafe { ManuallyDrop::take(&mut self.0) };
             std::mem::forget(self);
-            item
+            inner.item
         }
 
         fn map<U, IntoFn: FnOnce(T) -> U, FromFn: FnOnce(U) -> T>(
@@ -69,10 +72,11 @@ pub mod mem {
             into_fn: IntoFn,
             from_fn: FromFn,
         ) -> impl DropGuard<U> {
-            let inner = self.0.take().unwrap();
+            // SAFETY: we are consuming `self`, and forget it immediately after
+            let inner = unsafe { ManuallyDrop::take(&mut self.0) };
+            std::mem::forget(self);
             let inner_item = inner.item;
             let inner_destructor = inner.destructor;
-            std::mem::forget(self);
             drop_guard(into_fn(inner_item), |outer| {
                 inner_destructor(from_fn(outer))
             })
@@ -81,7 +85,7 @@ pub mod mem {
 
     /// Construct a `DropGuard`, wrapping the specified item, with the specified destructor.
     pub fn drop_guard<T, F: FnOnce(T)>(item: T, destructor: F) -> impl DropGuard<T> {
-        DropGuardImpl(Some(DropGuardImplInner { item, destructor }))
+        DropGuardImpl(ManuallyDrop::new(DropGuardImplInner { item, destructor }))
     }
 }
 

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -1,6 +1,7 @@
 //! This module contains all state of a packet which is moving through the system.
 
 use crate::config;
+use crate::ext::std::mem::DropGuard;
 use crate::net_defs::*;
 use bytes::buf;
 use std::mem::{size_of, size_of_val};
@@ -100,6 +101,16 @@ impl<'buf> Packet<'buf> {
     /// `headroom` indicates room to keep free at packet start for possible extension.
     pub fn new(buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE], headroom: usize) -> Self {
         Self::new_with_existing_data(buf, PACKET_BUFFER_MIN_BODY_OFFSET + headroom, 0)
+    }
+
+    /// Same as `new()`, but accepts a `DropGuard`-protected buffer, and produces
+    /// a `DropGuard`-protected packet buffer, so manually calling `destroy()`
+    /// is unnecessary.
+    pub fn new_guarded<B: DropGuard<&'buf mut [u8; config::PACKET_BUFFER_SIZE]>>(
+        buf: B,
+        headroom: usize,
+    ) -> impl DropGuard<Self> {
+        buf.map(move |b| Self::new(b, headroom), |p| p.destroy())
     }
 
     /// Consumes a packet handle, returning the underlying buffer.


### PR DESCRIPTION
There is a problem with using packet buffers in async functions: if they are held across a cancellation point (i.e. an `.await`), this causes the async function to no longer be cancel-safe, since the packet buffer will be dropped and not returned to the buffer pool.

We can't make buffers automagically return to the buffer pool in general, because doing so requires a reference to the buffer pool, which we don't want to make global or carry around with the packet.

So I invented `DropGuard`, which lets one _temporarily_ attach a destructor to a value, and added variants of `get_buffer()` and `Packet::new()` which utilize it.  (`get_buffers()` ideally would have this also but I can't find a satisfying way to do so, and it's not needed in the contexts where we need to hold buffers across cancellation points, which is specifically slow-path code.)