### PR TITLE
RcuBox get

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -51,7 +51,7 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
 
     // if there's already an entry, this is a duplicate request
     // (NOTE: we should be the only ones modifying this table!)
-    if asm.alt.inspect(&five_tuple, |_entry| ()).is_some() {
+    if asm.alt.get(&five_tuple).is_some() {
         return;
     }
 

--- a/adapter/ph/src/adapter_tables.rs
+++ b/adapter/ph/src/adapter_tables.rs
@@ -5,9 +5,10 @@
 #![allow(dead_code)]
 
 use crate::defs::FiveTuple;
-use crate::rcu::RcuBox;
+use crate::rcu::{RcuBox, RcuGuard};
 use crate::zpr::{CompressionMode, StreamId};
 use cslab::{RcuCslab, RcuCslabReader};
+use dashmap::mapref::one::Ref as DashMapRef;
 use dashmap::DashMap;
 use std::sync::Mutex;
 
@@ -29,6 +30,16 @@ pub struct AgentLookupTable {
     table: DashMap<FiveTuple, AltEntry>,
 }
 
+pub struct AltEntryGuard<'a>(DashMapRef<'a, FiveTuple, AltEntry>);
+
+impl std::ops::Deref for AltEntryGuard<'_> {
+    type Target = AltEntry;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
 impl AgentLookupTable {
     pub fn new() -> Self {
         Self {
@@ -43,6 +54,10 @@ impl AgentLookupTable {
         inspector: impl FnOnce(&AltEntry) -> T,
     ) -> Option<T> {
         self.table.get(five_tuple).map(|entry| inspector(&*entry))
+    }
+
+    pub fn get(&self, five_tuple: &FiveTuple) -> Option<AltEntryGuard<'_>> {
+        self.table.get(five_tuple).map(AltEntryGuard)
     }
 
     // FIXME: ideally we want `try_insert()` but dashmap doesn't support that…
@@ -81,6 +96,19 @@ pub struct DockLookupTable {
     reader: RcuBox<RcuCslabReader<DltPep>>,
 }
 
+pub struct DltPepGuard<'a> {
+    guard: RcuGuard<'a, RcuCslabReader<DltPep>>,
+    key: usize,
+}
+
+impl std::ops::Deref for DltPepGuard<'_> {
+    type Target = DltPep;
+
+    fn deref(&self) -> &Self::Target {
+        self.guard.get(self.key).unwrap()
+    }
+}
+
 impl DockLookupTable {
     pub fn new() -> Self {
         let table = RcuCslab::with_fixed_capacity(DOCK_LOOKUP_TABLE_SIZE);
@@ -99,6 +127,17 @@ impl DockLookupTable {
     ) -> Option<T> {
         self.reader
             .inspect(|reader| reader.get(tether_id as usize).map(inspector))
+    }
+
+    pub fn get(&self, tether_id: StreamId) -> Option<DltPepGuard<'_>> {
+        let guard = self.reader.get();
+        if guard.get(tether_id as usize).is_none() {
+            return None;
+        }
+        Some(DltPepGuard {
+            guard,
+            key: tether_id as usize,
+        })
     }
 
     pub fn insert(&self, pep: DltPep) -> Result<StreamId, ()> {

--- a/adapter/ph/src/dock_tables.rs
+++ b/adapter/ph/src/dock_tables.rs
@@ -4,7 +4,7 @@
 
 #![allow(dead_code)]
 
-use crate::rcu::RcuBox;
+use crate::rcu::{RcuBox, RcuGuard};
 use crate::zpr::{LinkId, StreamId};
 use cslab::{RcuCslab, RcuCslabReader};
 use std::sync::Mutex;
@@ -30,6 +30,19 @@ pub struct DockForwardingTable {
     reader: RcuBox<RcuCslabReader<DftPep>>,
 }
 
+pub struct DftPepGuard<'a> {
+    guard: RcuGuard<'a, RcuCslabReader<DftPep>>,
+    key: usize,
+}
+
+impl std::ops::Deref for DftPepGuard<'_> {
+    type Target = DftPep;
+
+    fn deref(&self) -> &Self::Target {
+        self.guard.get(self.key).unwrap()
+    }
+}
+
 impl DockForwardingTable {
     pub fn new() -> Self {
         let table = RcuCslab::with_fixed_capacity(DOCK_FORWARDING_TABLE_SIZE);
@@ -48,6 +61,17 @@ impl DockForwardingTable {
     ) -> Option<T> {
         self.reader
             .inspect(|reader| reader.get(tether_id as usize).map(inspector))
+    }
+
+    pub fn get(&self, tether_id: StreamId) -> Option<DftPepGuard<'_>> {
+        let guard = self.reader.get();
+        if guard.get(tether_id as usize).is_none() {
+            return None;
+        }
+        Some(DftPepGuard {
+            guard,
+            key: tether_id as usize,
+        })
     }
 
     pub fn insert(&self, pep: DftPep) -> Result<StreamId, ()> {

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -543,29 +543,17 @@ pub fn substrate_ingress<'pktbuf>(
 
         eprintln!("{}: enqueueing!", asm.system_name);
 
-        // because of how `inspect` works the borrow checker can't track
-        // who consumes this when...
-        let mut pkt = Some(pkt);
+        let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
+            drop_and_count(asm, pkt, CounterType::PeerRemoved);
+            return;
+        };
 
-        if asm
-            .peer_table
-            .inspect(ingress_link_id, |peer_state| {
-                // note: we know `pkt` is still `Some` as we're the first to get to it
-                match peer_state
-                    .mgmt_processor
-                    .try_enqueue_packet(pkt.take().unwrap())
-                {
-                    Ok(()) => (),
-                    Err(TryEnqueueError::Full(pkt)) => {
-                        eprintln!("{}: queue backpressure!", asm.system_name);
-                        drop_and_count(asm, pkt, CounterType::QueueBackpressure);
-                    }
-                }
-            })
-            .is_none()
-        {
-            // note: we know `pkt` is still `Some` as we know the above closure hasn't been executed
-            drop_and_count(asm, pkt.take().unwrap(), CounterType::PeerRemoved);
+        match peer_state.mgmt_processor.try_enqueue_packet(pkt) {
+            Ok(()) => (),
+            Err(TryEnqueueError::Full(pkt)) => {
+                eprintln!("{}: queue backpressure!", asm.system_name);
+                drop_and_count(asm, pkt, CounterType::QueueBackpressure);
+            }
         }
         return;
     }
@@ -607,16 +595,12 @@ pub fn agent_input<'pktbuf>(
     pkt.shrink_by(a2a_mac_size);
 
     // lookup PEP in DLT and expand compressed packet
-    if asm
-        .dlt
-        .inspect(tether_id, |pep| {
-            compress::expand(pep.compression_mode, &pep.five_tuple, &mut pkt)
-        })
-        .is_none()
-    {
+    let Some(pep) = asm.dlt.get(tether_id) else {
         drop_and_count(asm, pkt, CounterType::UnknownStreamId);
         return;
-    }
+    };
+
+    compress::expand(pep.compression_mode, &pep.five_tuple, &mut pkt);
 
     // check A2A MAC
     // TODO: use actual A2A SAID & keyed hash

--- a/adapter/ph/src/flow_control.rs
+++ b/adapter/ph/src/flow_control.rs
@@ -30,15 +30,13 @@ impl FlowControl {
     }
 
     pub fn check_packet(&self, packet: &[u8]) -> u32 {
-        self.inner_control
-            .inspect(|inner_flow| match &inner_flow.flow {
-                Some(program) => program.filter(packet),
-                None => 0,
-            })
+        match &self.inner_control.get().flow {
+            Some(program) => program.filter(packet),
+            None => 0,
+        }
     }
 
     pub fn program_exists(&self) -> bool {
-        self.inner_control
-            .inspect(|inner_flow| inner_flow.flow.is_some())
+        self.inner_control.get().flow.is_some()
     }
 }

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -2,7 +2,7 @@
 use crate::dock_tables::DockForwardingTable;
 use crate::km::{KeyManager, KmTransportSA, UnimplCodec, ZPIPair};
 use crate::queues;
