### PR TITLE
ZPI 0 checksum

### DIFF
--- a/adapter/ph/src/counters_enum.rs
+++ b/adapter/ph/src/counters_enum.rs
@@ -22,7 +22,7 @@ pub enum CounterType {
     BadMgmtResponse,
     UnexpectedMgmtResponse,
 
-    // § 8.2.1
+    // RFC 6.5 § 8.2.1
     UnknownZpi,
     SequenceError,
     MicvFailure,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -181,7 +181,10 @@ pub fn encrypt<'pktbuf>(
     let zpi = zpi_hdr.zpi as zpr::Zpi;
 
     if zpi == zpr::ZPI_0 {
-        pkt.put(net_defs::inet_checksum(&pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..]).as_slice());
+        pkt.put(
+            net_defs::inet_checksum(&pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..])
+                .as_slice(),
+        );
     } else {
         todo!("encryption");
     }
@@ -217,11 +220,13 @@ pub fn decrypt<'pktbuf>(
     let zpi = zpi_hdr.zpi as zpr::Zpi;
 
     if zpi == zpr::ZPI_0 {
-        if !net_defs::validate_inet_checksum(&pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..]) {
+        if !net_defs::validate_inet_checksum(
+            &pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..],
+        ) {
             return Err(DecryptError::MicvFailure);
         }
 
