### PR TITLE
Fast path: substrate egress & agent input

### DIFF
--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -14,6 +14,7 @@ use crate::zpr;
 use bytes::Buf;
 use std::time::SystemTime;
 use zerocopy::FromBytes;
+use zpr_ext::std::mem::{drop_guard, DropGuard};
 use zpr_ext::zerocopy::*;
 
 /// Drop a packet and count the drop with the given reason.
@@ -60,7 +61,7 @@ pub fn decap_zpi<'pktbuf>(
     let zpi_hdr = zdp::ZdpZpiHeader::read_from_buf(pkt).ok_or(DecapZpiError::BadStructure)?;
     let zpi = zpi_hdr.zpi as zpr::Zpi;
 
-    if zpi == 0 {
+    if zpi == zpr::ZPI_0 {
         Ok(zpi)
     } else {
         // TODO: lookup in table
@@ -177,7 +178,7 @@ pub fn encrypt<'pktbuf>(
         zdp::ZdpZpiHeader::ref_from_prefix(pkt.body()).expect("ZPI header must be present");
     let zpi = zpi_hdr.zpi as zpr::Zpi;
 
-    if zpi == 0 {
+    if zpi == zpr::ZPI_0 {
         // TODO: MAC
     } else {
         todo!("encryption");
@@ -213,10 +214,52 @@ pub fn decrypt<'pktbuf>(
         zdp::ZdpZpiHeader::ref_from_prefix(pkt.body()).ok_or(DecryptError::BadStructure)?;
     let zpi = zpi_hdr.zpi as zpr::Zpi;
 
-    if zpi == 0 {
+    if zpi == zpr::ZPI_0 {
         // TODO: MAC
         Ok(())
     } else {
         todo!("decryption");
+    }
+}
+
+/// Egress a ZDP packet on the given link ID, according to the given ZPI.
+/// The ZPI header will be added to the packet.
+pub fn substrate_egress<'pktbuf>(asm: &Assembly<'pktbuf>, link_id: zpr::LinkId, zpi: zpr::Zpi, mut pkt: Packet<'pktbuf>) {
+    encap_zpi(asm, link_id, zpi, &mut pkt);
+
+    maybe_capture(asm, Direction::Outbound, &mut pkt);
+
+    encrypt(asm, link_id, &mut pkt);
+
+    if link_id != zpr::ADAPTER_DOCKING_SESSION_ID {
+        todo!("link routing");
+    }
+
+    match asm
+        .outbound_send
+        .try_enqueue_packet(drop_guard(pkt, |p|
+            drop_and_count(asm, p, CounterType::OutPacksSent)
+        ))
+    {
+        Ok(()) => (),
+        Err(TryEnqueueError::Full(pkt)) =>
+            drop_and_count(asm, pkt.into_inner(), CounterType::OutPacksErr),
+    }
+}
+
+/// Send a compressed agent packet to the agent.
+/// The packet will be decompressed according to the given stream ID.
+pub fn agent_input<'pktbuf>(asm: &Assembly<'pktbuf>, _stream_id: zpr::StreamId, pkt: Packet<'pktbuf>) {
+    // TODO: decompress
+
+    // send out decapsulated packet
+    match asm.inbound_send
+        .try_enqueue_packet(drop_guard(pkt, |p|
+            drop_and_count(asm, p, CounterType::InPacksSent)
+        ))
+    {
+        Ok(()) => (),
+        Err(TryEnqueueError::Full(pkt)) =>
+            drop_and_count(asm, pkt.into_inner(), CounterType::InPacksDrop),
     }
 }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -224,7 +224,12 @@ pub fn decrypt<'pktbuf>(
 
 /// Egress a ZDP packet on the given link ID, according to the given ZPI.
 /// The ZPI header will be added to the packet.
-pub fn substrate_egress<'pktbuf>(asm: &Assembly<'pktbuf>, link_id: zpr::LinkId, zpi: zpr::Zpi, mut pkt: Packet<'pktbuf>) {
+pub fn substrate_egress<'pktbuf>(
+    asm: &Assembly<'pktbuf>,
+    link_id: zpr::LinkId,
+    zpi: zpr::Zpi,
+    mut pkt: Packet<'pktbuf>,
+) {
     encap_zpi(asm, link_id, zpi, &mut pkt);
 
     maybe_capture(asm, Direction::Outbound, &mut pkt);
@@ -235,31 +240,32 @@ pub fn substrate_egress<'pktbuf>(asm: &Assembly<'pktbuf>, link_id: zpr::LinkId, 
         todo!("link routing");
     }
 
-    match asm
-        .outbound_send
-        .try_enqueue_packet(drop_guard(pkt, |p|
-            drop_and_count(asm, p, CounterType::OutPacksSent)
-        ))
-    {
+    match asm.outbound_send.try_enqueue_packet(drop_guard(pkt, |p| {
+        drop_and_count(asm, p, CounterType::OutPacksSent)
+    })) {
         Ok(()) => (),
-        Err(TryEnqueueError::Full(pkt)) =>
-            drop_and_count(asm, pkt.into_inner(), CounterType::OutPacksErr),
+        Err(TryEnqueueError::Full(pkt)) => {
+            drop_and_count(asm, pkt.into_inner(), CounterType::OutPacksErr)
+        }
     }
 }
 
 /// Send a compressed agent packet to the agent.
 /// The packet will be decompressed according to the given stream ID.
-pub fn agent_input<'pktbuf>(asm: &Assembly<'pktbuf>, _stream_id: zpr::StreamId, pkt: Packet<'pktbuf>) {
+pub fn agent_input<'pktbuf>(
+    asm: &Assembly<'pktbuf>,
+    _stream_id: zpr::StreamId,
+    pkt: Packet<'pktbuf>,
+) {
     // TODO: decompress
 
     // send out decapsulated packet
-    match asm.inbound_send
-        .try_enqueue_packet(drop_guard(pkt, |p|
-            drop_and_count(asm, p, CounterType::InPacksSent)
-        ))
-    {
+    match asm.inbound_send.try_enqueue_packet(drop_guard(pkt, |p| {
+        drop_and_count(asm, p, CounterType::InPacksSent)
+    })) {
         Ok(()) => (),
-        Err(TryEnqueueError::Full(pkt)) =>
-            drop_and_count(asm, pkt.into_inner(), CounterType::InPacksDrop),
+        Err(TryEnqueueError::Full(pkt)) => {
+            drop_and_count(asm, pkt.into_inner(), CounterType::InPacksDrop)
+        }
     }
 }

--- a/adapter/ph/src/inbound_processor_worker.rs
+++ b/adapter/ph/src/inbound_processor_worker.rs
@@ -6,13 +6,13 @@ use crate::defs::Direction;
 use crate::fastpath;
 use crate::options::PhMode;
 use crate::packet::Packet;
-use crate::queues::InboundProcessorMessage;
+use crate::queues::{InboundProcessorMessage, TryEnqueueError};
 use crate::zdp::*;
 use bytes::Buf;
 use std::future::Future;
 use tokio::sync::mpsc;
 use zerocopy::FromBytes;
-use zpr_ext::std::mem::drop_guard;
+use zpr_ext::std::mem::{drop_guard, DropGuard};
 use zpr_ext::zerocopy::*;
 
 #[derive(Copy, Clone)]
@@ -113,12 +113,15 @@ async fn handle_packet<'pktbuf>(
                 }
 
                 // send out decapsulated packet
