### PR TITLE
use SO_REUSEPORT to support multiple ingress workers

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -579,6 +579,7 @@ dependencies = [
  "open-enum",
  "openssl",
  "openssl-sys",
+ "socket2",
  "tokio",
  "tokio-tun",
  "tokio-util",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -15,12 +15,13 @@ hdrhistogram = { version = "7.5.4" }
 open-enum = { version = "0.5.1" }
 openssl-sys = { version = "0.9.102" }
 openssl = { version = "0.10.64" }
+socket2 = { version = "0.5.7" }
 tokio-tun = { version = "0.11.5" }
+tokio-util = { version = "0.7.11", features = ["rt"] }
 tokio = { version = "1.37.0", features = ["full"] }
+tracing = "0.1.40"
 zerocopy-derive = { version = "0.7.34" }
 zerocopy = { version = "0.7.34", features = ["byteorder"] }
-tokio-util = { version = "0.7.11", features = ["rt"] }
-tracing = "0.1.40"
 zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "tokio-tun", "zerocopy"] }
 
 [features]

--- a/adapter/ph/src/agent_output_worker.rs
+++ b/adapter/ph/src/agent_output_worker.rs
@@ -10,6 +10,8 @@ use zpr_ext::tokio_tun::*;
 
 #[derive(Copy, Clone)]
 pub struct Config {
+    #[allow(dead_code)]
+    pub worker_index: usize,
     pub batch_size: usize,
 }
 

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -58,6 +58,8 @@ pub struct Assembly<'pktbuf> {
     pub tun_ctl: TunCtl<'pktbuf>,
 
     pub sync_req_state: SyncReqState<'pktbuf>,
+
+    pub peer_addr: std::net::SocketAddr, // TEMP HACK
 }
 
 pub struct SyncReqState<'pktbuf> {

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -257,11 +257,12 @@ pub fn substrate_egress<'pktbuf>(
         todo!("link routing");
     }
 
