### PR TITLE
introduce RCU-ish functionality to the PH

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "aarc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afe0fed346d4329c60bb25a742281e3a3af3fc7c41bdd137d059072ec20101db"
+
+[[package]]
 name = "addr2line"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +205,15 @@ name = "crossbeam-channel"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -508,17 +523,19 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "ph"
 version = "0.1.0"
 dependencies = [
+ "aarc",
  "arrayref",
  "bytes",
  "cbpf-rs",
  "clap",
+ "crossbeam-epoch",
  "enum-map",
  "foreign-types",
  "hdrhistogram",
@@ -747,7 +764,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -767,18 +784,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -789,9 +806,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -801,9 +818,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -813,15 +830,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -831,9 +848,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -843,9 +860,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -855,9 +872,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -867,9 +884,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+aarc = { version = "0.2.1", optional = true }
 arrayref = { version = "0.3.7" }
 bytes = { version = "1.7.1" }
 cbpf-rs = { path = "../../cbpf-rs" }
 clap = { version = "4.5.7", features = ["derive"] }
+crossbeam-epoch = { version = "0.9.18", optional = true }
 enum-map = { version = "2.7.3" }
 foreign-types = { version = "0.3.2" }
 hdrhistogram = { version = "7.5.4" }
@@ -24,7 +26,12 @@ zerocopy = { version = "0.7.34", features = ["byteorder"] }
 zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "tokio-tun", "zerocopy"] }
 
 [features]
+default = ["rcu-crossbeam-epoch"]
 ci = []
+rcu-rwlock = []
+rcu-mutex-arc = []
+rcu-crossbeam-epoch = ["dep:crossbeam-epoch"]
+rcu-aarc = ["dep:aarc"]
 
 [lib] 
 test = false

--- a/adapter/ph/src/flow_control.rs
+++ b/adapter/ph/src/flow_control.rs
@@ -1,9 +1,8 @@
+use crate::rcu::RcuBox;
 use cbpf_rs::BpfProgram;
-use std::sync::RwLock;
 
 pub struct FlowControl {
-    // TODO: replace this with RCU
-    inner_control: RwLock<InnerFlow>,
+    inner_control: RcuBox<InnerFlow>,
 }
 
 struct InnerFlow {
@@ -18,23 +17,22 @@ impl FlowControl {
     }
 
     pub fn set_program(&self, program: BpfProgram) {
-        self.inner_control.write().unwrap().flow = Some(program);
+        self.inner_control.write(InnerFlow { flow: Some(program) });
     }
 
     pub fn delete_program(&self) {
-        self.inner_control.write().unwrap().flow = None;
+        self.inner_control.write(InnerFlow { flow: None });
     }
 
     pub fn check_packet(&self, packet: &[u8]) -> u32 {
-        let inner_flow = &self.inner_control.read().unwrap().flow;
-        match inner_flow {
-            Some(program) => program.filter(packet),
-            None => 0,
-        }
+        self.inner_control.inspect(|inner_flow|
+            match &inner_flow.flow {
+                Some(program) => program.filter(packet),
+                None => 0,
+            })
     }
 
     pub fn program_exists(&self) -> bool {
-        let inner_flow = &self.inner_control.read().unwrap().flow;
-        inner_flow.is_some()
+        self.inner_control.inspect(|inner_flow| inner_flow.flow.is_some())
     }
 }