-                asm.inbound_send
-                    .enqueue_packet(drop_guard(pkt, |p| {
-                        asm.buffer_stack.put_buffer(p.destroy())
-                    }))
-                    .await;
-                asm.counters[CounterType::InPacksSent].increment();
+                match asm.inbound_send
+                    .try_enqueue_packet(drop_guard(pkt, |p|
+                        fastpath::drop_and_count(asm, p, CounterType::InPacksSent)
+                    ))
+                {
+                    Ok(()) => (),
+                    Err(TryEnqueueError::Full(pkt)) =>
+                        fastpath::drop_and_count(asm, pkt.into_inner(), CounterType::InPacksDrop),
+                }
             }
 
             packet_type => panic!("unhandled inbound packet type {}", packet_type.0),

--- a/adapter/ph/src/inbound_processor_worker.rs
+++ b/adapter/ph/src/inbound_processor_worker.rs
@@ -6,13 +6,12 @@ use crate::defs::Direction;
 use crate::fastpath;
 use crate::options::PhMode;
 use crate::packet::Packet;
-use crate::queues::{InboundProcessorMessage, TryEnqueueError};
+use crate::queues::InboundProcessorMessage;
 use crate::zdp::*;
 use bytes::Buf;
 use std::future::Future;
 use tokio::sync::mpsc;
 use zerocopy::FromBytes;
