### PR TITLE
clean up panics in fastpath

### DIFF
--- a/adapter/ph/src/capture_worker.rs
+++ b/adapter/ph/src/capture_worker.rs
@@ -5,6 +5,7 @@ use core::future::Future;
 use std::io;
 use tokio::fs::File;
 use tokio::sync::{mpsc, Mutex};
+use tracing::error;
 
 pub struct CaptureWorker {
     inner_cap: Mutex<InnerCap>,
@@ -28,17 +29,17 @@ impl CaptureWorker {
     }
 
     pub async fn flush_capture_file(&self) -> Result<(), io::Error> {
-        let sf = &mut self.inner_cap.lock().await.savefile;
-        match sf {
-            Some(ref mut sf) => sf.flush().await,
+        let savefile = &mut self.inner_cap.lock().await.savefile;
+        match savefile {
+            Some(ref mut savefile) => savefile.flush().await,
             None => Ok(()),
         }
     }
 
     pub async fn close_capture_file(&self) -> Result<(), io::Error> {
         match self.inner_cap.lock().await.savefile.take() {
-            Some(writer) => {
-                writer.close().await?;
+            Some(savefile) => {
+                savefile.close().await?;
             }
             None => (),
         }
@@ -65,13 +66,18 @@ async fn worker<'pktbuf>(
 
     // Batch accepts values from capture queue and writes them to the savefile
     while let _count @ 1.. = queue.recv_many(&mut messages, config.batch_size).await {
-        let mut locked_mutex = asm.capture_worker.inner_cap.lock().await;
-        match &mut locked_mutex.savefile {
-            Some(s_file) => {
-                for cap_pack in &messages {
-                    savefile_write(cap_pack, s_file).await;
+        let mut inner_cap = asm.capture_worker.inner_cap.lock().await;
+        match &mut inner_cap.savefile {
+            Some(ref mut savefile) => match savefile_write_batch(savefile, messages.iter()).await {
+                Ok(()) => (),
+                Err(err) => {
+                    error!("Error writing to capture file, ending capture: {}", err);
+                    match inner_cap.savefile.take().unwrap().close().await {
+                        Ok(_file) => (),
+                        Err(err) => error!("Error closing capture file: {}", err),
+                    }
                 }
-            }
+            },
             None => (),
         }
         asm.buffer_stack
@@ -91,13 +97,26 @@ where
     async move { worker(&cfg, &*asm, &mut queue).await }
 }
 
-async fn savefile_write(cap_pack: &CapPacket<'_>, savefile: &mut PcapWriter<File>) {
+async fn savefile_write_batch<'a, 'b: 'a>(
+    savefile: &'a mut PcapWriter<File>,
+    cap_packs: impl IntoIterator<Item = &'a CapPacket<'b>>,
+) -> io::Result<()> {
+    for cap_pack in cap_packs.into_iter() {
+        savefile_write(savefile, cap_pack).await?;
+    }
+
+    Ok(())
+}
+
+async fn savefile_write(
+    savefile: &mut PcapWriter<File>,
+    cap_pack: &CapPacket<'_>,
+) -> io::Result<()> {
     let packet = PcapPacket {
         timestamp: cap_pack.timestamp,
         orig_len: cap_pack.orig_len,
         data: cap_pack.packet.body(),
     };
 
-    // FIXME: handle write errors (maybe close the capture file?)
-    savefile.write(&packet).await.unwrap();
+    savefile.write(&packet).await
 }

--- a/adapter/ph/src/compress.rs
+++ b/adapter/ph/src/compress.rs
@@ -149,8 +149,8 @@ pub fn expand(compression_mode: CompressionMode, five_tuple: &FiveTuple, pkt: &m
         L3Type::Ipv4 => expand_addrs_v4(
             pkt,
             five_tuple.l4_protocol,
-            five_tuple.src_address.try_into().unwrap(),
-            five_tuple.dst_address.try_into().unwrap(),
+            five_tuple.src_address.read_as_v4().into(),
+            five_tuple.dst_address.read_as_v4().into(),
         ),
         L3Type::Ipv6 => expand_addrs_v6(
             pkt,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -188,8 +188,8 @@ pub fn encrypt<'pktbuf>(
     _link_id: zpr::LinkId,
     pkt: &mut Packet<'pktbuf>,
 ) {
-    let zpi_hdr =
-        zdp::ZdpZpiHeader::ref_from_prefix(pkt.body()).expect("ZPI header must be present");
+    let zpi_hdr = zdp::ZdpZpiHeader::ref_from_prefix(pkt.body())
+        .expect("coding error: ZPI header must be present");
     let zpi = zpi_hdr.zpi as zpr::Zpi;
 
     if zpi == zpr::ZPI_0 {
@@ -373,6 +373,7 @@ pub fn substrate_ingress<'pktbuf>(
         if asm
             .peer_table
             .inspect(ingress_link_id, |peer_state| {
+                // note: we know `pkt` is still `Some` as we're the first to get to it
                 match peer_state
                     .mgmt_processor
                     .try_enqueue_packet(pkt.take().unwrap())
@@ -386,6 +387,7 @@ pub fn substrate_ingress<'pktbuf>(
             })
             .is_none()
         {
+            // note: we know `pkt` is still `Some` as we know the above closure hasn't been executed
             drop_and_count(asm, pkt.take().unwrap(), CounterType::PeerRemoved);
         }
         return;

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -41,7 +41,9 @@ impl<'pktbuf> MgmtProcessor<'pktbuf> {
         match self.sender.try_send(MgmtProcessorMessage::Packet(packet)) {
             Ok(()) => Ok(()),
 
-            Err(TrySendError::Full(msg) | TrySendError::Closed(msg)) => {
+            Err(TrySendError::Closed(_)) => panic!("mgmt processor channel closed"),
+
+            Err(TrySendError::Full(msg)) => {
                 let MgmtProcessorMessage::Packet(pkt) = msg else {
                     unreachable!()
                 };
@@ -228,11 +230,10 @@ impl<'pktbuf> Capture<'pktbuf> {
             orig_len,
         };
         match self.sender.try_send(cap_pack) {
-            Ok(()) => return Ok(()),
-            Err(TrySendError::Full(cap_pack)) | Err(TrySendError::Closed(cap_pack)) => {
-                return Err(TryEnqueueError::Full(cap_pack.packet));
-            }
-        };
+            Ok(()) => Ok(()),
+            Err(TrySendError::Closed(_)) => panic!("capture channel closed"),
+            Err(TrySendError::Full(cap_pack)) => Err(TryEnqueueError::Full(cap_pack.packet)),
+        }
     }
 }
 
@@ -270,7 +271,9 @@ impl<'pktbuf> AdapterManager<'pktbuf> {
         {
             Ok(()) => Ok(()),
 
-            Err(TrySendError::Full(msg) | TrySendError::Closed(msg)) => match msg {
+            Err(TrySendError::Closed(_)) => panic!("adapter manager channel closed"),
+
+            Err(TrySendError::Full(msg)) => match msg {
                 AdapterManagerMessage::RequestTetherId(packet) => {
                     Err(TryEnqueueError::Full(packet))
                 }


### PR DESCRIPTION
Get rid of some chances to panic in the fastpath.

Introduce a couple new chances to panic (specifically, if a channel has disappeared out from under us -- this should never happen, if it does, we can't do anything smart about it other than restart).