### PR TITLE
A2A checksumming

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -147,6 +147,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +198,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "blake3"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -320,6 +339,12 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "cpufeatures"
@@ -894,6 +919,7 @@ dependencies = [
  "aarc",
  "arrayref",
  "base64 0.22.1",
+ "blake3",
  "bytes",
  "cbpf-rs",
  "clap",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 aarc = { version = "0.2.1", optional = true }
 arrayref = { version = "0.3.7" }
+blake3 = { version = "1.5.4" }
 bytes = { version = "1.7.1" }
 cbpf-rs = { path = "../../cbpf-rs" }
 clap = { version = "4.5.7", features = ["derive"] }

--- a/adapter/ph/src/compress.rs
+++ b/adapter/ph/src/compress.rs
@@ -125,6 +125,7 @@ fn expand_addrs_v6(
     };
 }
 
+/// Compress a packet.  Does not inspect payload length, so trailers (e.g. A2A MAC) may be present.
 pub fn compress(
     compression_mode: CompressionMode,
     l3_type: L3Type,
@@ -142,6 +143,7 @@ pub fn compress(
     }
 }
 
+/// Expand a packet.  Fills payload length from body length, so trailers (e.g. A2A MAC) must not be present.
 pub fn expand(compression_mode: CompressionMode, five_tuple: &FiveTuple, pkt: &mut Packet) {
     match five_tuple.l3_type {
         L3Type::Ipv4 => expand_addrs_v4(

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -15,11 +15,11 @@ use crate::queues::TryEnqueueError;
 use crate::zdp;
 use crate::zdp_ll;
 use crate::zpr;
+use blake3;
 use bytes::{Buf, BufMut};
-use std::mem::size_of;
 use std::net::SocketAddr;
 use std::time::SystemTime;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::FromBytes;
 use zpr_ext::std::mem::{drop_guard, DropGuard};
 use zpr_ext::zerocopy::*;
 
@@ -237,7 +237,7 @@ pub fn decrypt<'pktbuf>(
             return Err(DecryptError::MicvFailure);
         }
 
-        pkt.shrink(2); // remove checksum
+        pkt.shrink_by(2); // remove checksum
 
         Ok(())
     } else {
@@ -377,9 +377,25 @@ pub fn agent_input<'pktbuf>(
     stream_id: zpr::StreamId, // TODO: should we keep this in metadata? or per-flow header?
     mut pkt: Packet<'pktbuf>,
 ) {
-    // "Check" A2A checksum
-    pkt.advance(size_of::<zdp::ZdpSaidHeader>());
-    pkt.shrink(size_of::<zdp::ZdpMicvEnd>());
+    // extract A2A MAC
+    let Some(a2a_hdr) = zdp::ZdpA2aHeader::read_from_buf(&mut pkt) else {
+        drop_and_count(asm, pkt, CounterType::BadStructure);
+        return;
+    };
+
+    if a2a_hdr.a2a_said != 0 {
+        todo!("A2A SAID");
+    }
+
+    let a2a_mac_size = zdp::ZDP_A2A_MAC_SIZE; // TODO: checksum may be shorter depending on A2A SA
+
+    if pkt.body().len() < a2a_mac_size {
+        drop_and_count(asm, pkt, CounterType::BadStructure);
+        return;
+    }
+    let mut a2a_mac = [0u8; zdp::ZDP_A2A_MAC_SIZE];
+    a2a_mac[..a2a_mac_size].copy_from_slice(&pkt.body()[pkt.body().len() - a2a_mac_size..]);
+    pkt.shrink_by(a2a_mac_size);
 
     // lookup PEP in DLT and expand compressed packet
     if asm
@@ -391,6 +407,12 @@ pub fn agent_input<'pktbuf>(
     {
         drop_and_count(asm, pkt, CounterType::UnknownStreamId);
         return;
+    }
+
+    // check A2A MAC
+    // TODO: use actual A2A SAID & keyed hash
+    if blake3::hash(pkt.body()).as_bytes()[..a2a_mac_size] != a2a_mac[..a2a_mac_size] {
+        return drop_and_count(asm, pkt, CounterType::MicvFailure);
     }
 
     // send out decapsulated packet
@@ -407,6 +429,7 @@ pub fn agent_input<'pktbuf>(
 /// Process uncompressed packet from the agent.
 /// The packet will be compressed, or trigger a Bind request.
 pub fn agent_output<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) {
+    // determine five tuple
     let classification = match classifier::classify(&mut pkt) {
         Ok(cls) => cls,
         Err(_why) => {
@@ -419,7 +442,7 @@ pub fn agent_output<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) 
         ClassifierResult::OK | ClassifierResult::UnclassifiedL4 => (),
 
         ClassifierResult::FirstFragment | ClassifierResult::SubsequentFragment => {
-            // TODO; handle fragments!
+            // TODO: handle fragments!
             drop_and_count(asm, pkt, CounterType::InPacksDrop);
             return;
         }
@@ -431,10 +454,18 @@ pub fn agent_output<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) 
         }
     }
 
