### PR TITLE
restore name of TunCtl and use owning reference

### DIFF
--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -10,7 +10,7 @@ use crate::mgmt;
 use crate::packet::*;
 use crate::peer_table;
 use crate::queues::*;
-use crate::tun_ctl::CarrierSetter;
+use crate::tun_ctl::TunCtl;
 use crate::zdp::*;
 use crate::zpr;
 use bytes::Buf;
@@ -57,7 +57,7 @@ pub struct Assembly<'pktbuf> {
 
     pub counters: EnumMap<CounterType, Counter>,
 
-    pub tun_ctl: &'pktbuf dyn CarrierSetter,
+    pub tun_ctl: Box<dyn TunCtl + 'pktbuf>,
 
     pub sync_req_state: SyncReqState<'pktbuf>,
 
@@ -270,7 +270,7 @@ pub mod test {
         pub capture_worker: Option<CaptureWorker>,
         pub flow_control: Option<FlowControl>,
         pub counters: Option<EnumMap<CounterType, Counter>>,
-        pub tun_ctl: Option<&'a dyn CarrierSetter>,
+        pub tun_ctl: Option<Box<dyn TunCtl + 'a>>,
         pub sync_req_state: Option<SyncReqState<'a>>,
         pub peer_table: Option<peer_table::PeerTable>,
         pub adapter_docking_session_id: Option<zpr::LinkId>,
@@ -280,8 +280,8 @@ pub mod test {
     }
 
     #[allow(dead_code)]
-    struct DummyTunCtl;
-    impl CarrierSetter for DummyTunCtl {
+    struct DummyTunCtlImpl;
+    impl TunCtl for DummyTunCtlImpl {
         fn set_carrier(&self, _carrier: bool) -> std::io::Result<()> {
             Ok(())
         }
@@ -339,7 +339,7 @@ pub mod test {
         let counters = builder.counters.unwrap_or_else(|| {
             enum_map! { _ => Counter::new(), }
         });
-        let tun_ctl = builder.tun_ctl.unwrap_or_else(|| &DummyTunCtl);
+        let tun_ctl = builder.tun_ctl.unwrap_or_else(|| Box::new(DummyTunCtlImpl));
         let sync_req_state = builder
             .sync_req_state
             .unwrap_or_else(|| SyncReqState::new());

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -55,7 +55,7 @@ use counters_enum::*;
 use flow_control::FlowControl;
 use options::PhMode;
 use queues::*;
-use tun_ctl::CarrierSetter;
+use tun_ctl::TunCtl;
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -173,7 +173,7 @@ fn main() -> ExitCode {
                 .expect("unable to open TUN device")
                 .leak();
 
-            let tun_ctl = Box::leak(Box::new(tun_ctl::TunCtl::new(&tun_devs[0])));
+            let tun_ctl = Box::new(tun_ctl::TunCtlImpl::new(&tun_devs[0]));
 
             tun_ctl.set_carrier(false).unwrap();
 
@@ -281,7 +281,7 @@ fn main() -> ExitCode {
                 capture_worker,
                 flow_control,
                 counters,
-                tun_ctl: tun_ctl,
+                tun_ctl,
                 sync_req_state,
                 peer_table,
                 adapter_docking_session_id,

--- a/adapter/ph/src/tun_ctl.rs
+++ b/adapter/ph/src/tun_ctl.rs
@@ -2,29 +2,29 @@ use std::io::Result;
 use tokio_tun::Tun;
 use zpr_ext::tokio_tun::TunExt;
 
-pub trait CarrierSetter: Send + Sync {
-    // Inform the kernel's networking layer whether a carrier is present.
-    // (I.e. whether we are passing packets.)  This is reflected on the
-    // interface itself and is used by the kernel to make routing decisions.
+/// This interface provides shared access to the TUN device for controlling
+/// its state.  Its API is limited to restrict coupling of the full system
+/// with the TUN device.
+pub trait TunCtl: Sync {
+    /// Inform the kernel's networking layer whether a carrier is present.
+    /// (I.e. whether we are passing packets.)  This is reflected on the
+    /// interface itself and is used by the kernel to make routing decisions.
     fn set_carrier(&self, carrier: bool) -> Result<()>;
 }
 
-// This structure provides shared access to the TUN device
-// for controlling its state.  Though it is just a thin wrapper
-// around a `Tun` struct, its API is limited to restrict coupling
-// of the full system with the TUN device.
-
-pub struct TunCtl<'a> {
+/// Canonical implementation of the `TunCtl` interface, just a thin wrapper
+/// around a reference to a `Tun` struct.
+pub struct TunCtlImpl<'a> {
     tun: &'a Tun,
 }
 
-impl<'a> TunCtl<'a> {
+impl<'a> TunCtlImpl<'a> {
     pub fn new(tun: &'a Tun) -> Self {
         Self { tun }
     }
 }
 
-impl CarrierSetter for TunCtl<'_> {
+impl TunCtl for TunCtlImpl<'_> {
     fn set_carrier(&self, carrier: bool) -> Result<()> {
         self.tun.set_carrier(carrier)
     }


### PR DESCRIPTION
Implementation of my comments on PR #380.

Just renames CarrierSetter back to TunCtl (since the intent is for the interface to support more than just setting the carrier), replaces the shared reference in Assembly with an owning reference to retain the original ownership model, and reflects the implementation/interface split in the comments.