--- a/adapter/ph/src/flow_control.rs
+++ b/adapter/ph/src/flow_control.rs
@@ -17,7 +17,9 @@ impl FlowControl {
     }
 
     pub fn set_program(&self, program: BpfProgram) {
-        self.inner_control.write(InnerFlow { flow: Some(program) });
+        self.inner_control.write(InnerFlow {
+            flow: Some(program),
+        });
     }
 
     pub fn delete_program(&self) {
@@ -25,14 +27,15 @@ impl FlowControl {
     }
 
     pub fn check_packet(&self, packet: &[u8]) -> u32 {
-        self.inner_control.inspect(|inner_flow|
-            match &inner_flow.flow {
+        self.inner_control
+            .inspect(|inner_flow| match &inner_flow.flow {
                 Some(program) => program.filter(packet),
                 None => 0,
             })
     }
 
     pub fn program_exists(&self) -> bool {
-        self.inner_control.inspect(|inner_flow| inner_flow.flow.is_some())
+        self.inner_control
+            .inspect(|inner_flow| inner_flow.flow.is_some())
     }
 }

--- a/adapter/ph/src/lib.rs
+++ b/adapter/ph/src/lib.rs
@@ -22,6 +22,7 @@ pub mod outbound_recv_worker;
 pub mod packet;
 pub mod pcap_writer;
 pub mod queues;
+pub mod rcu;
 pub mod rpc_worker;
 pub mod test_packet;
 pub mod tun_ctl;

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -36,6 +36,7 @@ mod outbound_recv_worker;
 mod packet;
 mod pcap_writer;
 mod queues;
+mod rcu;
 mod rpc_worker;
 mod test_packet;
 mod tun_ctl;

--- a/adapter/ph/src/rcu.rs
+++ b/adapter/ph/src/rcu.rs
@@ -1,0 +1,167 @@
+//! Wrapper for RCU-"ish" functionality (<https://en.wikipedia.org/wiki/Read-copy-update>)
+//!
+//! This API is deliberately minimal, to restrict via what functionality
+//! we couple ourselves to a given RCU-like implementation.
+//!
+//! The capability expected of an RCU implementation, beyond what the API
+//! directly implies, is as follows.  Writes need not be efficient, but must
+//! not block reads, but should eventually complete even under contention. 
+//! Reads must be very efficient and not contend with each other.
+//! Garbage collection should be performed by the writer, not the reader.
+//!
+//! Multiple implementations are provided, since it's not clear which is
+//! best yet.  A couple simple std-only implementations are also provided,
+//! which do not meet the above performance requirements, but are useful
+//! for testing.  The active implementation is selected by a feature flag.
+
+#[cfg(all(feature = "rcu-rwlock", feature = "rcu-mutex-arc", feature = "rcu-crossbeam-epoch", feature = "rcu-aarc"))]
+compile_error!("exactly one rcu-* feature must be selected");
+
+#[cfg(not(any(feature = "rcu-rwlock", feature = "rcu-mutex-arc", feature = "rcu-crossbeam-epoch", feature = "rcu-aarc")))]
+compile_error!("exactly one rcu-* feature must be selected");
+
+#[cfg(feature = "rcu-rwlock")]
+mod rcu_impl {
+    use std::sync::RwLock;
+
+    /// An RCU-protected box.
+    pub struct RcuBox<T>(RwLock<T>);
+
+    impl<T> RcuBox<T> {
+        /// Create a new box containing the given value.
+        pub fn new(value: T) -> Self {
+            Self(RwLock::new(value))
+        }
+
+        /// Provide protected read access to the latest version of the
+        /// boxed value to the given function, whose result is returned.
+        pub fn inspect<U>(&self, f: impl FnOnce(&T) -> U) -> U {
+            f(&*self.0.read().unwrap())
+        }
+
+        /// Replace the boxed value with a new value.  The old value
+        /// will be destructed once all readers have completed. 
+        pub fn write(&self, new_value: T) {
+            let mut lock = self.0.write().unwrap();
+            let old = std::mem::replace(&mut *lock, new_value);
+            std::mem::drop(lock);
+            std::mem::drop(old);
+        }
+    }
+}
+
+#[cfg(feature = "rcu-mutex-arc")]
+mod rcu_impl {
+    use std::sync::{Arc, Mutex};
+
+    pub struct RcuBox<T>(Mutex<Arc<T>>);
+
+    impl<T> RcuBox<T> {
+        pub fn new(value: T) -> Self {
+            Self(Mutex::new(Arc::new(value)))
+        }
+
+        pub fn inspect<U>(&self, f: impl FnOnce(&T) -> U) -> U {
+            let lock = self.0.lock().unwrap();
+            let arc = lock.clone();
+            std::mem::drop(lock);
+            f(&*arc)
+        }
+
+        pub fn write(&self, new_value: T) {
+            let mut lock = self.0.lock().unwrap();
+            let old = std::mem::replace(&mut *lock, Arc::new(new_value));
+            std::mem::drop(lock);
+            std::mem::drop(old);
+        }
+    }
+}
+
+#[cfg(feature = "rcu-crossbeam-epoch")]
+mod rcu_impl {
+    use crossbeam_epoch as epoch;
+    use std::sync::atomic::Ordering;
+
+    pub struct RcuBox<T>(epoch::Atomic<T>);
+
+    impl<T> RcuBox<T> {
+        pub fn new(value: T) -> Self {
+            Self(epoch::Atomic::new(value))
+        }
+
+        pub fn inspect<U>(&self, f: impl FnOnce(&T) -> U) -> U {
+            let guard = epoch::pin();
+            let ptr = self.0.load(Ordering::Acquire, &guard);
+            // SAFETY: we only allow readers to access "live" values
+            let ref_ = unsafe { ptr.deref() };
+            f(ref_)
+        }
+
+        pub fn write(&self, new_value: T) {
+            let guard = epoch::pin();
+            let old_value = self.0.swap(epoch::Owned::from(new_value), Ordering::AcqRel, &guard);
+            // SAFETY: `old_value` is now unreachable
+            unsafe { guard.defer_destroy(old_value); }
+        }
+    }
+}
+
+#[cfg(feature = "rcu-aarc")]
+mod rcu_impl {
+    pub struct RcuBox<T: 'static>(aarc::AtomicArc<T>);
+
+    impl<T> RcuBox<T> {
+        pub fn new(value: T) -> Self {
+            Self(aarc::AtomicArc::new(Some(value)))
+        }
+
+        pub fn inspect<U>(&self, f: impl FnOnce(&T) -> U) -> U {
+            f(&*self.0.load::<aarc::Snapshot<_>>().unwrap())
+        }
+
+        pub fn write(&self, new_value: T) {
+            // NOTE: it's not clear from aarc docs in which threads GC is allowed;
+            // if in `load()` threads, this would be a deal-breaker
+            self.0.store(Some(&std::sync::Arc::new(new_value)))
+        }
+    }
+}
+
+// NOTE: left-right looked promising, but `ReadHandle` is not `Sync`,
+// so we'd have to create a thread-local variable for each `RcuBox`,
+// which just becomes a ton of overhead.
+
+// NOTE: haphazard also looked promising, but requires that
+// the pointed-to data is `Sync`, which is basically a nonstarter.
+
+// NOTE: urcu looked promising, but didn't compile.
+
+pub use rcu_impl::*;
+
+impl<T: Clone> RcuBox<T> {
+    /// Clone the value in the box.
+    pub fn clone_inner(&self) -> T {
+        self.inspect(|item| item.clone())
+    }
+}
+
+impl<T: Copy> RcuBox<T> {
+    /// Read a copy of the value in the box.
+    pub fn read(&self) -> T {
+        self.inspect(|item| *item)
+    }
+}
+
+impl<T: Default> Default for RcuBox<T> {
+    /// Creates a new box containing the boxed value type's default value.
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+impl<T> From<T> for RcuBox<T> {
+    /// Creates a new box from the given value.  Same as `RcuBox::new()`.
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}

--- a/adapter/ph/src/rcu.rs
+++ b/adapter/ph/src/rcu.rs
@@ -5,7 +5,7 @@
 //!
 //! The capability expected of an RCU implementation, beyond what the API
 //! directly implies, is as follows.  Writes need not be efficient, but must
-//! not block reads, but should eventually complete even under contention. 
+//! not block reads, but should eventually complete even under contention.
 //! Reads must be very efficient and not contend with each other.
 //! Garbage collection should be performed by the writer, not the reader.
 //!
@@ -14,10 +14,20 @@
 //! which do not meet the above performance requirements, but are useful
 //! for testing.  The active implementation is selected by a feature flag.
 
-#[cfg(all(feature = "rcu-rwlock", feature = "rcu-mutex-arc", feature = "rcu-crossbeam-epoch", feature = "rcu-aarc"))]
+#[cfg(all(
+    feature = "rcu-rwlock",
+    feature = "rcu-mutex-arc",
+    feature = "rcu-crossbeam-epoch",
+    feature = "rcu-aarc"
+))]
 compile_error!("exactly one rcu-* feature must be selected");
 