+    // compute A2A MAC
+    // TODO: use actual A2A SAID & keyed hash
+    let a2a_said: zpr::A2aSaid = 0;
+    let a2a_mac_size = zdp::ZDP_A2A_MAC_SIZE; // TODO: may be smaller depending on A2A SAID
+    let mut a2a_mac = [0u8; zdp::ZDP_A2A_MAC_SIZE];
+    // SECURITY: truncating BLAKE3 is safe
+    a2a_mac[..a2a_mac_size].copy_from_slice(&blake3::hash(pkt.body()).as_bytes()[..a2a_mac_size]);
+
     let five_tuple = *pkt.metadata().five_tuple(); // TODO: convince borrow checker we don't need to copy this out
 
-    match asm.alt.inspect(&five_tuple, |pep| {
-        // compress packet
+    // lookup five tuple in ALT and compress packet
+    let stream_id = match asm.alt.inspect(&five_tuple, |pep| {
         compress::compress(
             pep.compression_mode,
             five_tuple.l3_type,
@@ -442,23 +473,23 @@ pub fn agent_output<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) 
             &mut pkt,
         );
 
-        // "generate" A2A checksum
-        pkt.alloc_zeroed_header::<zdp::ZdpSaidHeader>().a2a_said = 0;
-        let micv: zdp::ZdpMicvEnd = zdp::ZdpMicvEnd { micv: 0 };
-        pkt.put(micv.as_bytes());
-
         pep.stream_id
     }) {
-        Some(stream_id) => {
-            forward(asm, zpr::AGENT_LINK_ID, stream_id, pkt);
-        }
+        Some(stream_id) => stream_id,
 
         None => {
             // TODO: issue bind request!
             drop_and_count(asm, pkt, CounterType::OtherError);
             return;
         }
-    }
+    };
+
+    // append A2A MAC
+    pkt.put(&a2a_mac[..a2a_mac_size]);
+    pkt.alloc_zeroed_header::<zdp::ZdpA2aHeader>().a2a_said = a2a_said;
+
+    // forward
+    forward(asm, zpr::AGENT_LINK_ID, stream_id, pkt);
 }
 
 /// Forward compressed packet.

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -234,7 +234,7 @@ impl KeyManager<'_> {
                 // Copy the encrypted data back into the message -- there should be sufficient room for it since
                 // caller should know our required padding space and alignment.
 
-                message.shrink(message.body().len()); // remove body
+                message.shrink_by(message.body().len()); // remove body
                 message.put(&encr_buf[0..len]); // write a new body
 
                 // Now write our headroom info:
@@ -292,7 +292,7 @@ impl KeyManager<'_> {
                     len
                 );
                 // Copy the decrypted data back into the message -- do not overwrite ZPI.
-                message.shrink(message.body().len()); // remove body
+                message.shrink_by(message.body().len()); // remove body
                 message.put(&decr_buf[0..len]); // write a new body
 
                 message.alloc_zeroed_header::<ZdpZpiHeader>().zpi = state.sa_id;

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -382,7 +382,7 @@ impl<'buf> Packet<'buf> {
     }
 
     /// Shrink the packet by `cnt` bytes (removing data from the tail).
