### PR TITLE
added pkt.advance to different branches of conditionals, altered cap …

### DIFF
--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -141,12 +141,16 @@ pub fn maybe_capture_batch<'a, 'pktbuf: 'a>(
                 }
 
                 None => {
+                    // remove direction indicator from beginning of packet
+                    pkt.advance(std::mem::size_of::<zdp_ll::ZdpLinkP2P>());
                     // No sense to try acquiring more buffers; exit the loop early.
                     break;
                 }
             }
         } else {
             num_filtered += 1;
+            // remove direction indicator from beginning of packet
+            pkt.advance(std::mem::size_of::<zdp_ll::ZdpLinkP2P>());
         }
     }
 

--- a/adapter/ph/test/capture-test.sh
+++ b/adapter/ph/test/capture-test.sh
@@ -36,7 +36,6 @@ function set_program() {
 
 function close_program() {
   SOCKET=$1
-  "$PH_DEBUG_BIN" -c DELETE-CAPTURE-PROGRAM -p "$SOCKET"
   "$PH_DEBUG_BIN" -c CLOSE-CAPTURE-FILE -p "$SOCKET"
 }
 
@@ -100,7 +99,7 @@ stty sane || true
 # Run test
 #
 
-set_program "$A_ZPR_SOCK" "$TMPDIR/cap_test1.pcap" 'link[0] == 1 || link[0] == 0'
+set_program "$A_ZPR_SOCK" "$TMPDIR/cap_test1.pcap" 'link[0] == 1'
 set_program "$B_ZPR_SOCK" "$TMPDIR/cap_test2.pcap" None
 
 PASS=0
@@ -113,9 +112,9 @@ close_program "$B_ZPR_SOCK"
 
 # Make sure correct number of incoming packets were captured, either 23 or 24 depending 
 # on whether two hello requests are received 
-tcpdump -r "$TMPDIR/cap_test1.pcap" 'link[0] = 1' > "$TMPDIR/checker.pcap"
+tcpdump -r "$TMPDIR/cap_test1.pcap" 'link[0] = 1 or link[0] == 0' > "$TMPDIR/checker.pcap"
 HELLO_COUNT="$(grep -c '0x0000:  0100 8800 0000' "$TMPDIR/checker.pcap")"
-PACKET_COUNT="$(grep -c '0x0000:  01' "$TMPDIR/checker.pcap")"
+PACKET_COUNT="$(grep -c '0x0000:  0' "$TMPDIR/checker.pcap")"
 
 if [[ ("$PACKET_COUNT" != "23" || "$HELLO_COUNT" != "1") &&  ("$PACKET_COUNT" != "24" || "$HELLO_COUNT" != "2") ]]
 then PASS=1


### PR DESCRIPTION
...test

This PR does two things:
- I altered the capture test to actually make sure that the program is filtering correctly: now the program should only capture inbound packets, but the tcpdump will count the number of inbound and outbound packets, to make sure packets are being properly filtered
- I also added pkt.advance to two places in the maybe_capture function where a `match` or conditional could cause the function to reach a place where the link-layer header was not removed, even though one had been added. 