-#[cfg(not(any(feature = "rcu-rwlock", feature = "rcu-mutex-arc", feature = "rcu-crossbeam-epoch", feature = "rcu-aarc")))]
+#[cfg(not(any(
+    feature = "rcu-rwlock",
+    feature = "rcu-mutex-arc",
+    feature = "rcu-crossbeam-epoch",
+    feature = "rcu-aarc"
+)))]
 compile_error!("exactly one rcu-* feature must be selected");
 
 #[cfg(feature = "rcu-rwlock")]
@@ -40,7 +50,7 @@ mod rcu_impl {
         }
 
         /// Replace the boxed value with a new value.  The old value
-        /// will be destructed once all readers have completed. 
+        /// will be destructed once all readers have completed.
         pub fn write(&self, new_value: T) {
             let mut lock = self.0.write().unwrap();
             let old = std::mem::replace(&mut *lock, new_value);
@@ -99,9 +109,13 @@ mod rcu_impl {
 
         pub fn write(&self, new_value: T) {
             let guard = epoch::pin();
-            let old_value = self.0.swap(epoch::Owned::from(new_value), Ordering::AcqRel, &guard);
+            let old_value = self
+                .0
+                .swap(epoch::Owned::from(new_value), Ordering::AcqRel, &guard);
             // SAFETY: `old_value` is now unreachable
-            unsafe { guard.defer_destroy(old_value); }
+            unsafe {
+                guard.defer_destroy(old_value);
+            }
         }
     }
 }


### PR DESCRIPTION
This is my attempt at a very basic [RCU](https://en.wikipedia.org/wiki/Read-copy-update)-"ish" API for the PH.  It's greatly simplified to restrict our usage of it, so we can swap out the backend implementation if needed.  There are several 3rd party crates which implement something "like" RCU and it's not obvious yet which is the best for us.  (Some already I've ruled out due to API incompatibility / design flaw reasons.)

Also, I've used this for the BPF filtering.  This needs a fast read-side (since we read it on every packet) so is a great candidate.

This needs tests, but they'd need to do concurrent control stuff, so I'm punting that for now.