### PR TITLE
Generate and exchange symmetric keys (and ZPIs) during KM handshake

### DIFF
--- a/adapter/cd/src/zdp/client.rs
+++ b/adapter/cd/src/zdp/client.rs
@@ -83,8 +83,8 @@ impl ZDPClient {
                                 info!("zdp/client - new SA established");
                                 let mut pkt_buf = [0u8; config::PACKET_BUFFER_SIZE];
                                 let mut pkt = km_demo::build_zdp_report_packet(&mut pkt_buf, b"hello to you my dear node!");
-                                let (zpi_encr, _) = mgr.get_send_zpis();
-                                pkt.body_mut()[0] = zpi_encr;
+                                let send_zpis = mgr.get_send_zpis();
+                                pkt.body_mut()[0] = send_zpis.encr;
                                 match mgr.encrypt_transport(&mut pkt) {
                                     Ok(()) => {
                                         match s_send.send(&pkt.body()).await {
@@ -139,7 +139,7 @@ impl ZDPClient {
                                 continue;
                             }
                             let zpi_hdr = zpi_hdr.unwrap();
-                            let (zpi_encr, zpi_hmac) = mgr.get_recv_zpis();
+                            let recv_zpis = mgr.get_recv_zpis();
                             match zpi_hdr.zpi {
                                 0 => {
                                     info!("zdp/client - received ZPI=0 message");
@@ -158,9 +158,9 @@ impl ZDPClient {
                                     }
                                 }
                                 _ => {
-                                    if zpi_hdr.zpi == zpi_hmac {
+                                    if zpi_hdr.zpi == recv_zpis.hmac {
                                         info!("zdp/client - received transit ZPI message, discarding");
-                                    } else if zpi_hdr.zpi == zpi_encr {
+                                    } else if zpi_hdr.zpi == recv_zpis.encr {
                                         info!("zdp/client - received transport message");
                                         let mut pkt_buf = [0u8; config::PACKET_BUFFER_SIZE];
                                         let mut pkt = Packet::new(&mut pkt_buf, km_demo::HEADROOM);
@@ -184,10 +184,10 @@ impl ZDPClient {
                                             Err(e) => {
                                                 info!("zdp/client - decrypt_transport failed: {}", e);
                                             }
-                                        }    
+                                        }
                                     } else {
-                                        info!("zdp/client - unknown ZPI: {} (expected {} or {})", zpi_hdr.zpi, zpi_encr, zpi_hmac);
-                                    } 
+                                        info!("zdp/client - unknown ZPI: {} (expected {:?}", zpi_hdr.zpi, recv_zpis);
+                                    }
 
                                 }
                             };

--- a/adapter/cd/src/zdp/client.rs
+++ b/adapter/cd/src/zdp/client.rs
@@ -19,9 +19,8 @@ use ph::zdp::*;
 use bytes::BufMut;
 use zerocopy::FromBytes;
 
-
-const ZPI_FULL_ENC:u8 = 200;
-const ZPI_TRANSIT_HMAC:u8 = 201;
+const ZPI_FULL_ENC: u8 = 200;
+const ZPI_TRANSIT_HMAC: u8 = 201;
 
 #[derive(Debug, Clone)]
 pub struct ZDPClient {
@@ -39,7 +38,13 @@ impl ZDPClient {
 
     // Dummy function for my testing only
     pub async fn run(&self, ctok: CancellationToken) -> io::Result<()> {
-        let noise = match KMNoise::new(true, Some(self.dock_noise_pub_key.into()), None, ZPI_FULL_ENC, ZPI_TRANSIT_HMAC) {
+        let noise = match KMNoise::new(
+            true,
+            Some(self.dock_noise_pub_key.into()),
+            None,
+            ZPI_FULL_ENC,
+            ZPI_TRANSIT_HMAC,
+        ) {
             Ok(n) => n,
             Err(e) => {
                 info!("zdp/client - KMNoise::new failed: {}", e);

--- a/adapter/cd/src/zdp/client.rs
+++ b/adapter/cd/src/zdp/client.rs
@@ -19,6 +19,10 @@ use ph::zdp::*;
 use bytes::BufMut;
 use zerocopy::FromBytes;
 
+
+const ZPI_FULL_ENC:u8 = 200;
+const ZPI_TRANSIT_HMAC:u8 = 201;
+
 #[derive(Debug, Clone)]
 pub struct ZDPClient {
     addr: SocketAddr,
@@ -35,7 +39,7 @@ impl ZDPClient {
 
     // Dummy function for my testing only
     pub async fn run(&self, ctok: CancellationToken) -> io::Result<()> {
-        let noise = match KMNoise::new(true, Some(self.dock_noise_pub_key.into()), None) {
+        let noise = match KMNoise::new(true, Some(self.dock_noise_pub_key.into()), None, ZPI_FULL_ENC, ZPI_TRANSIT_HMAC) {
             Ok(n) => n,
             Err(e) => {
                 info!("zdp/client - KMNoise::new failed: {}", e);
@@ -79,6 +83,8 @@ impl ZDPClient {
                                 info!("zdp/client - new SA established");
                                 let mut pkt_buf = [0u8; config::PACKET_BUFFER_SIZE];
                                 let mut pkt = km_demo::build_zdp_report_packet(&mut pkt_buf, b"hello to you my dear node!");
+                                let (zpi_encr, _) = mgr.get_send_zpis();
+                                pkt.body_mut()[0] = zpi_encr;
                                 match mgr.encrypt_transport(&mut pkt) {
                                     Ok(()) => {
                                         match s_send.send(&pkt.body()).await {
@@ -133,6 +139,7 @@ impl ZDPClient {
                                 continue;
                             }
                             let zpi_hdr = zpi_hdr.unwrap();
+                            let (zpi_encr, zpi_hmac) = mgr.get_recv_zpis();
                             match zpi_hdr.zpi {
                                 0 => {
                                     info!("zdp/client - received ZPI=0 message");
@@ -151,30 +158,37 @@ impl ZDPClient {
                                     }
                                 }
                                 _ => {
-                                    info!("zdp/client - received transport message");
-                                    let mut pkt_buf = [0u8; config::PACKET_BUFFER_SIZE];
-                                    let mut pkt = Packet::new(&mut pkt_buf, km_demo::HEADROOM);
-                                    pkt.put(&buf[0..input_len]);
-                                    match mgr.decrypt_transport(&mut pkt) {
-                                        Ok(()) => {
-                                            // Demo code sends a ZDP message like
-                                            //     [ZPI]
-                                            //     [BASE HEADER type = report]
-                                            //     [REPORT HEADER]
-                                            //     <STRING DATA>
-                                            match km_demo::parse_zdp_report_pkt(&pkt) {
-                                                Ok(s) => {
-                                                    info!("zdp/client - received report: *** {} ***", s);
-                                                }
-                                                Err(e) => {
-                                                    info!("zdp/client - error parsing report: {}", e);
+                                    if zpi_hdr.zpi == zpi_hmac {
+                                        info!("zdp/client - received transit ZPI message, discarding");
+                                    } else if zpi_hdr.zpi == zpi_encr {
+                                        info!("zdp/client - received transport message");
+                                        let mut pkt_buf = [0u8; config::PACKET_BUFFER_SIZE];
+                                        let mut pkt = Packet::new(&mut pkt_buf, km_demo::HEADROOM);
+                                        pkt.put(&buf[0..input_len]);
+                                        match mgr.decrypt_transport(&mut pkt) {
+                                            Ok(()) => {
+                                                // Demo code sends a ZDP message like
+                                                //     [ZPI]
+                                                //     [BASE HEADER type = report]
+                                                //     [REPORT HEADER]
+                                                //     <STRING DATA>
+                                                match km_demo::parse_zdp_report_pkt(&pkt) {
+                                                    Ok(s) => {
+                                                        info!("zdp/client - received report: *** {} ***", s);
+                                                    }
+                                                    Err(e) => {
+                                                        info!("zdp/client - error parsing report: {}", e);
+                                                    }
                                                 }
                                             }
-                                        }
-                                        Err(e) => {
-                                            info!("zdp/client - decrypt_transport failed: {}", e);
-                                        }
-                                    }
+                                            Err(e) => {
+                                                info!("zdp/client - decrypt_transport failed: {}", e);
+                                            }
+                                        }    
+                                    } else {
+                                        info!("zdp/client - unknown ZPI: {} (expected {} or {})", zpi_hdr.zpi, zpi_encr, zpi_hmac);
+                                    } 
+
                                 }
                             };
                         }

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -168,18 +168,18 @@ impl KeyManager<'_> {
         state.sa_id
     }
 
-    /// Returns the ZPIs used for sending messages, format is (FULL_ENCRYPTION_ZPI, TRANSIT_HMAC_ZPI).
+    /// Returns the ZPIs used for sending messages.
     /// Only set/valid after handshake is complete and SA is established.a
     /// Currently safe to cache this after handshake is done because (TODO) these do not change.
-    pub fn get_send_zpis(&self) -> (u8, u8) {
+    pub fn get_send_zpis(&self) -> ZPIPair {
         let state = self.shared.state.lock().unwrap();
         state.ts.send_zpis
     }
 
-    /// Returns the ZPIs used for receiving messages, format is (FULL_ENCRYPTION_ZPI, TRANSIT_HMAC_ZPI)
-    /// Only set/valid after handshake is complete and SA is established.a/// 
+    /// Returns the ZPIs used for receiving messages.
+    /// Only set/valid after handshake is complete and SA is established.a///
     /// Currently safe to cache this after handshake is done because (TODO) these do not change.
-    pub fn get_recv_zpis(&self) -> (u8, u8) {
+    pub fn get_recv_zpis(&self) -> ZPIPair {
         let state = self.shared.state.lock().unwrap();
         state.ts.recv_zpis
     }
@@ -199,7 +199,7 @@ impl KeyManager<'_> {
         let state = self.shared.state.lock().unwrap();
         state.ts.recv_hmac_key
     }
-    
+
 
     #[cfg(test)]
     fn set_sa_id(&self, sa_id: u8) {
@@ -211,12 +211,12 @@ impl KeyManager<'_> {
     /// This will encrypt the entire buffer, adding additional ciphertext on the end.
     /// For all packets, there must be enough space remaining in the packet buffer to
     /// accomodate expansion caused by encryption.
-    /// 
+    ///
     /// Do not send here:
     /// - Key Management messages
     /// - Agent Transit Data messages
     ///
-    /// Note that we encrypt `body.len()-1 bytes` from body index 1 (right after ZPI).  Body length 
+    /// Note that we encrypt `body.len()-1 bytes` from body index 1 (right after ZPI).  Body length
     /// will expand by the PADLEN indicated in the KM algorithm.
     ///
     /// `message` is expected to be a ZDP message starting with a ZPI value.  We do not check
@@ -245,14 +245,14 @@ impl KeyManager<'_> {
             ZdpPacketType::TransitPacket => {
                 return Err(KMError::InvalidPacketType);
             }
-            _ => message.body().len(),
+            _ => message.body().len() - 1,
         };
 
         // TODO: Ability to encrypt in place. Not sure how to accomplish. At very least we could use our own buffer pool.
         let mut encr_buf = [0u8; config::PACKET_BUFFER_SIZE];
         match state
             .statemachine
-            .encrypt_transport(&message.body()[1..encr_len+1], &mut encr_buf)
+            .encrypt_transport(&message.body()[1..encr_len + 1], &mut encr_buf)
         {
             Ok(len) => {
                 info!(
@@ -271,12 +271,12 @@ impl KeyManager<'_> {
 
     /// Decrypt a ZDP message using the current SA.  Expects that the ciphertext starts
     /// at index 1 (following the ZPI), and extends to `message.body.len()`.
-    /// 
+    ///
     /// This will overwrite the ciphertext body with the plaintext.
-    /// 
+    ///
     /// Caller must ensure that the SA used to encrypt the message is the one used to
     /// decrypt it.
-    /// 
+    ///
     /// `message` must be ZDP message starting with a ZPI (that we do not check).
     pub fn decrypt_transport(&self, message: &mut Packet) -> KMResult<()> {
         if message.body().len() < 1 {
@@ -310,7 +310,7 @@ impl KeyManager<'_> {
                     len
                 );
                 // Copy the decrypted data back into the message -- do not overwrite ZPI.
-                message.shrink(encr_len); // remove body
+                message.shrink(encr_len); // remove body, leave ZPI
                 message.put(&decr_buf[0..len]); // write a new body
             }
             Err(e) => {
@@ -547,7 +547,7 @@ impl KeyManager<'_> {
                                 error!("failed to enqueue SaIdChange signal")
                             }
                         }
-    
+
                     }
                     _ => {}
                 }
@@ -587,15 +587,24 @@ pub enum KMSMState {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct KMTransportState {
-    send_zpis: (u8, u8),  // TODO: create a type for this pair of ZPIs with names
-    recv_zpis: (u8, u8),
+    send_zpis: ZPIPair,
+    recv_zpis: ZPIPair,
     send_hmac_key: [u8; 32],
     recv_hmac_key: [u8; 32],
 }
 
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ZPIPair {
+    /// ZPI for full message encryption.
+    pub encr: u8,
+
+    /// ZPI for header hmac only.
+    pub hmac: u8,
+}
+
 impl KMTransportState {
-    /// ZPI pair ordering is (ZPI_FOR_FULL_ENCRYPTION, ZPI_FOR_TRANSIT_HMAC)
-    pub fn new(send_zpis: (u8, u8), recv_zpis: (u8, u8), send_key: [u8; 32], recv_key: [u8; 32]) -> KMTransportState {    
+    pub fn new(send_zpis: ZPIPair, recv_zpis: ZPIPair, send_key: [u8; 32], recv_key: [u8; 32]) -> KMTransportState {
         KMTransportState {
             send_zpis,
             recv_zpis,
@@ -606,20 +615,29 @@ impl KMTransportState {
     /// Creates zero'd out KMTransportState
     pub fn new_empty() -> KMTransportState {
         KMTransportState {
-            send_zpis: (0, 0),
-            recv_zpis: (0, 0),
+            send_zpis: ZPIPair::new_zero(),
+            recv_zpis: ZPIPair::new_zero(),
             send_hmac_key: [0u8; 32],
             recv_hmac_key: [0u8; 32],
         }
     }
     /// With ZPIs but empty keys.
-    pub fn new_with_zpis(send_zpis: (u8, u8), recv_zpis: (u8, u8)) -> KMTransportState {
+    pub fn new_with_zpis(send_zpis: ZPIPair, recv_zpis: ZPIPair) -> KMTransportState {
         KMTransportState {
             send_zpis,
             recv_zpis,
             send_hmac_key: [0u8; 32],
             recv_hmac_key: [0u8; 32],
         }
+    }
+}
+
+impl ZPIPair {
+    pub fn new_zero() -> ZPIPair {
+        ZPIPair { encr: 0, hmac: 0 }
+    }
+    pub fn new(encr: u8, hmac: u8) -> ZPIPair {
+        ZPIPair { encr, hmac }
     }
 }
 
@@ -898,8 +916,8 @@ mod test {
         let mut pkt = Packet::new(&mut buf, 64);
         //let hbytes = hdr.as_bytes();
         //pkt.body_mut()[0..hbytes.len()].copy_from_slice(&hbytes);
-        hdr.write_to_buf(&mut pkt);        
-        pkt.alloc_zeroed_header::<ZdpZpiHeader>().zpi = 0x33;        
+        hdr.write_to_buf(&mut pkt);
+        pkt.alloc_zeroed_header::<ZdpZpiHeader>().zpi = 0x33;
         let orig_len = pkt.body().len();
         assert!(orig_len == 1 + std::mem::size_of::<ZdpBaseHeader>());
 
@@ -910,7 +928,7 @@ mod test {
             }
         }
 
-        assert!(pkt.body().len() == orig_len, "body length changed: expected {}, got {}", orig_len, pkt.body().len());        
+        assert!(pkt.body().len() == orig_len, "body length changed: expected {}, got {}", orig_len, pkt.body().len());
         let encr_hdr =
             ZdpBaseHeader::ref_from_prefix(&pkt.body()[1..]).expect("failed to read back header");
 
@@ -938,7 +956,7 @@ mod test {
         //let hbytes = hdr.as_bytes();
         //pkt.body_mut()[0..hbytes.len()].copy_from_slice(&hbytes);
         hdr.write_to_buf(&mut pkt);
-        pkt.alloc_zeroed_header::<ZdpZpiHeader>().zpi = 33;                
+        pkt.alloc_zeroed_header::<ZdpZpiHeader>().zpi = 33;
         let orig_len = pkt.body().len();
         assert!(orig_len == 1 + std::mem::size_of::<ZdpBaseHeader>());
         match km.encrypt_transport(&mut pkt) {
@@ -954,7 +972,7 @@ mod test {
                 panic!("decrypt_transport failed: {}", e);
             }
         }
-        assert!(pkt.body()[0] == 33); // decrypt does not touch ZPI       
+        assert!(pkt.body()[0] == 33); // decrypt does not touch ZPI
         assert!(pkt.body().len() == orig_len, "body length changed: expected {}, got {}", orig_len, pkt.body().len());
 
         let encr_hdr =

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -200,7 +200,6 @@ impl KeyManager<'_> {
         state.ts.recv_hmac_key
     }
 
-
     #[cfg(test)]
     fn set_sa_id(&self, sa_id: u8) {
         let mut state = self.shared.state.lock().unwrap();
@@ -222,12 +221,13 @@ impl KeyManager<'_> {
     /// `message` is expected to be a ZDP message starting with a ZPI value.  We do not check
     /// the ZPI.  (TODO: A future version will add the ZPI as associated data in the AEAD cipher).
     pub fn encrypt_transport(&self, message: &mut Packet) -> KMResult<()> {
-        if message.body().len() < std::mem::size_of::<ZdpZpiHeader>() + std::mem::size_of::<ZdpBaseHeader>() {
+        if message.body().len()
+            < std::mem::size_of::<ZdpZpiHeader>() + std::mem::size_of::<ZdpBaseHeader>()
+        {
             return Err(KMError::ShortPacket);
         }
         let base_hdr =
             ZdpBaseHeader::ref_from_prefix(&message.body()[1..]).expect("too-short ZDP message");
-
 
         let codec: Arc<dyn Codec>;
         {
@@ -238,7 +238,7 @@ impl KeyManager<'_> {
                 return Err(KMError::SaIdZero);
             }
 
-            if !matches!(state.statemachine.get_state(), KMSMState::Transport{..}) {
+            if !matches!(state.statemachine.get_state(), KMSMState::Transport { .. }) {
                 return Err(KMError::InvalidState);
             }
 
@@ -324,8 +324,7 @@ impl KeyManager<'_> {
         // TODO: Ability to decrypt in place. Not sure how to accomplish.  At very least we could use our own buffer pool.
         let mut decr_buf = [0u8; config::PACKET_BUFFER_SIZE];
 
-        match codec.decrypt_transport_stateless(&message.body()[1..encr_len+1], &mut decr_buf)
-        {
+        match codec.decrypt_transport_stateless(&message.body()[1..encr_len + 1], &mut decr_buf) {
             Ok(len) => {
                 info!(
                     "noise: decrypt input {} bytes, output {} bytes",
@@ -570,11 +569,9 @@ impl KeyManager<'_> {
                                 error!("failed to enqueue SaIdChange signal")
                             }
                         }
-
                     }
                     _ => {}
                 }
-
             } else if next_state == KMSMState::Error {
                 error!("KM: stuck in error state");
                 return Err(KMError::MachineError(String::from("stuck in error state")));
@@ -617,7 +614,6 @@ pub struct KMTransportState {
     pub codec: Arc<dyn Codec>,
 }
 
-
 // Does not check the codec.
 impl PartialEq for KMTransportState {
     fn eq(&self, other: &Self) -> bool {
@@ -639,7 +635,6 @@ impl fmt::Debug for KMTransportState {
     }
 }
 
-
 pub trait Codec: Send + Sync {
     /// Encrypt `payload` into `message`.
     fn encrypt_transport_stateless(
@@ -654,7 +649,6 @@ pub trait Codec: Send + Sync {
         payload: &[u8],
         message: &mut [u8],
     ) -> Result<usize, KMError>;
-
 }
 
 struct UnimplCodec;
@@ -670,7 +664,9 @@ impl Codec for UnimplCodec {
         _payload: &[u8],
         _message: &mut [u8],
     ) -> Result<usize, KMError> {
-        Err(KMError::MachineError(String::from("encrypt not implemented")))
+        Err(KMError::MachineError(String::from(
+            "encrypt not implemented",
+        )))
     }
 
     fn decrypt_transport_stateless(
@@ -678,11 +674,11 @@ impl Codec for UnimplCodec {
         _payload: &[u8],
         _message: &mut [u8],
     ) -> Result<usize, KMError> {
-        Err(KMError::MachineError(String::from("decrypt not implemented")))
+        Err(KMError::MachineError(String::from(
+            "decrypt not implemented",
+        )))
     }
 }
-
-
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ZPIPair {
@@ -694,7 +690,13 @@ pub struct ZPIPair {
 }
 
 impl KMTransportState {
-    pub fn new(send_zpis: ZPIPair, recv_zpis: ZPIPair, send_key: [u8; 32], recv_key: [u8; 32], codec: Arc<dyn Codec>) -> KMTransportState {
+    pub fn new(
+        send_zpis: ZPIPair,
+        recv_zpis: ZPIPair,
+        send_key: [u8; 32],
+        recv_key: [u8; 32],
+        codec: Arc<dyn Codec>,
+    ) -> KMTransportState {
         KMTransportState {
             send_zpis,
             recv_zpis,
@@ -884,7 +886,6 @@ mod test {
             internals.tick_count += 1;
             Ok(None)
         }
-
     }
 
     #[tokio::test]
@@ -993,8 +994,11 @@ mod test {
 
     #[tokio::test]
     async fn test_km_encrypt_transport_non_transit() {
-        let codec = Arc::new(CopyCodec{});
-        let kmb = Box::new(TestKM::new(true, KMSMState::Transport(KMTransportState::new_empty_with_codec(codec))));
+        let codec = Arc::new(CopyCodec {});
+        let kmb = Box::new(TestKM::new(
+            true,
+            KMSMState::Transport(KMTransportState::new_empty_with_codec(codec)),
+        ));
         let km = KeyManager::new(kmb);
 
         // No need to start the machine since encrypt only cares about transport state and SA_ID.
@@ -1021,7 +1025,12 @@ mod test {
             }
         }
 
-        assert!(pkt.body().len() == orig_len, "body length changed: expected {}, got {}", orig_len, pkt.body().len());
+        assert!(
+            pkt.body().len() == orig_len,
+            "body length changed: expected {}, got {}",
+            orig_len,
+            pkt.body().len()
+        );
         let encr_hdr =
             ZdpBaseHeader::ref_from_prefix(&pkt.body()[1..]).expect("failed to read back header");
 
@@ -1032,8 +1041,11 @@ mod test {
 
     #[tokio::test]
     async fn test_km_decrypt_transport_non_transit() {
-        let codec = Arc::new(CopyCodec{});
-        let kmb = Box::new(TestKM::new(true, KMSMState::Transport(KMTransportState::new_empty_with_codec(codec))));
+        let codec = Arc::new(CopyCodec {});
+        let kmb = Box::new(TestKM::new(
+            true,
+            KMSMState::Transport(KMTransportState::new_empty_with_codec(codec)),
+        ));
         let km = KeyManager::new(kmb);
 
         // No need to start the machine since encrypt only cares about transport state and SA_ID.
@@ -1067,7 +1079,12 @@ mod test {
             }
         }
         assert!(pkt.body()[0] == 33); // decrypt does not touch ZPI
-        assert!(pkt.body().len() == orig_len, "body length changed: expected {}, got {}", orig_len, pkt.body().len());
+        assert!(
+            pkt.body().len() == orig_len,
+            "body length changed: expected {}, got {}",
+            orig_len,
+            pkt.body().len()
+        );
 
         let encr_hdr =
             ZdpBaseHeader::ref_from_prefix(&pkt.body()[1..]).expect("failed to read back header");

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -228,12 +228,28 @@ impl KeyManager<'_> {
         let base_hdr =
             ZdpBaseHeader::ref_from_prefix(&message.body()[1..]).expect("too-short ZDP message");
 
-        let mut state = self.shared.state.lock().unwrap();
-        if !matches!(state.statemachine.get_state(), KMSMState::Transport{..}) {
-            return Err(KMError::InvalidState);
-        }
-        if state.sa_id == 0 {
-            return Err(KMError::SaIdZero);
+
+        let codec: Arc<dyn Codec>;
+        {
+            // TODO: Here we take a quick lock to get the state. This would be better as an RLock
+            //       or really should use the RCU thing.
+            let state = self.shared.state.lock().unwrap();
+            if state.sa_id == 0 {
+                return Err(KMError::SaIdZero);
+            }
+
+            if !matches!(state.statemachine.get_state(), KMSMState::Transport{..}) {
+                return Err(KMError::InvalidState);
+            }
+
+            match state.statemachine.get_state() {
+                KMSMState::Transport(ts) => {
+                    codec = ts.codec;
+                }
+                _ => {
+                    return Err(KMError::InvalidState);
+                }
+            }
         }
 
         // The assumption here is that caller has already built in space of any padding required by key manager protocol.
@@ -250,10 +266,8 @@ impl KeyManager<'_> {
 
         // TODO: Ability to encrypt in place. Not sure how to accomplish. At very least we could use our own buffer pool.
         let mut encr_buf = [0u8; config::PACKET_BUFFER_SIZE];
-        match state
-            .statemachine
-            .encrypt_transport(&message.body()[1..encr_len + 1], &mut encr_buf)
-        {
+
+        match codec.encrypt_transport_stateless(&message.body()[1..encr_len + 1], &mut encr_buf) {
             Ok(len) => {
                 info!(
                     "noise: encrypt input {} bytes, output {} bytes",
@@ -282,26 +296,35 @@ impl KeyManager<'_> {
         if message.body().len() < 1 {
             return Err(KMError::ShortPacket);
         }
-        let mut state = self.shared.state.lock().unwrap();
-        if !matches!(state.statemachine.get_state(), KMSMState::Transport{..}) {
-            return Err(KMError::InvalidState);
+        let padlen: usize;
+        let codec: Arc<dyn Codec>;
+        {
+            // Just like in encrypt, we take a quick lock to get the state. This could be improved.
+            let state = self.shared.state.lock().unwrap();
+            match state.statemachine.get_state() {
+                KMSMState::Transport(ts) => {
+                    codec = ts.codec;
+                }
+                _ => {
+                    return Err(KMError::InvalidState);
+                }
+            }
+            padlen = state.kmsettings.padlen;
         }
 
-        // TODO: Ability to decrypt in place. Not sure how to accomplish.  At very least we could use our own buffer pool.
-        let mut decr_buf = [0u8; config::PACKET_BUFFER_SIZE];
         let encr_len = message.body().len() - 1;
         if encr_len == 0 {
             // empty?
             return Ok(());
         }
-
-        if encr_len < state.kmsettings.padlen {
+        if encr_len < padlen {
             return Err(KMError::ShortPacket);
         }
 
-        match state
-            .statemachine
-            .decrypt_transport(&message.body()[1..encr_len+1], &mut decr_buf)
+        // TODO: Ability to decrypt in place. Not sure how to accomplish.  At very least we could use our own buffer pool.
+        let mut decr_buf = [0u8; config::PACKET_BUFFER_SIZE];
+
+        match codec.decrypt_transport_stateless(&message.body()[1..encr_len+1], &mut decr_buf)
         {
             Ok(len) => {
                 info!(
@@ -585,13 +608,80 @@ pub enum KMSMState {
     Error,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone)]
 pub struct KMTransportState {
     send_zpis: ZPIPair,
     recv_zpis: ZPIPair,
     send_hmac_key: [u8; 32],
     recv_hmac_key: [u8; 32],
+    pub codec: Arc<dyn Codec>,
 }
+
+
+// Does not check the codec.
+impl PartialEq for KMTransportState {
+    fn eq(&self, other: &Self) -> bool {
+        self.send_zpis == other.send_zpis
+            && self.recv_zpis == other.recv_zpis
+            && self.send_hmac_key == other.send_hmac_key
+            && self.recv_hmac_key == other.recv_hmac_key
+    }
+}
+
+// Our debug formatter omits the codec.
+impl fmt::Debug for KMTransportState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "KMTransportState {{ send_zpis: {:?}, recv_zpis: {:?}, send_hmac_key: {:?}, recv_hmac_key: {:?} }}",
+            self.send_zpis, self.recv_zpis, self.send_hmac_key, self.recv_hmac_key
+        )
+    }
+}
+
+
+pub trait Codec: Send + Sync {
+    /// Encrypt `payload` into `message`.
+    fn encrypt_transport_stateless(
+        self: &Self,
+        payload: &[u8],
+        message: &mut [u8],
+    ) -> Result<usize, KMError>;
+
+    /// Decrypt `payload` into `message`
+    fn decrypt_transport_stateless(
+        self: &Self,
+        payload: &[u8],
+        message: &mut [u8],
+    ) -> Result<usize, KMError>;
+
+}
+
+struct UnimplCodec;
+impl UnimplCodec {
+    pub fn new() -> UnimplCodec {
+        UnimplCodec {}
+    }
+}
+
+impl Codec for UnimplCodec {
+    fn encrypt_transport_stateless(
+        self: &Self,
+        _payload: &[u8],
+        _message: &mut [u8],
+    ) -> Result<usize, KMError> {
+        Err(KMError::MachineError(String::from("encrypt not implemented")))
+    }
+
+    fn decrypt_transport_stateless(
+        self: &Self,
+        _payload: &[u8],
+        _message: &mut [u8],
+    ) -> Result<usize, KMError> {
+        Err(KMError::MachineError(String::from("decrypt not implemented")))
+    }
+}
+
 
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -604,14 +694,16 @@ pub struct ZPIPair {
 }
 
 impl KMTransportState {
-    pub fn new(send_zpis: ZPIPair, recv_zpis: ZPIPair, send_key: [u8; 32], recv_key: [u8; 32]) -> KMTransportState {
+    pub fn new(send_zpis: ZPIPair, recv_zpis: ZPIPair, send_key: [u8; 32], recv_key: [u8; 32], codec: Arc<dyn Codec>) -> KMTransportState {
         KMTransportState {
             send_zpis,
             recv_zpis,
             send_hmac_key: send_key,
             recv_hmac_key: recv_key,
+            codec,
         }
     }
+
     /// Creates zero'd out KMTransportState
     pub fn new_empty() -> KMTransportState {
         KMTransportState {
@@ -619,8 +711,20 @@ impl KMTransportState {
             recv_zpis: ZPIPair::new_zero(),
             send_hmac_key: [0u8; 32],
             recv_hmac_key: [0u8; 32],
+            codec: Arc::new(UnimplCodec::new()),
         }
     }
+
+    pub fn new_empty_with_codec(codec: Arc<dyn Codec>) -> KMTransportState {
+        KMTransportState {
+            send_zpis: ZPIPair::new_zero(),
+            recv_zpis: ZPIPair::new_zero(),
+            send_hmac_key: [0u8; 32],
+            recv_hmac_key: [0u8; 32],
+            codec,
+        }
+    }
+
     /// With ZPIs but empty keys.
     pub fn new_with_zpis(send_zpis: ZPIPair, recv_zpis: ZPIPair) -> KMTransportState {
         KMTransportState {
@@ -628,6 +732,7 @@ impl KMTransportState {
             recv_zpis,
             send_hmac_key: [0u8; 32],
             recv_hmac_key: [0u8; 32],
+            codec: Arc::new(UnimplCodec::new()),
         }
     }
 }
@@ -681,24 +786,6 @@ pub trait KeyManagerStateMachine: Send + Sync {
     /// May transition internal state
     /// If this returns error, internal state should be error too.
     fn tick(self: &mut Self) -> Result<Option<Bytes>, KMError>;
-
-    /// Encrypt `payload` into `message`.
-    ///
-    /// `sa_id` is the Security Association ID in use.
-    fn encrypt_transport(
-        self: &mut Self,
-        payload: &[u8],
-        message: &mut [u8],
-    ) -> Result<usize, KMError>;
-
-    /// Decrypt `payload` into `message`
-    ///
-    /// `sa_id` is the Security Association ID in use.
-    fn decrypt_transport(
-        self: &mut Self,
-        payload: &[u8],
-        message: &mut [u8],
-    ) -> Result<usize, KMError>;
 }
 
 #[cfg(test)]
@@ -743,6 +830,28 @@ mod test {
         }
     }
 
+    struct CopyCodec;
+
+    impl Codec for CopyCodec {
+        fn encrypt_transport_stateless(
+            self: &Self,
+            payload: &[u8],
+            message: &mut [u8],
+        ) -> Result<usize, KMError> {
+            message[0..payload.len()].copy_from_slice(payload);
+            Ok(payload.len())
+        }
+
+        fn decrypt_transport_stateless(
+            self: &Self,
+            payload: &[u8],
+            message: &mut [u8],
+        ) -> Result<usize, KMError> {
+            message[0..payload.len()].copy_from_slice(payload);
+            Ok(payload.len())
+        }
+    }
+
     impl KeyManagerStateMachine for TestKM {
         fn get_settings(&self) -> KMSettings {
             KMSettings {
@@ -776,23 +885,6 @@ mod test {
             Ok(None)
         }
 
-        fn encrypt_transport(
-            self: &mut Self,
-            payload: &[u8],
-            message: &mut [u8],
-        ) -> Result<usize, KMError> {
-            message[0..payload.len()].copy_from_slice(payload);
-            Ok(payload.len())
-        }
-
-        fn decrypt_transport(
-            self: &mut Self,
-            payload: &[u8],
-            message: &mut [u8],
-        ) -> Result<usize, KMError> {
-            message[0..payload.len()].copy_from_slice(payload);
-            Ok(payload.len())
-        }
     }
 
     #[tokio::test]
@@ -901,7 +993,8 @@ mod test {
 
     #[tokio::test]
     async fn test_km_encrypt_transport_non_transit() {
-        let kmb = Box::new(TestKM::new(true, KMSMState::Transport(KMTransportState::new_empty())));
+        let codec = Arc::new(CopyCodec{});
+        let kmb = Box::new(TestKM::new(true, KMSMState::Transport(KMTransportState::new_empty_with_codec(codec))));
         let km = KeyManager::new(kmb);
 
         // No need to start the machine since encrypt only cares about transport state and SA_ID.
@@ -939,7 +1032,8 @@ mod test {
 
     #[tokio::test]
     async fn test_km_decrypt_transport_non_transit() {
-        let kmb = Box::new(TestKM::new(true, KMSMState::Transport(KMTransportState::new_empty())));
+        let codec = Arc::new(CopyCodec{});
+        let kmb = Box::new(TestKM::new(true, KMSMState::Transport(KMTransportState::new_empty_with_codec(codec))));
         let km = KeyManager::new(kmb);
 
         // No need to start the machine since encrypt only cares about transport state and SA_ID.

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -130,6 +130,8 @@ struct KMState<'mgr> {
 
     // TODO: Can we get this channel outside of the mutex?
     mgmt_tx: Option<mpsc::Sender<Bytes>>, // Internal queue for key management messages to be processed.
+
+    ts: KMTransportState,
 }
 
 impl fmt::Debug for KMState<'_> {
@@ -154,18 +156,52 @@ impl KeyManager<'_> {
                     kmsettings: settings,
                     sa_id: 0,
                     mgmt_tx: None,
+                    ts: KMTransportState::new_empty(),
                 }),
             }),
         }
     }
 
+    /// Returns the current SA identifier.  If handshake has completed, then this is non-zero.
     pub fn get_sa_id(&self) -> u8 {
         let state = self.shared.state.lock().unwrap();
         state.sa_id
     }
 
-    // For testing
-    #[allow(dead_code)]
+    /// Returns the ZPIs used for sending messages, format is (FULL_ENCRYPTION_ZPI, TRANSIT_HMAC_ZPI).
+    /// Only set/valid after handshake is complete and SA is established.a
+    /// Currently safe to cache this after handshake is done because (TODO) these do not change.
+    pub fn get_send_zpis(&self) -> (u8, u8) {
+        let state = self.shared.state.lock().unwrap();
+        state.ts.send_zpis
+    }
+
+    /// Returns the ZPIs used for receiving messages, format is (FULL_ENCRYPTION_ZPI, TRANSIT_HMAC_ZPI)
+    /// Only set/valid after handshake is complete and SA is established.a/// 
+    /// Currently safe to cache this after handshake is done because (TODO) these do not change.
+    pub fn get_recv_zpis(&self) -> (u8, u8) {
+        let state = self.shared.state.lock().unwrap();
+        state.ts.recv_zpis
+    }
+
+    /// Return the key to use for generating HMAC on an outbound transit message.
+    /// Only set/valid after handshake is complete and SA is established.a
+    /// Currently safe to cache this after handshake is done because (TODO) these do not change.
+    pub fn get_send_hmac_key(&self) -> [u8; 32] {
+        let state = self.shared.state.lock().unwrap();
+        state.ts.send_hmac_key
+    }
+
+    /// Return the key to use for verifying the HMAC on an inbound transit message.
+    /// Only set/valid after handshake is complete and SA is established.a
+    /// Currently safe to cache this after handshake is done because (TODO) these do not change.
+    pub fn get_recv_hmac_key(&self) -> [u8; 32] {
+        let state = self.shared.state.lock().unwrap();
+        state.ts.recv_hmac_key
+    }
+    
+
+    #[cfg(test)]
     fn set_sa_id(&self, sa_id: u8) {
         let mut state = self.shared.state.lock().unwrap();
         state.sa_id = sa_id;
@@ -193,7 +229,7 @@ impl KeyManager<'_> {
             ZdpBaseHeader::ref_from_prefix(&message.body()[1..]).expect("too-short ZDP message");
 
         let mut state = self.shared.state.lock().unwrap();
-        if state.statemachine.get_state() != KMSMState::Transport {
+        if !matches!(state.statemachine.get_state(), KMSMState::Transport{..}) {
             return Err(KMError::InvalidState);
         }
         if state.sa_id == 0 {
@@ -247,7 +283,7 @@ impl KeyManager<'_> {
             return Err(KMError::ShortPacket);
         }
         let mut state = self.shared.state.lock().unwrap();
-        if state.statemachine.get_state() != KMSMState::Transport {
+        if !matches!(state.statemachine.get_state(), KMSMState::Transport{..}) {
             return Err(KMError::InvalidState);
         }
 
@@ -484,32 +520,38 @@ impl KeyManager<'_> {
 
             if next_state != prev_state {
                 info!("KM state transition {:?} -> {:?}", prev_state, next_state);
-                if next_state == KMSMState::Transport {
-                    let prev_id: zpr::SaId;
-                    let cur_id: zpr::SaId;
-                    {
-                        let mut state = self.shared.state.lock().unwrap();
-                        prev_id = state.sa_id;
-                        state.sa_id += 1;
-                        if state.sa_id == 0 {
-                            state.sa_id = 1;
+                match next_state {
+                    KMSMState::Transport(ts) => {
+                        let prev_id: zpr::SaId;
+                        let cur_id: zpr::SaId;
+                        {
+                            let mut state = self.shared.state.lock().unwrap();
+                            prev_id = state.sa_id;
+                            state.sa_id += 1;
+                            if state.sa_id == 0 {
+                                state.sa_id = 1;
+                            }
+                            cur_id = state.sa_id;
+                            state.ts = ts;
                         }
-                        cur_id = state.sa_id;
-                    }
-                    info!("KM: New SA_ID: {}", cur_id);
-                    match km_signals_out
-                        .send(KMSignal::SaIdChange {
-                            old: prev_id,
-                            new: cur_id,
-                        })
-                        .await
-                    {
-                        Ok(_) => {}
-                        Err(_) => {
-                            error!("failed to enqueue SaIdChange signal")
+                        info!("KM: New SA_ID: {}", cur_id);
+                        match km_signals_out
+                            .send(KMSignal::SaIdChange {
+                                old: prev_id,
+                                new: cur_id,
+                            })
+                            .await
+                        {
+                            Ok(_) => {}
+                            Err(_) => {
+                                error!("failed to enqueue SaIdChange signal")
+                            }
                         }
+    
                     }
+                    _ => {}
                 }
+
             } else if next_state == KMSMState::Error {
                 error!("KM: stuck in error state");
                 return Err(KMError::MachineError(String::from("stuck in error state")));
@@ -539,8 +581,46 @@ impl KeyManager<'_> {
 #[derive(Debug, Clone, PartialEq)]
 pub enum KMSMState {
     Configuring,
-    Transport,
+    Transport(KMTransportState),
     Error,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct KMTransportState {
+    send_zpis: (u8, u8),  // TODO: create a type for this pair of ZPIs with names
+    recv_zpis: (u8, u8),
+    send_hmac_key: [u8; 32],
+    recv_hmac_key: [u8; 32],
+}
+
+impl KMTransportState {
+    /// ZPI pair ordering is (ZPI_FOR_FULL_ENCRYPTION, ZPI_FOR_TRANSIT_HMAC)
+    pub fn new(send_zpis: (u8, u8), recv_zpis: (u8, u8), send_key: [u8; 32], recv_key: [u8; 32]) -> KMTransportState {    
+        KMTransportState {
+            send_zpis,
+            recv_zpis,
+            send_hmac_key: send_key,
+            recv_hmac_key: recv_key,
+        }
+    }
+    /// Creates zero'd out KMTransportState
+    pub fn new_empty() -> KMTransportState {
+        KMTransportState {
+            send_zpis: (0, 0),
+            recv_zpis: (0, 0),
+            send_hmac_key: [0u8; 32],
+            recv_hmac_key: [0u8; 32],
+        }
+    }
+    /// With ZPIs but empty keys.
+    pub fn new_with_zpis(send_zpis: (u8, u8), recv_zpis: (u8, u8)) -> KMTransportState {
+        KMTransportState {
+            send_zpis,
+            recv_zpis,
+            send_hmac_key: [0u8; 32],
+            recv_hmac_key: [0u8; 32],
+        }
+    }
 }
 
 /// A set of constant settings for a particular [KeyManagerStateMachine].  Used
@@ -803,7 +883,7 @@ mod test {
 
     #[tokio::test]
     async fn test_km_encrypt_transport_non_transit() {
-        let kmb = Box::new(TestKM::new(true, KMSMState::Transport));
+        let kmb = Box::new(TestKM::new(true, KMSMState::Transport(KMTransportState::new_empty())));
         let km = KeyManager::new(kmb);
 
         // No need to start the machine since encrypt only cares about transport state and SA_ID.
@@ -841,7 +921,7 @@ mod test {
 
     #[tokio::test]
     async fn test_km_decrypt_transport_non_transit() {
-        let kmb = Box::new(TestKM::new(true, KMSMState::Transport));
+        let kmb = Box::new(TestKM::new(true, KMSMState::Transport(KMTransportState::new_empty())));
         let km = KeyManager::new(kmb);
 
         // No need to start the machine since encrypt only cares about transport state and SA_ID.

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -172,33 +172,25 @@ impl KeyManager<'_> {
     }
 
     /// Encrypt a ZDP message for transport.  Key Management messages should not be sent here.
-    /// This overwrites the plaintext ZDP header at least.
-    /// For everything except transit packets, this also overwrites the payload.
-    ///
+    /// This will encrypt the entire buffer, adding additional ciphertext on the end.
     /// For all packets, there must be enough space remaining in the packet buffer to
     /// accomodate expansion caused by encryption.
+    /// 
+    /// Do not send here:
+    /// - Key Management messages
+    /// - Agent Transit Data messages
     ///
-    /// Note that we encrypt body.len() bytes from body index 0.  Body length will expand by
-    /// the PADLEN indicated in the KM algorithm.
+    /// Note that we encrypt `body.len()-1 bytes` from body index 1 (right after ZPI).  Body length 
+    /// will expand by the PADLEN indicated in the KM algorithm.
     ///
-    /// We also write into the headroom of the packet:
-    ///
-    /// ```text
-    ///     00     ZPI
-    ///     01,02  LENGTH of encrypted payload
-    /// ```
-    ///
-    /// TODO: Not sure this works at all for transit packet encryption -- if we are doing that.
-    ///
-    /// `message` is expected to be a ZDP message wihout a ZPI value.  We add a ZPI
-    /// value to the front of the message -- note that the value we add is just the
-    /// SA_ID.  It's up to caller to mix in the configuration ID value.
+    /// `message` is expected to be a ZDP message starting with a ZPI value.  We do not check
+    /// the ZPI.  (TODO: A future version will add the ZPI as associated data in the AEAD cipher).
     pub fn encrypt_transport(&self, message: &mut Packet) -> KMResult<()> {
-        let base_hdr =
-            ZdpBaseHeader::ref_from_prefix(message.body()).expect("too-short ZDP message");
-        if message.headroom_available() < 1 {
-            return Err(KMError::NoHeadroom);
+        if message.body().len() < std::mem::size_of::<ZdpZpiHeader>() + std::mem::size_of::<ZdpBaseHeader>() {
+            return Err(KMError::ShortPacket);
         }
+        let base_hdr =
+            ZdpBaseHeader::ref_from_prefix(&message.body()[1..]).expect("too-short ZDP message");
 
         let mut state = self.shared.state.lock().unwrap();
         if state.statemachine.get_state() != KMSMState::Transport {
@@ -215,7 +207,7 @@ impl KeyManager<'_> {
                 return Err(KMError::InvalidPacketType);
             }
             ZdpPacketType::TransitPacket => {
-                panic!("Transit packet encryption not implemented");
+                return Err(KMError::InvalidPacketType);
             }
             _ => message.body().len(),
         };
@@ -224,25 +216,15 @@ impl KeyManager<'_> {
         let mut encr_buf = [0u8; config::PACKET_BUFFER_SIZE];
         match state
             .statemachine
-            .encrypt_transport(&message.body()[0..encr_len], &mut encr_buf)
+            .encrypt_transport(&message.body()[1..encr_len+1], &mut encr_buf)
         {
             Ok(len) => {
                 info!(
                     "noise: encrypt input {} bytes, output {} bytes",
                     encr_len, len
                 );
-                // Copy the encrypted data back into the message -- there should be sufficient room for it since
-                // caller should know our required padding space and alignment.
-
-                message.shrink(message.body().len()); // remove body
+                message.shrink(encr_len); // remove body, leavign ZPI
                 message.put(&encr_buf[0..len]); // write a new body
-
-                // Now write our headroom info:
-                let head_buf = message.alloc_zeroed_headroom(3); // ZPI + LEN
-                head_buf[0] = state.sa_id;
-
-                let szbytes = (len as u16).to_be_bytes();
-                head_buf[1..3].copy_from_slice(&szbytes);
             }
             Err(e) => {
                 return Err(KMError::MachineError(e.to_string()));
@@ -251,39 +233,39 @@ impl KeyManager<'_> {
         Ok(())
     }
 
-    /// The message here must start with the ZPI value.
-    /// We assume that packet ZPI value has been clensed of the config ID and is only the SA_ID.
-    /// Key Management packets should not be sent here.
-    /// Does not remove the ZPI/SA_ID value.
+    /// Decrypt a ZDP message using the current SA.  Expects that the ciphertext starts
+    /// at index 1 (following the ZPI), and extends to `message.body.len()`.
+    /// 
+    /// This will overwrite the ciphertext body with the plaintext.
+    /// 
+    /// Caller must ensure that the SA used to encrypt the message is the one used to
+    /// decrypt it.
+    /// 
+    /// `message` must be ZDP message starting with a ZPI (that we do not check).
     pub fn decrypt_transport(&self, message: &mut Packet) -> KMResult<()> {
-        if message.body().len() < 3 {
-            // ZPI + LEN
+        if message.body().len() < 1 {
             return Err(KMError::ShortPacket);
         }
         let mut state = self.shared.state.lock().unwrap();
-        if message.body()[0] == 0 {
-            return Err(KMError::SaIdZero);
-        }
-        if state.sa_id != message.body()[0] {
-            return Err(KMError::SaIdMismatch);
-        }
         if state.statemachine.get_state() != KMSMState::Transport {
             return Err(KMError::InvalidState);
         }
 
         // TODO: Ability to decrypt in place. Not sure how to accomplish.  At very least we could use our own buffer pool.
         let mut decr_buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let encr_len = message.body().len() - 1;
+        if encr_len == 0 {
+            // empty?
+            return Ok(());
+        }
 
-        // read the size of the encrypted payload.  Size follows the ZPI/SA_ID value:
-        let encr_len: usize = u16::from_be_bytes([message.body()[1], message.body()[2]]) as usize;
-
-        if encr_len + 3 > message.body().len() {
+        if encr_len < state.kmsettings.padlen {
             return Err(KMError::ShortPacket);
         }
 
         match state
             .statemachine
-            .decrypt_transport(&message.body()[3..3 + encr_len], &mut decr_buf)
+            .decrypt_transport(&message.body()[1..encr_len+1], &mut decr_buf)
         {
             Ok(len) => {
                 info!(
@@ -292,10 +274,8 @@ impl KeyManager<'_> {
                     len
                 );
                 // Copy the decrypted data back into the message -- do not overwrite ZPI.
-                message.shrink(message.body().len()); // remove body
+                message.shrink(encr_len); // remove body
                 message.put(&decr_buf[0..len]); // write a new body
-
-                message.alloc_zeroed_header::<ZdpZpiHeader>().zpi = state.sa_id;
             }
             Err(e) => {
                 return Err(KMError::MachineError(e.to_string()));
@@ -571,7 +551,6 @@ pub struct KMSettings {
     pub zdp_km_type: zpr::KmId,
 
     /// Number of additional bytes required to encrypt a payload for transport.
-    /// Note that the KM itself adds 2 bytes for a length field.
     pub padlen: usize,
 
     /// If non-zero, then `payload`+`padlen` must be a multiple of `alignment`.
@@ -839,7 +818,11 @@ mod test {
         let mut pkt = Packet::new(&mut buf, 64);
         //let hbytes = hdr.as_bytes();
         //pkt.body_mut()[0..hbytes.len()].copy_from_slice(&hbytes);
-        hdr.write_to_buf(&mut pkt);
+        hdr.write_to_buf(&mut pkt);        
+        pkt.alloc_zeroed_header::<ZdpZpiHeader>().zpi = 0x33;        
+        let orig_len = pkt.body().len();
+        assert!(orig_len == 1 + std::mem::size_of::<ZdpBaseHeader>());
+
         match km.encrypt_transport(&mut pkt) {
             Ok(_) => {}
             Err(e) => {
@@ -847,12 +830,9 @@ mod test {
             }
         }
 
-        // The encrypt function writes a SA_ID to first byte.
-        assert!(pkt.body()[0] == 33);
-
-        // Rest of input is after the length...
+        assert!(pkt.body().len() == orig_len, "body length changed: expected {}, got {}", orig_len, pkt.body().len());        
         let encr_hdr =
-            ZdpBaseHeader::ref_from_prefix(&pkt.body()[3..]).expect("failed to read back header");
+            ZdpBaseHeader::ref_from_prefix(&pkt.body()[1..]).expect("failed to read back header");
 
         assert!(encr_hdr.packet_type == hdr.packet_type);
         assert!(encr_hdr.excess_length == hdr.excess_length);
@@ -878,22 +858,24 @@ mod test {
         //let hbytes = hdr.as_bytes();
         //pkt.body_mut()[0..hbytes.len()].copy_from_slice(&hbytes);
         hdr.write_to_buf(&mut pkt);
+        pkt.alloc_zeroed_header::<ZdpZpiHeader>().zpi = 33;                
+        let orig_len = pkt.body().len();
+        assert!(orig_len == 1 + std::mem::size_of::<ZdpBaseHeader>());
         match km.encrypt_transport(&mut pkt) {
             Ok(_) => {}
             Err(e) => {
                 panic!("encrypt_transport failed: {}", e);
             }
         }
-
+        assert!(pkt.body()[0] == 33); // encrypt does not touch ZPI
         match km.decrypt_transport(&mut pkt) {
             Ok(_) => {}
             Err(e) => {
                 panic!("decrypt_transport failed: {}", e);
             }
         }
-
-        // The decrypt function leaves the ZPI alone
-        assert!(pkt.body()[0] == 33);
+        assert!(pkt.body()[0] == 33); // decrypt does not touch ZPI       
+        assert!(pkt.body().len() == orig_len, "body length changed: expected {}, got {}", orig_len, pkt.body().len());
 
         let encr_hdr =
             ZdpBaseHeader::ref_from_prefix(&pkt.body()[1..]).expect("failed to read back header");

--- a/adapter/ph/src/km_demo.rs
+++ b/adapter/ph/src/km_demo.rs
@@ -29,7 +29,6 @@ pub const ZDP_REPORT_HDR_OFFSET: usize = ZDP_NON_PER_FLOW_MGMT_HEADER_OFFSET;
 pub const ZDP_REPORT_DATA_OFFSET: usize =
     ZDP_REPORT_HDR_OFFSET + std::mem::size_of::<ZdpReportHeader>();
 
-
 /// Creates a packet like: [ZdpZpiHeader][ZdpBaseHeader]|[ZdpReportHeader]|<report_data>
 /// ZPI set to zero.
 pub fn build_zdp_report_packet<'buf>(

--- a/adapter/ph/src/km_demo.rs
+++ b/adapter/ph/src/km_demo.rs
@@ -29,8 +29,9 @@ pub const ZDP_REPORT_HDR_OFFSET: usize = ZDP_NON_PER_FLOW_MGMT_HEADER_OFFSET;
 pub const ZDP_REPORT_DATA_OFFSET: usize =
     ZDP_REPORT_HDR_OFFSET + std::mem::size_of::<ZdpReportHeader>();
 
-/// Note no ZPI is added.
-/// Creates a packet like: [ZdpBaseHeader]|[ZdpReportHeader]|<report_data>
+
+/// Creates a packet like: [ZdpZpiHeader][ZdpBaseHeader]|[ZdpReportHeader]|<report_data>
+/// ZPI set to zero.
 pub fn build_zdp_report_packet<'buf>(
     pbuf: &'buf mut [u8; config::PACKET_BUFFER_SIZE],
     report_data: &[u8],
@@ -46,7 +47,7 @@ pub fn build_zdp_report_packet<'buf>(
     zdp_hdr.excess_length = 0;
     zdp_hdr.sequence_number = 0.into();
 
-    // Do not add ZPI here - SA_ID is added by KM.
+    pkt.alloc_zeroed_header::<ZdpZpiHeader>().zpi = 0;
 
     pkt.put(&report_data[..]);
     pkt

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -32,24 +32,20 @@
 //! `openssl genpkey -algorithm x25519` (but this generates 48 byte keys instead of 32, so
 //! you will need to do some editing to get the expected size).
 
-
 use crate::km::*;
 use crate::zpr;
 use bytes::{Bytes, BytesMut};
 use curve25519_dalek::montgomery::MontgomeryPoint;
-use std::time::Duration;
-use std::sync::Arc;
-use tracing::error;
 use openssl::rand::rand_bytes;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::error;
 use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
-
 
 static PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
 
-
 const NOISE_NONCE_LEN: usize = 8;
 const NOISE_PADLEN: usize = 16 + NOISE_NONCE_LEN; // 16 byte tag + 8 byte nonce
-
 
 impl From<snow::Error> for KMError {
     fn from(e: snow::Error) -> KMError {
@@ -66,7 +62,7 @@ pub struct KMNoise {
     hs_state: Option<snow::HandshakeState>,
     //t_state: Option<snow::TransportState>,
     recv_hmac_key: [u8; 32], // messages sent to us from peer will use this key (we create this)
-    send_hmac_key: Option<[u8; 32]>,  // messages sent to peer will use this key (peers creates this)
+    send_hmac_key: Option<[u8; 32]>, // messages sent to peer will use this key (peers creates this)
     recv_zpis: ZPIPair,
     send_zpis: Option<ZPIPair>,
 }
@@ -78,7 +74,6 @@ struct KeyMsg {
     pub zpi_transit_hmac: u8,
     pub hmac_key: [u8; 32],
 }
-
 
 impl KMNoise {
     /// Create the Noise KeyManager.
@@ -126,8 +121,11 @@ impl KMNoise {
             local_keypair: kp,
             hs_state: None,
             recv_hmac_key: [0u8; 32], // we generate this and send to peer
-            send_hmac_key: None, // we get this during handshake
-            recv_zpis: ZPIPair{ encr: zpi_full_encr, hmac: zpi_transmit_hmac },
+            send_hmac_key: None,      // we get this during handshake
+            recv_zpis: ZPIPair {
+                encr: zpi_full_encr,
+                hmac: zpi_transmit_hmac,
+            },
             send_zpis: None,
         })
     }
@@ -152,7 +150,6 @@ pub fn derive_public_key(private_key: &[u8; 32]) -> [u8; 32] {
     point.to_bytes()
 }
 
-
 struct NoiseCodec {
     snow_state: snow::StatelessTransportState,
 }
@@ -165,10 +162,11 @@ impl Codec for NoiseCodec {
     ) -> Result<usize, KMError> {
         rand_bytes(&mut message[..NOISE_NONCE_LEN]).unwrap();
         let nonce = u64::from_be_bytes(message[..NOISE_NONCE_LEN].try_into().unwrap());
-        match self.snow_state.write_message(nonce, payload, &mut message[NOISE_NONCE_LEN..]) {
-            Ok(len) => {
-                Ok(len + NOISE_NONCE_LEN)
-            }
+        match self
+            .snow_state
+            .write_message(nonce, payload, &mut message[NOISE_NONCE_LEN..])
+        {
+            Ok(len) => Ok(len + NOISE_NONCE_LEN),
             Err(e) => {
                 error!("noise: error encrypting message: {:?}", e);
                 Err(KMError::EncryptionError)
@@ -188,7 +186,10 @@ impl Codec for NoiseCodec {
             return Err(KMError::EncryptionError);
         }
         let nonce: u64 = u64::from_be_bytes(payload[0..NOISE_NONCE_LEN].try_into().unwrap());
-        match self.snow_state.read_message(nonce, &payload[NOISE_NONCE_LEN..plen], message) {
+        match self
+            .snow_state
+            .read_message(nonce, &payload[NOISE_NONCE_LEN..plen], message)
+        {
             Ok(len) => Ok(len),
             Err(e) => {
                 error!("noise: error decrypting message: {:?}", e);
@@ -197,7 +198,6 @@ impl Codec for NoiseCodec {
         }
     }
 }
-
 
 impl KeyManagerStateMachine for KMNoise {
     fn get_settings(&self) -> KMSettings {
@@ -307,7 +307,10 @@ impl KeyManagerStateMachine for KMNoise {
                                 return Err(KMError::HandshakeError);
                             }
                         };
-                        self.send_zpis = Some(ZPIPair{ encr: km.zpi_full_encr, hmac: km.zpi_transit_hmac });
+                        self.send_zpis = Some(ZPIPair {
+                            encr: km.zpi_full_encr,
+                            hmac: km.zpi_transit_hmac,
+                        });
                         self.send_hmac_key = Some(km.hmac_key);
                     }
                     Err(e) => {
@@ -358,10 +361,14 @@ impl KeyManagerStateMachine for KMNoise {
                     };
                     match hs.into_stateless_transport_mode() {
                         Ok(t) => {
-                            let codec = Arc::new(NoiseCodec {
-                                snow_state: t,
-                            });
-                            self.state = KMSMState::Transport(KMTransportState::new(send_zpis, self.recv_zpis, send_key, self.recv_hmac_key, codec));
+                            let codec = Arc::new(NoiseCodec { snow_state: t });
+                            self.state = KMSMState::Transport(KMTransportState::new(
+                                send_zpis,
+                                self.recv_zpis,
+                                send_key,
+                                self.recv_hmac_key,
+                                codec,
+                            ));
                         }
                         Err(e) => {
                             error!("noise: error switching to transport mode: {:?}", e);
@@ -399,10 +406,14 @@ impl KeyManagerStateMachine for KMNoise {
                     };
                     match hs.into_stateless_transport_mode() {
                         Ok(t) => {
-                            let codec = Arc::new(NoiseCodec {
-                                snow_state: t,
-                            });
-                            self.state = KMSMState::Transport(KMTransportState::new(send_zpis, self.recv_zpis, send_key, self.recv_hmac_key, codec));
+                            let codec = Arc::new(NoiseCodec { snow_state: t });
+                            self.state = KMSMState::Transport(KMTransportState::new(
+                                send_zpis,
+                                self.recv_zpis,
+                                send_key,
+                                self.recv_hmac_key,
+                                codec,
+                            ));
                             return Ok(None);
                         }
                         Err(e) => {
@@ -418,7 +429,6 @@ impl KeyManagerStateMachine for KMNoise {
         }
         Ok(None)
     }
-
 }
 
 #[cfg(test)]
@@ -488,7 +498,7 @@ mod test {
             "unexpected handshake message-1 length, got {}",
             handshake_msg_1.len()
         );
-        assert!(matches!(responder.get_state(), KMSMState::Transport{..}));
+        assert!(matches!(responder.get_state(), KMSMState::Transport { .. }));
 
         // <- e, ee, se
         match initiator.handle_message(&handshake_msg_1) {
@@ -498,7 +508,7 @@ mod test {
                 panic!("initiator.handle_message failed on handshake-1: {:?}", e);
             }
         };
-        assert!(matches!(initiator.get_state(), KMSMState::Transport{..}));
+        assert!(matches!(initiator.get_state(), KMSMState::Transport { .. }));
 
         // Handshake complete, now we can encrypt/decrypt
 
@@ -512,7 +522,10 @@ mod test {
         let plaintext = b"hello world";
 
         let mut out_buf = [0u8; 4096];
-        let out_len = match i_transport.codec.encrypt_transport_stateless(plaintext, &mut out_buf) {
+        let out_len = match i_transport
+            .codec
+            .encrypt_transport_stateless(plaintext, &mut out_buf)
+        {
             Ok(l) => l,
             Err(e) => {
                 panic!("error encrypting message: {:?}", e);
@@ -535,7 +548,10 @@ mod test {
         };
 
         let mut in_buf = [0u8; 4096];
-        let in_len = match r_transport.codec.decrypt_transport_stateless(&out_buf[..out_len], &mut in_buf) {
+        let in_len = match r_transport
+            .codec
+            .decrypt_transport_stateless(&out_buf[..out_len], &mut in_buf)
+        {
             Ok(l) => l,
             Err(e) => {
                 panic!("error decrypting message: {:?}", e);
@@ -615,7 +631,7 @@ mod test {
             "unexpected handshake message-1 length, got {}",
             handshake_msg_1.len()
         );
-        assert!(matches!(responder.get_state(), KMSMState::Transport{..}));
+        assert!(matches!(responder.get_state(), KMSMState::Transport { .. }));
 
         // <- e, ee, se
         match initiator.handle_message(&handshake_msg_1) {
@@ -625,7 +641,7 @@ mod test {
                 panic!("initiator.handle_message failed on handshake-1: {:?}", e);
             }
         };
-        assert!(matches!(initiator.get_state(), KMSMState::Transport{..}));
+        assert!(matches!(initiator.get_state(), KMSMState::Transport { .. }));
 
         // At this point each side should know the others hmac key, and the ZPIs should have been exchanged.
 
@@ -818,9 +834,17 @@ mod test {
         );
 
         // ZPIs should be exchanged.
-        assert!(ZPIPair::new(3, 4) == adapter.get_send_zpis(), "adapter send ZPIs mismatch: {:?}", adapter.get_send_zpis());
+        assert!(
+            ZPIPair::new(3, 4) == adapter.get_send_zpis(),
+            "adapter send ZPIs mismatch: {:?}",
+            adapter.get_send_zpis()
+        );
         assert!(ZPIPair::new(1, 2) == adapter.get_recv_zpis());
-        assert!(ZPIPair::new(1, 2) == node.get_send_zpis(), "node send ZPIs mismatch: {:?}", node.get_send_zpis());
+        assert!(
+            ZPIPair::new(1, 2) == node.get_send_zpis(),
+            "node send ZPIs mismatch: {:?}",
+            node.get_send_zpis()
+        );
         assert!(ZPIPair::new(3, 4) == node.get_recv_zpis());
 
         // HMAC keys created

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -45,7 +45,7 @@ use openssl::rand::rand_bytes;
 use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
 
 
-static PATTERN: &'static str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
+static PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
 
 const NOISE_PADLEN: usize = 24; // 16 byte tag + 8 byte nonce
 
@@ -67,8 +67,8 @@ pub struct KMNoise {
     t_state: Option<snow::TransportState>,
     recv_hmac_key: [u8; 32], // messages sent to us from peer will use this key (we create this)
     send_hmac_key: Option<[u8; 32]>,  // messages sent to peer will use this key (peers creates this)
-    recv_zpis: (u8, u8), // (FULL, HMAC) 
-    send_zpis: Option<(u8, u8)>, // (FULL, HMAC)
+    recv_zpis: ZPIPair,
+    send_zpis: Option<ZPIPair>,
 }
 
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
@@ -88,7 +88,7 @@ impl KMNoise {
     ///
     /// The ZPI stuff here is definately first pass. Currently there is no way to change the
     /// ZPI values.  The ZPIs passed in here are sent to the peer for use in messages sent to us.
-    /// 
+    ///
     /// - `peer_pub_key` is required for initiator, and should match the `local_keypair` of the responder.
     /// - `local_keypair` is optional. If not provided, a new keypair will be generated.
     /// - `zpi_full_encr` is the ZPI peer should use for full encryption messages.
@@ -126,9 +126,9 @@ impl KMNoise {
             local_keypair: kp,
             hs_state: None,
             t_state: None,
-            recv_hmac_key: [0u8; 32], // we generate this and send to peer            
-            send_hmac_key: None, // we get this during handshake            
-            recv_zpis: (zpi_full_encr, zpi_transmit_hmac),
+            recv_hmac_key: [0u8; 32], // we generate this and send to peer
+            send_hmac_key: None, // we get this during handshake
+            recv_zpis: ZPIPair{ encr: zpi_full_encr, hmac: zpi_transmit_hmac },
             send_zpis: None,
         })
     }
@@ -142,7 +142,7 @@ impl KMNoise {
     }
 
     /// Returns the ZPIs for sending, order is (ZPI_FULL_ENCRYPT, ZPI_TRANSIT_HMAC)
-    pub fn get_send_zpis(&self) -> Option<(u8, u8)> {
+    pub fn get_send_zpis(&self) -> Option<ZPIPair> {
         self.send_zpis
     }
 }
@@ -173,7 +173,7 @@ impl KeyManagerStateMachine for KMNoise {
             }
         };
         rand_bytes(&mut self.recv_hmac_key).unwrap(); // generate an HMAC key
-        self.send_hmac_key = None; 
+        self.send_hmac_key = None;
         if self.initiate {
             let rpk = self.peer_pub_key.as_ref().unwrap();
             let mut initiator = match snow::Builder::new(np)
@@ -194,8 +194,8 @@ impl KeyManagerStateMachine for KMNoise {
 
             let mut buf = BytesMut::zeroed(1024);
             let km = KeyMsg {
-                zpi_full_encr: self.recv_zpis.0,
-                zpi_transit_hmac: self.recv_zpis.1,
+                zpi_full_encr: self.recv_zpis.encr,
+                zpi_transit_hmac: self.recv_zpis.hmac,
                 hmac_key: self.recv_hmac_key,
             };
             let len = match initiator.write_message(km.as_bytes(), &mut buf) {
@@ -235,7 +235,7 @@ impl KeyManagerStateMachine for KMNoise {
     fn handle_message(&mut self, message: &[u8]) -> Result<Option<Bytes>, KMError> {
         if self.state == KMSMState::Configuring {
             let mut hs: snow::HandshakeState;
-            if self.hs_state.is_none() {                
+            if self.hs_state.is_none() {
                 error!("noise: handle_message called but no handshake state set up");
                 return Err(KMError::InvalidState);
             }
@@ -261,7 +261,7 @@ impl KeyManagerStateMachine for KMNoise {
                                 return Err(KMError::HandshakeError);
                             }
                         };
-                        self.send_zpis = Some((km.zpi_full_encr, km.zpi_transit_hmac));
+                        self.send_zpis = Some(ZPIPair{ encr: km.zpi_full_encr, hmac: km.zpi_transit_hmac });
                         self.send_hmac_key = Some(km.hmac_key);
                     }
                     Err(e) => {
@@ -276,10 +276,10 @@ impl KeyManagerStateMachine for KMNoise {
 
                 if !hs.is_handshake_finished() {
                     let payload = KeyMsg {
-                        zpi_full_encr: self.recv_zpis.0,
-                        zpi_transit_hmac: self.recv_zpis.1,
+                        zpi_full_encr: self.recv_zpis.encr,
+                        zpi_transit_hmac: self.recv_zpis.hmac,
                         hmac_key: self.recv_hmac_key,
-                    };                    
+                    };
                     let mut buf = BytesMut::zeroed(1024);
                     match hs.write_message(payload.as_bytes(), &mut buf) {
                         Ok(len) => {
@@ -299,8 +299,8 @@ impl KeyManagerStateMachine for KMNoise {
                     let send_zpis = match self.send_zpis {
                         Some(z) => z,
                         None => {
-                            error!("noise: XXX handshake finished by no ZPIs received");
-                            (0, 0)
+                            error!("noise: handshake finished by no ZPIs received");
+                            ZPIPair::new_zero()
                         }
                     };
                     let send_key = match self.send_hmac_key {
@@ -338,8 +338,8 @@ impl KeyManagerStateMachine for KMNoise {
                     let send_zpis = match self.send_zpis {
                         Some(z) => z,
                         None => {
-                            error!("noise: handshake finished by no ZPIs received"); 
-                            (0, 0)
+                            error!("noise: handshake finished by no ZPIs received");
+                            ZPIPair::new_zero()
                         }
                     };
                     let send_key = match self.send_hmac_key {
@@ -626,17 +626,17 @@ mod test {
         assert!(responder.get_send_hmac_key().is_some()); // must have been recieved
 
         assert!(initiator.get_recv_hmac_key() == responder.get_send_hmac_key().unwrap());
-        assert!(responder.get_recv_hmac_key() == initiator.get_send_hmac_key().unwrap());        
+        assert!(responder.get_recv_hmac_key() == initiator.get_send_hmac_key().unwrap());
 
         assert!(initiator.get_send_zpis().is_some());
-        let (initiator_zpi_full, initiator_zpi_hmac) = initiator.get_send_zpis().unwrap();
-        assert!(initiator_zpi_full == 3);
-        assert!(initiator_zpi_hmac == 4);
+        let initiator_zpis = initiator.get_send_zpis().unwrap();
+        assert!(initiator_zpis.encr == 3);
+        assert!(initiator_zpis.hmac == 4);
 
         assert!(responder.get_send_zpis().is_some());
-        let (responder_zpi_full, responder_zpi_hmac) = responder.get_send_zpis().unwrap();
-        assert!(responder_zpi_full == 1);
-        assert!(responder_zpi_hmac == 2);        
+        let responder_zpis = responder.get_send_zpis().unwrap();
+        assert!(responder_zpis.encr == 1);
+        assert!(responder_zpis.hmac == 2);
     }
 
     #[tokio::test]
@@ -808,16 +808,16 @@ mod test {
         );
 
         // ZPIs should be exchanged.
-        assert!((3, 4) == adapter.get_send_zpis(), "adapter send ZPIs mismatch: {:?}", adapter.get_send_zpis());
-        assert!((1, 2) == adapter.get_recv_zpis());  
-        assert!((1, 2) == node.get_send_zpis(), "node send ZPIs mismatch: {:?}", node.get_send_zpis());  
-        assert!((3, 4) == node.get_recv_zpis());                
+        assert!(ZPIPair::new(3, 4) == adapter.get_send_zpis(), "adapter send ZPIs mismatch: {:?}", adapter.get_send_zpis());
+        assert!(ZPIPair::new(1, 2) == adapter.get_recv_zpis());
+        assert!(ZPIPair::new(1, 2) == node.get_send_zpis(), "node send ZPIs mismatch: {:?}", node.get_send_zpis());
+        assert!(ZPIPair::new(3, 4) == node.get_recv_zpis());
 
         // HMAC keys created
         assert!(adapter.get_recv_hmac_key() != [0u8; 32]);
-        assert!(adapter.get_send_hmac_key() != [0u8; 32]);        
+        assert!(adapter.get_send_hmac_key() != [0u8; 32]);
         assert!(node.get_recv_hmac_key() != [0u8; 32]);
-        assert!(node.get_send_hmac_key() != [0u8; 32]);        
+        assert!(node.get_send_hmac_key() != [0u8; 32]);
 
         ctok.cancel()
     }

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -34,12 +34,16 @@
 //! into `wg pubkey` to get the public key.  You can also generate keys using `openssl`, eg
 //! `openssl genpkey -algorithm x25519`.
 
+
 use crate::km::*;
 use crate::zpr;
 use bytes::{Bytes, BytesMut};
 use curve25519_dalek::montgomery::MontgomeryPoint;
 use std::time::Duration;
-use tracing::{error, info};
+use tracing::error;
+use openssl::rand::rand_bytes;
+use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+
 
 static PATTERN: &'static str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
 
@@ -61,7 +65,20 @@ pub struct KMNoise {
     local_keypair: snow::Keypair,
     hs_state: Option<snow::HandshakeState>,
     t_state: Option<snow::TransportState>,
+    recv_hmac_key: [u8; 32], // messages sent to us from peer will use this key (we create this)
+    send_hmac_key: Option<[u8; 32]>,  // messages sent to peer will use this key (peers creates this)
+    recv_zpis: (u8, u8), // (FULL, HMAC) 
+    send_zpis: Option<(u8, u8)>, // (FULL, HMAC)
 }
+
+#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[repr(packed)]
+struct KeyMsg {
+    pub zpi_full_encr: u8,
+    pub zpi_transit_hmac: u8,
+    pub hmac_key: [u8; 32],
+}
+
 
 impl KMNoise {
     /// Create the Noise KeyManager.
@@ -69,12 +86,19 @@ impl KMNoise {
     /// This requires Noise keys.  Eventually (TODO) we will also pass certificates through here
     /// so that each side can check for certificate authority signautre.
     ///
+    /// The ZPI stuff here is definately first pass. Currently there is no way to change the
+    /// ZPI values.  The ZPIs passed in here are sent to the peer for use in messages sent to us.
+    /// 
     /// - `peer_pub_key` is required for initiator, and should match the `local_keypair` of the responder.
     /// - `local_keypair` is optional. If not provided, a new keypair will be generated.
+    /// - `zpi_full_encr` is the ZPI peer should use for full encryption messages.
+    /// - `zpi_transmit_hmac` is the ZPI peer should use for HMAC encrypted messages.
     pub fn new(
         initiate: bool,
         peer_pub_key: Option<Vec<u8>>,
         local_keypair: Option<snow::Keypair>,
+        zpi_full_encr: u8,
+        zpi_transmit_hmac: u8,
     ) -> Result<Self, KMError> {
         if initiate && peer_pub_key.is_none() {
             error!("noise: peer public key required for initiator");
@@ -94,7 +118,6 @@ impl KMNoise {
         } else {
             kp = snow::Builder::new(PATTERN.parse()?).generate_keypair()?;
         }
-
         Ok(KMNoise {
             settings,
             state: KMSMState::Configuring,
@@ -103,7 +126,24 @@ impl KMNoise {
             local_keypair: kp,
             hs_state: None,
             t_state: None,
+            recv_hmac_key: [0u8; 32], // we generate this and send to peer            
+            send_hmac_key: None, // we get this during handshake            
+            recv_zpis: (zpi_full_encr, zpi_transmit_hmac),
+            send_zpis: None,
         })
+    }
+
+    pub fn get_recv_hmac_key(&self) -> [u8; 32] {
+        self.recv_hmac_key
+    }
+
+    pub fn get_send_hmac_key(&self) -> Option<[u8; 32]> {
+        self.send_hmac_key
+    }
+
+    /// Returns the ZPIs for sending, order is (ZPI_FULL_ENCRYPT, ZPI_TRANSIT_HMAC)
+    pub fn get_send_zpis(&self) -> Option<(u8, u8)> {
+        self.send_zpis
     }
 }
 
@@ -132,6 +172,8 @@ impl KeyManagerStateMachine for KMNoise {
                 return Err(KMError::ConfigurationError);
             }
         };
+        rand_bytes(&mut self.recv_hmac_key).unwrap(); // generate an HMAC key
+        self.send_hmac_key = None; 
         if self.initiate {
             let rpk = self.peer_pub_key.as_ref().unwrap();
             let mut initiator = match snow::Builder::new(np)
@@ -151,7 +193,12 @@ impl KeyManagerStateMachine for KMNoise {
             };
 
             let mut buf = BytesMut::zeroed(1024);
-            let len = match initiator.write_message(&b"todo:cert here"[..], &mut buf) {
+            let km = KeyMsg {
+                zpi_full_encr: self.recv_zpis.0,
+                zpi_transit_hmac: self.recv_zpis.1,
+                hmac_key: self.recv_hmac_key,
+            };
+            let len = match initiator.write_message(km.as_bytes(), &mut buf) {
                 Ok(l) => l,
                 Err(e) => {
                     error!("noise: error writing handshake message: {:?}", e);
@@ -188,20 +235,34 @@ impl KeyManagerStateMachine for KMNoise {
     fn handle_message(&mut self, message: &[u8]) -> Result<Option<Bytes>, KMError> {
         if self.state == KMSMState::Configuring {
             let mut hs: snow::HandshakeState;
-            if self.hs_state.is_none() {
+            if self.hs_state.is_none() {                
                 error!("noise: handle_message called but no handshake state set up");
                 return Err(KMError::InvalidState);
             }
             if self.hs_state.is_some() {
                 hs = self.hs_state.take().unwrap();
-                let mut buf = BytesMut::zeroed(1024);
-                match hs.read_message(message, &mut buf) {
+                let mut payload = BytesMut::zeroed(1024);
+                // Our IK pattern has two handshake messages. In each we expect to find a KeyMsg in the payload.
+                match hs.read_message(&message[..], &mut payload) {
                     Ok(len) => {
                         // TODO: In future we plan to send the certificate over in the first handshake message buffer.
-                        info!(
-                            "noise: got {} byte payload in handshake message, ignoring",
-                            len
-                        );
+                        if len < std::mem::size_of::<KeyMsg>() {
+                            error!("noise: handshake payload is too short: {}", len);
+                            self.state = KMSMState::Error;
+                            self.hs_state = Some(hs);
+                            return Err(KMError::HandshakeError);
+                        }
+                        let km = match KeyMsg::ref_from_prefix(&payload[..len]) {
+                            Some(k) => k,
+                            None => {
+                                error!("noise: error parsing KeyMsg handshake payload");
+                                self.state = KMSMState::Error;
+                                self.hs_state = Some(hs);
+                                return Err(KMError::HandshakeError);
+                            }
+                        };
+                        self.send_zpis = Some((km.zpi_full_encr, km.zpi_transit_hmac));
+                        self.send_hmac_key = Some(km.hmac_key);
                     }
                     Err(e) => {
                         error!("noise: error handling handhsake message: {:?}", e);
@@ -214,8 +275,13 @@ impl KeyManagerStateMachine for KMNoise {
                 let mut hs_msg: Option<Bytes> = None;
 
                 if !hs.is_handshake_finished() {
+                    let payload = KeyMsg {
+                        zpi_full_encr: self.recv_zpis.0,
+                        zpi_transit_hmac: self.recv_zpis.1,
+                        hmac_key: self.recv_hmac_key,
+                    };                    
                     let mut buf = BytesMut::zeroed(1024);
-                    match hs.write_message(&[], &mut buf) {
+                    match hs.write_message(payload.as_bytes(), &mut buf) {
                         Ok(len) => {
                             buf.truncate(len);
                             hs_msg = Some(buf.freeze());
@@ -230,10 +296,24 @@ impl KeyManagerStateMachine for KMNoise {
                 }
 
                 if hs.is_handshake_finished() {
+                    let send_zpis = match self.send_zpis {
+                        Some(z) => z,
+                        None => {
+                            error!("noise: XXX handshake finished by no ZPIs received");
+                            (0, 0)
+                        }
+                    };
+                    let send_key = match self.send_hmac_key {
+                        Some(h) => h,
+                        None => {
+                            error!("noise: XXX handshake finished by no HMAC key received");
+                            [0u8; 32]
+                        }
+                    };
                     match hs.into_transport_mode() {
                         Ok(t) => {
                             self.t_state = Some(t);
-                            self.state = KMSMState::Transport;
+                            self.state = KMSMState::Transport(KMTransportState::new(send_zpis, self.recv_zpis, send_key, self.recv_hmac_key));
                         }
                         Err(e) => {
                             error!("noise: error switching to transport mode: {:?}", e);
@@ -255,10 +335,24 @@ impl KeyManagerStateMachine for KMNoise {
             if self.hs_state.is_some() {
                 hs = self.hs_state.take().unwrap();
                 if hs.is_handshake_finished() {
+                    let send_zpis = match self.send_zpis {
+                        Some(z) => z,
+                        None => {
+                            error!("noise: handshake finished by no ZPIs received"); 
+                            (0, 0)
+                        }
+                    };
+                    let send_key = match self.send_hmac_key {
+                        Some(h) => h,
+                        None => {
+                            error!("noise: handshake finished by no HMAC key received");
+                            [0u8; 32]
+                        }
+                    };
                     match hs.into_transport_mode() {
                         Ok(t) => {
                             self.t_state = Some(t);
-                            self.state = KMSMState::Transport;
+                            self.state = KMSMState::Transport(KMTransportState::new(send_zpis, self.recv_zpis, send_key, self.recv_hmac_key));
                             return Ok(None);
                         }
                         Err(e) => {
@@ -353,10 +447,10 @@ mod test {
             }
         };
 
-        let mut initiator = KMNoise::new(true, Some(node_kp.public.to_vec()), None).unwrap();
+        let mut initiator = KMNoise::new(true, Some(node_kp.public.to_vec()), None, 1, 2).unwrap();
         assert!(initiator.get_state() == KMSMState::Configuring);
 
-        let mut responder = KMNoise::new(false, None, Some(node_kp)).unwrap();
+        let mut responder = KMNoise::new(false, None, Some(node_kp), 3, 4).unwrap();
         assert!(responder.get_state() == KMSMState::Configuring);
 
         let handshake_msg_0 = match initiator.reset() {
@@ -369,7 +463,7 @@ mod test {
             }
         };
         assert!(
-            handshake_msg_0.len() == 110,
+            handshake_msg_0.len() == 130,
             "unexpected handshake message-0 length, got {}",
             handshake_msg_0.len()
         );
@@ -394,11 +488,11 @@ mod test {
             }
         };
         assert!(
-            handshake_msg_1.len() == 48,
+            handshake_msg_1.len() == 82,
             "unexpected handshake message-1 length, got {}",
             handshake_msg_1.len()
         );
-        assert!(responder.get_state() == KMSMState::Transport);
+        assert!(matches!(responder.get_state(), KMSMState::Transport{..}));
 
         // <- e, ee, se
         match initiator.handle_message(&handshake_msg_1) {
@@ -408,7 +502,7 @@ mod test {
                 panic!("initiator.handle_message failed on handshake-1: {:?}", e);
             }
         };
-        assert!(initiator.get_state() == KMSMState::Transport);
+        assert!(matches!(initiator.get_state(), KMSMState::Transport{..}));
 
         // Handshake complete, now we can encrypt/decrypt
 
@@ -466,10 +560,10 @@ mod test {
             public: nk_public.into(),
         };
 
-        let mut initiator = KMNoise::new(true, Some(node_kp.public.to_vec()), None).unwrap();
+        let mut initiator = KMNoise::new(true, Some(node_kp.public.to_vec()), None, 1, 2).unwrap();
         assert!(initiator.get_state() == KMSMState::Configuring);
 
-        let mut responder = KMNoise::new(false, None, Some(node_kp)).unwrap();
+        let mut responder = KMNoise::new(false, None, Some(node_kp), 3, 4).unwrap();
         assert!(responder.get_state() == KMSMState::Configuring);
 
         let handshake_msg_0 = match initiator.reset() {
@@ -482,7 +576,7 @@ mod test {
             }
         };
         assert!(
-            handshake_msg_0.len() == 110,
+            handshake_msg_0.len() == 130,
             "unexpected handshake message-0 length, got {}",
             handshake_msg_0.len()
         );
@@ -507,11 +601,11 @@ mod test {
             }
         };
         assert!(
-            handshake_msg_1.len() == 48,
+            handshake_msg_1.len() == 82,
             "unexpected handshake message-1 length, got {}",
             handshake_msg_1.len()
         );
-        assert!(responder.get_state() == KMSMState::Transport);
+        assert!(matches!(responder.get_state(), KMSMState::Transport{..}));
 
         // <- e, ee, se
         match initiator.handle_message(&handshake_msg_1) {
@@ -521,7 +615,28 @@ mod test {
                 panic!("initiator.handle_message failed on handshake-1: {:?}", e);
             }
         };
-        assert!(initiator.get_state() == KMSMState::Transport);
+        assert!(matches!(initiator.get_state(), KMSMState::Transport{..}));
+
+        // At this point each side should know the others hmac key, and the ZPIs should have been exchanged.
+
+        assert!(initiator.get_recv_hmac_key() != [0u8; 32]);
+        assert!(initiator.get_send_hmac_key().is_some()); // must have been recieved
+
+        assert!(responder.get_recv_hmac_key() != [0u8; 32]);
+        assert!(responder.get_send_hmac_key().is_some()); // must have been recieved
+
+        assert!(initiator.get_recv_hmac_key() == responder.get_send_hmac_key().unwrap());
+        assert!(responder.get_recv_hmac_key() == initiator.get_send_hmac_key().unwrap());        
+
+        assert!(initiator.get_send_zpis().is_some());
+        let (initiator_zpi_full, initiator_zpi_hmac) = initiator.get_send_zpis().unwrap();
+        assert!(initiator_zpi_full == 3);
+        assert!(initiator_zpi_hmac == 4);
+
+        assert!(responder.get_send_zpis().is_some());
+        let (responder_zpi_full, responder_zpi_hmac) = responder.get_send_zpis().unwrap();
+        assert!(responder_zpi_full == 1);
+        assert!(responder_zpi_hmac == 2);        
     }
 
     #[tokio::test]
@@ -534,8 +649,8 @@ mod test {
             }
         };
 
-        let initiator = KMNoise::new(true, Some(node_kp.public.to_vec()), None).unwrap();
-        let responder = KMNoise::new(false, None, Some(node_kp)).unwrap();
+        let initiator = KMNoise::new(true, Some(node_kp.public.to_vec()), None, 1, 2).unwrap();
+        let responder = KMNoise::new(false, None, Some(node_kp), 3, 4).unwrap();
 
         let adapter = km::KeyManager::new(Box::new(initiator));
         let node = km::KeyManager::new(Box::new(responder));
@@ -684,13 +799,25 @@ mod test {
             }
         }
 
-        // Finally, both should hve same SA-ID
+        // Both should hve same SA-ID
         assert!(
             adapter.get_sa_id() == node.get_sa_id(),
             "SA-ID mismatch: adapter={}, node={}",
             adapter.get_sa_id(),
             node.get_sa_id()
         );
+
+        // ZPIs should be exchanged.
+        assert!((3, 4) == adapter.get_send_zpis(), "adapter send ZPIs mismatch: {:?}", adapter.get_send_zpis());
+        assert!((1, 2) == adapter.get_recv_zpis());  
+        assert!((1, 2) == node.get_send_zpis(), "node send ZPIs mismatch: {:?}", node.get_send_zpis());  
+        assert!((3, 4) == node.get_recv_zpis());                
+
+        // HMAC keys created
+        assert!(adapter.get_recv_hmac_key() != [0u8; 32]);
+        assert!(adapter.get_send_hmac_key() != [0u8; 32]);        
+        assert!(node.get_recv_hmac_key() != [0u8; 32]);
+        assert!(node.get_send_hmac_key() != [0u8; 32]);        
 
         ctok.cancel()
     }

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -38,6 +38,7 @@ use crate::zpr;
 use bytes::{Bytes, BytesMut};
 use curve25519_dalek::montgomery::MontgomeryPoint;
 use std::time::Duration;
+use std::sync::Arc;
 use tracing::error;
 use openssl::rand::rand_bytes;
 use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
@@ -56,8 +57,6 @@ impl From<snow::Error> for KMError {
     }
 }
 
-/// Not multi-thread safe.
-/// TODO: Figure out how to make encryption/decryption parallelizable.
 pub struct KMNoise {
     settings: KMSettings,
     state: KMSMState,
@@ -65,7 +64,7 @@ pub struct KMNoise {
     peer_pub_key: Option<Vec<u8>>, // required if initiator
     local_keypair: snow::Keypair,
     hs_state: Option<snow::HandshakeState>,
-    t_state: Option<snow::TransportState>,
+    //t_state: Option<snow::TransportState>,
     recv_hmac_key: [u8; 32], // messages sent to us from peer will use this key (we create this)
     send_hmac_key: Option<[u8; 32]>,  // messages sent to peer will use this key (peers creates this)
     recv_zpis: ZPIPair,
@@ -126,7 +125,6 @@ impl KMNoise {
             peer_pub_key,
             local_keypair: kp,
             hs_state: None,
-            t_state: None,
             recv_hmac_key: [0u8; 32], // we generate this and send to peer
             send_hmac_key: None, // we get this during handshake
             recv_zpis: ZPIPair{ encr: zpi_full_encr, hmac: zpi_transmit_hmac },
@@ -142,7 +140,7 @@ impl KMNoise {
         self.send_hmac_key
     }
 
-    /// Returns the ZPIs for sending, order is (ZPI_FULL_ENCRYPT, ZPI_TRANSIT_HMAC)
+    /// Returns the ZPIs for sending
     pub fn get_send_zpis(&self) -> Option<ZPIPair> {
         self.send_zpis
     }
@@ -153,6 +151,53 @@ pub fn derive_public_key(private_key: &[u8; 32]) -> [u8; 32] {
     let point = MontgomeryPoint::mul_base_clamped(*private_key);
     point.to_bytes()
 }
+
+
+struct NoiseCodec {
+    snow_state: snow::StatelessTransportState,
+}
+
+impl Codec for NoiseCodec {
+    fn encrypt_transport_stateless(
+        self: &Self,
+        payload: &[u8],
+        message: &mut [u8],
+    ) -> Result<usize, KMError> {
+        rand_bytes(&mut message[..NOISE_NONCE_LEN]).unwrap();
+        let nonce = u64::from_be_bytes(message[..NOISE_NONCE_LEN].try_into().unwrap());
+        match self.snow_state.write_message(nonce, payload, &mut message[NOISE_NONCE_LEN..]) {
+            Ok(len) => {
+                Ok(len + NOISE_NONCE_LEN)
+            }
+            Err(e) => {
+                error!("noise: error encrypting message: {:?}", e);
+                Err(KMError::EncryptionError)
+            }
+        }
+    }
+
+    fn decrypt_transport_stateless(
+        self: &Self,
+        payload: &[u8],
+        message: &mut [u8],
+    ) -> Result<usize, KMError> {
+        // nonce is first 8 bytes of the message.
+        let plen = payload.len();
+        if plen < NOISE_NONCE_LEN {
+            error!("noise: message too short");
+            return Err(KMError::EncryptionError);
+        }
+        let nonce: u64 = u64::from_be_bytes(payload[0..NOISE_NONCE_LEN].try_into().unwrap());
+        match self.snow_state.read_message(nonce, &payload[NOISE_NONCE_LEN..plen], message) {
+            Ok(len) => Ok(len),
+            Err(e) => {
+                error!("noise: error decrypting message: {:?}", e);
+                Err(KMError::EncryptionError)
+            }
+        }
+    }
+}
+
 
 impl KeyManagerStateMachine for KMNoise {
     fn get_settings(&self) -> KMSettings {
@@ -311,10 +356,12 @@ impl KeyManagerStateMachine for KMNoise {
                             [0u8; 32]
                         }
                     };
-                    match hs.into_transport_mode() {
+                    match hs.into_stateless_transport_mode() {
                         Ok(t) => {
-                            self.t_state = Some(t);
-                            self.state = KMSMState::Transport(KMTransportState::new(send_zpis, self.recv_zpis, send_key, self.recv_hmac_key));
+                            let codec = Arc::new(NoiseCodec {
+                                snow_state: t,
+                            });
+                            self.state = KMSMState::Transport(KMTransportState::new(send_zpis, self.recv_zpis, send_key, self.recv_hmac_key, codec));
                         }
                         Err(e) => {
                             error!("noise: error switching to transport mode: {:?}", e);
@@ -350,10 +397,12 @@ impl KeyManagerStateMachine for KMNoise {
                             [0u8; 32]
                         }
                     };
-                    match hs.into_transport_mode() {
+                    match hs.into_stateless_transport_mode() {
                         Ok(t) => {
-                            self.t_state = Some(t);
-                            self.state = KMSMState::Transport(KMTransportState::new(send_zpis, self.recv_zpis, send_key, self.recv_hmac_key));
+                            let codec = Arc::new(NoiseCodec {
+                                snow_state: t,
+                            });
+                            self.state = KMSMState::Transport(KMTransportState::new(send_zpis, self.recv_zpis, send_key, self.recv_hmac_key, codec));
                             return Ok(None);
                         }
                         Err(e) => {
@@ -370,60 +419,6 @@ impl KeyManagerStateMachine for KMNoise {
         Ok(None)
     }
 
-    fn encrypt_transport(
-        self: &mut Self,
-        payload: &[u8],
-        message: &mut [u8],
-    ) -> Result<usize, KMError> {
-        let ts = match &mut self.t_state {
-            Some(t) => t,
-            None => {
-                error!("noise: encrypt_transport called in wrong state");
-                return Err(KMError::InvalidState);
-            }
-        };
-        let nonce = ts.sending_nonce();
-        message[..NOISE_NONCE_LEN].copy_from_slice(&nonce.to_be_bytes());
-        match ts.write_message(payload, &mut message[NOISE_NONCE_LEN..]) {
-            Ok(len) => {
-                Ok(len + NOISE_NONCE_LEN)
-            }
-            Err(e) => {
-                error!("noise: error encrypting message: {:?}", e);
-                Err(KMError::EncryptionError)
-            }
-        }
-    }
-
-    fn decrypt_transport(
-        self: &mut Self,
-        payload: &[u8],
-        message: &mut [u8],
-    ) -> Result<usize, KMError> {
-        let ts = match &mut self.t_state {
-            Some(t) => t,
-            None => {
-                error!("noise: decrypt_transport called in wrong state");
-                return Err(KMError::InvalidState);
-            }
-        };
-        // nonce is first 8 bytes in the message.
-        let plen = payload.len();
-        if plen < NOISE_NONCE_LEN {
-            error!("noise: message too short");
-            return Err(KMError::EncryptionError);
-        }
-        let nonce: u64 = u64::from_be_bytes(payload[0..NOISE_NONCE_LEN].try_into().unwrap());
-
-        ts.set_receiving_nonce(nonce);
-        match ts.read_message(&payload[NOISE_NONCE_LEN..plen], message) {
-            Ok(len) => Ok(len),
-            Err(e) => {
-                error!("noise: error decrypting message: {:?}", e);
-                Err(KMError::EncryptionError)
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -507,10 +502,17 @@ mod test {
 
         // Handshake complete, now we can encrypt/decrypt
 
+        let i_transport = match initiator.get_state() {
+            KMSMState::Transport(t) => t,
+            _ => {
+                panic!("unexpected state after handshake");
+            }
+        };
+
         let plaintext = b"hello world";
 
         let mut out_buf = [0u8; 4096];
-        let out_len = match initiator.encrypt_transport(plaintext, &mut out_buf) {
+        let out_len = match i_transport.codec.encrypt_transport_stateless(plaintext, &mut out_buf) {
             Ok(l) => l,
             Err(e) => {
                 panic!("error encrypting message: {:?}", e);
@@ -525,8 +527,15 @@ mod test {
             out_len
         );
 
+        let r_transport = match responder.get_state() {
+            KMSMState::Transport(t) => t,
+            _ => {
+                panic!("unexpected state after handshake");
+            }
+        };
+
         let mut in_buf = [0u8; 4096];
-        let in_len = match responder.decrypt_transport(&out_buf[..out_len], &mut in_buf) {
+        let in_len = match r_transport.codec.decrypt_transport_stateless(&out_buf[..out_len], &mut in_buf) {
             Ok(l) => l,
             Err(e) => {
                 panic!("error decrypting message: {:?}", e);

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -15,24 +15,22 @@
 //!    [ ZDP payload or message ]
 //!
 //!
-//!    |-------- n + 16 bytes ----------||--- 8 bytes ---|
-//!    [ encrypted buffer               ][     nonce     ]
+//!    |--- 8 bytes ---||-------- n + 16 bytes ----------|
+//!    [     nonce     ][ encrypted buffer               ]
 //!
 //!    So total extra space needed by encryption is 16 + 8 = 24 bytes.
 //! ```
-//!
-//! Note that we do not handle padding here. If padding is desireable
-//! caller needs to apply padding before calling encrypt.
 //!
 //! Note that the encrypt/decrypt functions expect to operate on entire
 //! buffer.  Caller is responsible for dealing with cases when only
 //! part of the buffer is to be encrypted or decrypted.
 //!
 //!
-//! Note you can create noise keys with the `wg` command line tool on recent versions of linux.
+//! Note you can create 32 byte noise keys with the `wg` command line tool on recent versions of linux.
 //! For example, to generate a private key: `wg genkey`.  Then you can pass that private key
 //! into `wg pubkey` to get the public key.  You can also generate keys using `openssl`, eg
-//! `openssl genpkey -algorithm x25519`.
+//! `openssl genpkey -algorithm x25519` (but this generates 48 byte keys instead of 32, so
+//! you will need to do some editing to get the expected size).
 
 
 use crate::km::*;
@@ -47,7 +45,10 @@ use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
 
 static PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
 
-const NOISE_PADLEN: usize = 24; // 16 byte tag + 8 byte nonce
+
+const NOISE_NONCE_LEN: usize = 8;
+const NOISE_PADLEN: usize = 16 + NOISE_NONCE_LEN; // 16 byte tag + 8 byte nonce
+
 
 impl From<snow::Error> for KMError {
     fn from(e: snow::Error) -> KMError {
@@ -382,10 +383,10 @@ impl KeyManagerStateMachine for KMNoise {
             }
         };
         let nonce = ts.sending_nonce();
-        match ts.write_message(payload, message) {
+        message[..NOISE_NONCE_LEN].copy_from_slice(&nonce.to_be_bytes());
+        match ts.write_message(payload, &mut message[NOISE_NONCE_LEN..]) {
             Ok(len) => {
-                message[len..len + 8].copy_from_slice(&nonce.to_be_bytes());
-                Ok(len + 8)
+                Ok(len + NOISE_NONCE_LEN)
             }
             Err(e) => {
                 error!("noise: error encrypting message: {:?}", e);
@@ -406,16 +407,16 @@ impl KeyManagerStateMachine for KMNoise {
                 return Err(KMError::InvalidState);
             }
         };
-        // nonce is last 8 bytes in the message.
+        // nonce is first 8 bytes in the message.
         let plen = payload.len();
-        if plen < 8 {
+        if plen < NOISE_NONCE_LEN {
             error!("noise: message too short");
             return Err(KMError::EncryptionError);
         }
-        let nonce: u64 = u64::from_be_bytes(payload[plen - 8..].try_into().unwrap());
+        let nonce: u64 = u64::from_be_bytes(payload[0..NOISE_NONCE_LEN].try_into().unwrap());
 
         ts.set_receiving_nonce(nonce);
-        match ts.read_message(&payload[..plen - 8], message) {
+        match ts.read_message(&payload[NOISE_NONCE_LEN..plen], message) {
             Ok(len) => Ok(len),
             Err(e) => {
                 error!("noise: error decrypting message: {:?}", e);

--- a/adapter/ph/src/km_xor.rs
+++ b/adapter/ph/src/km_xor.rs
@@ -4,9 +4,9 @@
 use crate::km::*;
 use crate::zpr;
 use bytes::Bytes;
+use std::sync::Arc;
 use std::time;
 use std::time::Duration;
-use std::sync::Arc;
 
 pub struct XorKeyManager {
     state: KMSMState,
@@ -104,7 +104,7 @@ impl KeyManagerStateMachine for XorKeyManager {
 
     fn handle_message(&mut self, _message: &[u8]) -> Result<Option<Bytes>, KMError> {
         if self.state == KMSMState::Configuring {
-            let codec = Arc::new(XorCodec{});
+            let codec = Arc::new(XorCodec {});
             self.state = KMSMState::Transport(KMTransportState::new_empty_with_codec(codec));
             if !self.initiate {
                 // Did not initiate, so send a reply back.
@@ -116,7 +116,10 @@ impl KeyManagerStateMachine for XorKeyManager {
     }
 
     fn tick(&mut self) -> Result<Option<Bytes>, KMError> {
-        if self.state == KMSMState::Configuring && self.initiate && self.hello_t.elapsed() > Duration::from_secs(5) {
+        if self.state == KMSMState::Configuring
+            && self.initiate
+            && self.hello_t.elapsed() > Duration::from_secs(5)
+        {
             // too long, send another hello.
             let handshake = Bytes::from_static(&[0, 255, 0, 12, 1, 2, 3, 4, 5, 6, 7, 8]); // TYPE | LEN | PAYLOAD
             self.hello_t = time::Instant::now();
@@ -124,7 +127,6 @@ impl KeyManagerStateMachine for XorKeyManager {
         }
         Ok(None)
     }
-
 }
 
 #[cfg(test)]
@@ -135,11 +137,15 @@ mod test {
     fn test_encrypt_decrypt() {
         let mut buf = [0u8; 64];
         let payload = Bytes::from_static(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        let codec = XorCodec{};
-        let sz = codec.encrypt_transport_stateless(&payload, &mut buf).unwrap();
+        let codec = XorCodec {};
+        let sz = codec
+            .encrypt_transport_stateless(&payload, &mut buf)
+            .unwrap();
         assert_eq!(sz, 12);
         let mut decbuf = [0u8; 64];
-        let decsz = codec.decrypt_transport_stateless(&buf[0..sz], &mut decbuf).unwrap();
+        let decsz = codec
+            .decrypt_transport_stateless(&buf[0..sz], &mut decbuf)
+            .unwrap();
         assert_eq!(decsz, 10);
         assert_eq!(&decbuf[0..decsz], &payload[..]);
     }

--- a/adapter/ph/src/km_xor.rs
+++ b/adapter/ph/src/km_xor.rs
@@ -63,13 +63,11 @@ impl KeyManagerStateMachine for XorKeyManager {
     }
 
     fn tick(&mut self) -> Result<Option<Bytes>, KMError> {
-        if self.state == KMSMState::Configuring {
-            if self.initiate && self.hello_t.elapsed() > Duration::from_secs(5) {
-                // too long, send another hello.
-                let handshake = Bytes::from_static(&[0, 255, 0, 12, 1, 2, 3, 4, 5, 6, 7, 8]); // TYPE | LEN | PAYLOAD
-                self.hello_t = time::Instant::now();
-                return Ok(Some(handshake));
-            }
+        if self.state == KMSMState::Configuring && self.initiate && self.hello_t.elapsed() > Duration::from_secs(5) {
+            // too long, send another hello.
+            let handshake = Bytes::from_static(&[0, 255, 0, 12, 1, 2, 3, 4, 5, 6, 7, 8]); // TYPE | LEN | PAYLOAD
+            self.hello_t = time::Instant::now();
+            return Ok(Some(handshake));
         }
         Ok(None)
     }

--- a/adapter/ph/src/km_xor.rs
+++ b/adapter/ph/src/km_xor.rs
@@ -6,6 +6,7 @@ use crate::zpr;
 use bytes::Bytes;
 use std::time;
 use std::time::Duration;
+use std::sync::Arc;
 
 pub struct XorKeyManager {
     state: KMSMState,
@@ -27,6 +28,57 @@ impl XorKeyManager {
             hello_t: time::Instant::now(),
             initiate,
         }
+    }
+}
+
+struct XorCodec;
+
+impl Codec for XorCodec {
+    // Write payload "encrypted" into `message`.
+    // Adds a 2 byte SIZE field at the front of the message.
+    fn encrypt_transport_stateless(
+        self: &Self,
+        payload: &[u8],
+        message: &mut [u8],
+    ) -> Result<usize, KMError> {
+        let sz = payload.len() + 2; // SIZE includes the 2 byte size field.
+        if sz > u16::MAX as usize {
+            return Err(KMError::EncryptionError);
+        }
+        let szbytes = (sz as u16).to_be_bytes();
+        message[0..2].copy_from_slice(&szbytes); // write SIZE as u16 to front of buffer
+
+        // Secret encrypto function:
+        for i in 0..payload.len() {
+            message[i + 2] = payload[i] ^ 0x7a;
+        }
+        Ok(sz)
+    }
+
+    // "Decrypt" the payload, write cleartext to `message`.
+    fn decrypt_transport_stateless(
+        self: &Self,
+        payload: &[u8],
+        message: &mut [u8],
+    ) -> Result<usize, KMError> {
+        let buf_sz = payload.len();
+        if buf_sz < 2 {
+            return Err(KMError::EncryptionError);
+        }
+        let msg_sz: u16 = u16::from_be_bytes([payload[0], payload[1]]);
+        if buf_sz < msg_sz as usize {
+            return Err(KMError::EncryptionError);
+        }
+        if msg_sz < 2 {
+            return Err(KMError::EncryptionError);
+        }
+        let msg_len: usize = (msg_sz - 2) as usize;
+
+        // Secret decrypto function:
+        for i in 0..msg_len {
+            message[i] = payload[i + 2] ^ 0x7a;
+        }
+        Ok(msg_len)
     }
 }
 
@@ -52,7 +104,8 @@ impl KeyManagerStateMachine for XorKeyManager {
 
     fn handle_message(&mut self, _message: &[u8]) -> Result<Option<Bytes>, KMError> {
         if self.state == KMSMState::Configuring {
-            self.state = KMSMState::Transport(KMTransportState::new_empty());
+            let codec = Arc::new(XorCodec{});
+            self.state = KMSMState::Transport(KMTransportState::new_empty_with_codec(codec));
             if !self.initiate {
                 // Did not initiate, so send a reply back.
                 let handshake_reply = Bytes::from_static(&[0, 255, 0, 12, 8, 7, 6, 5, 4, 3, 2, 1]); // TYPE | LEN | PAYLOAD
@@ -72,52 +125,6 @@ impl KeyManagerStateMachine for XorKeyManager {
         Ok(None)
     }
 
-    // Write payload "encrypted" into `message`.
-    // Adds a 2 byte SIZE field at the front of the message.
-    fn encrypt_transport(
-        self: &mut Self,
-        payload: &[u8],
-        message: &mut [u8],
-    ) -> Result<usize, KMError> {
-        let sz = payload.len() + 2; // SIZE includes the 2 byte size field.
-        if sz > u16::MAX as usize {
-            return Err(KMError::EncryptionError);
-        }
-        let szbytes = (sz as u16).to_be_bytes();
-        message[0..2].copy_from_slice(&szbytes); // write SIZE as u16 to front of buffer
-
-        // Secret encrypto function:
-        for i in 0..payload.len() {
-            message[i + 2] = payload[i] ^ 0x7a;
-        }
-        Ok(sz)
-    }
-
-    // "Decrypt" the payload, write cleartext to `message`.
-    fn decrypt_transport(
-        self: &mut Self,
-        payload: &[u8],
-        message: &mut [u8],
-    ) -> Result<usize, KMError> {
-        let buf_sz = payload.len();
-        if buf_sz < 2 {
-            return Err(KMError::EncryptionError);
-        }
-        let msg_sz: u16 = u16::from_be_bytes([payload[0], payload[1]]);
-        if buf_sz < msg_sz as usize {
-            return Err(KMError::EncryptionError);
-        }
-        if msg_sz < 2 {
-            return Err(KMError::EncryptionError);
-        }
-        let msg_len: usize = (msg_sz - 2) as usize;
-
-        // Secret decrypto function:
-        for i in 0..msg_len {
-            message[i] = payload[i + 2] ^ 0x7a;
-        }
-        Ok(msg_len)
-    }
 }
 
 #[cfg(test)]
@@ -126,13 +133,13 @@ mod test {
 
     #[test]
     fn test_encrypt_decrypt() {
-        let mut km = XorKeyManager::new(true);
         let mut buf = [0u8; 64];
         let payload = Bytes::from_static(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        let sz = km.encrypt_transport(&payload, &mut buf).unwrap();
+        let codec = XorCodec{};
+        let sz = codec.encrypt_transport_stateless(&payload, &mut buf).unwrap();
         assert_eq!(sz, 12);
         let mut decbuf = [0u8; 64];
-        let decsz = km.decrypt_transport(&buf[0..sz], &mut decbuf).unwrap();
+        let decsz = codec.decrypt_transport_stateless(&buf[0..sz], &mut decbuf).unwrap();
         assert_eq!(decsz, 10);
         assert_eq!(&decbuf[0..decsz], &payload[..]);
     }

--- a/adapter/ph/src/km_xor.rs
+++ b/adapter/ph/src/km_xor.rs
@@ -52,7 +52,7 @@ impl KeyManagerStateMachine for XorKeyManager {
 
     fn handle_message(&mut self, _message: &[u8]) -> Result<Option<Bytes>, KMError> {
         if self.state == KMSMState::Configuring {
-            self.state = KMSMState::Transport;
+            self.state = KMSMState::Transport(KMTransportState::new_empty());
             if !self.initiate {
                 // Did not initiate, so send a reply back.
                 let handshake_reply = Bytes::from_static(&[0, 255, 0, 12, 8, 7, 6, 5, 4, 3, 2, 1]); // TYPE | LEN | PAYLOAD

--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -65,6 +65,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +401,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "cslab"
+version = "0.1.0"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +449,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -547,6 +577,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "979f00864edc7516466d6b3157706e06c032f22715700ddd878228a91d02bc56"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,7 +673,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -709,6 +752,28 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "memchr"
@@ -954,9 +1019,12 @@ dependencies = [
  "cbpf-rs",
  "clap",
  "crossbeam-epoch",
+ "cslab",
  "curve25519-dalek",
+ "dashmap",
  "enum-map",
  "hdrhistogram",
+ "libc",
  "open-enum",
  "openssl",
  "openssl-sys",
@@ -1078,6 +1146,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1203,18 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1417,10 +1541,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -1555,11 +1683,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets",
 ]
 

--- a/node/src/zdp/server.rs
+++ b/node/src/zdp/server.rs
@@ -25,6 +25,9 @@ use zerocopy::FromBytes;
 use curve25519_dalek::montgomery::MontgomeryPoint;
 use snow;
 
+const ZPI_FULL_ENC:u8 = 100;
+const ZPI_TRANSIT_HMAC:u8 = 101;
+
 pub struct ZDPServer {
     addr: SocketAddr, // listen address, "host:port"
     noise_kp: snow::Keypair,
@@ -68,7 +71,7 @@ impl ZDPServer {
             private: self.noise_kp.private.clone(),
             public: self.noise_kp.public.clone(),
         };
-        let noise = match KMNoise::new(false, None, Some(kp)) {
+        let noise = match KMNoise::new(false, None, Some(kp), ZPI_FULL_ENC, ZPI_TRANSIT_HMAC) {
             Ok(n) => n,
             Err(e) => {
                 info!("error creating noise km: {:?}", e);
@@ -107,6 +110,8 @@ impl ZDPServer {
                                 if !sent_report && tt.elapsed() > Duration::from_secs(2) {
                                     let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
                                     let mut pkt =km_demo::build_zdp_report_packet(&mut buf, b"hello to you my darling client adapter!");
+                                    let (encr_zpi, _) = mgr.get_send_zpis();
+                                    pkt.body_mut()[0] = encr_zpi;
                                     match mgr.encrypt_transport(&mut pkt) {
                                         Ok(_) => {
                                             match s_send.send_to(&pkt.body(), cur_client.unwrap()).await {
@@ -212,10 +217,20 @@ impl ZDPServer {
                                 }
                                 _ => {
                                     info!("zdp/server - received transport message");
+                                    let (encr_zpi, transit_zpi) = mgr.get_recv_zpis();
                                     // Not sure the correct way to use these packet things.  But here we just create yet another buffer.
                                     let mut pkt_buf = [0u8; config::PACKET_BUFFER_SIZE];
                                     let mut pkt = Packet::new(&mut pkt_buf, km_demo::HEADROOM);
                                     pkt.put(&input_buf[..read_len]);
+                                    let zpi = pkt.body()[0];
+                                    if zpi == encr_zpi {
+                                        info!("zdp/server - ZPI indicates encrypted transport message");
+                                    } else if zpi == transit_zpi {
+                                        info!("zdp/server - ZPI indicates transit transport message, discarding");
+                                        continue;
+                                    } else {
+                                        info!("zdp/server - unexpected ZPI on message {} (expected {} or {})", zpi, encr_zpi, transit_zpi);
+                                    }
                                     match mgr.decrypt_transport(&mut pkt) {
                                         Ok(_) => {
                                             // Demo code sends a ZDP message like

--- a/node/src/zdp/server.rs
+++ b/node/src/zdp/server.rs
@@ -110,8 +110,8 @@ impl ZDPServer {
                                 if !sent_report && tt.elapsed() > Duration::from_secs(2) {
                                     let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
                                     let mut pkt =km_demo::build_zdp_report_packet(&mut buf, b"hello to you my darling client adapter!");
-                                    let (encr_zpi, _) = mgr.get_send_zpis();
-                                    pkt.body_mut()[0] = encr_zpi;
+                                    let send_zpis = mgr.get_send_zpis();
+                                    pkt.body_mut()[0] = send_zpis.encr;
                                     match mgr.encrypt_transport(&mut pkt) {
                                         Ok(_) => {
                                             match s_send.send_to(&pkt.body(), cur_client.unwrap()).await {
@@ -217,19 +217,19 @@ impl ZDPServer {
                                 }
                                 _ => {
                                     info!("zdp/server - received transport message");
-                                    let (encr_zpi, transit_zpi) = mgr.get_recv_zpis();
+                                    let recv_zpis = mgr.get_recv_zpis();
                                     // Not sure the correct way to use these packet things.  But here we just create yet another buffer.
                                     let mut pkt_buf = [0u8; config::PACKET_BUFFER_SIZE];
                                     let mut pkt = Packet::new(&mut pkt_buf, km_demo::HEADROOM);
                                     pkt.put(&input_buf[..read_len]);
                                     let zpi = pkt.body()[0];
-                                    if zpi == encr_zpi {
+                                    if zpi == recv_zpis.encr {
                                         info!("zdp/server - ZPI indicates encrypted transport message");
-                                    } else if zpi == transit_zpi {
-                                        info!("zdp/server - ZPI indicates transit transport message, discarding");
+                                    } else if zpi == recv_zpis.hmac {
+                                        info!("zdp/server - ZPI indicates agent transit transport message, discarding");
                                         continue;
                                     } else {
-                                        info!("zdp/server - unexpected ZPI on message {} (expected {} or {})", zpi, encr_zpi, transit_zpi);
+                                        info!("zdp/server - unexpected ZPI on message {} (expected {:?})", zpi, recv_zpis);
                                     }
                                     match mgr.decrypt_transport(&mut pkt) {
                                         Ok(_) => {


### PR DESCRIPTION
Uses the ability of our noise pattern to send a message along with the handshake to have both sides tell the other what symmetric key to use for HMACs, and what ZPIs to use.

Another small improvement here makes use of the stateless encrypt/decrypt functions in the noise library we are using.  This means we don't need to hold a lock during encrypt/decrypt.  This is still not as lock free or efficient as possible.