### PR TITLE
zpr-ext: attach_reuse_port_cbpf

### DIFF
--- a/zpr-ext/Cargo.lock
+++ b/zpr-ext/Cargo.lock
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "zpr-ext"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "libc",

--- a/zpr-ext/Cargo.toml
+++ b/zpr-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zpr-ext"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/zpr-ext/src/tokio.rs
+++ b/zpr-ext/src/tokio.rs
@@ -25,25 +25,29 @@ pub mod net {
 
         #[cfg(any(doc, target_os = "android", target_os = "linux"))]
         fn attach_reuse_port_cbpf(&self, filter: &[libc::sock_filter]) -> io::Result<()> {
-            unsafe {
-                let fprog = libc::sock_fprog {
-                    len: filter.len() as u16,
-                    filter: filter.as_ptr() as *mut _,
-                };
+            let fprog = libc::sock_fprog {
+                len: filter.len() as u16,
+                filter: filter.as_ptr().cast_mut(),
+            };
 
-                let res = libc::setsockopt(
+            let fprog_ptr = (&fprog as *const libc::sock_fprog).cast();
+            let fprog_size = std::mem::size_of_val(&fprog) as libc::socklen_t;
+
+            // SAFETY: `fprog_ptr` and `fprog_size` are of the appropriate type for SOL_SOCKET:SO_ATTACH_REUSEPORT_CBPF
+            let res = unsafe {
+                libc::setsockopt(
                     self.as_raw_fd(),
                     libc::SOL_SOCKET,
                     libc::SO_ATTACH_REUSEPORT_CBPF,
-                    (&fprog as *const libc::sock_fprog).cast(),
-                    std::mem::size_of_val(&fprog) as libc::socklen_t,
-                );
+                    fprog_ptr,
+                    fprog_size,
+                )
+            };
 
-                if res < 0 {
-                    Err(io::Error::last_os_error())
-                } else {
-                    Ok(())
-                }
+            if res < 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
             }
         }
     }

--- a/zpr-ext/src/tokio.rs
+++ b/zpr-ext/src/tokio.rs
@@ -4,12 +4,14 @@ pub mod net {
     };
     use nix::sys::socket;
     use std::io::{self, IoSlice, IoSliceMut};
-    use std::os::fd::AsFd;
+    use std::os::fd::{AsFd, AsRawFd};
     use tokio::io::Interest;
     use tokio::net::{UdpSocket, UnixStream};
 
     pub trait UdpSocketExt {
         fn mtu(&self) -> io::Result<u32>;
+        #[cfg(any(doc, target_os = "android", target_os = "linux"))]
+        fn attach_reuse_port_cbpf(&self, filter: &[libc::sock_filter]) -> io::Result<()>;
     }
 
     impl UdpSocketExt for UdpSocket {
@@ -18,6 +20,30 @@ pub mod net {
             match socket::getsockopt(self, socket::sockopt::IpMtu) {
                 Ok(mtu) => Ok(mtu as u32),
                 Err(errno) => Err(io::Error::from(errno)),
+            }
+        }
+
+        #[cfg(any(doc, target_os = "android", target_os = "linux"))]
+        fn attach_reuse_port_cbpf(&self, filter: &[libc::sock_filter]) -> io::Result<()> {
+            unsafe {
+                let fprog = libc::sock_fprog {
+                    len: filter.len() as u16,
+                    filter: filter.as_ptr() as *mut _,
+                };
+
+                let res = libc::setsockopt(
+                    self.as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_ATTACH_REUSEPORT_CBPF,
+                    (&fprog as *const libc::sock_fprog).cast(),
+                    std::mem::size_of_val(&fprog) as libc::socklen_t,
+                );
+
+                if res < 0 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(())
+                }
             }
         }
     }


### PR DESCRIPTION
Add a wrapper for SO_ATTACH_REUSEPORT_CBPF.  Prerequisite for #322 packet steering.