-use zpr_ext::std::mem::{drop_guard, DropGuard};
 use zpr_ext::zerocopy::*;
 
 #[derive(Copy, Clone)]
@@ -112,16 +111,7 @@ async fn handle_packet<'pktbuf>(
                     let _ = classify(&mut pkt);
                 }
 
-                // send out decapsulated packet
-                match asm.inbound_send
-                    .try_enqueue_packet(drop_guard(pkt, |p|
-                        fastpath::drop_and_count(asm, p, CounterType::InPacksSent)
-                    ))
-                {
-                    Ok(()) => (),
-                    Err(TryEnqueueError::Full(pkt)) =>
-                        fastpath::drop_and_count(asm, pkt.into_inner(), CounterType::InPacksDrop),
-                }
+                fastpath::agent_input(asm, 0, pkt);
             }
 
             packet_type => panic!("unhandled inbound packet type {}", packet_type.0),

--- a/adapter/ph/src/outbound_processor_worker.rs
+++ b/adapter/ph/src/outbound_processor_worker.rs
@@ -3,11 +3,11 @@ use crate::counters_enum::CounterType;
 use crate::defs::Direction;
 use crate::fastpath;
 use crate::packet::Packet;
-use crate::queues::OutboundProcessorMessage;
+use crate::queues::{OutboundProcessorMessage, TryEnqueueError};
 use crate::zdp::*;
 use core::future::Future;
 use tokio::sync::mpsc;
-use zpr_ext::std::mem::drop_guard;
+use zpr_ext::std::mem::{drop_guard, DropGuard};
 
 #[derive(Copy, Clone)]
 pub struct Config {
@@ -33,13 +33,13 @@ async fn worker<'pktbuf>(
                     let base_hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
                     base_hdr.packet_type = ZdpPacketType::TransitPacket;
 
-                    handle_packet(asm, pkt).await;
+                    handle_packet(asm, pkt);
                 }
                 OutboundProcessorMessage::TestPacket(pkt) => pkt.acknowledge(queue.len(), count),
                 OutboundProcessorMessage::NonFlowMgmt(pack_type, mut pkt) => {
                     let hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
                     hdr.packet_type = pack_type;
-                    handle_packet(asm, pkt).await;
+                    handle_packet(asm, pkt);
                 }
                 OutboundProcessorMessage::PerFlowMgmt(pack_type, stream_id, mut pkt) => {
                     let per_flow_hdr = pkt.alloc_zeroed_header::<ZdpPerFlowHeader>();
@@ -48,7 +48,7 @@ async fn worker<'pktbuf>(
                     let base_hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
                     base_hdr.packet_type = pack_type;
 
-                    handle_packet(asm, pkt).await;
+                    handle_packet(asm, pkt);
                 }
             }
         }