-use crate::rcu::RcuBox;
+use crate::rcu::{RcuBox, RcuGuard};
 use crate::sync_req;
 use crate::zpr::{LinkId, SubstrateAddr};
 use cslab::{RcuCslab, RcuCslabReader};
@@ -111,6 +111,19 @@ pub struct PeerTable<'pktbuf> {
     link_to_km_state: DashMap<LinkId, PeerKmState>,
 }
 
+pub struct PeerStateGuard<'a, 'pktbuf> {
+    guard: RcuGuard<'a, RcuCslabReader<PeerState<'pktbuf>>>,
+    key: usize,
+}
+
+impl<'pktbuf> std::ops::Deref for PeerStateGuard<'_, 'pktbuf> {
+    type Target = PeerState<'pktbuf>;
+
+    fn deref(&self) -> &Self::Target {
+        self.guard.get(self.key).unwrap()
+    }
+}
+
 #[derive(Debug)]
 pub enum PeerInsertError {
     TableFull,
@@ -189,6 +202,17 @@ impl<'pktbuf> PeerTable<'pktbuf> {
     ) -> Option<T> {
         self.peer_slab_reader
             .inspect(|r| r.get(link_id as usize).map(inspector))
+    }
+
+    pub fn get(&self, link_id: LinkId) -> Option<PeerStateGuard<'_, 'pktbuf>> {
+        let guard = self.peer_slab_reader.get();
+        if guard.get(link_id as usize).is_none() {
+            return None;
+        }
+        Some(PeerStateGuard {
+            guard,
+            key: link_id as usize,
+        })
     }
 
     /// Initialize state for the security association on the link.  The security association starts out as

--- a/adapter/ph/src/rcu.rs
+++ b/adapter/ph/src/rcu.rs
@@ -33,12 +33,23 @@ compile_error!("exactly one rcu-* feature must be selected");
 )))]
 compile_error!("exactly one rcu-* feature must be selected");
 
