### PR TITLE
actually compress/expand packets (L3 only for now)

### DIFF
--- a/adapter/ph/src/adapter_tables.rs
+++ b/adapter/ph/src/adapter_tables.rs
@@ -6,7 +6,7 @@
 
 use crate::defs::FiveTuple;
 use crate::rcu::RcuBox;
-use crate::zpr::{CompressionMode, L3Type, StreamId};
+use crate::zpr::{CompressionMode, StreamId};
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::DashMap;
 use std::sync::Mutex;
@@ -14,7 +14,6 @@ use std::sync::Mutex;
 const DOCK_LOOKUP_TABLE_SIZE: usize = 1 << 24; // 16 million
 
 pub struct AltPep {
-    pub l3_type: L3Type,
     pub compression_mode: CompressionMode,
     pub stream_id: StreamId,
 }
@@ -49,7 +48,6 @@ impl AgentLookupTable {
 }
 
 pub struct DltPep {
-    pub l3_type: L3Type,
     pub compression_mode: CompressionMode,
     pub five_tuple: FiveTuple,
 }

--- a/adapter/ph/src/classifier.rs
+++ b/adapter/ph/src/classifier.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use crate::net_defs::*;
 use crate::packet;
+use crate::zpr::L3Type;
 use std::mem::size_of;
 use zerocopy::{AsBytes, FromZeroes, KnownLayout, Unaligned};
 use zerocopy::{ByteOrder, FromBytes, NetworkEndian};
@@ -103,6 +104,8 @@ fn classify_ipv4(
     metadata: &mut packet::PacketMetadata,
     body: &[u8],
 ) -> Result<ClassifierResult, &'static str> {