-    pub fn shrink(&mut self, cnt: usize) {
+    pub fn shrink_by(&mut self, cnt: usize) {
         let md = self.metadata_mut();
         assert!(cnt <= md.len);
         md.len -= cnt;
@@ -647,20 +647,20 @@ mod tests {
     }
 
     #[test]
-    fn shrink_test() {
+    fn shrink_by_test() {
         let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
         let mut pkt = Packet::new(&mut buf, 0);
         pkt.put_u64(0x0102030405060708u64);
-        pkt.shrink(2);
+        pkt.shrink_by(2);
         assert_eq!(pkt.body(), [1, 2, 3, 4, 5, 6]);
     }
 
     #[test]
     #[should_panic]
-    fn shrink_too_much_test() {
+    fn shrink_by_too_much_test() {
         let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
         let mut pkt = Packet::new(&mut buf, 0);
         pkt.put_u64(0x0102030405060708u64);
-        pkt.shrink(10);
+        pkt.shrink_by(10);
     }
 }

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -150,15 +150,12 @@ impl ZdpKeyManagementHeader {
 
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(packed)]
-pub struct ZdpSaidHeader {
-    pub a2a_said: u8,
+pub struct ZdpA2aHeader {
+    pub a2a_said: zpr::A2aSaid,
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-#[repr(packed)]
-pub struct ZdpMicvEnd {
-    pub micv: u32,
-}
+/// Config-specified size of A2A MAC.  Algorithm-specified MAC may be smaller (but not larger).
+pub const ZDP_A2A_MAC_SIZE: usize = 8;
 
 const _: () = assert!(core::mem::size_of::<ZdpBaseHeader>() == 4);
 const _: () = assert!(core::mem::size_of::<ZdpPerFlowHeader>() == 4);

--- a/adapter/ph/src/zpr.rs
+++ b/adapter/ph/src/zpr.rs
@@ -32,6 +32,9 @@ pub type StreamId = u32;
 /// Reserved for node-to-node / control-plane traffic.
 pub const NODE_TO_NODE_STREAM_ID: StreamId = 0;
 
+/// Adapter-to-Adapter SAID.
+pub type A2aSaid = u8;
+
 /// Within a ZDP Key Management packet, indicates the Key Managenent algorithm identifier.
 pub type KmId = u16;
 

--- a/tools/zdp_dissector.lua
+++ b/tools/zdp_dissector.lua
@@ -10,9 +10,9 @@ seq_num = ProtoField.uint16("zdp.seq_num", "Sequence Number", base.DEC)
 stream_id = ProtoField.uint32("zdp.streamid", "Stream ID", base.DEC)
 pad = ProtoField.bytes("zdp.pad", "Pad")
 mac_addr = ProtoField.uint32("zdp.mac", "MAC", base.DEC)
-d2d_said = ProtoField.uint8("zdp.d2d_said", "D2D SAID", base.DEC)
+a2a_said = ProtoField.uint8("zdp.a2a_said", "A2A SAID", base.DEC)
 agent_packet = ProtoField.bytes("zdp.agent_packet", "Agent Packet")
-d2d_mac = ProtoField.uint32("zdp.d2d_mac", "D2D MAC", base.DEC)
+a2a_mac = ProtoField.uint32("zdp.a2a_mac", "A2A MAC", base.DEC)
 management_packet = ProtoField.bytes("zdp.management", "Management Packet")
 
 -- Agent Packet Headers
@@ -45,14 +45,14 @@ info_len = ProtoField.uint8("zdp.info_len", "Information Length", base.DEC)
 status_info = ProtoField.bytes("zdp.status_info", "Optional Additional Status Information")
 
 zdp_proto.fields = { zpi_val, zdp_type, excess_len, seq_num, stream_id, pad, 
-                     mac_addr, d2d_said, agent_packet, d2d_mac, management_packet, ip_version,
+                     mac_addr, a2a_said, agent_packet, a2a_mac, management_packet, ip_version,
                      ihl, dscp, frag_id, frag_offset, ttl, tc, fl, hop_limit, ip_options, mbz,
                      adl, aditional_data, req_seq_num, ip_protocol_present, source_port_present, 
                      destination_port_present, source_addr, dest_addr, ip_protocol, source_info, 
                      dest_info, status_code, info_len, status_info }
 
-TRANSIT_NON_AGENT_DATA = 18
-IP_NON_AGENT_DATA = 25
+TRANSIT_NON_AGENT_DATA = 22
+IP_NON_AGENT_DATA = 29
 STREAM_MGMT_NON_AGENT_DATA = 11
 MGMT_NON_AGENT_DATA = 7
 
@@ -79,10 +79,10 @@ function zdp_proto.dissector(buffer, pinfo, tree)
         -- Transit Packet
         zdp_header_subtree:add(stream_id, buffer(5, 4))
         -- zdp_header_subtree:add(pad, buffer(9, 8))
-        zdp_header_subtree:add(d2d_said, buffer(9, 1))
+        zdp_header_subtree:add(a2a_said, buffer(9, 1))
         zdp_header_subtree:add(agent_packet, buffer(10, real_len - TRANSIT_NON_AGENT_DATA))
-        zdp_header_subtree:add(d2d_mac, buffer(real_len - 8, 4))
-        zdp_header_subtree:add(mac_addr, buffer(real_len - 4, 4))
+        zdp_header_subtree:add(a2a_mac, buffer(real_len - 12, 8))
+        zdp_header_subtree:add(mac_addr, buffer(real_len - 8, 4))
 
         local agent_header_subtree = tree:add(zdp_proto, buffer(), "Compressed Agent Packet Header Data")
         local v4_v6 = get_first_four(buffer(10, 1):uint())


### PR DESCRIPTION
Actually generate/validate A2A checksum… almost.  This uses an _unkeyed_ BLAKE3 hash which of course gives no security against an adversary.  This is just an exercise in making sure the code to generate the checksum is in the right place and doing the right thing.

Also rename `Packet::shrink()` to `Packet::shrink_by()` because I forgot what it did.