### PR TITLE
ingress packet steering

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cbpf-rs"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "cc"
@@ -576,6 +576,7 @@ dependencies = [
  "crossbeam-epoch",
  "enum-map",
  "hdrhistogram",
+ "libc",
  "open-enum",
  "openssl",
  "openssl-sys",
@@ -930,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "zpr-ext"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "libc",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -12,6 +12,7 @@ clap = { version = "4.5.7", features = ["derive"] }
 crossbeam-epoch = { version = "0.9.18", optional = true }
 enum-map = { version = "2.7.3" }
 hdrhistogram = { version = "7.5.4" }
+libc = { version = "0.2.155" }
 open-enum = { version = "0.5.1" }
 openssl-sys = { version = "0.9.102" }
 openssl = { version = "0.10.64" }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(feature = "ci", deny(warnings))]
 
+use cbpf_rs::bpf_code;
 use clap::Parser;
 use enum_map::{enum_map, EnumMap};
 use std::fs;
@@ -12,6 +13,8 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_tun::TunBuilder;
+use tracing::warn;
+use zpr_ext::tokio::net::UdpSocketExt;
 
 mod agent_output_worker;
 mod assembly;
@@ -157,6 +160,7 @@ fn main() -> ExitCode {
 
             tun_ctl.set_carrier(false).unwrap();
 
+            // Open ingress sockets.
             let mut sockets = Vec::new();
             for _i in 0..substrate_socket_count {
                 let socket = socket2::Socket::new(
@@ -172,6 +176,77 @@ fn main() -> ExitCode {
                     .expect("unable to bind to self addr");
                 sockets.push(UdpSocket::from_std(socket.into()).unwrap());
             }
+
+            // Configure packet steering to separate flows for better load balancing.
+            // It's OK if this fails; flows will still be pinned to a queue;
+            // they'll just be pinned there with all other flows from the same link.
+            #[cfg(any(target_os = "android", target_os = "linux"))]
+            {
+                use crate::zdp::*;
+                use bpf_code::*;
+                use libc::sock_filter as sf;
+                use std::mem::{offset_of, size_of};
+
+                // TODO/FIXME: Ideally we want to select the queue by the _sum_ of the
+                // hash and stream ID, thus avoiding clumping due to correlated stream IDs between
+                // links.  That requires eBPF though, since the hash value is only present for
+                // eBPF programs (see <https://github.com/torvalds/linux/blob/master/net/core/sock_reuseport.c#L595-L598>).
+                // (`[SKF_AD_RXHASH]` just reads as 0!)
+                let prog = &[
+                    // [0] load ZPI and packet type
+                    sf {
+                        code: LD | H | ABS,
+                        jt: 0,
+                        jf: 0,
+                        k: 0,
+                    },
+                    // [1] if packet is encrypted, or packet is non-flow, fall back to hash
+                    sf {
+                        code: JMP | JSET | K,
+                        jt: 3,
+                        jf: 0,
+                        k: ((zpr::ZPI_ENCRYPTED_HEADER_FLAG as u32) << 8)
+                            | ZDP_PACKET_TYPE_NON_FLOW_FLAG as u32,
+                    },
+                    // [2] load stream ID
+                    sf {
+                        code: LD | W | ABS,
+                        jt: 0,
+                        jf: 0,
+                        k: (size_of::<ZdpZpiHeader>()
+                            + size_of::<ZdpBaseHeader>()
+                            + offset_of!(ZdpPerFlowHeader, stream_id))
+                            as u32,
+                    },
+                    // [3] modulo # of queues
+                    sf {
+                        code: ALU | MOD | K,
+                        jt: 0,
+                        jf: 0,
+                        k: substrate_socket_count,
+                    },
+                    // [4] return as selected queue #
+                    sf {
+                        code: RET | A,
+                        jt: 0,
+                        jf: 0,
+                        k: 0,
+                    },
+                    // [5] return huge value to force fallback to hash-based steering
+                    sf {
+                        code: RET | K,
+                        jt: 0,
+                        jf: 0,
+                        k: u32::MAX,
+                    },
+                ];
+
+                match sockets[0].attach_reuse_port_cbpf(prog) {
+                    Ok(()) => (),
+                    Err(err) => warn!("Unable to enable ingress packet steering: {err}"),
+                }
+            }
+
             let sockets = sockets.leak();
 
             let agent_input = AgentInput::new(tun_devs.iter());

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -47,9 +47,11 @@ pub enum ZdpPacketType {
     Report = 145,
 }
 
+pub const ZDP_PACKET_TYPE_NON_FLOW_FLAG: u8 = 0x80;
+
 impl ZdpPacketType {
     pub fn is_per_flow(self) -> bool {
-        self.0 < 128
+        self.0 & ZDP_PACKET_TYPE_NON_FLOW_FLAG == 0
     }
 
     pub fn is_response(self) -> bool {

--- a/adapter/ph/src/zpr.rs
+++ b/adapter/ph/src/zpr.rs
@@ -7,6 +7,9 @@ pub type Zpi = u8;
 /// ZPI 0, used for keying and early ZARP.
 pub const ZPI_0: Zpi = 0;
 
+/// Proposed value to allow easily distinguishing packets with plaintext payloads.
+pub const ZPI_ENCRYPTED_HEADER_FLAG: Zpi = 0x80;
+
 /// The Security Association ID must fit no more than 8 bits.  Note that it shares
 /// space with the ZPI.
 pub type SaId = u8;


### PR DESCRIPTION
Uses a cBPF program to tell the kernel how to steer packets into our queues.  As-is, this code steers unencrypted per-flow messages (which includes, importantly, transit packets) by stream ID, and all other packets by IP hash (effectively, by link ID).

This still suffers from the issue that stream IDs may be correlated between links (e.g. multiple links all using low-numbered stream IDs).  The solution to this issue is to add the IP hash to the stream ID.  Unfortunately that information is not available to a cBPF packet steerer (which I think must be an oversight by the kernel folk, since it's available to cBPF filters).  It _is_ available to an eBPF packet steerer, but that interface is more complex, so I'm just making that a TODO for now (#332).

Also, `main()` is getting messy, I've opened #333 to address that.