### PR TITLE
replace pcap dependency with homegrown solution

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -591,7 +591,6 @@ dependencies = [
  "open-enum",
  "openssl",
  "openssl-sys",
- "pcap",
  "tokio",
  "tokio-openssl",
  "tokio-tun",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -16,7 +16,6 @@ nix = { version = "0.29.0", features = ["fs", "ioctl", "net", "socket", "uio"] }
 open-enum = { version = "0.5.1" }
 openssl-sys = { version = "0.9.102" }
 openssl = { version = "0.10.64" }
-pcap = { version = "2.0.0" }
 tokio-openssl = { version = "0.6.4" }
 tokio-tun = { version = "0.11.5" }
 tokio = { version = "1.37.0", features = ["full"] }

--- a/adapter/ph/src/capture_worker.rs
+++ b/adapter/ph/src/capture_worker.rs
@@ -1,10 +1,10 @@
 use crate::assembly::Assembly;
+use crate::pcap_writer::*;
 use crate::queues::CapPacket;
 use core::future::Future;
-use libc::timeval;
-use pcap::{Capture, Dead, Error, Linktype, Packet, PacketHeader, Savefile};
+use std::io;
 use std::path::Path;
-use std::time::{Duration, UNIX_EPOCH};
+use tokio::fs::File;
 use tokio::sync::{mpsc, Mutex};
 
 pub struct CaptureWorker {
@@ -12,35 +12,39 @@ pub struct CaptureWorker {
 }
 
 struct InnerCap {
-    capture: Capture<Dead>,
-    savefile: Option<Savefile>,
+    savefile: Option<PcapWriter<File>>,
 }
 
 impl CaptureWorker {
     pub fn new() -> Self {
         Self {
-            inner_cap: InnerCap {
-                capture: Capture::dead(Linktype::USER0).unwrap(),
-                savefile: None,
-            }
-            .into(),
+            inner_cap: InnerCap { savefile: None }.into(),
         }
     }
-    pub async fn open_capture_file(&self, path: &Path) {
+
+    pub async fn open_capture_file(&self, path: &Path) -> Result<(), io::Error> {
         let mut inner_cap = self.inner_cap.lock().await;
-        inner_cap.savefile = Some(inner_cap.capture.savefile(path).unwrap());
+        inner_cap.savefile =
+            Some(PcapWriter::open(File::open(path).await?, linktype::USER0).await?);
+        Ok(())
     }
 
-    pub async fn flush_capture_file(&self) -> Result<(), Error> {
+    pub async fn flush_capture_file(&self) -> Result<(), io::Error> {
         let sf = &mut self.inner_cap.lock().await.savefile;
         match sf {
-            Some(ref mut sf) => sf.flush(),
+            Some(ref mut sf) => sf.flush().await,
             None => Ok(()),
         }
     }
 
-    pub async fn close_capture_file(&self) {
-        self.inner_cap.lock().await.savefile = None;
+    pub async fn close_capture_file(&self) -> Result<(), io::Error> {
+        match self.inner_cap.lock().await.savefile.take() {
+            Some(writer) => {
+                writer.close().await?;
+            }
+            None => (),
+        }
+        Ok(())
     }
 
     #[allow(dead_code)]
@@ -66,7 +70,7 @@ async fn worker<'pktbuf>(
         match &mut locked_mutex.savefile {
             Some(s_file) => {
                 for cap_pack in &messages {
-                    savefile_write(cap_pack, s_file);
+                    savefile_write(cap_pack, s_file).await;
                 }
             }
             None => (),
@@ -88,23 +92,13 @@ where
     async move { worker(&cfg, &*asm, &mut queue).await }
 }
 
-fn savefile_write(cap_pack: &CapPacket, savefile: &mut Savefile) {
-    let creation_time: Duration = cap_pack.timestamp.duration_since(UNIX_EPOCH).unwrap();
-    let ts: timeval = timeval {
-        tv_sec: creation_time.as_secs() as i64,
-        tv_usec: creation_time.subsec_micros() as i64,
-    };
-
-    let header: PacketHeader = PacketHeader {
-        ts,
-        caplen: cap_pack.packet.body().len() as u32,
-        len: cap_pack.orig_len as u32,
-    };
-
-    let packet: Packet = Packet {
-        header: &header,
+async fn savefile_write(cap_pack: &CapPacket<'_>, savefile: &mut PcapWriter<File>) {
+    let packet = PcapPacket {
+        timestamp: cap_pack.timestamp,
+        orig_len: cap_pack.orig_len,
         data: cap_pack.packet.body(),
     };
 
-    savefile.write(&packet);
+    // FIXME: handle write errors (maybe close the capture file?)
+    savefile.write(&packet).await.unwrap();
 }

--- a/adapter/ph/src/lib.rs
+++ b/adapter/ph/src/lib.rs
@@ -20,6 +20,7 @@ pub mod options;
 pub mod outbound_processor_worker;
 pub mod outbound_recv_worker;
 pub mod packet;
+pub mod pcap_writer;
 pub mod queues;
 pub mod rpc_worker;
 pub mod test_packet;

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -34,6 +34,7 @@ mod options;
 mod outbound_processor_worker;
 mod outbound_recv_worker;
 mod packet;
+mod pcap_writer;
 mod queues;
 mod rpc_worker;
 mod test_packet;

--- a/adapter/ph/src/pcap_writer.rs
+++ b/adapter/ph/src/pcap_writer.rs
@@ -1,0 +1,145 @@
+//! Simple PCAP writing functionality.
+//!
+//! Uses tokio for I/O, so e.g. writing over a network socket
+//! won't block the runtime.
+
+use std::io;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
+use zerocopy::AsBytes;
+use zerocopy_derive::AsBytes;
+
+/// Represents an open PCAP writer.
+pub struct PcapWriter<W: AsyncWrite> {
+    writer: BufWriter<W>,
+}
+
+// see <https://wiki.wireshark.org/Development/LibpcapFileFormat> for format details
+
+const PCAP_HDR_MAGIC_NUMBER: u32 = 0xa1b2c3d4;
+const PCAP_HDR_VERSION_MAJOR: u16 = 2;
+const PCAP_HDR_VERSION_MINOR: u16 = 4;
+
+/// Maximum size packet which may be captured.
+pub const MAX_SNAPLEN: usize = 1 << 18;
+
+#[derive(AsBytes)]
+#[repr(C)]
+struct PcapHdr {
+    magic_number: u32,
+    version_major: u16,
+    version_minor: u16,
+    thiszone: i32,
+    sigfigs: u32,
+    snaplen: u32,
+    network: u32,
+}
+
+#[derive(AsBytes)]
+#[repr(C)]
+struct PcaprecHdr {
+    ts_sec: u32,
+    ts_usec: u32,
+    incl_len: u32,
+    orig_len: u32,
+}
+
+/// A packet to be written out.
+pub struct PcapPacket<'a> {
+    pub timestamp: SystemTime,
+    pub orig_len: usize,
+    pub data: &'a [u8],
+}
+
+/// Link type values, which indicate the type of packets being written.
+/// See <https://www.tcpdump.org/linktypes.html> for protocol details.
+pub mod linktype {
+    #![allow(dead_code)]
+
+    /// BSD loopback encapsulation
+    pub const NULL: u32 = 0;
+
+    /// IEEE 802.3 Ethernet
+    pub const ETHERNET: u32 = 1;
+
+    /// PPP
+    pub const PPP: u32 = 9;
+
+    /// raw IP (IPv4 or IPv6)
+    pub const RAW: u32 = 101;
+
+    /// user-defined
+    pub const USER0: u32 = 147;
+    pub const USER1: u32 = 148;
+    pub const USER2: u32 = 149;
+    pub const USER3: u32 = 150;
+    pub const USER4: u32 = 151;
+    pub const USER5: u32 = 152;
+    pub const USER6: u32 = 153;
+    pub const USER7: u32 = 154;
+    pub const USER8: u32 = 155;
+    pub const USER9: u32 = 156;
+    pub const USER10: u32 = 157;
+    pub const USER11: u32 = 158;
+    pub const USER12: u32 = 159;
+    pub const USER13: u32 = 160;
+    pub const USER14: u32 = 161;
+    pub const USER15: u32 = 162;
+}
+
+impl<W: AsyncWrite + Unpin> PcapWriter<W> {
+    /// "Open" a new PCAP writer, using the specified async writer as the destination.
+    pub async fn open(writer: W, linktype: u32) -> io::Result<Self> {
+        let mut writer = BufWriter::new(writer);
+
+        let hdr = PcapHdr {
+            magic_number: PCAP_HDR_MAGIC_NUMBER,
+            version_major: PCAP_HDR_VERSION_MAJOR,
+            version_minor: PCAP_HDR_VERSION_MINOR,
+            thiszone: 0,
+            sigfigs: 0,
+            snaplen: MAX_SNAPLEN as u32,
+            network: linktype,
+        };
+
+        writer.write_all(hdr.as_bytes()).await?;
+
+        Ok(Self { writer })
+    }
+
+    /// Write a packet to the PCAP writer.
+    pub async fn write(&mut self, packet: &PcapPacket<'_>) -> io::Result<()> {
+        if packet.data.len() > MAX_SNAPLEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "packet too large",
+            ));
+        }
+
+        let ts = packet
+            .timestamp
+            .duration_since(UNIX_EPOCH)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+
+        let hdr = PcaprecHdr {
+            ts_sec: ts.as_secs() as u32,
+            ts_usec: ts.subsec_micros() as u32,
+            incl_len: packet.data.len() as u32,
+            orig_len: packet.orig_len as u32,
+        };
+
+        self.writer.write_all(hdr.as_bytes()).await?;
+        self.writer.write_all(packet.data).await?;
+
+        Ok(())
+    }
+
+    pub async fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush().await
+    }
+
+    pub async fn close(mut self) -> io::Result<W> {
+        self.writer.flush().await?;
+        Ok(self.writer.into_inner())
+    }
+}

--- a/adapter/ph/src/rpc_worker.rs
+++ b/adapter/ph/src/rpc_worker.rs
@@ -313,9 +313,10 @@ fn values_from_hist(hist_name: &str, units: &str, hist: &Histogram<u64>) -> Stri
 
 async fn set_capture(asm: &Assembly<'_>, path_str: &str) -> String {
     let path = Path::new(path_str);
-    asm.capture_worker.open_capture_file(path).await;
-
-    format!("Capture file opened at {}\n", path_str)
+    match asm.capture_worker.open_capture_file(path).await {
+        Ok(()) => format!("Capture file opened at {}\n", path_str),
+        Err(err) => format!("Error opening Capture file {}: {}\n", path_str, err),
+    }
 }
 
 async fn flush_capture(asm: &Assembly<'_>) -> String {
@@ -325,7 +326,7 @@ async fn flush_capture(asm: &Assembly<'_>) -> String {
 }
 
 async fn close_capture(asm: &Assembly<'_>) -> String {
-    asm.capture_worker.close_capture_file().await;
+    let _ = asm.capture_worker.close_capture_file().await;
     asm.flow_control.delete_program();
 
     String::from("Capture file closed\n")


### PR DESCRIPTION
The major change here is adding the `pcap_writer` module, which just implements a trivially simple PCAP file writer.  The key differences from the `pcap` crate or `pcap_file` are:
1. It's asynchronous – this means if the PCAP destination is e.g. a network file system or an SSH tunnel, it won't block the Tokio runtime.
2. It's not `pcap` – meaning we now can eliminate that (and the big C library which it depends on) as a dependency from the PH.

The remainder of changes just switch to using this instead of `pcap`, which, beside type changes, mostly are (1) switching some methods to async, (2) handling some new errors, and (3) opening the `File` ourselves.

(Long-term plan is also to switch away from having a `File` as the backing store, and instead allowing an arbitrary file descriptor, which is passed in via the RPC mechanism (#176).)