### PR TITLE
cbpf-rs: fix bugs found thanks to fuzz testing!

### DIFF
--- a/cbpf-rs/.gitignore
+++ b/cbpf-rs/.gitignore
@@ -1,1 +1,3 @@
-/target
+target
+fuzz/corpus
+fuzz/target

--- a/cbpf-rs/src/lib.rs
+++ b/cbpf-rs/src/lib.rs
@@ -527,7 +527,10 @@ impl BpfProgram {
             }
         }
 
-        if !insns.last().is_some_and(|insn| code_class(insn.code) == RET) {
+        if !insns
+            .last()
+            .is_some_and(|insn| code_class(insn.code) == RET)
+        {
             return Err(BpfError::MissingReturn);
         }
 

--- a/cbpf-rs/src/lib.rs
+++ b/cbpf-rs/src/lib.rs
@@ -51,6 +51,10 @@ pub mod bpf_code {
     pub const H: u16 = 0x08;
     pub const B: u16 = 0x10;
 
+    pub fn valid_code_size(code_size: u16) -> bool {
+        code_size != 0x18
+    }
+
     pub fn code_mode(code: u16) -> u16 {
         code & 0xe0
     }
@@ -280,8 +284,9 @@ impl BpfProgram {
                 u16pat!(LD | MEM) => a = *unsafe { mem.get_unchecked(insn.k as usize) },
                 u16pat!(LDX | MEM) => x = *unsafe { mem.get_unchecked(insn.k as usize) },
 
-                u16pat!(ST) => *unsafe { mem.get_unchecked_mut(insn.k as usize) } = a,
-                u16pat!(STX) => *unsafe { mem.get_unchecked_mut(insn.k as usize) } = x,
+                // NOTE: libpcap is bugged here and doesn't look for MEM
+                u16pat!(ST | MEM) => *unsafe { mem.get_unchecked_mut(insn.k as usize) } = a,
+                u16pat!(STX | MEM) => *unsafe { mem.get_unchecked_mut(insn.k as usize) } = x,
 
                 u16pat!(JMP | JA) => {
                     /* deliberate wrapping for backwards jumps */
@@ -391,14 +396,38 @@ impl BpfProgram {
             }
 
             match code_class(insn.code) {
-                LD | LDX => match code_mode(insn.code) {
+                LD => match code_mode(insn.code) {
                     IMM | LEN => {
                         if code_size(insn.code) != W {
                             return Err(BpfError::InvalidInstruction);
                         }
                     }
 
-                    ABS | IND => (),
+                    ABS | IND => {
+                        if !valid_code_size(code_size(insn.code)) {
+                            return Err(BpfError::InvalidInstruction);
+                        }
+                    }
+
+                    MEM => {
+                        if code_size(insn.code) != W {
+                            return Err(BpfError::InvalidInstruction);
+                        }
+
+                        if insn.k as usize >= MEMWORDS {
+                            return Err(BpfError::BadMemoryAccess);
+                        }
+                    }
+
+                    _ => return Err(BpfError::InvalidInstruction),
+                },
+
+                LDX => match code_mode(insn.code) {
+                    IMM | LEN => {
+                        if code_size(insn.code) != W {
+                            return Err(BpfError::InvalidInstruction);
+                        }
+                    }
 
                     MSH => {
                         if code_size(insn.code) != B {
@@ -498,7 +527,7 @@ impl BpfProgram {
             }
         }
 
-        if !insns.last().is_some_and(|insn| insn.code == RET) {
+        if !insns.last().is_some_and(|insn| code_class(insn.code) == RET) {
             return Err(BpfError::MissingReturn);
         }
 


### PR DESCRIPTION
@owenrhysthomas's fuzz testing work (#344) has paid off!!  Running on my laptop found a bunch of bugs within 5 minutes.  All relating to opcode handling differences between validation and filtering.  This PR contains fixes for them.

Also this fixes a bug I found by observation, that the validator incorrectly rejects programs which end in `ret A`.

Running now for about 1/2 hour fuzzing finds no more issues, so I think we're good now?

For reference: `cargo fuzz run filter` should run fuzz testing for packet filtering.

(Note, excepting the `ret A` bug, all of these were also present in the `libpcap` source I modeled this after.)

Once ZPR is open-sourced we will have to add this to the `rust-fuzz` [trophy case](https://github.com/rust-fuzz/trophy-case) Owen found :)