### PR TITLE
add tokio ancillary data functions

### DIFF
--- a/zpr-ext/Cargo.lock
+++ b/zpr-ext/Cargo.lock
@@ -232,7 +232,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/zpr-ext/Cargo.toml
+++ b/zpr-ext/Cargo.toml
@@ -11,6 +11,9 @@ tokio-tun = { version = "0.11.5", optional = true }
 tokio = { version = "1.37.0", features = ["net"], optional = true }
 zerocopy = { version = "0.7.34", optional = true }
 
+[dev-dependencies]
+tokio = { version = "1.37.0", features = ["macros", "time", "rt"] }
+
 [features]
 # Each feature flag is the name of a library the user is already using
 # and would like to have "extended".

--- a/zpr-ext/src/std.rs
+++ b/zpr-ext/src/std.rs
@@ -283,8 +283,7 @@ pub mod os {
                         && (*cmsghdr).cmsg_level == libc::SOL_SOCKET
                         && (*cmsghdr).cmsg_type == libc::SCM_RIGHTS
                     {
-                        let size_of_hdr = (2
-                            * libc::CMSG_LEN(std::mem::size_of::<RawFd>() as _)
+                        let size_of_hdr = (2 * libc::CMSG_LEN(std::mem::size_of::<RawFd>() as _)
                             - libc::CMSG_LEN((2 * std::mem::size_of::<RawFd>()) as _))
                             as usize;
                         let num_fds =
@@ -321,9 +320,9 @@ pub mod os {
                     &self,
                     bufs: &mut [IoSliceMut<'_>],
                     ancillary: &mut SocketAncillary<'_>,
-               ) -> Result<usize> {
+                ) -> Result<usize> {
                     uds_recv_vectored_with_ancillary(self.as_fd(), bufs, ancillary)
-               }
+                }
             }
 
             #[cfg(test)]

--- a/zpr-ext/src/std.rs
+++ b/zpr-ext/src/std.rs
@@ -145,7 +145,7 @@ pub mod os {
         pub mod net {
             use libc;
             use std::io::{Error, IoSlice, IoSliceMut, Result};
-            use std::os::fd::{AsRawFd, RawFd};
+            use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
             use std::os::unix::net::UnixStream;
             use std::ptr;
             use std::vec::Vec;
@@ -216,6 +216,94 @@ pub mod os {
                 ) -> Result<usize>;
             }
 
+            #[cfg(any(doc, target_os = "android", target_os = "linux"))]
+            pub(crate) fn uds_send_vectored_with_ancillary(
+                fd: BorrowedFd<'_>,
+                bufs: &[IoSlice<'_>],
+                ancillary: &mut SocketAncillary<'_>,
+            ) -> Result<usize> {
+                let fds_size = std::mem::size_of_val(&ancillary.fds[..]);
+
+                let mut msghdr = libc::msghdr {
+                    msg_name: ptr::null_mut(),
+                    msg_namelen: 0,
+                    msg_iov: bufs.as_ptr() as *mut _,
+                    msg_iovlen: bufs.len(),
+                    msg_control: ptr::null_mut(),
+                    msg_controllen: 0,
+                    msg_flags: 0,
+                };
+
+                if fds_size > 0 {
+                    unsafe {
+                        msghdr.msg_control = (&mut ancillary.buffer).as_mut_ptr().cast();
+                        msghdr.msg_controllen = libc::CMSG_SPACE(fds_size as _) as _;
+
+                        let cmsghdr = libc::CMSG_FIRSTHDR(&msghdr);
+                        (*cmsghdr).cmsg_len = libc::CMSG_LEN(fds_size as _) as _;
+                        (*cmsghdr).cmsg_level = libc::SOL_SOCKET;
+                        (*cmsghdr).cmsg_type = libc::SCM_RIGHTS;
+                        libc::CMSG_DATA(cmsghdr).copy_from_nonoverlapping(
+                            (&ancillary.fds[..]).as_ptr().cast(),
+                            fds_size,
+                        );
+                    }
+                }
+
+                let res = unsafe { libc::sendmsg(fd.as_raw_fd(), &msghdr, 0) };
+
+                if res > 0 {
+                    Ok(res as usize)
+                } else {
+                    Err(Error::last_os_error())
+                }
+            }
+
+            #[cfg(any(doc, target_os = "android", target_os = "linux"))]
+            pub(crate) fn uds_recv_vectored_with_ancillary(
+                fd: BorrowedFd<'_>,
+                bufs: &mut [IoSliceMut<'_>],
+                ancillary: &mut SocketAncillary<'_>,
+            ) -> Result<usize> {
+                let mut msghdr = libc::msghdr {
+                    msg_name: ptr::null_mut(),
+                    msg_namelen: 0,
+                    msg_iov: bufs.as_ptr() as *mut _,
+                    msg_iovlen: bufs.len(),
+                    msg_control: (&mut ancillary.buffer).as_mut_ptr().cast(),
+                    msg_controllen: ancillary.buffer.len() as _,
+                    msg_flags: 0,
+                };
+
+                let res = unsafe { libc::recvmsg(fd.as_raw_fd(), &mut msghdr, 0) };
+
+                unsafe {
+                    let cmsghdr = libc::CMSG_FIRSTHDR(&msghdr);
+                    if !cmsghdr.is_null()
+                        && (*cmsghdr).cmsg_level == libc::SOL_SOCKET
+                        && (*cmsghdr).cmsg_type == libc::SCM_RIGHTS
+                    {
+                        let size_of_hdr = (2
+                            * libc::CMSG_LEN(std::mem::size_of::<RawFd>() as _)
+                            - libc::CMSG_LEN((2 * std::mem::size_of::<RawFd>()) as _))
+                            as usize;
+                        let num_fds =
+                            ((*cmsghdr).cmsg_len - size_of_hdr) / std::mem::size_of::<RawFd>();
+                        ancillary.fds.clear();
+                        ancillary.fds.extend_from_slice(std::slice::from_raw_parts(
+                            libc::CMSG_DATA(cmsghdr).cast(),
+                            num_fds,
+                        ));
+                    }
+                }
+
+                if res > 0 {
+                    Ok(res as usize)
+                } else {
+                    Err(Error::last_os_error())
+                }
+            }
+
             impl UnixStreamExt for UnixStream {
                 /// This is a very silly and limited implementation of `send_vectored_with_ancillary()` as we await
                 /// stabilization of [unix_socket_ancillary_data](https://github.com/rust-lang/rust/issues/76915).
@@ -225,41 +313,7 @@ pub mod os {
                     bufs: &[IoSlice<'_>],
                     ancillary: &mut SocketAncillary<'_>,
                 ) -> Result<usize> {
-                    let fds_size = std::mem::size_of_val(&ancillary.fds[..]);
-
-                    let mut msghdr = libc::msghdr {
-                        msg_name: ptr::null_mut(),
-                        msg_namelen: 0,
-                        msg_iov: bufs.as_ptr() as *mut _,
-                        msg_iovlen: bufs.len(),
-                        msg_control: ptr::null_mut(),
-                        msg_controllen: 0,
-                        msg_flags: 0,
-                    };
-
-                    if fds_size > 0 {
-                        unsafe {
-                            msghdr.msg_control = (&mut ancillary.buffer).as_mut_ptr().cast();
-                            msghdr.msg_controllen = libc::CMSG_SPACE(fds_size as _) as _;
-
-                            let cmsghdr = libc::CMSG_FIRSTHDR(&msghdr);
-                            (*cmsghdr).cmsg_len = libc::CMSG_LEN(fds_size as _) as _;
-                            (*cmsghdr).cmsg_level = libc::SOL_SOCKET;
-                            (*cmsghdr).cmsg_type = libc::SCM_RIGHTS;
-                            libc::CMSG_DATA(cmsghdr).copy_from_nonoverlapping(
-                                (&ancillary.fds[..]).as_ptr().cast(),
-                                fds_size,
-                            );
-                        }
-                    }
-
-                    let res = unsafe { libc::sendmsg(self.as_raw_fd(), &msghdr, 0) };
-
-                    if res > 0 {
-                        Ok(res as usize)
-                    } else {
-                        Err(Error::last_os_error())
-                    }
+                    uds_send_vectored_with_ancillary(self.as_fd(), bufs, ancillary)
                 }
 
                 #[cfg(any(doc, target_os = "android", target_os = "linux"))]
@@ -267,45 +321,9 @@ pub mod os {
                     &self,
                     bufs: &mut [IoSliceMut<'_>],
                     ancillary: &mut SocketAncillary<'_>,
-                ) -> Result<usize> {
-                    let mut msghdr = libc::msghdr {
-                        msg_name: ptr::null_mut(),
-                        msg_namelen: 0,
-                        msg_iov: bufs.as_ptr() as *mut _,
-                        msg_iovlen: bufs.len(),
-                        msg_control: (&mut ancillary.buffer).as_mut_ptr().cast(),
-                        msg_controllen: ancillary.buffer.len() as _,
-                        msg_flags: 0,
-                    };
-
-                    let res = unsafe { libc::recvmsg(self.as_raw_fd(), &mut msghdr, 0) };
-
-                    unsafe {
-                        let cmsghdr = libc::CMSG_FIRSTHDR(&msghdr);
-                        if !cmsghdr.is_null()
-                            && (*cmsghdr).cmsg_level == libc::SOL_SOCKET
-                            && (*cmsghdr).cmsg_type == libc::SCM_RIGHTS
-                        {
-                            let size_of_hdr = (2
-                                * libc::CMSG_LEN(std::mem::size_of::<RawFd>() as _)
-                                - libc::CMSG_LEN((2 * std::mem::size_of::<RawFd>()) as _))
-                                as usize;
-                            let num_fds =
-                                ((*cmsghdr).cmsg_len - size_of_hdr) / std::mem::size_of::<RawFd>();
-                            ancillary.fds.clear();
-                            ancillary.fds.extend_from_slice(std::slice::from_raw_parts(
-                                libc::CMSG_DATA(cmsghdr).cast(),
-                                num_fds,
-                            ));
-                        }
-                    }
-
-                    if res > 0 {
-                        Ok(res as usize)
-                    } else {
-                        Err(Error::last_os_error())
-                    }
-                }
+               ) -> Result<usize> {
+                    uds_recv_vectored_with_ancillary(self.as_fd(), bufs, ancillary)
+               }
             }
 
             #[cfg(test)]

--- a/zpr-ext/src/tokio.rs
+++ b/zpr-ext/src/tokio.rs
@@ -1,5 +1,7 @@
 pub mod net {
-    use crate::std::os::unix::net::{SocketAncillary, uds_recv_vectored_with_ancillary, uds_send_vectored_with_ancillary};
+    use crate::std::os::unix::net::{
+        uds_recv_vectored_with_ancillary, uds_send_vectored_with_ancillary, SocketAncillary,
+    };
     use nix::sys::socket;
     use std::io::{self, IoSlice, IoSliceMut};
     use std::os::fd::AsFd;
@@ -28,7 +30,9 @@ pub mod net {
     ) -> io::Result<usize> {
         loop {
             stream.writable().await?;
-            match stream.try_io(Interest::WRITABLE, || uds_send_vectored_with_ancillary(stream.as_fd(), bufs, ancillary)) {
+            match stream.try_io(Interest::WRITABLE, || {
+                uds_send_vectored_with_ancillary(stream.as_fd(), bufs, ancillary)
+            }) {
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => continue,
                 res => break res,
             }
@@ -43,7 +47,9 @@ pub mod net {
     ) -> io::Result<usize> {
         loop {
             stream.readable().await?;
-            match stream.try_io(Interest::WRITABLE, || uds_recv_vectored_with_ancillary(stream.as_fd(), bufs, ancillary)) {
+            match stream.try_io(Interest::WRITABLE, || {
+                uds_recv_vectored_with_ancillary(stream.as_fd(), bufs, ancillary)
+            }) {
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => continue,
                 res => break res,
             }
@@ -75,7 +81,9 @@ pub mod net {
                         &s2,
                         &mut [IoSliceMut::new(&mut data_out[..])],
                         &mut ancillary_out
-                    ).await.unwrap(),
+                    )
+                    .await
+                    .unwrap(),
                     3
                 );
 
@@ -107,7 +115,9 @@ pub mod net {
                     &s1,
                     &[IoSlice::new(data_in)],
                     &mut ancillary_in
-                ).await.unwrap(),
+                )
+                .await
+                .unwrap(),
                 3
             );
 

--- a/zpr-ext/src/tokio.rs
+++ b/zpr-ext/src/tokio.rs
@@ -1,7 +1,10 @@
 pub mod net {
+    use crate::std::os::unix::net::{SocketAncillary, uds_recv_vectored_with_ancillary, uds_send_vectored_with_ancillary};
     use nix::sys::socket;
-    use std::io;
-    use tokio::net::UdpSocket;
+    use std::io::{self, IoSlice, IoSliceMut};
+    use std::os::fd::AsFd;
+    use tokio::io::Interest;
+    use tokio::net::{UdpSocket, UnixStream};
 
     pub trait UdpSocketExt {
         fn mtu(&self) -> io::Result<u32>;
@@ -14,6 +17,101 @@ pub mod net {
                 Ok(mtu) => Ok(mtu as u32),
                 Err(errno) => Err(io::Error::from(errno)),
             }
+        }
+    }
+
+    #[cfg(any(doc, target_os = "android", target_os = "linux"))]
+    pub async fn unix_stream_send_vectored_with_ancillary(
+        stream: &UnixStream,
+        bufs: &[IoSlice<'_>],
+        ancillary: &mut SocketAncillary<'_>,
+    ) -> io::Result<usize> {
+        loop {
+            stream.writable().await?;
+            match stream.try_io(Interest::WRITABLE, || uds_send_vectored_with_ancillary(stream.as_fd(), bufs, ancillary)) {
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => continue,
+                res => break res,
+            }
+        }
+    }
+
+    #[cfg(any(doc, target_os = "android", target_os = "linux"))]
+    pub async fn unix_stream_recv_vectored_with_ancillary(
+        stream: &UnixStream,
+        bufs: &mut [IoSliceMut<'_>],
+        ancillary: &mut SocketAncillary<'_>,
+    ) -> io::Result<usize> {
+        loop {
+            stream.readable().await?;
+            match stream.try_io(Interest::WRITABLE, || uds_recv_vectored_with_ancillary(stream.as_fd(), bufs, ancillary)) {
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => continue,
+                res => break res,
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::std::os::unix::net::{AncillaryData, SocketAncillary};
+        use std::fs::File;
+        use std::io::Read;
+        use std::os::fd::{AsRawFd, FromRawFd};
+        use tokio::net::UnixStream;
+        use tokio::{task, time};
+
+        #[tokio::test]
+        async fn ancillary_fd() {
+            let zero_file = File::open("/dev/zero").unwrap();
+
+            let (s1, s2) = UnixStream::pair().unwrap();
+
+            let receiver = task::spawn(async move {
+                let mut data_out = [0u8; 4];
+                let mut ancillary_out_buf = [0u8; 256];
+                let mut ancillary_out = SocketAncillary::new(&mut ancillary_out_buf);
+                assert_eq!(
+                    unix_stream_recv_vectored_with_ancillary(
+                        &s2,
+                        &mut [IoSliceMut::new(&mut data_out[..])],
+                        &mut ancillary_out
+                    ).await.unwrap(),
+                    3
+                );
+
+                let mut messages = ancillary_out.messages();
+
+                let fds: Vec<_> = match messages.next().unwrap().unwrap() {
+                    AncillaryData::ScmRights(fds) => fds.collect(),
+                    AncillaryData::ScmCredentials(_) => panic!("expected ScmRights"),
+                };
+                assert!(fds.len() == 1);
+
+                let mut buf = 123u8;
+                unsafe { File::from_raw_fd(fds[0]) }
+                    .read_exact(std::slice::from_mut(&mut buf))
+                    .unwrap();
+                assert_eq!(buf, 0u8);
+
+                assert!(messages.next().is_none());
+            });
+
+            time::sleep(std::time::Duration::from_secs(1)).await;
+
+            let data_in = &[1u8, 2u8, 3u8];
+            let mut ancillary_in_buf = [0u8; 256];
+            let mut ancillary_in = SocketAncillary::new(&mut ancillary_in_buf);
+            ancillary_in.add_fds(&[zero_file.as_raw_fd()]);
+            assert_eq!(
+                unix_stream_send_vectored_with_ancillary(
+                    &s1,
+                    &[IoSlice::new(data_in)],
+                    &mut ancillary_in
+                ).await.unwrap(),
+                3
+            );
+
+            receiver.await.unwrap();
         }
     }
 }


### PR DESCRIPTION
Factored out the core body of the ancillary data functions (no changes in them).  Then added tokio-aware wrappers around them.