@@ -67,7 +67,7 @@ where
     async move { worker(&cfg, &*asm, &mut queue).await }
 }
 
-async fn handle_packet<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) {
+fn handle_packet<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) {
     // fill in metadata
     pkt.metadata_mut().flow_id = 0; // TODO: fill from IP header
 
@@ -80,12 +80,12 @@ async fn handle_packet<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf
     // forward encapsulated packet on
     match asm
         .outbound_send
-        .enqueue_packet(drop_guard(pkt, |p| {
-            asm.buffer_stack.put_buffer(p.destroy())
-        }))
-        .await
+        .try_enqueue_packet(drop_guard(pkt, |p|
+            fastpath::drop_and_count(asm, p, CounterType::OutPacksSent)
+        ))
     {
-        Ok(()) => asm.counters[CounterType::OutPacksSent].increment(),
-        Err(_) => asm.counters[CounterType::OutPacksErr].increment(),
+        Ok(()) => (),
+        Err(TryEnqueueError::Full(pkt)) =>
+            fastpath::drop_and_count(asm, pkt.into_inner(), CounterType::OutPacksErr),
     }
 }

--- a/adapter/ph/src/outbound_processor_worker.rs
+++ b/adapter/ph/src/outbound_processor_worker.rs
@@ -30,14 +30,24 @@ async fn worker<'pktbuf>(
                     let base_hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
                     base_hdr.packet_type = ZdpPacketType::TransitPacket;
 
-                    fastpath::substrate_egress(asm, zpr::ADAPTER_DOCKING_SESSION_ID, zpr::ZPI_0, pkt);
+                    fastpath::substrate_egress(
+                        asm,
+                        zpr::ADAPTER_DOCKING_SESSION_ID,
+                        zpr::ZPI_0,
+                        pkt,
+                    );
                 }
                 OutboundProcessorMessage::TestPacket(pkt) => pkt.acknowledge(queue.len(), count),
                 OutboundProcessorMessage::NonFlowMgmt(pack_type, mut pkt) => {
                     let hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
                     hdr.packet_type = pack_type;
 
-                    fastpath::substrate_egress(asm, zpr::ADAPTER_DOCKING_SESSION_ID, zpr::ZPI_0, pkt);
+                    fastpath::substrate_egress(
+                        asm,
+                        zpr::ADAPTER_DOCKING_SESSION_ID,
+                        zpr::ZPI_0,
+                        pkt,
+                    );
                 }
                 OutboundProcessorMessage::PerFlowMgmt(pack_type, stream_id, mut pkt) => {
                     let per_flow_hdr = pkt.alloc_zeroed_header::<ZdpPerFlowHeader>();
@@ -46,7 +56,12 @@ async fn worker<'pktbuf>(
                     let base_hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
                     base_hdr.packet_type = pack_type;
 
-                    fastpath::substrate_egress(asm, zpr::ADAPTER_DOCKING_SESSION_ID, zpr::ZPI_0, pkt);
+                    fastpath::substrate_egress(
+                        asm,
+                        zpr::ADAPTER_DOCKING_SESSION_ID,
+                        zpr::ZPI_0,
+                        pkt,
+                    );
                 }
             }
         }

--- a/adapter/ph/src/outbound_processor_worker.rs
+++ b/adapter/ph/src/outbound_processor_worker.rs
@@ -1,13 +1,10 @@
 use crate::assembly::Assembly;
-use crate::counters_enum::CounterType;
-use crate::defs::Direction;
 use crate::fastpath;
-use crate::packet::Packet;
-use crate::queues::{OutboundProcessorMessage, TryEnqueueError};
+use crate::queues::OutboundProcessorMessage;
 use crate::zdp::*;
+use crate::zpr;
 use core::future::Future;
 use tokio::sync::mpsc;
