### PR TITLE
slowdown KM retry

### DIFF
--- a/adapter/cd/src/zdp/client.rs
+++ b/adapter/cd/src/zdp/client.rs
@@ -145,7 +145,6 @@ impl ZDPClient {
                                 continue;
                             }
                             let zpi_hdr = zpi_hdr.unwrap();
-                            let my_sa = mgr.get_transport_state().unwrap();
                             match zpi_hdr.zpi {
                                 0 => {
                                     info!("zdp/client - received ZPI=0 message");
@@ -164,6 +163,13 @@ impl ZDPClient {
                                     }
                                 }
                                 _ => {
+                                    let my_sa = match mgr.get_transport_state() {
+                                        Some(sa) => sa,
+                                        None => {
+                                            info!("zdp/client - got non zpi=0 message before SA established (ZPI={})", zpi_hdr.zpi);
+                                            continue;
+                                        }
+                                    };
                                     if zpi_hdr.zpi == my_sa.recv_zpis.hmac {
                                         info!("zdp/client - received transit ZPI message, discarding");
                                     } else if zpi_hdr.zpi == my_sa.recv_zpis.encr {

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 aarc = { version = "0.2.1", optional = true }
 arrayref = { version = "0.3.7" }
+base64 = "0.22.1"
 blake3 = { version = "1.5.4" }
 bytes = { version = "1.7.1" }
 cbpf-rs = { path = "../../cbpf-rs" }
@@ -31,7 +32,6 @@ zerocopy = { version = "0.7.34", features = ["byteorder", "derive"] }
 zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "tokio-tun", "zerocopy"] }
 
 [dev-dependencies]
-base64 = "0.22.1"
 
 [features]
 default = ["rcu-crossbeam-epoch"]

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -41,7 +41,6 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
         return;
     }
 
-
     let five_tuple = pkt.metadata().five_tuple();
 
     // if there's already an entry, this is a duplicate request
@@ -53,7 +52,6 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
 
     // copy out five tuple so we can give away packet
     let five_tuple = *five_tuple;
-
 
     // if there's already an entry, this is a duplicate request
     // (NOTE: we should be the only ones modifying this table!)
@@ -72,7 +70,6 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
         fastpath::drop_and_count(asm, pkt, CounterType::DroppedNoSA);
         return;
     }
-
 
     // mark ALT entry as pending to attempt to (i.e. racily) prevent
     // fastpath from issuing multiple requests

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -8,7 +8,7 @@ use crate::queues::AdapterManagerMessage;
 use crate::zpr;
 use std::future::Future;
 use tokio::sync::mpsc;
-use tracing::debug;
+use tracing::{debug, error};
 
 async fn worker<'pktbuf>(
     asm: &Assembly<'pktbuf>,