+    metadata.set_l3_type(L3Type::Ipv4);
+
     // Check that there's enough room in the packet data for the base header (no options)
     if size_of::<IPv4Header>() > body.len() {
         return Err("Packet length error");
@@ -129,7 +132,7 @@ fn classify_ipv4(
     const MORE_FRAGMENTS_MASK: u16 = 0x2000;
     let frag_offset = NetworkEndian::read_u16(&ipv4_header.frag_offset);
     if frag_offset & FRAGMENT_OFFSET_MASK != 0 {
-        metadata.set_protocol(ipv4_header.proto);
+        metadata.set_l4_protocol(ipv4_header.proto);
         return Ok(ClassifierResult::SubsequentFragment);
     }
 
@@ -147,6 +150,8 @@ fn classify_ipv6(
     metadata: &mut packet::PacketMetadata,
     body: &[u8],
 ) -> Result<ClassifierResult, &'static str> {
+    metadata.set_l3_type(L3Type::Ipv6);
+
     // Check that there's enough room in the packet data for the base header (no options)
     if size_of::<IPv6Header>() > body.len() {
         return Err("Packet length error");
@@ -169,7 +174,7 @@ fn classify_next_header(
     body: &[u8],
     protocol: IpProtocol,
 ) -> Result<ClassifierResult, &'static str> {
-    metadata.set_protocol(protocol);
+    metadata.set_l4_protocol(protocol);
     match protocol {
         0 => return skip_v6_option(metadata, body),  // Hop-by-hop
         1 => return classify_icmp(metadata, body),   // ICMP
@@ -325,7 +330,7 @@ mod tests {
         assert_eq!(IpAddress::new_zeroed(), metadata.get_dst_address());
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
-        assert_eq!(0u8, metadata.get_protocol());
+        assert_eq!(0u8, metadata.get_l4_protocol());
     }
 
     // Begin IPv4 tests
@@ -359,7 +364,7 @@ mod tests {
         );
         assert_eq!(0x14u16, metadata.get_src_port_hbo());
         assert_eq!(0x50u16, metadata.get_dst_port_hbo());
-        assert_eq!(6u8, metadata.get_protocol());
+        assert_eq!(6u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -384,6 +389,7 @@ mod tests {
         );
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv4, metadata.get_l3_type());
         assert_eq!(
             [0x04, 0x03, 0x02, 0x01],
             metadata.get_dst_address().read_as_v4()
@@ -394,7 +400,7 @@ mod tests {
         );
         assert_eq!(0x14u16, metadata.get_src_port_hbo());
         assert_eq!(0x50u16, metadata.get_dst_port_hbo());
-        assert_eq!(6u8, metadata.get_protocol());
+        assert_eq!(6u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -419,6 +425,7 @@ mod tests {
         );
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv4, metadata.get_l3_type());
         assert_eq!(
             [0x04, 0x03, 0x02, 0x01],
             metadata.get_dst_address().read_as_v4()
@@ -429,7 +436,7 @@ mod tests {
         );
         assert_eq!(0x0u16, metadata.get_src_port_hbo());
         assert_eq!(0x0u16, metadata.get_dst_port_hbo());
-        assert_eq!(6u8, metadata.get_protocol());
+        assert_eq!(6u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -452,7 +459,7 @@ mod tests {
         assert_eq!(IpAddress::new_zeroed(), metadata.get_dst_address());
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
-        assert_eq!(0u8, metadata.get_protocol());
+        assert_eq!(0u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -474,11 +481,12 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv4, metadata.get_l3_type());
         assert_eq!(IpAddress::new_zeroed(), metadata.get_src_address());
         assert_eq!(IpAddress::new_zeroed(), metadata.get_dst_address());
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
-        assert_eq!(0u8, metadata.get_protocol());
+        assert_eq!(0u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -500,11 +508,12 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv4, metadata.get_l3_type());
         assert_eq!(IpAddress::new_zeroed(), metadata.get_src_address());
         assert_eq!(IpAddress::new_zeroed(), metadata.get_dst_address());
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
-        assert_eq!(0u8, metadata.get_protocol());
+        assert_eq!(0u8, metadata.get_l4_protocol());
     }
 
     // Begin IPv6 tests
@@ -532,6 +541,7 @@ mod tests {
         assert_eq!(ClassifierResult::OK, classify(&mut packet).unwrap());
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv6, metadata.get_l3_type());
         assert_eq!(
             IpAddress {
                 v6: [
@@ -552,7 +562,7 @@ mod tests {
         );
         assert_eq!(43424u16, metadata.get_src_port_hbo());
         assert_eq!(8080u16, metadata.get_dst_port_hbo());
-        assert_eq!(6u8, metadata.get_protocol());
+        assert_eq!(6u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -586,6 +596,7 @@ mod tests {
         );
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv6, metadata.get_l3_type());
         assert_eq!(
             IpAddress {
                 v6: [
@@ -606,7 +617,7 @@ mod tests {
         );
         assert_eq!(6363u16, metadata.get_dst_port_hbo());
         assert_eq!(6363u16, metadata.get_src_port_hbo());
-        assert_eq!(17u8, metadata.get_protocol());
+        assert_eq!(17u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -633,6 +644,7 @@ mod tests {
         );
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv6, metadata.get_l3_type());
         assert_eq!(
             IpAddress {
                 v6: [
@@ -653,7 +665,7 @@ mod tests {
         );
         assert_eq!(0u16, metadata.get_dst_port_hbo());
         assert_eq!(0u16, metadata.get_src_port_hbo());
-        assert_eq!(44u8, metadata.get_protocol());
+        assert_eq!(44u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -690,6 +702,7 @@ mod tests {
         );
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv6, metadata.get_l3_type());
         assert_eq!(
             IpAddress {
                 v6: [
@@ -710,7 +723,7 @@ mod tests {
         );
         assert_eq!(0u16, metadata.get_dst_port_hbo());
         assert_eq!(0u16, metadata.get_src_port_hbo());
-        assert_eq!(41u8, metadata.get_protocol());
+        assert_eq!(41u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -739,6 +752,7 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv6, metadata.get_l3_type());
         assert_eq!(
             IpAddress {
                 v6: [
@@ -759,7 +773,7 @@ mod tests {
         );
         assert_eq!(0u16, metadata.get_dst_port_hbo());
         assert_eq!(0u16, metadata.get_src_port_hbo());
-        assert_eq!(43u8, metadata.get_protocol());
+        assert_eq!(43u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -773,11 +787,12 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv6, metadata.get_l3_type());
         assert_eq!(IpAddress::new_zeroed(), metadata.get_src_address());
         assert_eq!(IpAddress::new_zeroed(), metadata.get_dst_address());
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
-        assert_eq!(0u8, metadata.get_protocol());
+        assert_eq!(0u8, metadata.get_l4_protocol());
     }
 
     // Begin TCP tests
@@ -799,6 +814,7 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv4, metadata.get_l3_type());
         assert_eq!(
             [0x04, 0x03, 0x02, 0x01],
             metadata.get_dst_address().read_as_v4()
@@ -809,7 +825,7 @@ mod tests {
         );
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
-        assert_eq!(6u8, metadata.get_protocol());
+        assert_eq!(6u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -830,6 +846,7 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv4, metadata.get_l3_type());
         assert_eq!(
             [0x04, 0x03, 0x02, 0x01],
             metadata.get_dst_address().read_as_v4()
@@ -840,7 +857,7 @@ mod tests {
         );
         assert_eq!(0x0u16, metadata.get_src_port_hbo());
         assert_eq!(0x0u16, metadata.get_dst_port_hbo());
-        assert_eq!(6u8, metadata.get_protocol());
+        assert_eq!(6u8, metadata.get_l4_protocol());
     }
 
     #[test]
@@ -861,6 +878,7 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv4, metadata.get_l3_type());
         assert_eq!(
             [0x04, 0x03, 0x02, 0x01],
             metadata.get_dst_address().read_as_v4()
@@ -871,7 +889,7 @@ mod tests {
         );
         assert_eq!(0x0u16, metadata.get_src_port_hbo());
         assert_eq!(0x0u16, metadata.get_dst_port_hbo());
-        assert_eq!(6u8, metadata.get_protocol());
+        assert_eq!(6u8, metadata.get_l4_protocol());
     }
 
     // Begin UDP tests
@@ -893,6 +911,7 @@ mod tests {
         assert!(classify(&mut packet).is_err());
 
         let metadata = packet.metadata();
+        assert_eq!(L3Type::Ipv4, metadata.get_l3_type());
         assert_eq!(
             [0x04, 0x03, 0x02, 0x01],
             metadata.get_dst_address().read_as_v4()
@@ -903,6 +922,6 @@ mod tests {
         );
         assert_eq!(0u16, metadata.get_src_port_hbo());
         assert_eq!(0u16, metadata.get_dst_port_hbo());
-        assert_eq!(6u8, metadata.get_protocol());
+        assert_eq!(6u8, metadata.get_l4_protocol());
     }
 }

--- a/adapter/ph/src/compress.rs
+++ b/adapter/ph/src/compress.rs
@@ -1,10 +1,10 @@
 //! ZDP Header Compression (RFC 6.5 § 5.26)
 
-#![allow(dead_code)]
-
 use crate::classifier;
+use crate::defs::FiveTuple;
 use crate::net_defs;
 use crate::packet::Packet;
+use crate::zpr::{CompressionMode, L3Type};
 use bytes::Buf;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use zerocopy::FromBytes;
@@ -12,7 +12,7 @@ use zerocopy::{AsBytes, FromZeroes, Unaligned};
 
 #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(packed)]
-pub struct CompressedIPv4Header {
+struct CompressedIPv4Header {
     pub vhl: u8,
     pub dscp: u8,
     pub frag_id: [u8; 2],
@@ -22,22 +22,14 @@ pub struct CompressedIPv4Header {
 
 #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(packed)]
-pub struct CompressedIPv6Header {
+struct CompressedIPv6Header {
     pub version_and_tc_upper: u8,
     pub tc_lower_and_fl_upper: u8,
     pub fl_lower: [u8; 2],
     pub hop_limit: u8,
 }
 
-pub fn compress_addrs(pkt: &mut Packet) {
-    match classifier::get_ip_version(pkt.body()) {
-        4 => compress_addrs_v4(pkt),
-        6 => compress_addrs_v6(pkt),
-        _ => (),
-    }
-}
-
-pub fn compress_addrs_v4(pkt: &mut Packet) {
+fn compress_addrs_v4(pkt: &mut Packet) {
     let hdr = classifier::IPv4Header::ref_from_prefix(pkt.body()).unwrap();
     let vhl = hdr.vhl;
     let dscp = hdr.dscp;
@@ -55,7 +47,7 @@ pub fn compress_addrs_v4(pkt: &mut Packet) {
     chdr.ttl = ttl;
 }
 
-pub fn expand_addrs_v4(pkt: &mut Packet, proto: u8, src_address: Ipv4Addr, dst_address: Ipv4Addr) {
+fn expand_addrs_v4(pkt: &mut Packet, proto: u8, src_address: Ipv4Addr, dst_address: Ipv4Addr) {
     let chdr = CompressedIPv4Header::ref_from_prefix(pkt.body()).unwrap();
     let vhl = chdr.vhl;
     let dscp = chdr.dscp;
@@ -86,7 +78,7 @@ pub fn expand_addrs_v4(pkt: &mut Packet, proto: u8, src_address: Ipv4Addr, dst_a
         .header_checksum = csum;
 }
 
-pub fn compress_addrs_v6(pkt: &mut Packet) {
+fn compress_addrs_v6(pkt: &mut Packet) {
     let hdr = classifier::IPv6Header::ref_from_prefix(pkt.body()).unwrap();
     let version_and_tc_upper = hdr.version_and_tc_upper;
     let tc_lower_and_fl_upper = hdr.tc_lower_and_fl_upper;
@@ -102,7 +94,7 @@ pub fn compress_addrs_v6(pkt: &mut Packet) {
     chdr.hop_limit = hop_limit;
 }
 
-pub fn expand_addrs_v6(
+fn expand_addrs_v6(
     pkt: &mut Packet,
     next_header: u8,
     src_address: Ipv6Addr,
@@ -131,4 +123,97 @@ pub fn expand_addrs_v6(
     hdr.dst_address = net_defs::IpAddress {
         v6: dst_address.octets(),
     };
+}
+
+pub fn compress(
+    compression_mode: CompressionMode,
+    l3_type: L3Type,
+    _l4_protocol: net_defs::IpProtocol,
+    pkt: &mut Packet,
+) {
+    match l3_type {
+        L3Type::Ipv4 => compress_addrs_v4(pkt),
+        L3Type::Ipv6 => compress_addrs_v6(pkt),
+        other => panic!("bad L3 type: {}", other.0),
+    }
+
+    if compression_mode != 0 {
+        todo!("L4 compression");
+    }
+}
+
+pub fn expand(compression_mode: CompressionMode, five_tuple: &FiveTuple, pkt: &mut Packet) {
+    match five_tuple.l3_type {
+        L3Type::Ipv4 => expand_addrs_v4(
+            pkt,
+            five_tuple.l4_protocol,
+            five_tuple.src_address.try_into().unwrap(),
+            five_tuple.dst_address.try_into().unwrap(),
+        ),
+        L3Type::Ipv6 => expand_addrs_v6(
+            pkt,
+            five_tuple.l4_protocol,
+            five_tuple.src_address.into(),
+            five_tuple.dst_address.into(),
+        ),
+        other => panic!("bad L3 type: {}", other.0),
+    }
+
+    if compression_mode != 0 {
+        todo!("L4 compression");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::classifier;
+    use crate::config;
+    use crate::packet::Packet;
+    use crate::zpr::CompressionMode;
+    use bytes::BufMut;
+
+    #[test]
+    fn test_round_trip() {
+        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
+
+        for &body in TEST_CASES {
+            let mut pkt = Packet::new(&mut buf, 256);
+            pkt.put(body);
+
+            let cls_res = classifier::classify(&mut pkt).unwrap();
+            assert!(
+                cls_res == classifier::ClassifierResult::OK
+                    || cls_res == classifier::ClassifierResult::UnclassifiedL4
+            );
+            let ft = *pkt.metadata().five_tuple();
+
+            let compression_mode: CompressionMode = 0; // TODO: iterate through compression modes
+            compress(compression_mode, ft.l3_type, ft.l4_protocol, &mut pkt);
+            expand(compression_mode, &ft, &mut pkt);
+
+            assert_eq!(pkt.body(), body);
+        }
+    }
+
+    const TEST_CASES: &[&[u8]] = &[
+        // ICMP Echo (ping) request
+        &[
+            0x45, 0x00, 0x00, 0x54, 0x46, 0xa2, 0x40, 0x00, 0x40, 0x01, 0x70, 0xb3, 0xc0, 0xa8,
+            0x01, 0x01, 0xc0, 0xa8, 0x01, 0x02, 0x08, 0x00, 0x5d, 0x2e, 0xf6, 0xae, 0x00, 0x01,
+            0x3c, 0xa0, 0xcc, 0x66, 0x00, 0x00, 0x00, 0x00, 0xda, 0x47, 0x02, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+            0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29,
+            0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+        ],
+        // ICMPv6 Neighbor Soliciation
+        &[
+            0x60, 0x00, 0x00, 0x00, 0x00, 0x20, 0x3a, 0xff, 0xfe, 0x80, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x0c, 0xbb, 0x7e, 0xa4, 0x55, 0xf1, 0x07, 0x9f, 0xff, 0x02, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xff, 0xf1, 0x00, 0x01, 0x87, 0x00,
+            0x1a, 0xe5, 0x00, 0x00, 0x00, 0x00, 0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x0c, 0xbb, 0x7e, 0xa4, 0x55, 0xf1, 0x00, 0x01, 0x01, 0x01, 0xe4, 0x60, 0x17, 0xd8,
+            0x9a, 0x4b,
+        ],
+    ];
 }

--- a/adapter/ph/src/defs.rs
+++ b/adapter/ph/src/defs.rs
@@ -1,6 +1,7 @@
 //! Common definitions that have no more specific place to live.
 
 use crate::net_defs;
+use crate::zpr;
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 /// Packet direction with respect to an interface.
@@ -18,25 +19,26 @@ pub enum Direction {
 pub struct FiveTuple {
     pub src_address: net_defs::IpAddress,
     pub dst_address: net_defs::IpAddress,
-    pub protocol: net_defs::IpProtocol,
-    pub padding: [u8; 1],
+    pub l3_type: zpr::L3Type,
+    pub l4_protocol: net_defs::IpProtocol,
     pub src_port: u16,
     pub dst_port: u16,
 }
 
 impl FiveTuple {
     pub fn new(
+        l3_type: zpr::L3Type,
         src_address: net_defs::IpAddress,
         dst_address: net_defs::IpAddress,
-        protocol: net_defs::IpProtocol,
+        l4_protocol: net_defs::IpProtocol,
         src_port: u16,
         dst_port: u16,
     ) -> Self {
         Self {
             src_address,
             dst_address,
-            protocol,
-            padding: [0],
+            l3_type,
+            l4_protocol,
             src_port,
             dst_port,
         }
@@ -46,8 +48,8 @@ impl FiveTuple {
         Self {
             src_address: self.dst_address,
             dst_address: self.src_address,
-            protocol: self.protocol,
-            padding: [0],
+            l3_type: self.l3_type,
+            l4_protocol: self.l4_protocol,
             src_port: self.dst_port,
             dst_port: self.src_port,
         }
@@ -58,8 +60,13 @@ impl std::fmt::Display for FiveTuple {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
-            "({}, {}, {}, {}, {})",
-            self.src_address, self.dst_address, self.protocol, self.src_port, self.dst_port
+            "({}, {}, {}, {}, {}, {})",
+            self.l3_type,
+            self.src_address,
+            self.dst_address,
+            self.l4_protocol,
+            self.src_port,
+            self.dst_port
         )
     }
 }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -5,6 +5,7 @@
 
 use crate::assembly::Assembly;
 use crate::classifier::{self, ClassifierResult};
+use crate::compress;
 use crate::counters_enum::CounterType;
 use crate::defs::Direction;
 use crate::net_defs;
@@ -376,26 +377,21 @@ pub fn agent_input<'pktbuf>(
     stream_id: zpr::StreamId, // TODO: should we keep this in metadata? or per-flow header?
     mut pkt: Packet<'pktbuf>,
 ) {
-    // lookup stream ID in DLT
+    // "Check" A2A checksum
+    pkt.advance(size_of::<zdp::ZdpSaidHeader>());
+    pkt.shrink(size_of::<zdp::ZdpMicvEnd>());
+
+    // lookup PEP in DLT and expand compressed packet
     if asm
         .dlt
         .inspect(stream_id, |pep| {
-            // decompress
-            if pep.compression_mode != 0 {
-                todo!("L4 compression");
-            }
-
-            // TODO
+            compress::expand(pep.compression_mode, &pep.five_tuple, &mut pkt)
         })
         .is_none()
     {
         drop_and_count(asm, pkt, CounterType::UnknownStreamId);
         return;
     }
-
-    // "Check" A2A checksum
-    pkt.advance(size_of::<zdp::ZdpSaidHeader>());
-    pkt.shrink(size_of::<zdp::ZdpMicvEnd>());
 
     // send out decapsulated packet
     match asm.agent_input.try_enqueue_packet(drop_guard(pkt, |p| {
@@ -438,11 +434,13 @@ pub fn agent_output<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) 
     let five_tuple = *pkt.metadata().five_tuple(); // TODO: convince borrow checker we don't need to copy this out
 
     match asm.alt.inspect(&five_tuple, |pep| {
-        if pep.compression_mode != 0 {
-            todo!("L4 compression")
-        }
-
-        // TODO: compress!
+        // compress packet
+        compress::compress(
+            pep.compression_mode,
+            five_tuple.l3_type,
+            five_tuple.l4_protocol,
+            &mut pkt,
+        );
 
         // "generate" A2A checksum
         pkt.alloc_zeroed_header::<zdp::ZdpSaidHeader>().a2a_said = 0;

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -173,6 +173,7 @@ fn main() -> ExitCode {
             // TEMP HACK: fill ALT & DLT based on TUN local & remote addresses
             for (remote_stream_id, protocol) in [1, 6, 17].into_iter().enumerate() {
                 let five_tuple = defs::FiveTuple::new(
+                    zpr::L3Type::Ipv4,
                     tun_devs[0].address().unwrap().into(),
                     tun_devs[0].destination().unwrap().into(),
                     protocol,
@@ -182,14 +183,12 @@ fn main() -> ExitCode {
                 alt.insert(
                     five_tuple,
                     adapter_tables::AltPep {
-                        l3_type: zpr::L3Type::IPv4,
                         compression_mode: 0,
                         stream_id: remote_stream_id as zpr::StreamId, /* TOTAL HACK */
                     },
                 );
                 let local_stream_id = dlt
                     .insert(adapter_tables::DltPep {
-                        l3_type: zpr::L3Type::IPv4,
                         compression_mode: 0,
                         five_tuple: five_tuple.reverse(),
                     })

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -35,6 +35,10 @@ impl IpAddress {
     pub fn read_as_v4(&self) -> [u8; 4] {
         *array_ref!(self.v6, 12, 4)
     }
+
+    pub fn is_v4(&self) -> bool {
+        self.v6[..12] == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff]
+    }
 }
 
 impl From<Ipv4Addr> for IpAddress {
@@ -54,6 +58,18 @@ impl From<IpAddr> for IpAddress {
         match addr {
             IpAddr::V4(v4) => v4.into(),
             IpAddr::V6(v6) => v6.into(),
+        }
+    }
+}
+
+impl TryFrom<IpAddress> for Ipv4Addr {
+    type Error = ();
+
+    fn try_from(addr: IpAddress) -> Result<Self, Self::Error> {
+        if addr.is_v4() {
+            Ok(addr.read_as_v4().into())
+        } else {
+            Err(())
         }
     }
 }

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -9,6 +9,7 @@
 use crate::config;
 use crate::defs::*;
 use crate::net_defs::*;
+use crate::zpr::L3Type;
 use bytes::buf;
 use std::mem::{size_of, size_of_val};
 use zerocopy::{AsBytes, ByteOrder, FromBytes, FromZeroes, NetworkEndian};
@@ -159,6 +160,10 @@ pub struct PacketMetadata {
 
 #[allow(dead_code)]
 impl PacketMetadata {
+    pub fn set_l3_type(&mut self, l3_type: L3Type) {
+        self.five_tuple.l3_type = l3_type;
+    }
+
     pub fn set_addresses(&mut self, src_addr: IpAddress, dst_addr: IpAddress) {
         self.five_tuple.src_address = src_addr;
         self.five_tuple.dst_address = dst_addr;
@@ -172,8 +177,12 @@ impl PacketMetadata {
         self.five_tuple.dst_port = NetworkEndian::read_u16(&dport)
     }
 
-    pub fn set_protocol(&mut self, proto: u8) {
-        self.five_tuple.protocol = proto
+    pub fn set_l4_protocol(&mut self, proto: IpProtocol) {
+        self.five_tuple.l4_protocol = proto
+    }
+
+    pub fn get_l3_type(&self) -> L3Type {
+        self.five_tuple.l3_type
     }
 
     pub fn get_src_address(&self) -> IpAddress {
@@ -192,8 +201,8 @@ impl PacketMetadata {
         self.five_tuple.dst_port
     }
 
-    pub fn get_protocol(&self) -> u8 {
-        self.five_tuple.protocol
+    pub fn get_l4_protocol(&self) -> IpProtocol {
+        self.five_tuple.l4_protocol
     }
 
     pub fn five_tuple(&self) -> &FiveTuple {

--- a/adapter/ph/src/zpr.rs
+++ b/adapter/ph/src/zpr.rs
@@ -1,6 +1,9 @@
 //! ZPR concepts, excluding the ZDP protocol.
 #![allow(dead_code)]
 
+use open_enum::open_enum;
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
+
 /// Substrate Address
 pub type SubstrateAddr = std::net::SocketAddr;
 
@@ -42,11 +45,22 @@ pub const KM_ID_IKEV2: KmId = 1;
 pub const KM_ID_NOISE: KmId = 2;
 
 /// ZPR agent packet L3 type (RFC 6.5 § 6.3.11)
-#[derive(Clone, Copy)]
+#[open_enum]
+#[derive(Clone, Copy, Debug, Hash, AsBytes, FromBytes, FromZeroes)]
 #[repr(u8)]
 pub enum L3Type {
-    IPv4 = 4,
-    IPv6 = 6,
+    Ipv4 = 4,
+    Ipv6 = 6,
+}
+
+impl std::fmt::Display for L3Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match *self {
+            Self::Ipv4 => write!(f, "IPv4"),
+            Self::Ipv6 => write!(f, "IPv6"),
+            other => write!(f, "[unknown L3 type {}]", other.0),
+        }
+    }
 }
 
 /// Bitmask indicating how an agent packet is compressed.


### PR DESCRIPTION
also:
* move L3 type into FiveTuple
* fill L3 type in classifier
* L3Type is now an open_enum
* rename 5t protocol -> l4_protocol