-use zpr_ext::std::mem::{drop_guard, DropGuard};
 
 #[derive(Copy, Clone)]
 pub struct Config {
@@ -33,13 +30,14 @@ async fn worker<'pktbuf>(
                     let base_hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
                     base_hdr.packet_type = ZdpPacketType::TransitPacket;
 
-                    handle_packet(asm, pkt);
+                    fastpath::substrate_egress(asm, zpr::ADAPTER_DOCKING_SESSION_ID, zpr::ZPI_0, pkt);
                 }
                 OutboundProcessorMessage::TestPacket(pkt) => pkt.acknowledge(queue.len(), count),
                 OutboundProcessorMessage::NonFlowMgmt(pack_type, mut pkt) => {
                     let hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
                     hdr.packet_type = pack_type;
-                    handle_packet(asm, pkt);
+
+                    fastpath::substrate_egress(asm, zpr::ADAPTER_DOCKING_SESSION_ID, zpr::ZPI_0, pkt);
                 }
                 OutboundProcessorMessage::PerFlowMgmt(pack_type, stream_id, mut pkt) => {
                     let per_flow_hdr = pkt.alloc_zeroed_header::<ZdpPerFlowHeader>();
@@ -48,7 +46,7 @@ async fn worker<'pktbuf>(
                     let base_hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
                     base_hdr.packet_type = pack_type;
 
-                    handle_packet(asm, pkt);
+                    fastpath::substrate_egress(asm, zpr::ADAPTER_DOCKING_SESSION_ID, zpr::ZPI_0, pkt);
                 }
             }
         }
@@ -65,27 +63,4 @@ where
 {
     let cfg = *config;
     async move { worker(&cfg, &*asm, &mut queue).await }
-}
-
-fn handle_packet<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) {
-    // fill in metadata
-    pkt.metadata_mut().flow_id = 0; // TODO: fill from IP header
-
-    fastpath::encap_zpi(asm, 0, 0, &mut pkt);
-
-    fastpath::maybe_capture(asm, Direction::Outbound, &mut pkt);
-
-    fastpath::encrypt(asm, 0, &mut pkt);
-
-    // forward encapsulated packet on
-    match asm
-        .outbound_send
-        .try_enqueue_packet(drop_guard(pkt, |p|
-            fastpath::drop_and_count(asm, p, CounterType::OutPacksSent)
-        ))
-    {
-        Ok(()) => (),
-        Err(TryEnqueueError::Full(pkt)) =>
-            fastpath::drop_and_count(asm, pkt.into_inner(), CounterType::OutPacksErr),
-    }
 }

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -77,10 +77,10 @@ impl<'a> InboundSend<'a> {
         }
     }
 