@@ -37,16 +37,28 @@ pub fn launch<'pktbuf>(
 async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pktbuf>) {
     // TODO: node version... that just allocates a tether ID directly from the internal dock, no messages exchanged
     if matches!(asm.ph_mode, PhMode::Node) {
+        fastpath::drop_and_count(asm, pkt, CounterType::DroppedNop);
         return;
     }
 
     // just extract 5t and drop packet for now, storing & resending it later is a TODO
     let five_tuple = *pkt.metadata().five_tuple();
-    fastpath::drop_and_count(asm, pkt, CounterType::DroppedAwaitingBind);
 
     // if there's already an entry, this is a duplicate request
     // (NOTE: we should be the only ones modifying this table!)
     if asm.alt.get(&five_tuple).is_some() {
+        fastpath::drop_and_count(asm, pkt, CounterType::DroppedDuplicate);
+        return;
+    }
+
+    // NOPE ! not if the link is not ready.
+    let link_id = asm.hack_get_adapter_docking_session_id();
+    if !asm.peer_table.is_security_assocaition_established(link_id) {
+        error!(
+            "{}: Link {} has no security association, aborting bind request operation",
+            asm.system_name, link_id
+        );
+        fastpath::drop_and_count(asm, pkt, CounterType::DroppedNoSA);
         return;
     }
 
@@ -58,11 +70,9 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
     let compression_mode: zpr::CompressionMode = 0;
 
     debug!(
-        "{}: Issuing bind request for {}",
-        asm.system_name, five_tuple
+        "{}: link {}: Issuing bind request for {} (is now set PENDING)",
+        asm.system_name, link_id, five_tuple
     );
-
-    // send Bind request
 
     match mgmt::send_bind_agent_address_request(
         asm,

--- a/adapter/ph/src/counters_enum.rs
+++ b/adapter/ph/src/counters_enum.rs
@@ -22,6 +22,9 @@ pub enum CounterType {
 
     QueueBackpressure,
     DroppedAwaitingBind,
+    DroppedNop,       // normal, not an error drop
+    DroppedDuplicate, // some sort of duplicate detected
+    DroppedNoSA,      // no security association on link
 
     BadMgmtResponse,
     UnexpectedMgmtResponse,
@@ -60,6 +63,9 @@ impl CounterType {
 
             Self::QueueBackpressure => "QueueBackpressure",
             Self::DroppedAwaitingBind => "Dropped Awaiting Bind",
+            Self::DroppedDuplicate => "Dropped Duplicate",
+            Self::DroppedNop => "Dropped No Operation",
+            Self::DroppedNoSA => "Dropped No Security Association",
 
             Self::BadMgmtResponse => "Bad Management Response",
             Self::UnexpectedMgmtResponse => "Unexpected Management Response",

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -50,38 +50,6 @@ pub fn encap_zpi<'pktbuf>(
     pkt.alloc_zeroed_header::<zdp::ZdpZpiHeader>().zpi = zpi;
 }
 
-pub enum DecapZpiError {
-    BadStructure,
-    UnknownZpi,
-}
-
-impl From<DecapZpiError> for CounterType {
-    fn from(value: DecapZpiError) -> Self {
-        match value {
-            DecapZpiError::BadStructure => Self::BadStructure,
-            DecapZpiError::UnknownZpi => Self::UnknownZpi,
-        }
-    }
-}
-
-/// Remove the ZPI header from a packet.
-/// Returns the ZPI value, or an error if it's invalid for the given link.
-pub fn decap_zpi<'pktbuf>(
-    _asm: &Assembly<'pktbuf>,
-    _link_id: zpr::LinkId,
-    pkt: &mut Packet<'pktbuf>,
-) -> Result<zpr::Zpi, DecapZpiError> {
-    let zpi_hdr = zdp::ZdpZpiHeader::read_from_buf(pkt).ok_or(DecapZpiError::BadStructure)?;
-    let zpi = zpi_hdr.zpi as zpr::Zpi;
-
-    if zpi == zpr::ZPI_0 {
-        Ok(zpi)
-    } else {
-        // TODO: lookup in table
-        Err(DecapZpiError::UnknownZpi)
-    }
-}
-
 /// Offer a packet to be captured by the packet capture facility.
 /// The packet must be a complete ZDP message.
 /// Despite the &mut borrow, the packet will return materially unchanged.
@@ -338,9 +306,9 @@ fn substrate_egress_common<'pktbuf>(
     {
         Some(transport_sa) => {
             if transit {
-                real_zpi = transport_sa.recv_zpis.hmac;
+                real_zpi = transport_sa.send_zpis.hmac;
             } else {
-                real_zpi = transport_sa.recv_zpis.encr;
+                real_zpi = transport_sa.send_zpis.encr;
             }
             assert!(real_zpi != zpr::ZPI_0);
             Some(transport_sa)
@@ -487,8 +455,8 @@ pub fn substrate_ingress<'pktbuf>(
             } else {
                 // We have an SA and ZPI does not match.
                 info!(
-                    "ingress: link {}: unexpected ZPI value {} (expected {:?})",
-                    ingress_link_id, zpi_hdr.zpi, transport_sa.recv_zpis
+                    "{}: ingress: link {}: unexpected ZPI value {} (expected {:?})",
+                    asm.system_name, ingress_link_id, zpi_hdr.zpi, transport_sa.recv_zpis
                 );
                 drop_and_count(asm, pkt, CounterType::UnknownZpi);
                 return;
@@ -504,8 +472,8 @@ pub fn substrate_ingress<'pktbuf>(
         // Not under a security assocation  which means only ZPI 0 is allowed
         if zpi_hdr.zpi != zpr::ZPI_0 {
             info!(
-                "ingress: link {}: ZPI {} not allowed on unestablished SA",
-                ingress_link_id, zpi_hdr.zpi
+                "{}: ingress: link {}: ZPI {} not allowed on unestablished SA",
+                asm.system_name, ingress_link_id, zpi_hdr.zpi
             );
             drop_and_count(asm, pkt, CounterType::UnknownZpi);
             return;
@@ -522,14 +490,14 @@ pub fn substrate_ingress<'pktbuf>(
     // Watch out -- may not be secure
     maybe_capture(asm, Direction::Inbound, &mut pkt);
 
-    // now pop the ZPI off the packet
-    let _zpi = match decap_zpi(asm, ingress_link_id, &mut pkt) {
-        Ok(zpi) => zpi,
-        Err(err) => {
-            drop_and_count(asm, pkt, err);
+    // now pop the ZPI off the packet. We've already checked it.
+    match zdp::ZdpZpiHeader::read_from_buf(&mut pkt) {
+        Some(_) => (),
+        None => {
+            drop_and_count(asm, pkt, CounterType::BadStructure);
             return;
         }
-    };
+    }
 
     let Some(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(&mut pkt) else {
         return drop_and_count(asm, pkt, CounterType::BadStructure);
@@ -540,8 +508,8 @@ pub fn substrate_ingress<'pktbuf>(
     if !secure && base_hdr.packet_type != zdp::ZdpPacketType::KeyManagement {
         if !asm.flags.allow_insecure_zpi_zero {
             warn!(
-                "ingress: link {}: ZPI 0 only allows key management messages, not {:?}",
-                ingress_link_id, base_hdr.packet_type
+                "{}: ingress: link {}: ZPI 0 only allows key management messages, not {:?}",
+                asm.system_name, ingress_link_id, base_hdr.packet_type
             );
             drop_and_count(asm, pkt, CounterType::OtherError);
             return;

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -576,24 +576,26 @@ impl KeyManager {
             }
         }
 
-        // Tick machine, even during error.
-        let resp: Option<Bytes>;
-        {
-            let mut state = self.shared.state.lock().unwrap();
-            resp = match state.statemachine.tick() {
-                Ok(h) => h,
-                Err(e) => {
-                    warn!("error during tick processing: {}", e);
-                    None
-                }
-            };
-        }
-        if let Some(r) = resp {
-            match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
-                Ok(_) => {}
-                Err(_) => {
-                    error!("failed to enqueue oubound KM message");
-                    return Err(KmError::EnqueueFailed);
+        // Unless we did a reset, tick machine, even during error.
+        if !did_reset {
+            let resp: Option<Bytes>;
+            {
+                let mut state = self.shared.state.lock().unwrap();
+                resp = match state.statemachine.tick() {
+                    Ok(h) => h,
+                    Err(e) => {
+                        warn!("error during tick processing: {}", e);
+                        None
+                    }
+                };
+            }
+            if let Some(r) = resp {
+                match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
+                    Ok(_) => {}
+                    Err(_) => {
+                        error!("failed to enqueue oubound KM message");
+                        return Err(KmError::EnqueueFailed);
+                    }
                 }
             }
         }

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -23,7 +23,7 @@ use bytes::{BufMut, Bytes};
 
 use zerocopy::FromBytes;
 
-use tracing::{error, warn, info};
+use tracing::{error, info, warn};
 
 use crate::config;
 use crate::packet::Packet;
@@ -425,7 +425,6 @@ impl KeyManager {
                 prev_state = state.statemachine.get_state();
             }
 
-
             tokio::select! {
                 _ = ctok.cancelled() => {
                     match self.send_signal(&km_signals_out, link_id, KmSignal::Termination).await {
@@ -535,7 +534,6 @@ impl KeyManager {
         km_signals_out: &mpsc::Sender<KmLinkMsg<KmSignal>>,
         cur_state: &KmSMState,
     ) -> KmResult<()> {
-
         let mut resp: Option<Bytes> = None;
         let mut did_reset = false;
 
@@ -720,7 +718,6 @@ impl KeyManager {
         }
         Ok(())
     }
-
 }
 
 impl KmTransportSA {

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -23,7 +23,7 @@ use bytes::{BufMut, Bytes};
 
 use zerocopy::FromBytes;
 
-use tracing::{error, info};
+use tracing::{error, warn, info};
 
 use crate::config;
 use crate::packet::Packet;
@@ -266,7 +266,7 @@ struct KmState {
     sa_id: zpr::SaId,                     // current SA identifier
     mgmt_tx: Option<mpsc::Sender<Bytes>>, // Internal queue for key management messages to be processed.
     ts: KmTransportSA,
-    restart_request: Option<bool>,
+    restart_request: bool,
     error_signaled: bool,
 }
 
@@ -295,7 +295,7 @@ impl KeyManager {
                     sa_id: 0,
                     mgmt_tx: None,
                     ts: Default::default(),
-                    restart_request: None,
+                    restart_request: false,
                     error_signaled: false,
                 }),
             }),
@@ -378,7 +378,7 @@ impl KeyManager {
         if state.statemachine.get_state() != KmSMState::Error {
             return Err(KmError::InvalidState);
         }
-        state.restart_request = Some(true);
+        state.restart_request = true;
         Ok(())
     }
 
@@ -425,46 +425,34 @@ impl KeyManager {
                 prev_state = state.statemachine.get_state();
             }
 
-            match prev_state {
-                KmSMState::Error => match self
-                    .handle_state_error(link_id, &km_signals_out, &km_buffers_out)
-                    .await
-                {
-                    Ok(_) => {}
-                    Err(e) => {
-                        return Err(e);
-                    }
-                },
-                _ => {
-                    tokio::select! {
-                        _ = ctok.cancelled() => {
-                            match self.send_signal(&km_signals_out, link_id, KmSignal::Termination).await {
-                                Ok(_) => {}
-                                Err(_) => {}
-                            };
-                            break;
-                        }
 
-                        Some(inmsg) = km_rx.recv() => {
-                            match self.dispatch_km_message(inmsg, link_id, &km_buffers_out).await {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    return Err(e);
-                                }
-                            }
-                        }
+            tokio::select! {
+                _ = ctok.cancelled() => {
+                    match self.send_signal(&km_signals_out, link_id, KmSignal::Termination).await {
+                        Ok(_) => {}
+                        Err(_) => {}
+                    };
+                    break;
+                }
 
-                        _ = interval.tick() => {
-                            match self.tick_statemachine(link_id, &km_buffers_out).await {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    return Err(e);
-                                }
-                            }
+                Some(inmsg) = km_rx.recv() => {
+                    match self.dispatch_km_message(inmsg, link_id, &km_buffers_out).await {
+                        Ok(_) => {}
+                        Err(e) => {
+                            return Err(e);
                         }
                     }
                 }
-            };
+
+                _ = interval.tick() => {
+                    match self.tick_statemachine(link_id, &km_buffers_out, &km_signals_out, &prev_state).await {
+                        Ok(_) => {}
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    }
+                }
+            }
 
             {
                 let state = self.shared.state.lock().unwrap();
@@ -544,14 +532,60 @@ impl KeyManager {
         &self,
         link_id: zpr::LinkId,
         km_buffers_out: &mpsc::Sender<KmLinkMsg<Bytes>>,
+        km_signals_out: &mpsc::Sender<KmLinkMsg<KmSignal>>,
+        cur_state: &KmSMState,
     ) -> KmResult<()> {
+
+        let mut resp: Option<Bytes> = None;
+        let mut did_reset = false;
+
+        if *cur_state == KmSMState::Error {
+            {
+                let mut state = self.shared.state.lock().unwrap();
+                if state.restart_request {
+                    resp = match state.statemachine.reset() {
+                        Ok(h) => {
+                            did_reset = true;
+                            h
+                        }
+                        Err(e) => {
+                            return Err(KmError::MachineError(e.to_string()));
+                        }
+                    };
+                    state.restart_request = false;
+                }
+            }
+            if let Some(r) = resp {
+                match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
+                    Ok(_) => {}
+                    Err(_) => {
+                        error!("failed to enqueue outbound KM message");
+                        return Err(KmError::EnqueueFailed);
+                    }
+                }
+            }
+            if did_reset {
+                match self
+                    .send_signal(km_signals_out, link_id, KmSignal::Reset)
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(_) => {
+                        error!("failed to enqueue reset signal, aborting");
+                        return Err(KmError::EnqueueFailed);
+                    }
+                }
+            }
+        }
+
+        // Tick machine, even during error.
         let resp: Option<Bytes>;
         {
             let mut state = self.shared.state.lock().unwrap();
             resp = match state.statemachine.tick() {
                 Ok(h) => h,
                 Err(e) => {
-                    error!("failed to tick key manager: {}", e);
+                    warn!("error during tick processing: {}", e);
                     None
                 }
             };
@@ -580,7 +614,7 @@ impl KeyManager {
             // We transitioned out of error state -- clear error related settings.
             let mut state = self.shared.state.lock().unwrap();
             state.error_signaled = false;
-            state.restart_request = None;
+            state.restart_request = false;
         }
         match next_state {
             KmSMState::Transport(ts) => {
@@ -628,7 +662,30 @@ impl KeyManager {
                     }
                 }
             }
-            _ => {}
+            KmSMState::Error => {
+                let needs_error_signal: bool;
+                {
+                    let state = self.shared.state.lock().unwrap();
+                    needs_error_signal = !state.error_signaled;
+                }
+                if needs_error_signal {
+                    match self
+                        .send_signal(km_signals_out, link_id, KmSignal::Error)
+                        .await
+                    {
+                        Ok(_) => {}
+                        Err(_) => {
+                            error!("failed to enqueue error signal, aborting");
+                            return Err(KmError::EnqueueFailed);
+                        }
+                    }
+                    {
+                        let mut state = self.shared.state.lock().unwrap();
+                        state.error_signaled = true;
+                    }
+                }
+            }
+            KmSMState::Configuring => {}
         };
         Ok(())
     }
@@ -664,76 +721,6 @@ impl KeyManager {
         Ok(())
     }
 
-    /// Deal with case where the state machine is in the error state.
-    /// If we have been instructed previously to restart the machine (see [KeyManager::restart]) then
-    /// this will reset the state machine and send a reset signal, possibly also generating
-    /// a new handshake message.
-    async fn handle_state_error(
-        &self,
-        link_id: zpr::LinkId,
-        km_signals_out: &mpsc::Sender<KmLinkMsg<KmSignal>>,
-        km_buffers_out: &mpsc::Sender<KmLinkMsg<Bytes>>,
-    ) -> KmResult<()> {
-        let mut resp: Option<Bytes> = None;
-        let mut did_reset = false;
-        let restart_request;
-
-        let needs_error_signal: bool;
-        {
-            let state = self.shared.state.lock().unwrap();
-            needs_error_signal = !state.error_signaled;
-            restart_request = state.restart_request.unwrap_or(false);
-        }
-        if needs_error_signal {
-            match self
-                .send_signal(km_signals_out, link_id, KmSignal::Error)
-                .await
-            {
-                Ok(_) => {}
-                Err(_) => {
-                    error!("failed to enqueue error signal, aborting");
-                    return Err(KmError::EnqueueFailed);
-                }
-            }
-            {
-                let mut state = self.shared.state.lock().unwrap();
-                state.error_signaled = true;
-            }
-        }
-        if restart_request {
-            let mut state = self.shared.state.lock().unwrap();
-            resp = match state.statemachine.reset() {
-                Ok(h) => h,
-                Err(e) => {
-                    return Err(KmError::MachineError(e.to_string()));
-                }
-            };
-            did_reset = true;
-            state.restart_request = None;
-        }
-        if did_reset {
-            match self
-                .send_signal(km_signals_out, link_id, KmSignal::Reset)
-                .await
-            {
-                Ok(_) => {}
-                Err(_) => {
-                    error!("failed to enqueue reset signal, aborting");
-                    return Err(KmError::EnqueueFailed);
-                }
-            }
-            if let Some(r) = resp {
-                match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
-                    Ok(_) => {}
-                    Err(_) => {
-                        error!("failed to enqueue outbound KM message");
-                        return Err(KmError::EnqueueFailed);
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
 }
 
 impl KmTransportSA {

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -172,6 +172,9 @@ pub enum KmSignal {
 
     /// When a security association is established.
     SaEstablished(KmTransportSA),
+
+    /// Sent during a clean shutdown of the KeyManager (when the CancellationToken is cancelled).
+    Termination,
 }
 
 /// Encapsulates all the "state" set up by an SA.
@@ -263,6 +266,8 @@ struct KmState {
     sa_id: zpr::SaId,                     // current SA identifier
     mgmt_tx: Option<mpsc::Sender<Bytes>>, // Internal queue for key management messages to be processed.
     ts: KmTransportSA,
+    restart_request: Option<bool>,
+    error_signaled: bool,
 }
 
 impl fmt::Debug for KmState {
@@ -290,6 +295,8 @@ impl KeyManager {
                     sa_id: 0,
                     mgmt_tx: None,
                     ts: Default::default(),
+                    restart_request: None,
+                    error_signaled: false,
                 }),
             }),
         }
@@ -362,6 +369,19 @@ impl KeyManager {
         }
     }
 
+    /// Indicate that the KM state machine should restart out of the error state.
+    /// For an initiator type link, this will trigger generation of a new handshake message.
+    ///
+    /// [KmError::InvalidState] is returned if state machine is not in error state.
+    pub fn restart(&self) -> KmResult<()> {
+        let mut state = self.shared.state.lock().unwrap();
+        if state.statemachine.get_state() != KmSMState::Error {
+            return Err(KmError::InvalidState);
+        }
+        state.restart_request = Some(true);
+        Ok(())
+    }
+
     /// Blocking run loop for the key manager.  This runs the key management algorithm
     /// state machine handing KM messages in and out.
     ///
@@ -427,19 +447,33 @@ impl KeyManager {
 
             match prev_state {
                 KmSMState::Error => {
-                    // If error, send reset and loop again
-                    match km_signals_out
-                        .send(KmLinkMsg::new(link_id, KmSignal::Error))
-                        .await
+                    let mut resp: Option<Bytes> = None;
+                    let mut did_reset = false;
+                    let restart_request;
+
+                    let needs_error_signal: bool;
                     {
-                        Ok(_) => {}
-                        Err(_) => {
-                            error!("failed to enqueue error signal, aborting");
-                            return Err(KmError::EnqueueFailed);
+                        let state = self.shared.state.lock().unwrap();
+                        needs_error_signal = !state.error_signaled;
+                        restart_request = state.restart_request.unwrap_or(false);
+                    }
+                    if needs_error_signal {
+                        match km_signals_out
+                            .send(KmLinkMsg::new(link_id, KmSignal::Error))
+                            .await
+                        {
+                            Ok(_) => {}
+                            Err(_) => {
+                                error!("failed to enqueue error signal, aborting");
+                                return Err(KmError::EnqueueFailed);
+                            }
+                        }
+                        {
+                            let mut state = self.shared.state.lock().unwrap();
+                            state.error_signaled = true;
                         }
                     }
-                    let resp: Option<Bytes>;
-                    {
+                    if restart_request {
                         let mut state = self.shared.state.lock().unwrap();
                         resp = match state.statemachine.reset() {
                             Ok(h) => h,
@@ -447,23 +481,27 @@ impl KeyManager {
                                 return Err(KmError::MachineError(e.to_string()));
                             }
                         };
+                        did_reset = true;
+                        state.restart_request = None;
                     }
-                    match km_signals_out
-                        .send(KmLinkMsg::new(link_id, KmSignal::Reset))
-                        .await
-                    {
-                        Ok(_) => {}
-                        Err(_) => {
-                            error!("failed to enqueue reset signal, aborting");
-                            return Err(KmError::EnqueueFailed);
-                        }
-                    }
-                    if let Some(resp) = resp {
-                        match km_buffers_out.send(KmLinkMsg::new(link_id, resp)).await {
+                    if did_reset {
+                        match km_signals_out
+                            .send(KmLinkMsg::new(link_id, KmSignal::Reset))
+                            .await
+                        {
                             Ok(_) => {}
                             Err(_) => {
-                                error!("failed to enqueue outbound KM message");
+                                error!("failed to enqueue reset signal, aborting");
                                 return Err(KmError::EnqueueFailed);
+                            }
+                        }
+                        if let Some(r) = resp {
+                            match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
+                                Ok(_) => {}
+                                Err(_) => {
+                                    error!("failed to enqueue outbound KM message");
+                                    return Err(KmError::EnqueueFailed);
+                                }
                             }
                         }
                     }
@@ -472,6 +510,10 @@ impl KeyManager {
                 _ => {
                     tokio::select! {
                         _ = ctok.cancelled() => {
+                            match km_signals_out.send(KmLinkMsg::new(link_id, KmSignal::Termination)).await {
+                                Ok(_) => {}
+                                Err(_) => {}
+                            };
                             break;
                         }
 
@@ -531,6 +573,12 @@ impl KeyManager {
 
             if next_state != prev_state {
                 info!("KM state transition {:?} -> {:?}", prev_state, next_state);
+                if matches!(prev_state, KmSMState::Error) {
+                    // We transitioned out of error state -- clear error related settings.
+                    let mut state = self.shared.state.lock().unwrap();
+                    state.error_signaled = false;
+                    state.restart_request = None;
+                }
                 match next_state {
                     KmSMState::Transport(ts) => {
                         let prev_id: zpr::SaId;
@@ -579,10 +627,6 @@ impl KeyManager {
                     }
                     _ => {}
                 }
-            } else if next_state == KmSMState::Error {
-                error!("KM: stuck in error state");
-                return Err(KmError::MachineError(String::from("stuck in error state")));
-                // TODO: Maybe use a timer and keep trying to reset?
             }
         }
 
@@ -734,6 +778,7 @@ pub fn decrypt_transport_zdp(message: &mut Packet, codec: Arc<dyn Codec>) -> KmR
 ///     Error <-------+
 ///```
 ///
+/// Note that moving from Error back to Configuring requires a an external call to [KeyManager::restart].
 /// Not (yet) accounting for "rekeying".
 ///
 #[derive(Debug, Clone, PartialEq)]

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -409,32 +409,12 @@ impl KeyManager {
 
         let mut interval = time::interval(tick_interval);
 
-        let handshake: Option<Bytes>;
-        {
-            let mut state = self.shared.state.lock().unwrap();
-            handshake = match state.statemachine.reset() {
-                Ok(h) => h,
-                Err(e) => return Err(KmError::MachineError(e.to_string())),
-            };
-        }
-        match km_signals_out
-            .send(KmLinkMsg::new(link_id, KmSignal::Reset))
+        self.start_state_machine_internal(link_id, &km_signals_out, &km_buffers_out)
             .await
-        {
-            Ok(_) => {}
-            Err(_) => {
-                error!("failed to enqueue reset signal")
-            }
-        }
-        if let Some(handshake) = handshake {
-            match km_buffers_out
-                .send(KmLinkMsg::new(link_id, handshake))
-                .await
-            {
-                Ok(_) => {}
-                Err(_) => return Err(KmError::EnqueueFailed),
-            }
-        };
+            .or_else(|e| {
+                error!("failed to start state machine: {}", e);
+                Err(e)
+            })?;
 
         let mut prev_state: KmSMState;
         let mut next_state: KmSMState;
@@ -446,71 +426,19 @@ impl KeyManager {
             }
 
             match prev_state {
-                KmSMState::Error => {
-                    let mut resp: Option<Bytes> = None;
-                    let mut did_reset = false;
-                    let restart_request;
-
-                    let needs_error_signal: bool;
-                    {
-                        let state = self.shared.state.lock().unwrap();
-                        needs_error_signal = !state.error_signaled;
-                        restart_request = state.restart_request.unwrap_or(false);
+                KmSMState::Error => match self
+                    .handle_state_error(link_id, &km_signals_out, &km_buffers_out)
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(e) => {
+                        return Err(e);
                     }
-                    if needs_error_signal {
-                        match km_signals_out
-                            .send(KmLinkMsg::new(link_id, KmSignal::Error))
-                            .await
-                        {
-                            Ok(_) => {}
-                            Err(_) => {
-                                error!("failed to enqueue error signal, aborting");
-                                return Err(KmError::EnqueueFailed);
-                            }
-                        }
-                        {
-                            let mut state = self.shared.state.lock().unwrap();
-                            state.error_signaled = true;
-                        }
-                    }
-                    if restart_request {
-                        let mut state = self.shared.state.lock().unwrap();
-                        resp = match state.statemachine.reset() {
-                            Ok(h) => h,
-                            Err(e) => {
-                                return Err(KmError::MachineError(e.to_string()));
-                            }
-                        };
-                        did_reset = true;
-                        state.restart_request = None;
-                    }
-                    if did_reset {
-                        match km_signals_out
-                            .send(KmLinkMsg::new(link_id, KmSignal::Reset))
-                            .await
-                        {
-                            Ok(_) => {}
-                            Err(_) => {
-                                error!("failed to enqueue reset signal, aborting");
-                                return Err(KmError::EnqueueFailed);
-                            }
-                        }
-                        if let Some(r) = resp {
-                            match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
-                                Ok(_) => {}
-                                Err(_) => {
-                                    error!("failed to enqueue outbound KM message");
-                                    return Err(KmError::EnqueueFailed);
-                                }
-                            }
-                        }
-                    }
-                }
-
+                },
                 _ => {
                     tokio::select! {
                         _ = ctok.cancelled() => {
-                            match km_signals_out.send(KmLinkMsg::new(link_id, KmSignal::Termination)).await {
+                            match self.send_signal(&km_signals_out, link_id, KmSignal::Termination).await {
                                 Ok(_) => {}
                                 Err(_) => {}
                             };
@@ -518,47 +446,19 @@ impl KeyManager {
                         }
 
                         Some(inmsg) = km_rx.recv() => {
-                            let resp: Option<Bytes>;
-                            {
-                                let mut state = self.shared.state.lock().unwrap();
-                                resp = match state.statemachine.handle_message(&inmsg) {
-                                    Ok(h) => h,
-                                    Err(e) => {
-                                        error!("failed to handle key manager message: {}", e);
-                                        None
-                                    }
-                                };
-                            }
-                            if let Some(resp) = resp {
-                                match km_buffers_out.send(KmLinkMsg::new(link_id, resp)).await {
-                                    Ok(_) => {},
-                                    Err(_) => {
-                                        error!("failed to enqueue outbound KM message");
-                                        return Err(KmError::EnqueueFailed);
-                                    }
+                            match self.dispatch_km_message(inmsg, link_id, &km_buffers_out).await {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    return Err(e);
                                 }
                             }
                         }
 
                         _ = interval.tick() => {
-                            let resp: Option<Bytes>;
-                            {
-                                let mut state = self.shared.state.lock().unwrap();
-                                resp = match state.statemachine.tick() {
-                                    Ok(h) => h,
-                                    Err(e) => {
-                                        error!("failed to tick key manager: {}", e);
-                                        None
-                                    }
-                                };
-                            }
-                            if let Some(resp) = resp {
-                                match km_buffers_out.send(KmLinkMsg::new(link_id, resp)).await {
-                                    Ok(_) => {},
-                                    Err(_) => {
-                                        error!("failed to enqueue oubound KM message");
-                                        return Err(KmError::EnqueueFailed);
-                                    }
+                            match self.tick_statemachine(link_id, &km_buffers_out).await {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    return Err(e);
                                 }
                             }
                         }
@@ -572,63 +472,59 @@ impl KeyManager {
             }
 
             if next_state != prev_state {
-                info!("KM state transition {:?} -> {:?}", prev_state, next_state);
-                if matches!(prev_state, KmSMState::Error) {
-                    // We transitioned out of error state -- clear error related settings.
-                    let mut state = self.shared.state.lock().unwrap();
-                    state.error_signaled = false;
-                    state.restart_request = None;
-                }
-                match next_state {
-                    KmSMState::Transport(ts) => {
-                        let prev_id: zpr::SaId;
-                        let cur_id: zpr::SaId;
-                        let mut my_sa = ts.clone();
-                        {
-                            let mut state = self.shared.state.lock().unwrap();
-                            prev_id = state.sa_id;
-                            state.sa_id += 1;
-                            if state.sa_id == 0 {
-                                state.sa_id = 1;
-                            }
-                            cur_id = state.sa_id;
-                            // Capture the SA and update the SA_ID.
-                            my_sa.sa_id = cur_id;
-                            state.ts = my_sa.clone();
-                        }
-                        info!("KM: New SA_ID: {}", cur_id);
-                        match self
-                            .send_signal(
-                                &km_signals_out,
-                                link_id,
-                                KmSignal::SaIdChange {
-                                    old: prev_id,
-                                    new: cur_id,
-                                },
-                            )
-                            .await
-                        {
-                            Ok(_) => {}
-                            Err(_) => {
-                                error!("failed to enqueue SaIdChange signal");
-                                return Err(KmError::EnqueueFailed);
-                            }
-                        }
-                        match self
-                            .send_signal(&km_signals_out, link_id, KmSignal::SaEstablished(my_sa))
-                            .await
-                        {
-                            Ok(_) => {}
-                            Err(_) => {
-                                error!("failed to enqueue SaIdEstablished signal");
-                                return Err(KmError::EnqueueFailed);
-                            }
-                        }
+                match self
+                    .handle_state_transition(prev_state, next_state, link_id, &km_signals_out)
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(e) => {
+                        return Err(e);
                     }
-                    _ => {}
                 }
             }
         }
+
+        Ok(())
+    }
+
+    /// Kick off the [KeyManagerStateMachine] by calling its reset method.
+    /// As a side effect this also sends the [KmSignal::Reset] signal out our signal channel.
+    /// If the state machine produces a handshake message as a result of reset, then that
+    /// is sent our our message channel.
+    async fn start_state_machine_internal(
+        &self,
+        link_id: zpr::LinkId,
+        km_signals_out: &mpsc::Sender<KmLinkMsg<KmSignal>>,
+        km_buffers_out: &mpsc::Sender<KmLinkMsg<Bytes>>,
+    ) -> KmResult<()> {
+        let handshake: Option<Bytes>;
+        {
+            let mut state = self.shared.state.lock().unwrap();
+            handshake = match state.statemachine.reset() {
+                Ok(h) => h,
+                Err(e) => return Err(KmError::MachineError(e.to_string())),
+            };
+        }
+
+        match self
+            .send_signal(&km_signals_out, link_id, KmSignal::Reset)
+            .await
+        {
+            Ok(_) => {}
+            Err(_) => {
+                error!("failed to enqueue reset signal")
+            }
+        };
+
+        if let Some(handshake) = handshake {
+            match km_buffers_out
+                .send(KmLinkMsg::new(link_id, handshake))
+                .await
+            {
+                Ok(_) => {}
+                Err(_) => return Err(KmError::EnqueueFailed),
+            }
+        };
 
         Ok(())
     }
@@ -641,6 +537,202 @@ impl KeyManager {
         signal: KmSignal,
     ) -> impl Future<Output = Result<(), mpsc::error::SendError<KmLinkMsg<KmSignal>>>> + 'a {
         chan.send(KmLinkMsg::new(link_id, signal))
+    }
+
+    /// Calls the state machine's tick method and sends any resulting message.
+    async fn tick_statemachine(
+        &self,
+        link_id: zpr::LinkId,
+        km_buffers_out: &mpsc::Sender<KmLinkMsg<Bytes>>,
+    ) -> KmResult<()> {
+        let resp: Option<Bytes>;
+        {
+            let mut state = self.shared.state.lock().unwrap();
+            resp = match state.statemachine.tick() {
+                Ok(h) => h,
+                Err(e) => {
+                    error!("failed to tick key manager: {}", e);
+                    None
+                }
+            };
+        }
+        if let Some(r) = resp {
+            match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
+                Ok(_) => {}
+                Err(_) => {
+                    error!("failed to enqueue oubound KM message");
+                    return Err(KmError::EnqueueFailed);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_state_transition(
+        &self,
+        prev_state: KmSMState,
+        next_state: KmSMState,
+        link_id: zpr::LinkId,
+        km_signals_out: &mpsc::Sender<KmLinkMsg<KmSignal>>,
+    ) -> KmResult<()> {
+        info!("KM state transition {:?} -> {:?}", prev_state, next_state);
+        if matches!(prev_state, KmSMState::Error) {
+            // We transitioned out of error state -- clear error related settings.
+            let mut state = self.shared.state.lock().unwrap();
+            state.error_signaled = false;
+            state.restart_request = None;
+        }
+        match next_state {
+            KmSMState::Transport(ts) => {
+                let prev_id: zpr::SaId;
+                let cur_id: zpr::SaId;
+                let mut my_sa = ts.clone();
+                {
+                    let mut state = self.shared.state.lock().unwrap();
+                    prev_id = state.sa_id;
+                    state.sa_id += 1;
+                    if state.sa_id == 0 {
+                        state.sa_id = 1;
+                    }
+                    cur_id = state.sa_id;
+                    // Capture the SA and update the SA_ID.
+                    my_sa.sa_id = cur_id;
+                    state.ts = my_sa.clone();
+                }
+                info!("KM: New SA_ID: {}", cur_id);
+                match self
+                    .send_signal(
+                        &km_signals_out,
+                        link_id,
+                        KmSignal::SaIdChange {
+                            old: prev_id,
+                            new: cur_id,
+                        },
+                    )
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(_) => {
+                        error!("failed to enqueue SaIdChange signal");
+                        return Err(KmError::EnqueueFailed);
+                    }
+                }
+                match self
+                    .send_signal(&km_signals_out, link_id, KmSignal::SaEstablished(my_sa))
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(_) => {
+                        error!("failed to enqueue SaIdEstablished signal");
+                        return Err(KmError::EnqueueFailed);
+                    }
+                }
+            }
+            _ => {}
+        };
+        Ok(())
+    }
+
+    /// Deliver a Key Management Payload to the state machine implemntation, forwarding out
+    /// a response message if there is one.
+    async fn dispatch_km_message(
+        &self,
+        inmsg: Bytes,
+        link_id: zpr::LinkId,
+        km_buffers_out: &mpsc::Sender<KmLinkMsg<Bytes>>,
+    ) -> KmResult<()> {
+        let resp: Option<Bytes>;
+        {
+            let mut state = self.shared.state.lock().unwrap();
+            resp = match state.statemachine.handle_message(&inmsg) {
+                Ok(h) => h,
+                Err(e) => {
+                    error!("failed to handle key manager message: {}", e);
+                    None
+                }
+            };
+        }
+        if let Some(r) = resp {
+            match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
+                Ok(_) => {}
+                Err(_) => {
+                    error!("failed to enqueue outbound KM message");
+                    return Err(KmError::EnqueueFailed);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Deal with case where the state machine is in the error state.
+    /// If we have been instructed previously to restart the machine (see [KeyManager::restart]) then
+    /// this will reset the state machine and send a reset signal, possibly also generating
+    /// a new handshake message.
+    async fn handle_state_error(
+        &self,
+        link_id: zpr::LinkId,
+        km_signals_out: &mpsc::Sender<KmLinkMsg<KmSignal>>,
+        km_buffers_out: &mpsc::Sender<KmLinkMsg<Bytes>>,
+    ) -> KmResult<()> {
+        let mut resp: Option<Bytes> = None;
+        let mut did_reset = false;
+        let restart_request;
+
+        let needs_error_signal: bool;
+        {
+            let state = self.shared.state.lock().unwrap();
+            needs_error_signal = !state.error_signaled;
+            restart_request = state.restart_request.unwrap_or(false);
+        }
+        if needs_error_signal {
+            match self
+                .send_signal(km_signals_out, link_id, KmSignal::Error)
+                .await
+            {
+                Ok(_) => {}
+                Err(_) => {
+                    error!("failed to enqueue error signal, aborting");
+                    return Err(KmError::EnqueueFailed);
+                }
+            }
+            {
+                let mut state = self.shared.state.lock().unwrap();
+                state.error_signaled = true;
+            }
+        }
+        if restart_request {
+            let mut state = self.shared.state.lock().unwrap();
+            resp = match state.statemachine.reset() {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(KmError::MachineError(e.to_string()));
+                }
+            };
+            did_reset = true;
+            state.restart_request = None;
+        }
+        if did_reset {
+            match self
+                .send_signal(km_signals_out, link_id, KmSignal::Reset)
+                .await
+            {
+                Ok(_) => {}
+                Err(_) => {
+                    error!("failed to enqueue reset signal, aborting");
+                    return Err(KmError::EnqueueFailed);
+                }
+            }
+            if let Some(r) = resp {
+                match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
+                    Ok(_) => {}
+                    Err(_) => {
+                        error!("failed to enqueue outbound KM message");
+                        return Err(KmError::EnqueueFailed);
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -171,6 +171,10 @@ async fn message_worker<'pktbuf>(
     msg_queue: &mut mpsc::Receiver<KmLinkMsg<Bytes>>,
 ) {
     while let Some(km_buf_msg) = msg_queue.recv().await {
+        info!(
+            "{}: km_multiplexor: sending KM message generated on link {}",
+            asm.system_name, km_buf_msg.link_id
+        );
         mgmt::send_key_management(&*asm, km_buf_msg.link_id, zpr::KM_ID_NOISE, &km_buf_msg.msg)
             .await;
     }

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -5,10 +5,17 @@ use crate::mgmt;
 use crate::peer_table::KmHandle;
 use crate::zpr;
 use bytes::Bytes;
+use std::collections::HashMap;
 use std::future::Future;
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, time};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
+
+/// How often the signal monitor worker checks the error conditions
+/// on the KeyManager state machines.  Indirectly, this controls how
+/// quickly the KeyManager state machines will restart the handshake
+/// process in case of error.
+const CHECK_ERROR_INTERVAL: time::Duration = time::Duration::from_secs(1);
 
 #[derive(Debug)]
 pub enum KmMsgProcessingError {
@@ -51,6 +58,13 @@ impl KmState {
     }
 }
 
+#[derive(Debug, Clone)]
+struct ErrorStatus {
+    error_count: usize,
+    last_error_t: time::Instant,
+    restart_t: time::Instant,
+}
+
 /// This is one of the multiplexor related workers, the other one is in main.rs.
 /// This watches for signals from the running KeyManagers and updates the SAState
 /// when SA's are established.
@@ -62,6 +76,9 @@ async fn signal_worker<'pktbuf>(
 ) {
     let sp_ctok = asm.km_state.ctok.clone();
 
+    let mut status: HashMap<zpr::LinkId, ErrorStatus> = HashMap::new();
+    let mut interval = time::interval(CHECK_ERROR_INTERVAL);
+
     loop {
         tokio::select! {
             _ = sp_ctok.cancelled() => {
@@ -69,11 +86,36 @@ async fn signal_worker<'pktbuf>(
                 break;
             }
 
+            _ = interval.tick() => {
+                let now = time::Instant::now();
+                for (link_id, stat) in status.iter_mut() {
+                    if stat.error_count > 0 && stat.last_error_t >= stat.restart_t {
+                        if now - stat.last_error_t > time::Duration::from_secs(stat.error_count as u64) {
+                            info!("km_multiplexor: restarting KM on link {}", link_id);
+                            if let Some(km) = asm.peer_table.clone_km_manager(*link_id) {
+                                match km.restart() {
+                                    Ok(_) => {
+                                        stat.restart_t = now;
+                                    }
+                                    Err(e) => {
+                                        error!("km_multiplexor: failed to restart KM on link {}: {:?}", link_id, e);
+                                        stat.error_count += 1;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             Some(linkmsg) = sig_queue.recv() => {
                 info!("km_multiplexor: signal {:?} on link {}", linkmsg.msg, linkmsg.link_id);
                 match linkmsg.msg {
                     KmSignal::SaIdChange { old, new } => {
                         info!("km_multiplexor: SA ID change on link {}: {} -> {}", linkmsg.link_id, old, new);
+                        if old == 0 {
+                            let _ = status.remove(&linkmsg.link_id);
+                        }
                     }
                     KmSignal::SaEstablished(sa) => {
                         match asm.peer_table.set_security_association(linkmsg.link_id, sa) {
@@ -82,8 +124,37 @@ async fn signal_worker<'pktbuf>(
                                 error!("km_multiplexor: failed to set SA established: {:?}", e);
                             }
                         }
+                        match status.get_mut(&linkmsg.link_id) {
+                            Some(s) if s.error_count == 0 => {
+                                s.error_count = 0;
+                            }
+                            Some(_) => {}
+                            None => (),
+                        }
                     }
-                    _ => { warn!("km_multiplexor: unhandled signal on link {}: {:?}", linkmsg.link_id, linkmsg.msg); }
+                    KmSignal::Reset => { }
+                    KmSignal::Error => {
+                        let stat = match status.get_mut(&linkmsg.link_id) {
+                            Some(s) => s,
+                            None => {
+                                let ts = time::Instant::now();
+                                let estat = ErrorStatus {
+                                    error_count: 0,
+                                    last_error_t: ts,
+                                    restart_t: ts,
+                                };
+                                status.insert(linkmsg.link_id, estat);
+                                status.get_mut(&linkmsg.link_id).unwrap()
+                            }
+                        };
+                        stat.error_count += 1;
+                        stat.last_error_t = time::Instant::now();
+                        warn!("km_multiplexor: Error signal on link {}", linkmsg.link_id);
+                    }
+                    KmSignal::Termination => {
+                        let _ = status.remove(&linkmsg.link_id);
+                        info!("km_multiplexor: termination signal on link {}", linkmsg.link_id);
+                    }
                 }
             }
         }

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -171,10 +171,6 @@ async fn message_worker<'pktbuf>(
     msg_queue: &mut mpsc::Receiver<KmLinkMsg<Bytes>>,
 ) {
     while let Some(km_buf_msg) = msg_queue.recv().await {
-        info!(
-            "{}: km_multiplexor: sending KM message generated on link {}",
-            asm.system_name, km_buf_msg.link_id
-        );
         mgmt::send_key_management(&*asm, km_buf_msg.link_id, zpr::KM_ID_NOISE, &km_buf_msg.msg)
             .await;
     }

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -90,10 +90,10 @@ async fn signal_worker<'pktbuf>(
                 let now = time::Instant::now();
                 for (link_id, stat) in status.iter_mut() {
                     if stat.error_count > 0 && stat.last_error_t >= stat.restart_t && now - stat.last_error_t > time::Duration::from_secs(stat.error_count as u64) {
-                        info!("km_multiplexor: restarting KM on link {}", link_id);
                         if let Some(km) = asm.peer_table.clone_km_manager(*link_id) {
                             match km.restart() {
                                 Ok(_) => {
+                                    info!("km_multiplexor: restarted key manager on link {} (error_count = {})", link_id, stat.error_count);
                                     stat.restart_t = now;
                                 }
                                 Err(e) => {
@@ -101,6 +101,8 @@ async fn signal_worker<'pktbuf>(
                                     stat.error_count += 1;
                                 }
                             }
+                        } else {
+                            error!("km_multiplexor: unable to restart key manager on link {}: not found in peer table", link_id);
                         }
                     }
                 }

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -82,7 +82,7 @@ async fn signal_worker<'pktbuf>(
     loop {
         tokio::select! {
             _ = sp_ctok.cancelled() => {
-                info!("KM Multiplexor shutting down");
+                info!("{}: KM Multiplexor shutting down", asm.system_name);
                 break;
             }
 
@@ -93,35 +93,38 @@ async fn signal_worker<'pktbuf>(
                         if let Some(km) = asm.peer_table.clone_km_manager(*link_id) {
                             match km.restart() {
                                 Ok(_) => {
-                                    info!("km_multiplexor: restarted key manager on link {} (error_count = {})", link_id, stat.error_count);
+                                    info!("{}: km_multiplexor: restarted key manager on link {} (error_count = {})", asm.system_name, link_id, stat.error_count);
                                     stat.restart_t = now;
                                 }
                                 Err(e) => {
-                                    error!("km_multiplexor: failed to restart KM on link {}: {:?}", link_id, e);
+                                    error!("{}: km_multiplexor: failed to restart KM on link {}: {:?}", asm.system_name, link_id, e);
                                     stat.error_count += 1;
                                 }
                             }
                         } else {
-                            error!("km_multiplexor: unable to restart key manager on link {}: not found in peer table", link_id);
+                            error!("{}: km_multiplexor: unable to restart key manager on link {}: not found in peer table", asm.system_name, link_id);
                         }
                     }
                 }
             }
 
             Some(linkmsg) = sig_queue.recv() => {
-                info!("km_multiplexor: signal {:?} on link {}", linkmsg.msg, linkmsg.link_id);
+                info!("{}: km_multiplexor: link: {}, signal {:?}", asm.system_name, linkmsg.link_id, linkmsg.msg);
                 match linkmsg.msg {
                     KmSignal::SaIdChange { old, new } => {
-                        info!("km_multiplexor: SA ID change on link {}: {} -> {}", linkmsg.link_id, old, new);
+                        info!("{}: km_multiplexor: SA ID change on link {}: {} -> {}", asm.system_name, linkmsg.link_id, old, new);
                         if old == 0 {
                             let _ = status.remove(&linkmsg.link_id);
                         }
                     }
                     KmSignal::SaEstablished(sa) => {
+                        info!("{}: km_multiplexor: link {}: SA established (SEND_ZPIS: {:?}, RECV_ZPIS: {:?}",
+                            asm.system_name, linkmsg.link_id, sa.send_zpis, sa.recv_zpis);
+
                         match asm.peer_table.set_security_association(linkmsg.link_id, sa) {
                             Ok(_) => (),
                             Err(e) => {
-                                error!("km_multiplexor: failed to set SA established: {:?}", e);
+                                error!("{}: km_multiplexor: failed to set SA established: {:?}", asm.system_name, e);
                             }
                         }
                         match status.get_mut(&linkmsg.link_id) {
@@ -149,11 +152,11 @@ async fn signal_worker<'pktbuf>(
                         };
                         stat.error_count += 1;
                         stat.last_error_t = time::Instant::now();
-                        warn!("km_multiplexor: Error signal on link {}", linkmsg.link_id);
+                        warn!("{}: km_multiplexor: Error signal on link {}", asm.system_name, linkmsg.link_id);
                     }
                     KmSignal::Termination => {
                         let _ = status.remove(&linkmsg.link_id);
-                        info!("km_multiplexor: termination signal on link {}", linkmsg.link_id);
+                        info!("{}: km_multiplexor: termination signal on link {}", asm.system_name, linkmsg.link_id);
                     }
                 }
             }
@@ -260,8 +263,8 @@ pub async fn drop_link<'pktbuf>(asm: &Assembly<'pktbuf>, link_id: zpr::LinkId) {
             Ok(_) => (),
             Err(e) => {
                 error!(
-                    "KeyManager statemachine shutdown join failed on link {}: {:?}",
-                    link_id, e
+                    "{}: KeyManager statemachine shutdown join failed on link {}: {:?}",
+                    asm.system_name, link_id, e
                 );
             }
         }
@@ -288,7 +291,10 @@ fn add_noise_link(
         match spawn_mgr.start(spawn_ctok, spawn_km_tx, spawn_sig_tx).await {
             Ok(_) => (),
             Err(e) => {
-                error!("KeyManager failed on link {}: {:?}", link_id, e);
+                error!(
+                    "{}: KeyManager failed on link {}: {:?}",
+                    asm.system_name, link_id, e
+                );
             }
         }
     });

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -15,7 +15,7 @@ use tracing::{error, info, warn};
 /// on the KeyManager state machines.  Indirectly, this controls how
 /// quickly the KeyManager state machines will restart the handshake
 /// process in case of error.
-const CHECK_ERROR_INTERVAL: time::Duration = time::Duration::from_secs(1);
+const CHECK_ERROR_INTERVAL: time::Duration = time::Duration::from_millis(500);
 
 #[derive(Debug)]
 pub enum KmMsgProcessingError {

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -60,9 +60,9 @@ impl KmState {
 
 #[derive(Debug, Clone)]
 struct ErrorStatus {
-    error_count: usize,
-    last_error_t: time::Instant,
-    restart_t: time::Instant,
+    error_count: usize,          // if zero then no error
+    last_error_t: time::Instant, // Last time error occurred
+    restart_t: time::Instant,    // Last time we restarted the KM
 }
 
 /// This is one of the multiplexor related workers, the other one is in main.rs.
@@ -89,18 +89,16 @@ async fn signal_worker<'pktbuf>(
             _ = interval.tick() => {
                 let now = time::Instant::now();
                 for (link_id, stat) in status.iter_mut() {
-                    if stat.error_count > 0 && stat.last_error_t >= stat.restart_t {
-                        if now - stat.last_error_t > time::Duration::from_secs(stat.error_count as u64) {
-                            info!("km_multiplexor: restarting KM on link {}", link_id);
-                            if let Some(km) = asm.peer_table.clone_km_manager(*link_id) {
-                                match km.restart() {
-                                    Ok(_) => {
-                                        stat.restart_t = now;
-                                    }
-                                    Err(e) => {
-                                        error!("km_multiplexor: failed to restart KM on link {}: {:?}", link_id, e);
-                                        stat.error_count += 1;
-                                    }
+                    if stat.error_count > 0 && stat.last_error_t >= stat.restart_t && now - stat.last_error_t > time::Duration::from_secs(stat.error_count as u64) {
+                        info!("km_multiplexor: restarting KM on link {}", link_id);
+                        if let Some(km) = asm.peer_table.clone_km_manager(*link_id) {
+                            match km.restart() {
+                                Ok(_) => {
+                                    stat.restart_t = now;
+                                }
+                                Err(e) => {
+                                    error!("km_multiplexor: failed to restart KM on link {}: {:?}", link_id, e);
+                                    stat.error_count += 1;
                                 }
                             }
                         }

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -46,7 +46,7 @@ static PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
 
 /// Will transition to error state if we are handshake initator and do not get
 /// a handshake response within this time.
-const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
 const NOISE_NONCE_LEN: usize = 8;
 pub const NOISE_PADLEN: usize = 16 + NOISE_NONCE_LEN; // 16 byte tag + 8 byte nonce

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -38,11 +38,16 @@ use bytes::{Bytes, BytesMut};
 use curve25519_dalek::montgomery::MontgomeryPoint;
 use openssl::rand::rand_bytes;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::error;
 use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
 
 static PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
+
+
+/// Will transition to error state if we are handshake initator and do not get
+/// a handshake response within this time.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 
 const NOISE_NONCE_LEN: usize = 8;
 pub const NOISE_PADLEN: usize = 16 + NOISE_NONCE_LEN; // 16 byte tag + 8 byte nonce
@@ -59,6 +64,7 @@ pub struct KmNoise {
     initiate: bool,
     peer_pub_key: Option<Vec<u8>>, // required if initiator
     local_keypair: snow::Keypair,
+    hs_sent_t: Option<Instant>,
     hs_state: Option<snow::HandshakeState>,
     //t_state: Option<snow::TransportState>,
     recv_hmac_key: [u8; 32], // messages sent to us from peer will use this key (we create this)
@@ -119,6 +125,7 @@ impl KmNoise {
             initiate,
             peer_pub_key,
             local_keypair: kp,
+            hs_sent_t: None,
             hs_state: None,
             recv_hmac_key: [0u8; 32], // we generate this and send to peer
             send_hmac_key: None,      // we get this during handshake
@@ -256,6 +263,7 @@ impl KeyManagerStateMachine for KmNoise {
             };
             buf.truncate(len);
             self.hs_state = Some(initiator);
+            self.hs_sent_t = Some(Instant::now());
             Ok(Some(buf.freeze()))
         } else {
             let responder = match snow::Builder::new(np)
@@ -383,7 +391,6 @@ impl KeyManagerStateMachine for KmNoise {
     }
 
     fn tick(&mut self) -> Result<Option<Bytes>, KmError> {
-        // TODO: Timeout handling
         if self.state == KmSMState::Configuring {
             let hs: snow::HandshakeState;
             if self.hs_state.is_some() {
@@ -422,6 +429,13 @@ impl KeyManagerStateMachine for KmNoise {
                         }
                     }
                 } else {
+                    if self.initiate && self.hs_sent_t.is_some() && Instant::now().duration_since(self.hs_sent_t.unwrap()) > HANDSHAKE_TIMEOUT {
+                        error!("noise: handhsake timeout");
+                        self.hs_state = None;
+                        self.hs_sent_t = None;
+                        self.state = KmSMState::Error;
+                        return Err(KmError::HandshakeError);
+                    }
                     self.hs_state = Some(hs);
                 }
             }

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -44,7 +44,6 @@ use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
 
 static PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
 
-
 /// Will transition to error state if we are handshake initator and do not get
 /// a handshake response within this time.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -429,7 +428,11 @@ impl KeyManagerStateMachine for KmNoise {
                         }
                     }
                 } else {
-                    if self.initiate && self.hs_sent_t.is_some() && Instant::now().duration_since(self.hs_sent_t.unwrap()) > HANDSHAKE_TIMEOUT {
+                    if self.initiate
+                        && self.hs_sent_t.is_some()
+                        && Instant::now().duration_since(self.hs_sent_t.unwrap())
+                            > HANDSHAKE_TIMEOUT
+                    {
                         error!("noise: handhsake timeout");
                         self.hs_state = None;
                         self.hs_sent_t = None;

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -15,7 +15,7 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_tun::TunBuilder;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 use tracing_subscriber;
 use zpr_ext::tokio::net::UdpSocketExt;
 
@@ -101,6 +101,9 @@ struct CmdLine {
 
     #[arg(long)]
     allow_insecure_zpi_zero: bool,
+
+    #[arg(long)]
+    debug: bool,
 }
 
 fn emit_counts(system_name: &String, counts_map: &EnumMap<CounterType, Counter>) {
@@ -111,8 +114,16 @@ fn emit_counts(system_name: &String, counts_map: &EnumMap<CounterType, Counter>)
 }
 
 fn main() -> ExitCode {
-    tracing_subscriber::fmt::init();
     let cmd_line = CmdLine::parse();
+
+    let mut subscriber = tracing_subscriber::fmt::fmt();
+    if cmd_line.debug {
+        subscriber = subscriber.with_max_level(tracing::Level::DEBUG);
+    } else {
+        subscriber = subscriber.with_max_level(tracing::Level::INFO);
+    }
+    let subscriber = subscriber.finish();
+    tracing::subscriber::set_global_default(subscriber).unwrap();
 
     let system_name = cmd_line.name;
     let sock_path = cmd_line.control_path;
@@ -337,6 +348,7 @@ fn main() -> ExitCode {
             .unwrap();
         let dock_noise_public_key = km_noise::derive_public_key(&dock_noise_private_key);
 
+        // Presence of peer2 means we are a node.
         if let Some(pa2) = peer_addr2 {
             let peer_id2 = asm
                 .hack_add_peer(peer_table::PeerType::Adapter, pa2)
@@ -345,13 +357,12 @@ fn main() -> ExitCode {
             asm.peer_ids.lock().unwrap().push(peer_id2);
 
             if !disable_km {
-                km_multiplexor::add_adapter_link(
-                    asm,
-                    peer_id2,
-                    ZPIPair::new(1, 2),
-                    dock_noise_public_key,
-                )
-                .unwrap();
+                let dock_keypair = snow::Keypair {
+                    private: dock_noise_private_key.to_vec(),
+                    public: dock_noise_public_key.to_vec(),
+                };
+                km_multiplexor::add_node_link(asm, peer_id2, ZPIPair::new(1, 2), dock_keypair)
+                    .unwrap();
             }
         }
 
@@ -462,9 +473,32 @@ fn main() -> ExitCode {
 
         if matches!(ph_mode, PhMode::Adapter) {
             let dsid = asm.hack_get_adapter_docking_session_id();
+            info!(
+                "{}: waiting on security assocaition establishment on link {}",
+                asm.system_name, dsid
+            );
+            while !asm.peer_table.is_security_assocaition_established(dsid) {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            }
+            info!(
+                "{}: security assocaition established successfully on link {}",
+                asm.system_name, dsid
+            );
+
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
             mgmt::send_report(asm, dsid, "Reporting for Duty!").await;
             mgmt::send_discard(asm, dsid).await;
-            mgmt::send_hello_request(asm, dsid).await.unwrap();
+            match mgmt::send_hello_request(asm, dsid).await {
+                Ok(_) => info!(
+                    "{}: hello request sent successfully on link {}",
+                    asm.system_name, dsid
+                ),
+                Err(e) => error!(
+                    "{}: hello request failed on link {}: {:?}",
+                    asm.system_name, dsid, e
+                ),
+            }
         }
 
         while let Some(res) = js.join_next().await {

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(feature = "ci", deny(warnings))]
 
+use base64::prelude::*;
 use cbpf_rs::bpf_code;
 use clap::Parser;
 use enum_map::{enum_map, EnumMap};
@@ -17,7 +18,6 @@ use tokio_tun::TunBuilder;
 use tracing::warn;
 use tracing_subscriber;
 use zpr_ext::tokio::net::UdpSocketExt;
-use base64::prelude::*;
 
 mod adapter_manager_worker;
 mod adapter_tables;
@@ -64,8 +64,8 @@ use flow_control::FlowControl;
 use km::ZPIPair;
 use km_multiplexor::KmState;
 use queues::*;
-use tun_ctl::TunCtl;
 use tracing::info;
+use tun_ctl::TunCtl;
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -325,7 +325,11 @@ fn main() -> ExitCode {
             }));
 
             // TEMP HACK to statically install peers
-            let dock_noise_private_key:[u8; 32] = BASE64_STANDARD.decode("AB2eP6zV7ve0A4eQgNVNXlAM2q0rYerCPXFMl+/ntUw=").unwrap().try_into().unwrap();
+            let dock_noise_private_key: [u8; 32] = BASE64_STANDARD
+                .decode("AB2eP6zV7ve0A4eQgNVNXlAM2q0rYerCPXFMl+/ntUw=")
+                .unwrap()
+                .try_into()
+                .unwrap();
             let dock_noise_public_key = km_noise::derive_public_key(&dock_noise_private_key);
 
             if let Some(pa2) = peer_addr2 {
@@ -454,18 +458,27 @@ fn main() -> ExitCode {
             if matches!(ph_mode, PhMode::Adapter) {
                 let dsid = asm.hack_get_adapter_docking_session_id();
 
-                info!("adapter: {}: waiting for KM to be established on my docking session link {}", asm.system_name,dsid);
+                info!(
+                    "adapter: {}: waiting for KM to be established on my docking session link {}",
+                    asm.system_name, dsid
+                );
                 while !asm.peer_table.is_security_assocaition_established(dsid) {
                     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                 }
-                info!("adapter: {}: KM ESTABLISHED on link {}", asm.system_name,dsid);
+                info!(
+                    "adapter: {}: KM ESTABLISHED on link {}",
+                    asm.system_name, dsid
+                );
 
                 mgmt::send_report(asm, dsid, "Reporting for Duty!").await;
                 mgmt::send_discard(asm, dsid).await;
                 match mgmt::send_hello_request(asm, dsid).await {
                     Ok(_) => (),
                     Err(e) => {
-                        warn!("adapter: {}: failed to send hello request: {:?}", asm.system_name, e);
+                        warn!(
+                            "adapter: {}: failed to send hello request: {:?}",
+                            asm.system_name, e
+                        );
                     }
                 }
             }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -306,7 +306,7 @@ fn main() -> ExitCode {
     let mut flags: PhFlags = Default::default();
     flags.allow_insecure_zpi_zero = allow_insecure_zpi_zero;
 
-            // TEMP HACK to statically install peers
+    // TEMP HACK to statically install peers
     let asm = Box::leak(Box::new(Assembly {
         flags,
         ph_mode,

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -485,7 +485,12 @@ fn main() -> ExitCode {
                 asm.system_name, dsid
             );
 
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            // HACK - In our tests we need to send from adapter through the node to the adapter.
+            // We do not know when the other adapter has setup its association. So lets give
+            // it a little time here.
+            info!("{}: waiting for the other adapter to (hopfully) establish its security association...", asm.system_name);
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
 
             mgmt::send_report(asm, dsid, "Reporting for Duty!").await;
             mgmt::send_discard(asm, dsid).await;

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -17,6 +17,7 @@ use tokio_tun::TunBuilder;
 use tracing::warn;
 use tracing_subscriber;
 use zpr_ext::tokio::net::UdpSocketExt;
+use base64::prelude::*;
 
 mod adapter_manager_worker;
 mod adapter_tables;
@@ -64,6 +65,7 @@ use km::ZPIPair;
 use km_multiplexor::KmState;
 use queues::*;
 use tun_ctl::TunCtl;
+use tracing::info;
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -323,7 +325,9 @@ fn main() -> ExitCode {
             }));
 
             // TEMP HACK to statically install peers
-            let dock_noise_public_key = [0; 32]; // XXX TODO
+            let dock_noise_private_key:[u8; 32] = BASE64_STANDARD.decode("AB2eP6zV7ve0A4eQgNVNXlAM2q0rYerCPXFMl+/ntUw=").unwrap().try_into().unwrap();
+            let dock_noise_public_key = km_noise::derive_public_key(&dock_noise_private_key);
+
             if let Some(pa2) = peer_addr2 {
                 let peer_id2 = asm
                     .hack_add_peer(peer_table::PeerType::Adapter, pa2)
@@ -364,21 +368,12 @@ fn main() -> ExitCode {
                     .unwrap();
                 } else {
                     let dock_keypair = snow::Keypair {
-                        // XXX also TODO!
-                        private: [0; 32].to_vec(),
-                        public: [0; 32].to_vec(),
+                        private: dock_noise_private_key.to_vec(),
+                        public: dock_noise_public_key.to_vec(),
                     };
                     km_multiplexor::add_node_link(asm, peer_id, ZPIPair::new(5, 6), dock_keypair)
                         .unwrap();
                 }
-                let dock_noise_public_key = [0; 32]; // XXX TODO
-                km_multiplexor::add_adapter_link(
-                    asm,
-                    peer_id,
-                    ZPIPair::new(1, 2),
-                    dock_noise_public_key,
-                )
-                .unwrap();
             }
             // END HACK
 
@@ -458,9 +453,21 @@ fn main() -> ExitCode {
 
             if matches!(ph_mode, PhMode::Adapter) {
                 let dsid = asm.hack_get_adapter_docking_session_id();
+
+                info!("adapter: {}: waiting for KM to be established on my docking session link {}", asm.system_name,dsid);
+                while !asm.peer_table.is_security_assocaition_established(dsid) {
+                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                }
+                info!("adapter: {}: KM ESTABLISHED on link {}", asm.system_name,dsid);
+
                 mgmt::send_report(asm, dsid, "Reporting for Duty!").await;
                 mgmt::send_discard(asm, dsid).await;
-                mgmt::send_hello_request(asm, dsid).await.unwrap();
+                match mgmt::send_hello_request(asm, dsid).await {
+                    Ok(_) => (),
+                    Err(e) => {
+                        warn!("adapter: {}: failed to send hello request: {:?}", asm.system_name, e);
+                    }
+                }
             }
 
             while let Some(res) = js.join_next().await {

--- a/adapter/ph/test/basic-test.sh
+++ b/adapter/ph/test/basic-test.sh
@@ -55,28 +55,30 @@ echo "Launching DUTs"
 #
 # Launch PHs
 #
+sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
+     --name "zpr-node" --control-path "$NODE_SOCK" \
+     --self-addr 0.0.0.0:12345 --peer-addr1 "$A_SUBSTRATE_ADDR":12345 \
+     --peer-addr2 "$B_SUBSTRATE_ADDR":12345 \
+     --ca-file ca.crt --certificate-file node.crt --private-key-file node.key \
+     --tun-if tun0 &
+CHILDREN=(${CHILDREN[@]} "$!")
+
 
 sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_A":12345 \
   --ca-file ca.crt --certificate-file adapter1.crt --private-key-file adapter1.key \
-  --disable-km --allow-insecure-zpi-zero --tun-if tun0 &
+  --tun-if tun0 &
 CHILDREN=(${CHILDREN[@]} "$!")
+
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-b" --control-path "$ADAPTER2_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_B":12345 \
   --ca-file ca.crt --certificate-file adapter2.crt --private-key-file adapter2.key \
-  --disable-km --allow-insecure-zpi-zero --tun-if tun0 &
+  --tun-if tun0 &
 CHILDREN=(${CHILDREN[@]} "$!")
 
-sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
-  --name "zpr-node" --control-path "$NODE_SOCK" \
-  --self-addr 0.0.0.0:12345 --peer-addr1 "$A_SUBSTRATE_ADDR":12345 \
-  --peer-addr2 "$B_SUBSTRATE_ADDR":12345 \
-  --ca-file ca.crt --certificate-file node.crt --private-key-file node.key \
-  --disable-km --allow-insecure-zpi-zero --tun-if tun0 &
-CHILDREN=(${CHILDREN[@]} "$!")
 
 
 #
@@ -90,6 +92,29 @@ wait_for 5 check_carrier zpr-node tun0 || { echo "FAILURE"; exit 1; }
 echo "Carrier has arrived."
 
 stty sane || true
+
+
+echo "=========================================================="
+echo "=========================================================="
+echo "=========================================================="
+echo "=========================================================="
+echo "PAUSING FOR KEY MANAGEMENT EXCHANGE ..."
+echo "=========================================================="
+echo "=========================================================="
+echo "=========================================================="
+echo "=========================================================="
+sleep 10
+
+
+echo "=========================================================="
+echo "=========================================================="
+echo "=========================================================="
+echo "=========================================================="
+echo "TEST STARTING"
+echo "=========================================================="
+echo "=========================================================="
+echo "=========================================================="
+echo "=========================================================="
 
 
 #

--- a/adapter/ph/test/basic-test.sh
+++ b/adapter/ph/test/basic-test.sh
@@ -63,6 +63,7 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
      --tun-if tun0 &
 CHILDREN=(${CHILDREN[@]} "$!")
 
+sleep 2
 
 sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \

--- a/adapter/ph/test/capture-test.sh
+++ b/adapter/ph/test/capture-test.sh
@@ -113,17 +113,14 @@ echo "Carrier has arrived."
 
 stty sane || true
 
-
 #
 # Run test
 #
 
 set_program "$ADAPTER2_SOCK" "$TMPDIR/cap_test2.pcap" None
 
-
 echo "wait for KM"
 sleep 7
-
 
 echo "starting PING test..."
 
@@ -141,17 +138,12 @@ tcpdump -r "$TMPDIR/cap_test1.pcap" 'link[0] = 1 or link[0] == 0' >"$TMPDIR/chec
 # The node is configured in main.rs to expect ZPI 5 for management packets and 6 for transit
 # when getting messages from peer 1.
 MGMT_PACKET_COUNT="$(grep -c '0x0105: ' "$TMPDIR/checker.txt" || echo 0)"
-TOTAL_PACKET_COUNT="$(grep -c '0x0106: ' "$TMPDIR/checker.txt" || echo 0)"
+AGENT_PACKET_COUNT="$(grep -c '0x0106: ' "$TMPDIR/checker.txt" || echo 0)"
 
 echo "============================= CHECKER"
 cat "$TMPDIR/checker.txt"
 
 echo
-
-
-echo "TOTAL_PACKET_COUNT = ${TOTAL_PACKET_COUNT}"
-echo "AGENT_PACHET_COUNT = ${AGENT_PACKET_COUNT}"
-
 
 if [[ MGMT_PACKET_COUNT == 0 || AGENT_PACKET_COUNT == 0 ]]; then
   PASS=1

--- a/adapter/ph/test/capture-test.sh
+++ b/adapter/ph/test/capture-test.sh
@@ -35,8 +35,8 @@ function set_program() {
   PROGRAM=$3
   "$PH_DEBUG_BIN" -c SET-CAPTURE-FILE -p "$SOCKET" --file-path "$FILE_NAME"
 
-  if [ "$PROGRAM" != "None" ]
-  then "$PH_DEBUG_BIN" -c SET-CAPTURE-PROGRAM -p "$SOCKET" --program "$PROGRAM"
+  if [ "$PROGRAM" != "None" ]; then
+    "$PH_DEBUG_BIN" -c SET-CAPTURE-PROGRAM -p "$SOCKET" --program "$PROGRAM"
   fi
 }
 
@@ -54,8 +54,7 @@ CHILDREN=()
 trap cleanup EXIT
 
 TMPDIR=$(mktemp -d)
-pushd "$TMPDIR" > /dev/null
-
+pushd "$TMPDIR" >/dev/null
 
 #
 # Prepare for test
@@ -69,46 +68,51 @@ create_ca_key_and_cert ca
 create_agent_key_and_cert ca server
 create_agent_key_and_cert ca client
 
-
 #
 # Launch PHs
 #
+sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
+  --name "zpr-node" --control-path "$NODE_SOCK" \
+  --self-addr 0.0.0.0:12345 --peer-addr1 "$A_SUBSTRATE_ADDR":12345 \
+  --peer-addr2 "$B_SUBSTRATE_ADDR":12345 \
+  --ca-file ca.crt --certificate-file node.crt --private-key-file node.key \
+  --tun-if tun0 &
+CHILDREN=(${CHILDREN[@]} "$!")
 
 sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_A":12345 \
   --ca-file ca.crt --certificate-file adapter1.crt --private-key-file adapter1.key \
-  --disable-km --allow-insecure-zpi-zero --tun-if tun0 &
+  --tun-if tun0 &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-b" --control-path "$ADAPTER2_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_B":12345 \
   --ca-file ca.crt --certificate-file adapter2.crt --private-key-file adapter2.key \
-  --disable-km --allow-insecure-zpi-zero --tun-if tun0 &
+  --tun-if tun0 &
 CHILDREN=(${CHILDREN[@]} "$!")
 
-sleep 1  # FIXME: I think we need this b/c DTLS doesn't deal with dropped initial packet well
+sleep 1 # FIXME: I think we need this b/c DTLS doesn't deal with dropped initial packet well
 set_program "$ADAPTER1_SOCK" "$TMPDIR/cap_test1.pcap" 'link[0] == 1'
-
-sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
-  --name "zpr-node" --control-path "$NODE_SOCK" \
-  --self-addr 0.0.0.0:12345 --peer-addr1 "$A_SUBSTRATE_ADDR":12345 \
-  --peer-addr2 "$B_SUBSTRATE_ADDR":12345 \
-  --ca-file ca.crt --certificate-file node.crt --private-key-file node.key \
-  --disable-km --allow-insecure-zpi-zero --tun-if tun0 &
-CHILDREN=(${CHILDREN[@]} "$!")
 
 #
 # Wait for connectivity
 #
 
 echo "Wait for TUN carrier..."
-wait_for 5 check_carrier zpr-a tun0 || { echo "FAILURE"; exit 1; }
-wait_for 5 check_carrier zpr-b tun0 || { echo "FAILURE"; exit 1; }
+wait_for 5 check_carrier zpr-a tun0 || {
+  echo "FAILURE"
+  exit 1
+}
+wait_for 5 check_carrier zpr-b tun0 || {
+  echo "FAILURE"
+  exit 1
+}
 echo "Carrier has arrived."
 
 stty sane || true
+
 
 #
 # Run test
@@ -116,37 +120,49 @@ stty sane || true
 
 set_program "$ADAPTER2_SOCK" "$TMPDIR/cap_test2.pcap" None
 
+
+echo "wait for KM"
+sleep 7
+
+
+echo "starting PING test..."
+
 PASS=0
-if ! ping_test
-then PASS=1
+if ! ping_test; then
+  PASS=1
 fi
 
 close_program "$ADAPTER1_SOCK"
 close_program "$ADAPTER2_SOCK"
 
 # Make sure at least both agent and mgmt packets were captured.
-tcpdump -r "$TMPDIR/cap_test1.pcap" 'link[0] = 1 or link[0] == 0' > "$TMPDIR/checker.txt"
+tcpdump -r "$TMPDIR/cap_test1.pcap" 'link[0] = 1 or link[0] == 0' >"$TMPDIR/checker.txt"
 AGENT_PACKET_COUNT="$(grep -c '0x0000:  0100 00' "$TMPDIR/checker.txt" || echo 0)"
 TOTAL_PACKET_COUNT="$(grep -c '0x0000:  0100' "$TMPDIR/checker.txt" || echo 0)"
+
+echo "TOTAL_PACKET_COUNT = ${TOTAL_PACKET_COUNT}"
+echo "AGENT_PACHET_COUNT = ${AGENT_PACKET_COUNT}"
+
+
 let MGMT_PACKET_COUNT=TOTAL_PACKET_COUNT-AGENT_PACKET_COUNT
 
-if [[ MGMT_PACKET_COUNT == 0 || AGENT_PACKET_COUNT == 0 ]]
-then PASS=1
+if [[ MGMT_PACKET_COUNT == 0 || AGENT_PACKET_COUNT == 0 ]]; then
+  PASS=1
 fi
 
 # Make sure no data was captured when program is not set
 SIZE="$(stat -c %s "$TMPDIR/cap_test2.pcap")"
 
-if [[ "$SIZE" != "24" ]]
-then PASS=1
+if [[ "$SIZE" != "24" ]]; then
+  PASS=1
 fi
 
 #
 # Cleanup
 #
 
-sudo kill "${CHILDREN[@]}" 2> /dev/null || true
-sleep 1  # FIXME: let's do something better here
+sudo kill "${CHILDREN[@]}" 2>/dev/null || true
+sleep 1 # FIXME: let's do something better here
 stty sane || true
 
 #
@@ -154,9 +170,10 @@ stty sane || true
 #
 
 echo
-if [[ "$PASS" == 0 ]]
-then echo "SUCCESS"
-else echo "FAILURE"
+if [[ "$PASS" == 0 ]]; then
+  echo "SUCCESS"
+else
+  echo "FAILURE"
 fi
 
 exit "$PASS"

--- a/adapter/ph/test/capture-test.sh
+++ b/adapter/ph/test/capture-test.sh
@@ -79,6 +79,8 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --tun-if tun0 &
 CHILDREN=(${CHILDREN[@]} "$!")
 
+sleep 2
+
 sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_A":12345 \

--- a/adapter/ph/test/capture-test.sh
+++ b/adapter/ph/test/capture-test.sh
@@ -137,14 +137,21 @@ close_program "$ADAPTER2_SOCK"
 
 # Make sure at least both agent and mgmt packets were captured.
 tcpdump -r "$TMPDIR/cap_test1.pcap" 'link[0] = 1 or link[0] == 0' >"$TMPDIR/checker.txt"
-AGENT_PACKET_COUNT="$(grep -c '0x0000:  0100 00' "$TMPDIR/checker.txt" || echo 0)"
-TOTAL_PACKET_COUNT="$(grep -c '0x0000:  0100' "$TMPDIR/checker.txt" || echo 0)"
+
+# The node is configured in main.rs to expect ZPI 5 for management packets and 6 for transit
+# when getting messages from peer 1.
+MGMT_PACKET_COUNT="$(grep -c '0x0105: ' "$TMPDIR/checker.txt" || echo 0)"
+TOTAL_PACKET_COUNT="$(grep -c '0x0106: ' "$TMPDIR/checker.txt" || echo 0)"
+
+echo "============================= CHECKER"
+cat "$TMPDIR/checker.txt"
+
+echo
+
 
 echo "TOTAL_PACKET_COUNT = ${TOTAL_PACKET_COUNT}"
 echo "AGENT_PACHET_COUNT = ${AGENT_PACKET_COUNT}"
 
-
-let MGMT_PACKET_COUNT=TOTAL_PACKET_COUNT-AGENT_PACKET_COUNT
 
 if [[ MGMT_PACKET_COUNT == 0 || AGENT_PACKET_COUNT == 0 ]]; then
   PASS=1


### PR DESCRIPTION
Moved the retry logic out of KM state machine as it was just running way to fast and I think we will want to have more control over that.  Now the logic is up to use of the KM.  So for us that is km_multiplexor.

Also put some noise key material into "main" so that it makes sense if anybody ever tries to run this with KM enabled.

I believe we are reworking main anyway, so this is probably very temporary.