### PR TITLE
copy only caplen bytes during pcap

### DIFF
--- a/adapter/ph/src/capture_worker.rs
+++ b/adapter/ph/src/capture_worker.rs
@@ -97,10 +97,9 @@ fn savefile_write(cap_pack: &CapPacket, savefile: &mut Savefile) {
 
     let header: PacketHeader = PacketHeader {
         ts,
-        caplen: std::cmp::min(cap_pack.packet.body().len() as u32, cap_pack.caplen),
-        len: cap_pack.packet.body().len() as u32,
+        caplen: cap_pack.packet.body().len() as u32,
+        len: cap_pack.orig_len as u32,
     };
-    //println!("packet.body.len: {}, caplen: {}", cap_pack.packet.body().len() as u32, cap_pack.caplen);
 
     let packet: Packet = Packet {
         header: &header,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -117,16 +117,16 @@ pub fn maybe_capture_batch<'a, 'pktbuf: 'a>(
             }) {
                 Some(buf) => {
                     let orig_len = pkt.body().len();
-                    let pkt_clone: Packet = pkt.clone_prefix_into(buf, std::cmp::min(caplen, orig_len));
+                    let pkt_clone: Packet =
+                        pkt.clone_prefix_into(buf, std::cmp::min(caplen, orig_len));
                     // remove direction indicator from beginning of packet
                     pkt.advance(std::mem::size_of::<zdp_ll::ZdpLinkP2P>());
 
                     // Checks to see if the packet enqueue was successful
-                    match asm.capture_queue.try_enqueue_packet(
-                        pkt_clone,
-                        capture_time,
-                        orig_len,
-                    ) {
+                    match asm
+                        .capture_queue
+                        .try_enqueue_packet(pkt_clone, capture_time, orig_len)
+                    {
                         Ok(()) => num_captured += 1,
 
                         Err(TryEnqueueError::Full(ret_packet)) => {

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -106,7 +106,7 @@ pub fn maybe_capture_batch<'a, 'pktbuf: 'a>(
         ll_hdr.direction = zdp_ll::encode_direction(dir);
 
         // FIXME: ideally, take an RCU reference to the program once on function entry
-        let caplen = asm.flow_control.check_packet(pkt.body());
+        let caplen = asm.flow_control.check_packet(pkt.body()) as usize;
         if caplen > 0 {
             match bufs.pop().or_else(|| {
                 if out_of_bufs {
@@ -116,7 +116,8 @@ pub fn maybe_capture_batch<'a, 'pktbuf: 'a>(
                 }
             }) {
                 Some(buf) => {
-                    let pkt_clone: Packet = pkt.clone_into(buf);
+                    let orig_len = pkt.body().len();
+                    let pkt_clone: Packet = pkt.clone_prefix_into(buf, std::cmp::min(caplen, orig_len));
                     // remove direction indicator from beginning of packet
                     pkt.advance(std::mem::size_of::<zdp_ll::ZdpLinkP2P>());
 
@@ -124,7 +125,7 @@ pub fn maybe_capture_batch<'a, 'pktbuf: 'a>(
                     match asm.capture_queue.try_enqueue_packet(
                         pkt_clone,
                         capture_time,
-                        caplen, // TODO: pass full packet length instead, and only copy caplen bytes
+                        orig_len,
                     ) {
                         Ok(()) => num_captured += 1,
 

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -160,7 +160,7 @@ impl<'buf> Packet<'buf> {
     pub fn clone_into_with_headroom<'other>(
         &self,
         buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
-        headroom: usize
+        headroom: usize,
     ) -> Packet<'other> {
         self.clone_prefix_into_with_headroom(buf, headroom, self.body().len())
     }

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -143,7 +143,16 @@ impl<'buf> Packet<'buf> {
         &self,
         buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
     ) -> Packet<'other> {
-        self.clone_into_with_headroom(buf, self.headroom_available())
+        self.clone_prefix_into_with_headroom(buf, self.headroom_available(), self.body().len())
+    }
+
+    /// Like `clone_into()`, but only copy a prefix of the packet's data.
+    pub fn clone_prefix_into<'other>(
+        &self,
+        buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
+        len: usize,
+    ) -> Packet<'other> {
+        self.clone_prefix_into_with_headroom(buf, self.headroom_available(), len)
     }
 
     /// Copy this packet's metadata and data into a new buffer, returning a handle for it.
@@ -151,16 +160,27 @@ impl<'buf> Packet<'buf> {
     pub fn clone_into_with_headroom<'other>(
         &self,
         buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
+        headroom: usize
+    ) -> Packet<'other> {
+        self.clone_prefix_into_with_headroom(buf, headroom, self.body().len())
+    }
+
+    fn clone_prefix_into_with_headroom<'other>(
+        &self,
+        buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
         headroom: usize,
+        len: usize,
     ) -> Packet<'other> {
         let body = self.body();
-        assert!(headroom <= size_of_val(buf) - body.len() - PACKET_BUFFER_MIN_BODY_OFFSET);
+        assert!(len <= body.len());
+        assert!(headroom <= size_of_val(buf) - len - PACKET_BUFFER_MIN_BODY_OFFSET);
         buf[..size_of::<PacketMetadata>()]
             .copy_from_slice(&self.buf[..size_of::<PacketMetadata>()]);
         let offset = PACKET_BUFFER_MIN_BODY_OFFSET + headroom;
-        buf[offset..offset + body.len()].copy_from_slice(body);
+        buf[offset..offset + len].copy_from_slice(body);
         let mut pkt = Packet { buf };
         pkt.metadata_mut().offset = offset;
+        pkt.metadata_mut().len = len;
         pkt
     }
 

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -219,7 +219,7 @@ impl<'a> OutboundSend<'a> {
 pub struct CapPacket<'pktbuf> {
     pub packet: Packet<'pktbuf>,
     pub timestamp: SystemTime,
-    pub caplen: u32,
+    pub orig_len: usize,
 }
 
 pub struct Capture<'pktbuf> {
@@ -241,12 +241,12 @@ impl<'pktbuf> Capture<'pktbuf> {
         &self,
         packet: Packet<'pktbuf>,
         timestamp: SystemTime,
-        caplen: u32,
+        orig_len: usize,
     ) {
         let cap_pack: CapPacket = CapPacket {
             packet,
             timestamp,
-            caplen,
+            orig_len,
         };
         self.sender.send(cap_pack).await.unwrap();
     }
@@ -256,12 +256,12 @@ impl<'pktbuf> Capture<'pktbuf> {
         &self,
         packet: Packet<'pktbuf>,
         timestamp: SystemTime,
-        caplen: u32,
+        orig_len: usize,
     ) -> Result<(), TryEnqueueError<Packet<'pktbuf>>> {
         let cap_pack: CapPacket = CapPacket {
             packet,
             timestamp,
-            caplen,
+            orig_len,
         };
         match self.sender.try_send(cap_pack) {
             Ok(()) => return Ok(()),


### PR DESCRIPTION
This is a simple optimization I realized we could make: when cloning a packet for packet capture, we only need to copy the prefix of the packet which we're actually going to write.  Since that copy happens in the data path, this can prevent the data path from being unnecessarily bogged down if it's configured to capture only headers, but most packets are very large.

The bulk of the code is just the new functionality in `Packet` to make a clone of only part of a `Packet`.  Otherwise I just swapped the `caplen` variable out for `orig_len`, since the captured packet's length is now effectively `caplen`.