### PR TITLE
adds a helper function for testing with assembly

### DIFF
--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -10,7 +10,7 @@ use crate::mgmt;
 use crate::packet::*;
 use crate::peer_table;
 use crate::queues::*;
-use crate::tun_ctl::TunCtl;
+use crate::tun_ctl::CarrierSetter;
 use crate::zdp::*;
 use crate::zpr;
 use bytes::Buf;
@@ -57,7 +57,7 @@ pub struct Assembly<'pktbuf> {
 
     pub counters: EnumMap<CounterType, Counter>,
 
-    pub tun_ctl: TunCtl<'pktbuf>,
+    pub tun_ctl: &'pktbuf dyn CarrierSetter,
 
     pub sync_req_state: SyncReqState<'pktbuf>,
 
@@ -251,3 +251,137 @@ impl<'pktbuf> Assembly<'pktbuf> {
         }
     }
 }
+
+
+#[cfg(test)]
+pub mod test {
+
+    use super::*;
+    use enum_map::{enum_map, EnumMap};
+    use tokio::net::UdpSocket;
+    use tokio::sync::mpsc;
+
+    #[allow(dead_code)]
+    pub struct TestAssemblyBuilder<'a> {
+        pub buffer_stack: Option<BufferStack<'a, { config::PACKET_BUFFER_SIZE }>>,
+        pub mgmt_processor: Option<MgmtProcessor<'a>>,
+        pub agent_input: Option<AgentInput<'a>>,
+        pub substrate_egress: Option<SubstrateEgress<'a>>,
+        pub capture_queue: Option<Capture<'a>>,
+        pub capture_worker: Option<CaptureWorker>,
+        pub flow_control: Option<FlowControl>,
+        pub counters: Option<EnumMap<CounterType, Counter>>,
+        pub tun_ctl: Option<&'a dyn CarrierSetter>,
+        pub sync_req_state: Option<SyncReqState<'a>>,
+        pub peer_table: Option<peer_table::PeerTable>,
+        pub adapter_docking_session_id: Option<zpr::LinkId>,
+        pub alt: Option<adapter_tables::AgentLookupTable>,
+        pub dlt: Option<adapter_tables::DockLookupTable>,
+        pub adapter_manager: Option<AdapterManager<'a>>,
+    }
+
+    #[allow(dead_code)]
+    struct DummyTunCtl;
+    impl CarrierSetter for DummyTunCtl {
+        fn set_carrier(&self, _carrier: bool) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[allow(dead_code)]
+    impl TestAssemblyBuilder<'_> {
+        pub fn new() -> Self {
+            Self {
+                buffer_stack: None,
+                mgmt_processor: None,
+                agent_input: None,
+                substrate_egress: None,
+                capture_queue: None,
+                capture_worker: None,
+                flow_control: None,
+                counters: None,
+                tun_ctl: None,
+                sync_req_state: None,
+                peer_table: None,
+                adapter_docking_session_id: None,
+                alt: None,
+                dlt: None,
+                adapter_manager: None,
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn create_assembly(builder: TestAssemblyBuilder) -> Assembly {
+        let buffer_stack = builder.buffer_stack.unwrap_or_else(|| {
+            let buf_storage = vec![[0u8; config::PACKET_BUFFER_SIZE]; 0];
+            BufferStack::new(buf_storage.leak::<'static>())
+        });
+        let mgmt_processor = builder.mgmt_processor.unwrap_or_else(|| {
+            let (mp_inq, _mp_outq) = mpsc::channel(1);
+            MgmtProcessor::new(mp_inq)
+        });
+        let agent_input = builder.agent_input.unwrap_or_else(|| {
+            let v: Vec<&tokio_tun::Tun> = Vec::new();
+            AgentInput::new(v)
+        });
+        let substrate_egress = builder.substrate_egress.unwrap_or_else(|| {
+            let v: Vec<&UdpSocket> = Vec::new();
+            SubstrateEgress::new(v)
+        });
+        let capture_queue = builder.capture_queue.unwrap_or_else(|| {
+            let (cq_inq, _cq_outq) = mpsc::channel(1);
+            Capture::new(cq_inq)
+        });
+        let capture_worker = builder.capture_worker.unwrap_or_else(|| {
+            CaptureWorker::new()
+        });
+        let flow_control = builder.flow_control.unwrap_or_else(|| {
+            FlowControl::new()
+        });
+        let counters = builder.counters.unwrap_or_else(|| {
+            enum_map! { _ => Counter::new(), }
+        });
+        let tun_ctl = builder.tun_ctl.unwrap_or_else(|| {
+            &DummyTunCtl
+        });
+        let sync_req_state = builder.sync_req_state.unwrap_or_else(|| {
+            SyncReqState::new()
+        });
+        let peer_table = builder.peer_table.unwrap_or_else(|| {
+            peer_table::PeerTable::new()
+        });
+        let adapter_docking_session_id = builder.adapter_docking_session_id.unwrap_or_else(|| {
+        0
+        });
+        let alt = builder.alt.unwrap_or_else(|| {
+            adapter_tables::AgentLookupTable::new()
+        });
+        let dlt = builder.dlt.unwrap_or_else(|| {
+            adapter_tables::DockLookupTable::new()
+        });
+        let adapter_manager = builder.adapter_manager.unwrap_or_else(|| {
+            let (cq_inq, _cq_outq) = mpsc::channel(1);
+            AdapterManager::new(cq_inq)
+        });
+
+        Assembly {
+            buffer_stack,
+            mgmt_processor,
+            agent_input,
+            substrate_egress,
+            capture_queue,
+            capture_worker,
+            flow_control,
+            counters,
+            tun_ctl,
+            sync_req_state,
+            peer_table,
+            adapter_docking_session_id,
+            alt,
+            dlt,
+            adapter_manager,
+        }
+    }
+}
+

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -252,7 +252,6 @@ impl<'pktbuf> Assembly<'pktbuf> {
     }
 }
 
-
 #[cfg(test)]
 pub mod test {
 
@@ -333,33 +332,27 @@ pub mod test {
             let (cq_inq, _cq_outq) = mpsc::channel(1);
             Capture::new(cq_inq)
         });
-        let capture_worker = builder.capture_worker.unwrap_or_else(|| {
-            CaptureWorker::new()
-        });
-        let flow_control = builder.flow_control.unwrap_or_else(|| {
-            FlowControl::new()
-        });
+        let capture_worker = builder
+            .capture_worker
+            .unwrap_or_else(|| CaptureWorker::new());
+        let flow_control = builder.flow_control.unwrap_or_else(|| FlowControl::new());
         let counters = builder.counters.unwrap_or_else(|| {
             enum_map! { _ => Counter::new(), }
         });
-        let tun_ctl = builder.tun_ctl.unwrap_or_else(|| {
-            &DummyTunCtl
-        });
-        let sync_req_state = builder.sync_req_state.unwrap_or_else(|| {
-            SyncReqState::new()
-        });
-        let peer_table = builder.peer_table.unwrap_or_else(|| {
-            peer_table::PeerTable::new()
-        });
-        let adapter_docking_session_id = builder.adapter_docking_session_id.unwrap_or_else(|| {
-        0
-        });
-        let alt = builder.alt.unwrap_or_else(|| {
-            adapter_tables::AgentLookupTable::new()
-        });
-        let dlt = builder.dlt.unwrap_or_else(|| {
-            adapter_tables::DockLookupTable::new()
-        });
+        let tun_ctl = builder.tun_ctl.unwrap_or_else(|| &DummyTunCtl);
+        let sync_req_state = builder
+            .sync_req_state
+            .unwrap_or_else(|| SyncReqState::new());
+        let peer_table = builder
+            .peer_table
+            .unwrap_or_else(|| peer_table::PeerTable::new());
+        let adapter_docking_session_id = builder.adapter_docking_session_id.unwrap_or_else(|| 0);
+        let alt = builder
+            .alt
+            .unwrap_or_else(|| adapter_tables::AgentLookupTable::new());
+        let dlt = builder
+            .dlt
+            .unwrap_or_else(|| adapter_tables::DockLookupTable::new());
         let adapter_manager = builder.adapter_manager.unwrap_or_else(|| {
             let (cq_inq, _cq_outq) = mpsc::channel(1);
             AdapterManager::new(cq_inq)
@@ -384,4 +377,3 @@ pub mod test {
         }
     }
 }
-

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -372,4 +372,3 @@ fn main() -> ExitCode {
 
     ExitCode::SUCCESS
 }
-

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -55,6 +55,7 @@ use counters_enum::*;
 use flow_control::FlowControl;
 use options::PhMode;
 use queues::*;
+use tun_ctl::CarrierSetter;
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -172,7 +173,7 @@ fn main() -> ExitCode {
                 .expect("unable to open TUN device")
                 .leak();
 
-            let tun_ctl = tun_ctl::TunCtl::new(&tun_devs[0]);
+            let tun_ctl = Box::leak(Box::new(tun_ctl::TunCtl::new(&tun_devs[0])));
 
             tun_ctl.set_carrier(false).unwrap();
 
@@ -280,7 +281,7 @@ fn main() -> ExitCode {
                 capture_worker,
                 flow_control,
                 counters,
-                tun_ctl,
+                tun_ctl: tun_ctl,
                 sync_req_state,
                 peer_table,
                 adapter_docking_session_id,
@@ -371,3 +372,4 @@ fn main() -> ExitCode {
 
     ExitCode::SUCCESS
 }
+

--- a/adapter/ph/src/tun_ctl.rs
+++ b/adapter/ph/src/tun_ctl.rs
@@ -2,6 +2,16 @@ use std::io::Result;
 use tokio_tun::Tun;
 use zpr_ext::tokio_tun::TunExt;
 
+
+
+pub trait CarrierSetter: Send + Sync {
+    // Inform the kernel's networking layer whether a carrier is present.
+    // (I.e. whether we are passing packets.)  This is reflected on the
+    // interface itself and is used by the kernel to make routing decisions.
+    fn set_carrier(&self, carrier: bool) -> Result<()>;
+}
+
+
 // This structure provides shared access to the TUN device
 // for controlling its state.  Though it is just a thin wrapper
 // around a `Tun` struct, its API is limited to restrict coupling
@@ -15,11 +25,11 @@ impl<'a> TunCtl<'a> {
     pub fn new(tun: &'a Tun) -> Self {
         Self { tun }
     }
+}
 
-    // Inform the kernel's networking layer whether a carrier is present.
-    // (I.e. whether we are passing packets.)  This is reflected on the
-    // interface itself and is used by the kernel to make routing decisions.
-    pub fn set_carrier(&self, carrier: bool) -> Result<()> {
+impl CarrierSetter for TunCtl<'_> {
+    fn set_carrier(&self, carrier: bool) -> Result<()> {
         self.tun.set_carrier(carrier)
     }
 }
+

--- a/adapter/ph/src/tun_ctl.rs
+++ b/adapter/ph/src/tun_ctl.rs
@@ -2,15 +2,12 @@ use std::io::Result;
 use tokio_tun::Tun;
 use zpr_ext::tokio_tun::TunExt;
 
-
-
 pub trait CarrierSetter: Send + Sync {
     // Inform the kernel's networking layer whether a carrier is present.
     // (I.e. whether we are passing packets.)  This is reflected on the
     // interface itself and is used by the kernel to make routing decisions.
     fn set_carrier(&self, carrier: bool) -> Result<()>;
 }
-
 
 // This structure provides shared access to the TUN device
 // for controlling its state.  Though it is just a thin wrapper
@@ -32,4 +29,3 @@ impl CarrierSetter for TunCtl<'_> {
         self.tun.set_carrier(carrier)
     }
 }
-


### PR DESCRIPTION
This is a helper function for test mode that allows you to create an assembly with various bits stubbed out.

This is not used in this PR but I am using it in my next one involving hooking up KM.  The "allow dead code" stuff is just temporary.