### PR TITLE
separate PerFlowHeader from BaseHeader

### DIFF
--- a/adapter/ph/src/inbound_processor_worker.rs
+++ b/adapter/ph/src/inbound_processor_worker.rs
@@ -63,17 +63,23 @@ async fn handle_packet<'pktbuf>(
 ) {
     pkt.advance(std::mem::size_of::<u8>()); // Account for extra byte at beginning because of ZPI
 
-    let base_hdr = ZdpBaseHeader::ref_from_prefix(pkt.body()).expect("too-short inbound packet");
+    let base_hdr = ZdpBaseHeader::ref_from_prefix(pkt.body()).expect("too-short ZDP message");
 
-    if base_hdr.packet_type.is_per_flow() {
-        let hdr = ZdpPerFlowHeader::ref_from_prefix(pkt.body()).expect("too-short inbound packet");
+    // copy out relevant header info
+    let packet_type = base_hdr.packet_type;
+    let _sequence_number = base_hdr.sequence_number;
+
+    // strip base header
+    pkt.advance(std::mem::size_of::<ZdpBaseHeader>());
+
+    if packet_type.is_per_flow() {
+        let per_flow_hdr =
+            ZdpPerFlowHeader::ref_from_prefix(pkt.body()).expect("too-short per-flow message");
 
         // copy out relevant header info
-        let packet_type = hdr.base_header.packet_type;
-        let _sequence_number = hdr.base_header.sequence_number;
-        let stream_id = hdr.stream_id;
+        let stream_id = per_flow_hdr.stream_id;
 
-        // strip packet header
+        // strip per-flow header
         pkt.advance(std::mem::size_of::<ZdpPerFlowHeader>());
 
         match packet_type {
@@ -92,13 +98,6 @@ async fn handle_packet<'pktbuf>(
             packet_type => panic!("unhandled inbound packet type {}", packet_type.0),
         }
     } else {
-        // copy out relevant header info
-        let packet_type = base_hdr.packet_type;
-        let _sequence_number = base_hdr.sequence_number;
-
-        // strip packet header
-        pkt.advance(std::mem::size_of::<ZdpBaseHeader>());
-
         match packet_type {
             ZdpPacketType::Report => {
                 let hdr =

--- a/adapter/ph/src/outbound_processor_worker.rs
+++ b/adapter/ph/src/outbound_processor_worker.rs
@@ -26,9 +26,14 @@ async fn worker<'pktbuf>(
         for pkt in pkts.drain(..) {
             match pkt {
                 OutboundProcessorMessage::Packet(mut pkt) => {
-                    // allocate and fill in the header
-                    let hdr = pkt.alloc_zeroed_header::<ZdpPerFlowHeader>();
-                    hdr.base_header.packet_type = ZdpPacketType::TransitPacket;
+                    // allocate and fill in the headers
+                    let stream_id = pkt.metadata().flow_id;
+                    let per_flow_hdr = pkt.alloc_zeroed_header::<ZdpPerFlowHeader>();
+                    per_flow_hdr.stream_id = stream_id;
+
+                    let base_hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
+                    base_hdr.packet_type = ZdpPacketType::TransitPacket;
+
                     handle_packet(pkt, asm).await;
                 }
                 OutboundProcessorMessage::TestPacket(pkt) => pkt.acknowledge(queue.len(), count),
@@ -38,9 +43,12 @@ async fn worker<'pktbuf>(
                     handle_packet(pkt, asm).await;
                 }
                 OutboundProcessorMessage::PerFlowMgmt(pack_type, stream_id, mut pkt) => {
-                    let hdr = pkt.alloc_zeroed_header::<ZdpPerFlowHeader>();
-                    hdr.base_header.packet_type = pack_type;
-                    hdr.stream_id = stream_id;
+                    let per_flow_hdr = pkt.alloc_zeroed_header::<ZdpPerFlowHeader>();
+                    per_flow_hdr.stream_id = stream_id;
+
+                    let base_hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
+                    base_hdr.packet_type = pack_type;
+
                     handle_packet(pkt, asm).await;
                 }
             }

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -85,7 +85,6 @@ pub struct ZdpBaseHeader {
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(packed)]
 pub struct ZdpPerFlowHeader {
-    pub base_header: ZdpBaseHeader,
     pub stream_id: u32,
 }
 
@@ -103,4 +102,5 @@ pub struct ZdpReportHeader {
     pub report_data_length: u16,
 }
 
-const _: () = assert!(core::mem::size_of::<ZdpPerFlowHeader>() == 8);
+const _: () = assert!(core::mem::size_of::<ZdpBaseHeader>() == 4);
+const _: () = assert!(core::mem::size_of::<ZdpPerFlowHeader>() == 4);


### PR DESCRIPTION
This stems from a discussion with Sarah yesterday.  Basically the code becomes a bit cleaner if we treat the BaseHeader and PerFlowHeader as two separate things, which come after one another in a packet, rather than the PerFlowHeader "containing" the BaseHeader.