-    pub fn try_enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>
-        (&self, mut packet: P) ->
-        Result<(), TryEnqueueError<P>>
-    {
+    pub fn try_enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>(
+        &self,
+        mut packet: P,
+    ) -> Result<(), TryEnqueueError<P>> {
         let tun = self.tuns[packet.flowhash() as usize % self.tuns.len()];
 
         let proto = net_defs::ip_ethertype(net_defs::ip_version(packet.body()));

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -12,7 +12,7 @@ use crate::net_defs;
 use crate::packet::Packet;
 use crate::test_packet::*;
 use crate::zdp;
-use std::io::{ErrorKind, IoSlice};
+use std::io::ErrorKind;
 use std::result::Result;
 use std::time::SystemTime;
 use tokio::net::UdpSocket;
@@ -21,6 +21,10 @@ use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::oneshot::error::RecvError;
 use zpr_ext::std::mem::DropGuard;
 use zpr_ext::tokio_tun::tun_pi;
+
+pub enum TryEnqueueError<T> {
+    Full(T),
+}
 
 pub enum InboundProcessorMessage<'pktbuf> {
     Packet(Packet<'pktbuf>),
@@ -73,8 +77,10 @@ impl<'a> InboundSend<'a> {
         }
     }
 
-    // TODO: batch enqueue
-    pub async fn enqueue_packet(&self, mut packet: impl DropGuard<Packet<'_>>) {
+    pub fn try_enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>
+        (&self, mut packet: P) ->
+        Result<(), TryEnqueueError<P>>
+    {
         let tun = self.tuns[packet.flowhash() as usize % self.tuns.len()];
 
         let proto = net_defs::ip_ethertype(net_defs::ip_version(packet.body()));
@@ -87,9 +93,11 @@ impl<'a> InboundSend<'a> {
             },
         );
 
-        tun.send_vectored(&[IoSlice::new(packet.body())])
-            .await
-            .unwrap(); // any error here is unrecoverable (TUN device is broken)
+        match tun.try_send(packet.body()) {
+            Ok(_) => Ok(()),
+            Err(err) if err.kind() == ErrorKind::WouldBlock => Err(TryEnqueueError::Full(packet)),
+            Err(err) => panic!("unrecoverable TUN error: {}", err),
+        }
     }
 
     pub fn fanout(&self) -> usize {
@@ -184,13 +192,13 @@ impl<'a> OutboundSend<'a> {
     }
 
     // TODO: batch enqueue
-    pub async fn enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>(
+    pub fn try_enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>(
         &self,
         packet: P,
-    ) -> Result<(), P> {
+    ) -> Result<(), TryEnqueueError<P>> {
         let socket = self.sockets[packet.flowhash() as usize % self.sockets.len()];
 
-        match socket.send(packet.body()).await {
+        match socket.try_send(packet.body()) {
             Ok(_) => Ok(()),
 
             Err(err) => {
@@ -199,10 +207,12 @@ impl<'a> OutboundSend<'a> {
                         panic!("Unrecoverable I/O error: {}", err)
                     }
 
+                    ErrorKind::WouldBlock => Err(TryEnqueueError::Full(packet)),
+
                     // most other network errors are temporary; return packet to caller
                     // TODO: it would be nice to report to the user _why_ packets aren't moving;
                     // this depends on <https://github.com/rust-lang/rust/issues/86442> though
-                    _ => Err(packet),
+                    _ => Err(TryEnqueueError::Full(packet)),
                 }
             }
         }
@@ -223,10 +233,6 @@ pub struct CapPacket<'pktbuf> {
 
 pub struct Capture<'pktbuf> {
     sender: mpsc::Sender<CapPacket<'pktbuf>>,
-}
-
-pub enum TryEnqueueError<T> {
-    Full(T),
 }
 
 #[allow(dead_code)]

--- a/adapter/ph/src/zpr.rs
+++ b/adapter/ph/src/zpr.rs
@@ -1,7 +1,20 @@
 //! ZPR concepts, excluding the ZDP protocol.
+#![allow(dead_code)]
 
 /// ZPR Parameter Index
 pub type Zpi = u8;
 
+/// ZPI 0, used for keying and early ZARP.
+pub const ZPI_0: Zpi = 0;
+
 /// Link or Docking Session ID
 pub type LinkId = u32;
+
+/// Link ID used by an adapter to refer to its docking session.
+pub const ADAPTER_DOCKING_SESSION_ID: LinkId = 0;
+
+/// Stream ID
+pub type StreamId = u32;
+
+/// Reserved for node-to-node / control-plane traffic.
+pub const NODE_TO_NODE_STREAM_ID: StreamId = 0;


### PR DESCRIPTION
Refactor the "sending" code from the processors to live in the `fastpath` module.

`substrate_egress()` accepts a ZDP message and does the following:
1. add a ZPI header
2. possibly capture the packet
3. encrypt the packet
4. send out out the appropriate substrate link
(it is the lower-left-hand quadrant of the diagram)

`agent_input()` accepts a compressed IP packet and does the following:
1. decompress the header
2. send it out via the TUN interface
(it is the lower-right-hand quadrant of the diagram)

Notably, these two functions are not async, and do not block.