-    match asm
-        .substrate_egress
-        .try_enqueue_packet(drop_guard(pkt, |p| {
-            drop_and_count(asm, p, CounterType::OutPacksSent)
-        })) {
+    let dest_sa = asm.peer_addr; // TEMP HACK
+
+    match asm.substrate_egress.try_enqueue_packet(
+        drop_guard(pkt, |p| drop_and_count(asm, p, CounterType::OutPacksSent)),
+        dest_sa,
+    ) {
         Ok(()) => (),
         Err(TryEnqueueError::Full(pkt)) => {
             drop_and_count(asm, pkt.into_inner(), CounterType::OutPacksErr)

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -163,10 +163,6 @@ fn main() -> ExitCode {
                     .await
                     .expect("unable to bind to self addr"),
             ));
-            socket
-                .connect(peer_addr)
-                .await
-                .expect("unable to connect to peer addr");
 
             let agent_input = AgentInput::new(tun_devs.iter());
             let substrate_egress = SubstrateEgress::new([&*socket]);
@@ -182,6 +178,7 @@ fn main() -> ExitCode {
                 counters,
                 tun_ctl,
                 sync_req_state,
+                peer_addr,
             }));
 
             // TODO signal handler goes here

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -101,12 +101,13 @@ fn main() -> ExitCode {
     // sizes below which are all just double the batch size.  Performance
     // testing will inform us the correct values for these, which balance
     // throughput with service time.
+    let substrate_socket_count = 4;
     let substrate_ingress_batch_size = 8;
     let mgmt_processor_queue_size = 16;
     let agent_output_batch_size = 4;
     let capture_queue_size = 16;
     let capture_batch_size = 8;
-    let tun_queue_count = 1;
+    let tun_queue_count = 4;
 
     let buf_storage = vec![[0u8; config::PACKET_BUFFER_SIZE]; 256];
     let buffer_stack = BufferStack::new(buf_storage.leak::<'static>());
@@ -158,14 +159,26 @@ fn main() -> ExitCode {
             let tun_ctl = tun_ctl::TunCtl::new(&tun_devs[0]);
 
             tun_ctl.set_carrier(false).unwrap();
-            let socket = Box::leak(Box::new(
-                UdpSocket::bind(self_addr)
-                    .await
-                    .expect("unable to bind to self addr"),
-            ));
+
+            let mut sockets = Vec::new();
+            for _i in 0..substrate_socket_count {
+                let socket = socket2::Socket::new(
+                    socket2::Domain::for_address(self_addr),
+                    socket2::Type::DGRAM,
+                    None,
+                )
+                .unwrap();
+                socket.set_nonblocking(true).unwrap();
+                socket.set_reuse_port(true).unwrap();
+                socket
+                    .bind(&socket2::SockAddr::from(self_addr))
+                    .expect("unable to bind to self addr");
+                sockets.push(UdpSocket::from_std(socket.into()).unwrap());
+            }
+            let sockets = sockets.leak();
 
             let agent_input = AgentInput::new(tun_devs.iter());
-            let substrate_egress = SubstrateEgress::new([&*socket]);
+            let substrate_egress = SubstrateEgress::new(sockets.iter());
 
             let asm = Box::leak(Box::new(Assembly {
                 buffer_stack,
@@ -213,9 +226,10 @@ fn main() -> ExitCode {
 
             js.spawn(mgmt_processor_worker::launch(&*asm, mp_outq));
 
-            for tun_dev in tun_devs.iter() {
+            for (worker_index, tun_dev) in tun_devs.iter().enumerate() {
                 js.spawn(agent_output_worker::launch(
                     &agent_output_worker::Config {
+                        worker_index,
                         batch_size: agent_output_batch_size,
                     },
                     &*asm,
@@ -237,13 +251,16 @@ fn main() -> ExitCode {
             eprintln!("Connected!"); // FIXME: it's a lie
             asm.tun_ctl.set_carrier(true).unwrap();
 
-            js.spawn(substrate_ingress_worker::launch(
-                &substrate_ingress_worker::Config {
-                    batch_size: substrate_ingress_batch_size,
-                },
-                &*asm,
-                &*socket,
-            ));
+            for (worker_index, socket) in sockets.iter().enumerate() {
+                js.spawn(substrate_ingress_worker::launch(
+                    &substrate_ingress_worker::Config {
+                        worker_index,
+                        batch_size: substrate_ingress_batch_size,
+                    },
+                    &*asm,
+                    socket,
+                ));
+            }
 
             mgmt::send_report(asm, zpr::ADAPTER_DOCKING_SESSION_ID, "Reporting for Duty!").await;
             mgmt::send_discard(asm, zpr::ADAPTER_DOCKING_SESSION_ID).await;

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -127,10 +127,11 @@ impl<'a> SubstrateEgress<'a> {
     pub fn try_enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>(
         &self,
         packet: P,
+        dest_sa: std::net::SocketAddr,
     ) -> Result<(), TryEnqueueError<P>> {
         let socket = self.sockets[packet.flowhash() as usize % self.sockets.len()];
 
-        match socket.try_send(packet.body()) {
+        match socket.try_send_to(packet.body(), dest_sa) {
             Ok(_) => Ok(()),
 
             Err(err) => {

--- a/adapter/ph/src/substrate_ingress_worker.rs
+++ b/adapter/ph/src/substrate_ingress_worker.rs
@@ -8,6 +8,8 @@ use tokio::net::UdpSocket;
 
 #[derive(Copy, Clone)]
 pub struct Config {
+    #[allow(dead_code)]
+    pub worker_index: usize,
     pub batch_size: usize,
 }
 

--- a/adapter/ph/test/basic-test.sh
+++ b/adapter/ph/test/basic-test.sh
@@ -65,8 +65,8 @@ function create_network() {
 
   # TUN devices
 
-  sudo ip -n zpr-a tuntap add name tun0 mode tun user "$ZPR_USER"
-  sudo ip -n zpr-b tuntap add name tun0 mode tun user "$ZPR_USER"
+  sudo ip -n zpr-a tuntap add name tun0 mode tun user "$ZPR_USER" multi_queue
+  sudo ip -n zpr-b tuntap add name tun0 mode tun user "$ZPR_USER" multi_queue
 
   sudo ip -n zpr-a addr add "$A_ZPR_ADDR" peer "$B_ZPR_ADDR" dev tun0
   sudo ip -n zpr-b addr add "$B_ZPR_ADDR" peer "$A_ZPR_ADDR" dev tun0


### PR DESCRIPTION
Two changes here:

1. I use the SO_REUSEPORT socket option to allow opening multiple susbtrate ingress sockets, and therefore multiple substrate ingress workers.  This sets us up for correctly writing code which is shared by multiple workers (such as the Dock Lookup Table).  In this configuration, packets get distributed by the kernel to workers based on their IP flow hash, meaning that links (which are identified by IP source address+port) get pinned to a worker.  This is good because DLT keys (link:flow) can be partitioned by link ID.  This is bad because it can lead to uneven load balancing (e.g. if there's only one link, only one worker will get used); that will be addressed in another PR.

2. The sockets no longer `connect()`, we now use `send_to()` to specify the destination for each packet.  This was necessary for load balancing to work correctly.  (If the sockets were connected Linux did not load balance amongst them.)  It's labeled as a "TEMP HACK" for now because I have a follow-on task to actually make a link lookup table, vs. right now it only works for a single link.

These mostly address #322.