-#[cfg(feature = "rcu-rwlock")]
+#[cfg(any(feature = "rcu-rwlock", doc))]
 mod rcu_impl {
-    use std::sync::RwLock;
+    use std::sync::{RwLock, RwLockReadGuard};
 
     /// An RCU-protected box.
     pub struct RcuBox<T>(RwLock<T>);
+
+    /// A protected reference to the item in an RCU-protected box.
+    pub struct RcuGuard<'a, T>(RwLockReadGuard<'a, T>);
+
+    impl<T> std::ops::Deref for RcuGuard<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            self.0.deref()
+        }
+    }
 
     impl<T> RcuBox<T> {
         /// Create a new box containing the given value.
@@ -52,6 +63,11 @@ mod rcu_impl {
             f(&*self.0.read().unwrap())
         }
 
+        /// Get a protected reference to the latest version of the boxed value.
+        pub fn get(&self) -> RcuGuard<'_, T> {
+            RcuGuard(self.0.read().unwrap())
+        }
+
         /// Replace the boxed value with a new value.  The old value
         /// will be destructed once all readers have completed.
         pub fn write(&self, new_value: T) {
@@ -63,11 +79,24 @@ mod rcu_impl {
     }
 }
 
-#[cfg(feature = "rcu-mutex-arc")]
+#[cfg(all(feature = "rcu-mutex-arc", not(doc)))]
 mod rcu_impl {
     use std::sync::{Arc, Mutex};
 
     pub struct RcuBox<T>(Mutex<Arc<T>>);
+
+    pub struct RcuGuard<'a, T> {
+        phantom: std::marker::PhantomData<&'a T>,
+        arc: Arc<T>,
+    }
+
+    impl<T> std::ops::Deref for RcuGuard<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            self.arc.deref()
+        }
+    }
 
     impl<T> RcuBox<T> {
         pub fn new(value: T) -> Self {
@@ -81,6 +110,14 @@ mod rcu_impl {
             f(&*arc)
         }
 
+        pub fn get(&self) -> RcuGuard<'_, T> {
+            let lock = self.0.lock().unwrap();
+            RcuGuard {
+                phantom: std::marker::PhantomData,
+                arc: lock.clone(),
+            }
+        }
+
         pub fn write(&self, new_value: T) {
             let mut lock = self.0.lock().unwrap();
             let old = std::mem::replace(&mut *lock, Arc::new(new_value));
@@ -90,12 +127,27 @@ mod rcu_impl {
     }
 }
 
-#[cfg(feature = "rcu-crossbeam-epoch")]
+#[cfg(all(feature = "rcu-crossbeam-epoch", not(doc)))]
 mod rcu_impl {
     use crossbeam_epoch as epoch;
     use std::sync::atomic::Ordering;
 
     pub struct RcuBox<T>(epoch::Atomic<T>);
+
+    pub struct RcuGuard<'a, T> {
+        guard: epoch::Guard,
+        atomic: &'a epoch::Atomic<T>,
+    }
+
+    impl<T> std::ops::Deref for RcuGuard<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            let ptr = self.atomic.load(Ordering::Acquire, &self.guard);
+            // SAFETY: we only allow readers to access "live" values
+            unsafe { ptr.deref() }
+        }
+    }
 
     impl<T> RcuBox<T> {
         pub fn new(value: T) -> Self {
@@ -108,6 +160,13 @@ mod rcu_impl {
             // SAFETY: we only allow readers to access "live" values
             let ref_ = unsafe { ptr.deref() };
             f(ref_)
+        }
+
+        pub fn get(&self) -> RcuGuard<'_, T> {
+            RcuGuard {
+                guard: epoch::pin(),
+                atomic: &self.0,
+            }
         }
 
         pub fn write(&self, new_value: T) {
@@ -123,9 +182,26 @@ mod rcu_impl {
     }
 }
 
-#[cfg(feature = "rcu-aarc")]
+// NOTE: `rcu-aarc` doesn't actually compile because of the requirement that
+// the contained type has static lifetime.  However -- I think we *could* work
+// with this constraint in most cases if we change type annotations
+// in some places, so I'm keeping it around for now.
+#[cfg(all(feature = "rcu-aarc", not(doc)))]
 mod rcu_impl {
     pub struct RcuBox<T: 'static>(aarc::AtomicArc<T>);
+
+    pub struct RcuGuard<'a, T> {
+        phantom: std::marker::PhantomData<&'a T>,
+        snapshot: aarc::Snapshot<T>,
+    }
+
+    impl<T> std::ops::Deref for RcuGuard<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            self.snapshot.deref()
+        }
+    }
 
     impl<T> RcuBox<T> {
         pub fn new(value: T) -> Self {
@@ -134,6 +210,13 @@ mod rcu_impl {
 
         pub fn inspect<U>(&self, f: impl FnOnce(&T) -> U) -> U {
             f(&*self.0.load::<aarc::Snapshot<_>>().unwrap())
+        }
+
+        pub fn get(&self) -> RcuGuard<'_, T> {
+            RcuGuard {
+                phantom: std::marker::PhantomData,
+                snapshot: self.0.load::<aarc::Snapshot<_>>().unwrap(),
+            }
         }
 
         pub fn write(&self, new_value: T) {


### PR DESCRIPTION
Finally figured out how to implement a simple `get()` for `RcuBox`!

Did that, then implemented `get()` using that for the `RcuCslab`-based tables, and then used `get()` in some places.

(Not all -- some I'm about to rewrite in another branch so don't want to conflict, others actually work better using `inspect()` since it's effectively `.get().map()`.)

Since there's a lot of copy-paste in the table implementations now, I opened #392 to address that.