-        pkt.shrink(2);  // remove checksum
+        pkt.shrink(2); // remove checksum
 
         Ok(())
     } else {

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -181,6 +181,7 @@ pub fn encrypt<'pktbuf>(
     let zpi = zpi_hdr.zpi as zpr::Zpi;
 
     if zpi == zpr::ZPI_0 {
+        // RFC 6.5 § 5.25.2
         pkt.put(
             net_defs::inet_checksum(&pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..])
                 .as_slice(),
@@ -220,6 +221,7 @@ pub fn decrypt<'pktbuf>(
     let zpi = zpi_hdr.zpi as zpr::Zpi;
 
     if zpi == zpr::ZPI_0 {
+        // RFC 6.5 § 5.25.2
         if !net_defs::validate_inet_checksum(
             &pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..],
         ) {

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -6,12 +6,13 @@
 use crate::assembly::Assembly;
 use crate::counters_enum::CounterType;
 use crate::defs::Direction;
+use crate::net_defs;
 use crate::packet::Packet;
 use crate::queues::TryEnqueueError;
 use crate::zdp;
 use crate::zdp_ll;
 use crate::zpr;
-use bytes::Buf;
+use bytes::{Buf, BufMut};
 use std::time::SystemTime;
 use zerocopy::FromBytes;
 use zpr_ext::std::mem::{drop_guard, DropGuard};
@@ -180,7 +181,7 @@ pub fn encrypt<'pktbuf>(
     let zpi = zpi_hdr.zpi as zpr::Zpi;
 
     if zpi == zpr::ZPI_0 {
-        // TODO: MAC
+        pkt.put(net_defs::inet_checksum(&pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..]).as_slice());
     } else {
         todo!("encryption");
     }
@@ -216,7 +217,12 @@ pub fn decrypt<'pktbuf>(
     let zpi = zpi_hdr.zpi as zpr::Zpi;
 
     if zpi == zpr::ZPI_0 {
-        // TODO: MAC
+        if !net_defs::validate_inet_checksum(&pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..]) {
+            return Err(DecryptError::MicvFailure);
+        }
+
+        pkt.shrink(2);  // remove checksum
+
         Ok(())
     } else {
         todo!("decryption");

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -48,8 +48,8 @@ pub fn ip_ethertype(ip_version: u8) -> u16 {
     }
 }
 
-/// RFC 1071 Internet Checksum.  The input data must be non-empty, length at
-/// most 64 KiB, and length a multiple of 4.
+/// RFC 1071 Internet Checksum.  The input data must be non-empty, and
+/// length at most ~128 KiB.
 pub fn inet_checksum(data: &[u8]) -> [u8; 2] {
     // NOTE: This benchmarks about twice as fast as the `internet-checksum` crate,
     // and is many fewer lines of code.
@@ -79,35 +79,39 @@ pub fn inet_checksum(data: &[u8]) -> [u8; 2] {
     // Split into the aligned and unaligned case.  We could sum 32 bits at a
     // time instead, but we're mostly summing short spans, so having only
     // one unaligned case shortens the branch logic here.
-    if (&data[0] as *const u8 as *const u16).is_aligned() {
-        let last_byte = if data.len() % 2 == 0 {
+    if (&data[0] as *const u8 as *const u16).is_aligned() ^ (data.len() % 2 == 1) {
+        let first_byte = if data.len() % 2 == 0 {
             0
         } else {
-            data[data.len() - 1]
+            data[0]
         };
-        let extra_sum = u16::from_ne_bytes([last_byte, 0]);
+        let extra_sum = u16::from_ne_bytes([0, first_byte]);
 
         // SAFETY: we have verified alignment and length
         let data16 = unsafe {
-            std::slice::from_raw_parts(&data[0] as *const u8 as *const u16, data.len() / 2)
+            std::slice::from_raw_parts(&data[data.len() % 2] as *const u8 as *const u16, data.len() / 2)
         };
 
-        inet_checksum_helper(extra_sum, data16).to_be_bytes()
+        inet_checksum_helper(extra_sum, data16).to_ne_bytes()
     } else {
-        let last_byte = if data.len() % 2 == 0 {
-            data[data.len() - 1]
+        let first_byte = if data.len() % 2 == 0 {
+            data[0]
         } else {
             0
         };
-        let extra_sum = u16::from_ne_bytes([last_byte, data[0]]);
+        let extra_sum = u16::from_ne_bytes([data[data.len() - 1], first_byte]);
 
         // SAFETY: we are compensating for alignment
         let data16 = unsafe {
-            std::slice::from_raw_parts(&data[1] as *const u8 as *const u16, (data.len() - 1) / 2)
+            std::slice::from_raw_parts(&data[1 - data.len() % 2] as *const u8 as *const u16, (data.len() - 1) / 2)
         };
         // NOTE: purposefully to_le_bytes(), to compensate for misalignment
-        inet_checksum_helper(extra_sum, data16).to_le_bytes()
+        inet_checksum_helper(extra_sum, data16).swap_bytes().to_ne_bytes()
     }
+}
+
+pub fn validate_inet_checksum(data: &[u8]) -> bool {
+    inet_checksum(data) == [0u8; 2]
 }
 
 #[cfg(test)]
@@ -129,12 +133,31 @@ mod tests {
     }
 
     #[test]
+    fn test_checksum_order() {
+        for buf in TEST_DATA {
+            let mut v = Vec::new();
+            v.extend_from_slice(&buf[..buf.len() - 2]);
+            assert_eq!(inet_checksum(v.as_slice()), buf[buf.len() - 2..]);
+        }
+    }
+
+    #[test]
     fn test_checksum_unaligned() {
         for buf in TEST_DATA {
             let mut v = Vec::new();
             v.push(0);
             v.extend_from_slice(buf);
             assert_eq!(inet_checksum(&v[1..]), [0u8; 2]);
+        }
+    }
+
+    #[test]
+    fn test_checksum_order_unaligned() {
+        for buf in TEST_DATA {
+            let mut v = Vec::new();
+            v.push(0);
+            v.extend_from_slice(&buf[..buf.len() - 2]);
+            assert_eq!(inet_checksum(v.as_slice()), buf[buf.len() - 2..]);
         }
     }
 

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -80,33 +80,33 @@ pub fn inet_checksum(data: &[u8]) -> [u8; 2] {
     // time instead, but we're mostly summing short spans, so having only
     // one unaligned case shortens the branch logic here.
     if (&data[0] as *const u8 as *const u16).is_aligned() ^ (data.len() % 2 == 1) {
-        let first_byte = if data.len() % 2 == 0 {
-            0
-        } else {
-            data[0]
-        };
+        let first_byte = if data.len() % 2 == 0 { 0 } else { data[0] };
         let extra_sum = u16::from_ne_bytes([0, first_byte]);
 
         // SAFETY: we have verified alignment and length
         let data16 = unsafe {
-            std::slice::from_raw_parts(&data[data.len() % 2] as *const u8 as *const u16, data.len() / 2)
+            std::slice::from_raw_parts(
+                &data[data.len() % 2] as *const u8 as *const u16,
+                data.len() / 2,
+            )
         };
 
         inet_checksum_helper(extra_sum, data16).to_ne_bytes()
     } else {
-        let first_byte = if data.len() % 2 == 0 {
-            data[0]
-        } else {
-            0
-        };
+        let first_byte = if data.len() % 2 == 0 { data[0] } else { 0 };
         let extra_sum = u16::from_ne_bytes([data[data.len() - 1], first_byte]);
 
         // SAFETY: we are compensating for alignment
         let data16 = unsafe {
-            std::slice::from_raw_parts(&data[1 - data.len() % 2] as *const u8 as *const u16, (data.len() - 1) / 2)
+            std::slice::from_raw_parts(
+                &data[1 - data.len() % 2] as *const u8 as *const u16,
+                (data.len() - 1) / 2,
+            )
         };
         // NOTE: purposefully to_le_bytes(), to compensate for misalignment
-        inet_checksum_helper(extra_sum, data16).swap_bytes().to_ne_bytes()
+        inet_checksum_helper(extra_sum, data16)
+            .swap_bytes()
+            .to_ne_bytes()
     }
 }
 

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -165,7 +165,8 @@ impl<'buf> Packet<'buf> {
         self.clone_prefix_into_with_headroom(buf, headroom, self.body().len())
     }
 
-    fn clone_prefix_into_with_headroom<'other>(
+    /// Like `clone_into_with_headroom()`, but only copy a prefix of the packet's data.
+    pub fn clone_prefix_into_with_headroom<'other>(
         &self,
         buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
         headroom: usize,
@@ -251,6 +252,13 @@ impl<'buf> Packet<'buf> {
     /// The structure allocated will be zeroed.
     pub fn alloc_zeroed_header<T: AsBytes + FromBytes + FromZeroes>(&mut self) -> &mut T {
         T::mut_from(self.alloc_zeroed_headroom(size_of::<T>())).unwrap()
+    }
+
+    /// Shrink the packet by `cnt` bytes (removing data from the tail).
+    pub fn shrink(&mut self, cnt: usize) {
+        let md = self.metadata_mut();
+        assert!(cnt <= md.len);
+        md.len -= cnt;
     }
 
     /// `flowhash()` is different for different flows, but not necessarily vice-versa.
@@ -491,7 +499,7 @@ mod tests {
         let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
         let mut pkt = Packet::new(&mut buf, 0);
         pkt.put_u64(0x0102030405060708u64);
-        assert_eq!(pkt.body()[..8], [1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(pkt.body(), [1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
     #[test]
@@ -500,7 +508,7 @@ mod tests {
         let mut pkt = Packet::new(&mut buf, 0);
         pkt.put_u32(0x01020304u32);
         pkt.put_u32(0x05060708u32);
-        assert_eq!(pkt.body()[..8], [1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(pkt.body(), [1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
     #[test]
@@ -509,5 +517,23 @@ mod tests {
         let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
         let mut pkt = Packet::new(&mut buf, PACKET_BUFFER_MAX_BODY_SIZE);
         pkt.put_u8(1);
+    }
+
+    #[test]
+    fn shrink_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let mut pkt = Packet::new(&mut buf, 0);
+        pkt.put_u64(0x0102030405060708u64);
+        pkt.shrink(2);
+        assert_eq!(pkt.body(), [1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn shrink_too_much_test() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let mut pkt = Packet::new(&mut buf, 0);
+        pkt.put_u64(0x0102030405060708u64);
+        pkt.shrink(10);
     }
 }

--- a/adapter/ph/src/rcu.rs
+++ b/adapter/ph/src/rcu.rs
@@ -14,6 +14,8 @@
 //! which do not meet the above performance requirements, but are useful
 //! for testing.  The active implementation is selected by a feature flag.
 
+#![allow(dead_code)]
+
 #[cfg(all(
     feature = "rcu-rwlock",
     feature = "rcu-mutex-arc",


### PR DESCRIPTION
Implement ZPI 0 checksumming, which is Internet checksum.

Also, my Internet checksum code was generating checksums in the wrong byte order in some cases.  The unit tests weren't catching it because they only ever validated a checksum, which means checking against 0, for which byte order doesn't matter.