### PR TITLE
send & check sequence numbers on sync reqs

### DIFF
--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -523,9 +523,7 @@ pub fn substrate_ingress<'pktbuf>(
     // In ZPI zero only KM messages are allowed (well, and APR ARP which we don't support yet)
     // Can be overridden (FOR TESTING ONLY) in the flags.
     if !secure && base_hdr.packet_type != zdp::ZdpPacketType::KeyManagement {
-        if asm.flags.allow_insecure_zpi_zero {
-            warn!("operating in insecure mode - allow_insecure_zpi_zero is ENABLED");
-        } else {
+        if !asm.flags.allow_insecure_zpi_zero {
             warn!(
                 "ingress: link {}: ZPI 0 only allows key management messages, not {:?}",
                 ingress_link_id, base_hdr.packet_type

--- a/adapter/ph/src/mgmt.rs
+++ b/adapter/ph/src/mgmt.rs
@@ -49,7 +49,15 @@ pub async fn send_non_flow_mgmt_response<'pktbuf>(
     sequence_number: zpr::SeqNum,
     packet: Packet<'pktbuf>,
 ) {
-    send_mgmt_helper(asm, link_id, packet_type, None, Some(sequence_number), packet).await
+    send_mgmt_helper(
+        asm,
+        link_id,
+        packet_type,
+        None,
+        Some(sequence_number),
+        packet,
+    )
+    .await
 }
 
 pub async fn send_per_flow_mgmt_response<'pktbuf>(
@@ -60,7 +68,15 @@ pub async fn send_per_flow_mgmt_response<'pktbuf>(
     sequence_number: zpr::SeqNum,
     packet: Packet<'pktbuf>,
 ) {
-    send_mgmt_helper(asm, link_id, packet_type, Some(stream_id), Some(sequence_number), packet).await
+    send_mgmt_helper(
+        asm,
+        link_id,
+        packet_type,
+        Some(stream_id),
+        Some(sequence_number),
+        packet,
+    )
+    .await
 }
 
 async fn send_mgmt_helper<'pktbuf>(

--- a/adapter/ph/src/mgmt.rs
+++ b/adapter/ph/src/mgmt.rs
@@ -138,21 +138,14 @@ async fn send_sync_req_helper<'pktbuf>(
     zdp_request_type: zdp::ZdpPacketType,
     zdp_response_type: zdp::ZdpPacketType,
     stream_id: Option<zpr::StreamId>,
-    pkt_fn: impl Fn(&mut Packet<'_>) + Send + 'static,
+    pkt_fn: impl Fn(&mut Packet<'_>) + 'static,
 ) -> Result<Packet<'pktbuf>, SyncReqError> {
     // acquire a permit to send a manamgement message
-    let Some(permit_future) = asm.peer_table.inspect(link_id, |peer_state| {
-        peer_state.sync_req_state.acquire_permit()
-    }) else {
+    let Some(peer_state) = asm.peer_table.get(link_id) else {
         return Err(SyncReqError::LinkClosed);
     };
-    let permit = permit_future.await;
-
-    let Some(mut response_future) = asm.peer_table.inspect(link_id, |peer_state| {
-        peer_state.sync_req_state.install_response_listener(&permit)
-    }) else {
-        return Err(SyncReqError::LinkClosed);
-    };
+    let permit = peer_state.sync_req_state.acquire_permit().await;
+    let mut response_future = peer_state.sync_req_state.install_response_listener(&permit);
 
     for _i in 0..=config::DEFAULT_REQUEST_RETRY_COUNT {
         let buf = drop_guard(asm.buffer_stack.get_buffer().await, |buf| {
@@ -186,11 +179,11 @@ async fn send_sync_req_helper<'pktbuf>(
             _ = sleep(Duration::from_secs(config::DEFAULT_REQUEST_RETRY_TIMER as u64)) => ()
         }
     }
-    asm.peer_table.inspect(link_id, |peer_state| {
-        peer_state.sync_req_state.clear_response_listener(&permit)
-    });
+
+    peer_state.sync_req_state.clear_response_listener(&permit);
     let response = response_future.hangup();
     drop(permit);
+
     match_received(asm, response, SyncReqError::Timeout, zdp_response_type)
 }
 

--- a/adapter/ph/src/mgmt.rs
+++ b/adapter/ph/src/mgmt.rs
@@ -31,6 +31,7 @@ pub async fn send_non_flow_mgmt<'pktbuf>(
 
 /// Send a unidirectional per-flow management message on the given link.
 /// The packet should contain only the message body.
+#[allow(dead_code)]
 pub async fn send_per_flow_mgmt<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     link_id: zpr::LinkId,
@@ -39,6 +40,27 @@ pub async fn send_per_flow_mgmt<'pktbuf>(
     packet: Packet<'pktbuf>,
 ) {
     send_mgmt_helper(asm, link_id, packet_type, Some(stream_id), None, packet).await
+}
+
+pub async fn send_non_flow_mgmt_response<'pktbuf>(
+    asm: &Assembly<'pktbuf>,
+    link_id: zpr::LinkId,
+    packet_type: zdp::ZdpPacketType,
+    sequence_number: zpr::SeqNum,
+    packet: Packet<'pktbuf>,
+) {
+    send_mgmt_helper(asm, link_id, packet_type, None, Some(sequence_number), packet).await
+}
+
+pub async fn send_per_flow_mgmt_response<'pktbuf>(
+    asm: &Assembly<'pktbuf>,
+    link_id: zpr::LinkId,
+    packet_type: zdp::ZdpPacketType,
+    stream_id: zpr::StreamId,
+    sequence_number: zpr::SeqNum,
+    packet: Packet<'pktbuf>,
+) {
+    send_mgmt_helper(asm, link_id, packet_type, Some(stream_id), Some(sequence_number), packet).await
 }
 
 async fn send_mgmt_helper<'pktbuf>(
@@ -60,6 +82,7 @@ async fn send_mgmt_helper<'pktbuf>(
     hdr.packet_type = packet_type;
 
     if let Some(sequence_number) = sequence_number {
+        // uses only suffix of sequence number
         hdr.sequence_number = (sequence_number as u16).into();
     }
 
@@ -377,6 +400,25 @@ pub async fn send_bind_agent_address_request<'a, 'pktbuf>(
     }
 }
 
+/// Send a key management message out the given link.
+pub async fn send_key_management<'pktbuf>(
+    asm: &Assembly<'pktbuf>,
+    link_id: zpr::LinkId,
+    km_id: zpr::KmId,
+    payload: &[u8],
+) {
+    let buf = asm.buffer_stack.get_buffer().await;
+    let mut pkt = Packet::new(buf, config::DEFAULT_MESSAGE_HEADROOM);
+
+    let km_hdr = pkt.alloc_zeroed_header::<zdp::ZdpKeyManagementHeader>();
+    km_hdr.message_type = km_id.into();
+    km_hdr.message_length = (payload.len() as u16).into();
+
+    pkt.put(payload);
+
+    send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::KeyManagement, pkt).await;
+}
+
 pub enum HandleMgmtError {
     UnknownType(u8),
     UnexpectedMgmtResponse,
@@ -443,6 +485,7 @@ pub async fn handle_discard<'pktbuf>(
 pub async fn handle_hello_request<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     ingress_link_id: zpr::LinkId,
+    seq_num: zpr::SeqNum,
     pkt: Packet<'pktbuf>,
 ) -> HandleMgmtResult<'pktbuf> {
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
@@ -451,10 +494,11 @@ pub async fn handle_hello_request<'pktbuf>(
 
     eprintln!("{}: Received HelloRequest", asm.system_name);
 
-    send_non_flow_mgmt(
+    send_non_flow_mgmt_response(
         asm,
         ingress_link_id,
         zdp::ZdpPacketType::HelloResponse,
+        seq_num,
         rsp_pkt,
     )
     .await;
@@ -467,6 +511,7 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     ingress_link_id: zpr::LinkId,
     _stream_id: zpr::StreamId, // ignored
+    seq_num: zpr::SeqNum,
     mut pkt: Packet<'pktbuf>,
 ) -> HandleMgmtResult<'pktbuf> {
     let Some(hdr) = zdp::ZdpBindAgentAddressRequestHeader::read_from_buf(&mut pkt) else {
@@ -688,35 +733,17 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
     );
 
     // respond to requestor
-    send_per_flow_mgmt(
+    send_per_flow_mgmt_response(
         asm,
         ingress_link_id,
         zdp::ZdpPacketType::BindAgentAddressResponse,
         ingress_tether_id,
+        seq_num,
         rsp_pkt,
     )
     .await;
 
     Ok(())
-}
-
-/// Send a key management message out the given link.
-pub async fn send_key_management<'pktbuf>(
-    asm: &Assembly<'pktbuf>,
-    link_id: zpr::LinkId,
-    km_id: zpr::KmId,
-    payload: &[u8],
-) {
-    let buf = asm.buffer_stack.get_buffer().await;
-    let mut pkt = Packet::new(buf, config::DEFAULT_MESSAGE_HEADROOM);
-
-    let km_hdr = pkt.alloc_zeroed_header::<zdp::ZdpKeyManagementHeader>();
-    km_hdr.message_type = km_id.into();
-    km_hdr.message_length = (payload.len() as u16).into();
-
-    pkt.put(payload);
-
-    send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::KeyManagement, pkt).await;
 }
 
 // ZPI and Base header is already gone by the time we get here.  So we expect

--- a/adapter/ph/src/mgmt.rs
+++ b/adapter/ph/src/mgmt.rs
@@ -24,14 +24,9 @@ pub async fn send_non_flow_mgmt<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
-    mut packet: Packet<'pktbuf>,
+    packet: Packet<'pktbuf>,
 ) {
-    debug_assert!(!packet_type.is_per_flow());
-
-    let hdr = packet.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
-    hdr.packet_type = packet_type;
-
-    fastpath::substrate_egress_blocking(asm, link_id, packet).await;
+    send_mgmt_helper(asm, link_id, packet_type, None, None, packet).await
 }
 
 /// Send a unidirectional per-flow management message on the given link.
@@ -41,15 +36,32 @@ pub async fn send_per_flow_mgmt<'pktbuf>(
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
     stream_id: zpr::StreamId,
+    packet: Packet<'pktbuf>,
+) {
+    send_mgmt_helper(asm, link_id, packet_type, Some(stream_id), None, packet).await
+}
+
+async fn send_mgmt_helper<'pktbuf>(
+    asm: &Assembly<'pktbuf>,
+    link_id: zpr::LinkId,
+    packet_type: zdp::ZdpPacketType,
+    stream_id: Option<zpr::StreamId>,
+    sequence_number: Option<zpr::SeqNum>,
     mut packet: Packet<'pktbuf>,
 ) {
-    debug_assert!(packet_type.is_per_flow());
+    debug_assert_eq!(stream_id.is_some(), packet_type.is_per_flow());
 
-    let per_flow_hdr = packet.alloc_zeroed_header::<zdp::ZdpPerFlowHeader>();
-    per_flow_hdr.stream_id = stream_id.into();
+    if let Some(stream_id) = stream_id {
+        let per_flow_hdr = packet.alloc_zeroed_header::<zdp::ZdpPerFlowHeader>();
+        per_flow_hdr.stream_id = stream_id.into();
+    }
 
     let hdr = packet.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
     hdr.packet_type = packet_type;
+
+    if let Some(sequence_number) = sequence_number {
+        hdr.sequence_number = (sequence_number as u16).into();
+    }
 
     fastpath::substrate_egress_blocking(asm, link_id, packet).await;
 }
@@ -154,22 +166,16 @@ async fn send_sync_req_helper<'pktbuf>(
         let mut packet = Packet::new_guarded(buf, config::DEFAULT_MESSAGE_HEADROOM);
         pkt_fn(&mut packet);
 
-        // Determine if sending a non-flow or per-flow message
-        match stream_id {
-            Some(stream_id) => {
-                send_per_flow_mgmt(
-                    asm,
-                    link_id,
-                    zdp_request_type,
-                    stream_id,
-                    packet.into_inner(),
-                )
-                .await;
-            }
-            None => {
-                send_non_flow_mgmt(asm, link_id, zdp_request_type, packet.into_inner()).await;
-            }
-        }
+        send_mgmt_helper(
+            asm,
+            link_id,
+            zdp_request_type,
+            stream_id,
+            Some(permit.seq_num()),
+            packet.into_inner(),
+        )
+        .await;
+
         tokio::select! {
             response = &mut response_future => {
                 drop(permit);

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -64,21 +64,21 @@ async fn handle_packet<'pktbuf>(
     );
 
     let packet_type = base_hdr.packet_type;
+    let seq_num = base_hdr.sequence_number.get() as u64;  // TODO: reconstitute full seq num given expected seq num state
 
     if packet_type.is_response() {
         eprintln!("{}: got response from {}", asm.system_name, ingress_link_id);
 
         // Gets the designated sender, attempts to send the response, if not drops
         // the packet and increments corresponding counter
-        let mut pkt = Some(pkt);
-        asm.peer_table
-            .inspect(ingress_link_id, |peer_state| {
-                peer_state
-                    .sync_req_state
-                    .forward_response((packet_type, pkt.take().unwrap()))
-                    .map_err(|pkt| (HandleMgmtError::UnexpectedMgmtResponse, pkt))
-            })
-            .unwrap_or_else(|| Err((HandleMgmtError::UnexpectedMgmtResponse, pkt.take().unwrap())))
+        let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
+            return Err((HandleMgmtError::UnexpectedMgmtResponse, pkt))
+        };
+
+        peer_state
+            .sync_req_state
+            .forward_response(seq_num, (packet_type, pkt))
+            .map_err(|pkt| (HandleMgmtError::UnexpectedMgmtResponse, pkt))
     } else if base_hdr.packet_type.is_per_flow() {
         let Some(per_flow_hdr) = ZdpPerFlowHeader::read_from_buf(&mut pkt) else {
             return Err((HandleMgmtError::BadStructure, pkt));
@@ -89,9 +89,8 @@ async fn handle_packet<'pktbuf>(
         match base_hdr.packet_type {
             ZdpPacketType::TransitPacket => panic!("unexpected Transit Packet in management path"),
 
-            ZdpPacketType::BindAgentAddressRequest => {
-                mgmt::handle_bind_agent_address_request(asm, ingress_link_id, stream_id, pkt).await
-            }
+            ZdpPacketType::BindAgentAddressRequest =>
+                mgmt::handle_bind_agent_address_request(asm, ingress_link_id, stream_id, seq_num, pkt).await,
 
             packet_type => Err((HandleMgmtError::UnknownType(packet_type.0), pkt)),
         }
@@ -101,13 +100,11 @@ async fn handle_packet<'pktbuf>(
 
             ZdpPacketType::Discard => mgmt::handle_discard(asm, ingress_link_id, pkt).await,
 
-            ZdpPacketType::KeyManagement => {
-                mgmt::handle_key_management(asm, ingress_link_id, pkt).await
-            }
+            ZdpPacketType::KeyManagement =>
+                mgmt::handle_key_management(asm, ingress_link_id, pkt).await,
 
-            ZdpPacketType::HelloRequest => {
-                mgmt::handle_hello_request(asm, ingress_link_id, pkt).await
-            }
+            ZdpPacketType::HelloRequest =>
+                mgmt::handle_hello_request(asm, ingress_link_id, seq_num, pkt).await,
 
             packet_type => Err((HandleMgmtError::UnknownType(packet_type.0), pkt)),
         }

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -54,14 +54,14 @@ async fn handle_packet<'pktbuf>(
     ingress_link_id: zpr::LinkId,
     mut pkt: Packet<'pktbuf>,
 ) -> HandleMgmtResult<'pktbuf> {
-    eprintln!(
-        "{}: handling mgmt message from {}",
-        asm.system_name, ingress_link_id
-    );
-
     let Some(base_hdr) = ZdpBaseHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };
+
+    eprintln!(
+        "{}: handling mgmt message from {} type {:?} seq_num {}",
+        asm.system_name, ingress_link_id, base_hdr.packet_type, base_hdr.sequence_number
+    );
 
     let packet_type = base_hdr.packet_type;
 

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -64,7 +64,7 @@ async fn handle_packet<'pktbuf>(
     );
 
     let packet_type = base_hdr.packet_type;
-    let seq_num = base_hdr.sequence_number.get() as u64;  // TODO: reconstitute full seq num given expected seq num state
+    let seq_num = base_hdr.sequence_number.get() as u64; // TODO: reconstitute full seq num given expected seq num state
 
     if packet_type.is_response() {
         eprintln!("{}: got response from {}", asm.system_name, ingress_link_id);
@@ -72,7 +72,7 @@ async fn handle_packet<'pktbuf>(
         // Gets the designated sender, attempts to send the response, if not drops
         // the packet and increments corresponding counter
         let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
-            return Err((HandleMgmtError::UnexpectedMgmtResponse, pkt))
+            return Err((HandleMgmtError::UnexpectedMgmtResponse, pkt));
         };
 
         peer_state
@@ -89,8 +89,16 @@ async fn handle_packet<'pktbuf>(
         match base_hdr.packet_type {
             ZdpPacketType::TransitPacket => panic!("unexpected Transit Packet in management path"),
 
-            ZdpPacketType::BindAgentAddressRequest =>
-                mgmt::handle_bind_agent_address_request(asm, ingress_link_id, stream_id, seq_num, pkt).await,
+            ZdpPacketType::BindAgentAddressRequest => {
+                mgmt::handle_bind_agent_address_request(
+                    asm,
+                    ingress_link_id,
+                    stream_id,
+                    seq_num,
+                    pkt,
+                )
+                .await
+            }
 
             packet_type => Err((HandleMgmtError::UnknownType(packet_type.0), pkt)),
         }
@@ -100,11 +108,13 @@ async fn handle_packet<'pktbuf>(
 
             ZdpPacketType::Discard => mgmt::handle_discard(asm, ingress_link_id, pkt).await,
 
-            ZdpPacketType::KeyManagement =>
-                mgmt::handle_key_management(asm, ingress_link_id, pkt).await,
+            ZdpPacketType::KeyManagement => {
+                mgmt::handle_key_management(asm, ingress_link_id, pkt).await
+            }
 
-            ZdpPacketType::HelloRequest =>
-                mgmt::handle_hello_request(asm, ingress_link_id, seq_num, pkt).await,
+            ZdpPacketType::HelloRequest => {
+                mgmt::handle_hello_request(asm, ingress_link_id, seq_num, pkt).await
+            }
 
             packet_type => Err((HandleMgmtError::UnknownType(packet_type.0), pkt)),
         }

--- a/adapter/ph/src/sync_req.rs
+++ b/adapter/ph/src/sync_req.rs
@@ -3,8 +3,8 @@ use crate::zdp;
 use crate::zpr;
 use std::future::Future;
 use std::sync::Mutex as StdMutex;
-use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
 use tokio::sync::oneshot;
+use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
 
 pub struct SyncReqState<'pktbuf> {
     listener_state: StdMutex<ListenerState<'pktbuf>>,
@@ -31,7 +31,9 @@ pub struct Permit<'a> {
 }
 
 impl Permit<'_> {
-    pub fn seq_num(&self) -> zpr::SeqNum { self.seq_num }
+    pub fn seq_num(&self) -> zpr::SeqNum {
+        self.seq_num
+    }
 }
 
 pub struct ResponseError();
@@ -71,9 +73,7 @@ impl<'pktbuf> SyncReqState<'pktbuf> {
             // is only correct with window size == 1.  Growing the window
             // size (and implementing it correctly) is pending further
             // design decisions.
-            window_state: TokioMutex::new(WindowState {
-                next_seq_num: 0,
-            }),
+            window_state: TokioMutex::new(WindowState { next_seq_num: 0 }),
         }
     }
 
@@ -81,11 +81,17 @@ impl<'pktbuf> SyncReqState<'pktbuf> {
         let mut window_state = self.window_state.lock().await;
         let seq_num = window_state.next_seq_num;
         window_state.next_seq_num += 1;
-        Permit { window_state, seq_num }
+        Permit {
+            window_state,
+            seq_num,
+        }
     }
 
     pub fn is_associated_permit(&self, permit: &Permit) -> bool {
-        std::ptr::eq(TokioMutexGuard::mutex(&permit.window_state), &self.window_state)
+        std::ptr::eq(
+            TokioMutexGuard::mutex(&permit.window_state),
+            &self.window_state,
+        )
     }
 
     pub fn install_response_listener(&self, permit: &Permit) -> ResponseFuture<'pktbuf> {
@@ -100,7 +106,11 @@ impl<'pktbuf> SyncReqState<'pktbuf> {
         self.listener_state.lock().unwrap().response_listener = None;
     }
 
-    pub fn forward_response(&self, seq_num: zpr::SeqNum, response: Response<'pktbuf>) -> Result<(), Packet<'pktbuf>> {
+    pub fn forward_response(
+        &self,
+        seq_num: zpr::SeqNum,
+        response: Response<'pktbuf>,
+    ) -> Result<(), Packet<'pktbuf>> {
         let listener = &mut self.listener_state.lock().unwrap().response_listener;
         match listener {
             Some((expected_seq_num, _)) => {

--- a/adapter/ph/src/sync_req.rs
+++ b/adapter/ph/src/sync_req.rs
@@ -12,7 +12,7 @@ pub struct SyncReqState<'pktbuf> {
 }
 
 struct ListenerState<'pktbuf> {
-    response_listener: Option<oneshot::Sender<Response<'pktbuf>>>,
+    response_listener: Option<(zpr::SeqNum, oneshot::Sender<Response<'pktbuf>>)>,
 }
 
 struct WindowState {
@@ -91,7 +91,7 @@ impl<'pktbuf> SyncReqState<'pktbuf> {
     pub fn install_response_listener(&self, permit: &Permit) -> ResponseFuture<'pktbuf> {
         assert!(self.is_associated_permit(permit));
         let (sender, receiver) = oneshot::channel();
-        self.listener_state.lock().unwrap().response_listener = Some(sender);  // TODO: seq_num
+        self.listener_state.lock().unwrap().response_listener = Some((permit.seq_num(), sender));
         ResponseFuture { receiver }
     }
 
@@ -100,14 +100,22 @@ impl<'pktbuf> SyncReqState<'pktbuf> {
         self.listener_state.lock().unwrap().response_listener = None;
     }
 
-    pub fn forward_response(&self, response: Response<'pktbuf>) -> Result<(), Packet<'pktbuf>> {
-        match self.listener_state.lock().unwrap().response_listener.take() {
-            Some(sender) => match sender.send(response) {
-                Ok(()) => Ok(()),
-                Err(response) => Err(response.1),
-            },
+    pub fn forward_response(&self, seq_num: zpr::SeqNum, response: Response<'pktbuf>) -> Result<(), Packet<'pktbuf>> {
+        let listener = &mut self.listener_state.lock().unwrap().response_listener;
+        match listener {
+            Some((expected_seq_num, _)) => {
+                if seq_num != *expected_seq_num {
+                    eprintln!("expected seq num {} got {}", expected_seq_num, seq_num);
+                    return Err(response.1);
+                }
 
-            None => Err(response.1),
+                match listener.take().unwrap().1.send(response) {
+                    Ok(()) => Ok(()),
+                    Err(response) => Err(response.1),
+                }
+            }
+
+            _ => Err(response.1),
         }
     }
 }

--- a/adapter/ph/src/sync_req.rs
+++ b/adapter/ph/src/sync_req.rs
@@ -1,21 +1,38 @@
 use crate::packet::Packet;
 use crate::zdp;
+use crate::zpr;
 use std::future::Future;
-use std::sync::Mutex;
-use tokio::sync::{oneshot, SemaphorePermit, Semaphore, TryAcquireError};
+use std::sync::Mutex as StdMutex;
+use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
+use tokio::sync::oneshot;
 
 pub struct SyncReqState<'pktbuf> {
-    state: Mutex<SyncReqStateInner<'pktbuf>>,
-    permit_semaphore: Semaphore,
+    listener_state: StdMutex<ListenerState<'pktbuf>>,
+    window_state: TokioMutex<WindowState>,
 }
 
-struct SyncReqStateInner<'pktbuf> {
+struct ListenerState<'pktbuf> {
     response_listener: Option<oneshot::Sender<Response<'pktbuf>>>,
+}
+
+struct WindowState {
+    next_seq_num: zpr::SeqNum,
 }
 
 pub type Response<'pktbuf> = (zdp::ZdpPacketType, Packet<'pktbuf>);
 
-pub type Permit<'a> = SemaphorePermit<'a>;
+pub struct Permit<'a> {
+    /// use our lock on the window state as a semaphore
+    /// (this is an appropriate use of a tokio-Mutex which is
+    /// essentially just a semaphore)
+    window_state: TokioMutexGuard<'a, WindowState>,
+    /// sequence number associated with this permit
+    seq_num: zpr::SeqNum,
+}
+
+impl Permit<'_> {
+    pub fn seq_num(&self) -> zpr::SeqNum { self.seq_num }
+}
 
 pub struct ResponseError();
 
@@ -47,46 +64,44 @@ impl<'pktbuf> Future for ResponseFuture<'pktbuf> {
 impl<'pktbuf> SyncReqState<'pktbuf> {
     pub fn new() -> Self {
         Self {
-            state: Mutex::new(SyncReqStateInner {
+            listener_state: StdMutex::new(ListenerState {
                 response_listener: None,
             }),
-            permit_semaphore: Semaphore::new(1),
+            // NOTE/TODO/FIXME: all the synchronization logic in this file
+            // is only correct with window size == 1.  Growing the window
+            // size (and implementing it correctly) is pending further
+            // design decisions.
+            window_state: TokioMutex::new(WindowState {
+                next_seq_num: 0,
+            }),
         }
     }
 
     pub async fn acquire_permit(&self) -> Permit {
-        self.permit_semaphore.acquire()
-                .await
-                .expect("coding error: semaphore closed")
+        let mut window_state = self.window_state.lock().await;
+        let seq_num = window_state.next_seq_num;
+        window_state.next_seq_num += 1;
+        Permit { window_state, seq_num }
     }
 
-    pub fn is_associated_permit(&self, _permit: &Permit) -> bool {
-        true  // TODO
-    }
-
-    #[allow(dead_code)]
-    pub fn try_acquire_permit(&self) -> Option<Permit> {
-        match self.permit_semaphore.try_acquire() {
-            Ok(permit) => Some(permit),
-            Err(TryAcquireError::Closed) => panic!("coding error: semaphore closed"),
-            Err(TryAcquireError::NoPermits) => None,
-        }
+    pub fn is_associated_permit(&self, permit: &Permit) -> bool {
+        std::ptr::eq(TokioMutexGuard::mutex(&permit.window_state), &self.window_state)
     }
 
     pub fn install_response_listener(&self, permit: &Permit) -> ResponseFuture<'pktbuf> {
         assert!(self.is_associated_permit(permit));
         let (sender, receiver) = oneshot::channel();
-        self.state.lock().unwrap().response_listener = Some(sender);
+        self.listener_state.lock().unwrap().response_listener = Some(sender);  // TODO: seq_num
         ResponseFuture { receiver }
     }
 
     pub fn clear_response_listener(&self, permit: &Permit) {
         assert!(self.is_associated_permit(permit));
-        self.state.lock().unwrap().response_listener = None;
+        self.listener_state.lock().unwrap().response_listener = None;
     }
 
     pub fn forward_response(&self, response: Response<'pktbuf>) -> Result<(), Packet<'pktbuf>> {
-        match self.state.lock().unwrap().response_listener.take() {
+        match self.listener_state.lock().unwrap().response_listener.take() {
             Some(sender) => match sender.send(response) {
                 Ok(()) => Ok(()),
                 Err(response) => Err(response.1),

--- a/adapter/ph/src/sync_req.rs
+++ b/adapter/ph/src/sync_req.rs
@@ -1,12 +1,12 @@
 use crate::packet::Packet;
 use crate::zdp;
 use std::future::Future;
-use std::sync::{Arc, Mutex};
-use tokio::sync::{oneshot, OwnedSemaphorePermit, Semaphore, TryAcquireError};
+use std::sync::Mutex;
+use tokio::sync::{oneshot, SemaphorePermit, Semaphore, TryAcquireError};
 
 pub struct SyncReqState<'pktbuf> {
     state: Mutex<SyncReqStateInner<'pktbuf>>,
-    permit_semaphore: Arc<Semaphore>,
+    permit_semaphore: Semaphore,
 }
 
 struct SyncReqStateInner<'pktbuf> {
@@ -15,7 +15,7 @@ struct SyncReqStateInner<'pktbuf> {
 
 pub type Response<'pktbuf> = (zdp::ZdpPacketType, Packet<'pktbuf>);
 
-pub type Permit = OwnedSemaphorePermit;
+pub type Permit<'a> = SemaphorePermit<'a>;
 
 pub struct ResponseError();
 
@@ -50,26 +50,23 @@ impl<'pktbuf> SyncReqState<'pktbuf> {
             state: Mutex::new(SyncReqStateInner {
                 response_listener: None,
             }),
-            permit_semaphore: Arc::new(Semaphore::new(1)),
+            permit_semaphore: Semaphore::new(1),
         }
     }
 
-    pub fn acquire_permit(&self) -> impl Future<Output = Permit> {
-        let sem = self.permit_semaphore.clone();
-        async {
-            sem.acquire_owned()
+    pub async fn acquire_permit(&self) -> Permit {
+        self.permit_semaphore.acquire()
                 .await
                 .expect("coding error: semaphore closed")
-        }
     }
 
-    pub fn is_associated_permit(&self, permit: &Permit) -> bool {
-        Arc::ptr_eq(permit.semaphore(), &self.permit_semaphore)
+    pub fn is_associated_permit(&self, _permit: &Permit) -> bool {
+        true  // TODO
     }
 
     #[allow(dead_code)]
     pub fn try_acquire_permit(&self) -> Option<Permit> {
-        match self.permit_semaphore.clone().try_acquire_owned() {
+        match self.permit_semaphore.try_acquire() {
             Ok(permit) => Some(permit),
             Err(TryAcquireError::Closed) => panic!("coding error: semaphore closed"),
             Err(TryAcquireError::NoPermits) => None,

--- a/adapter/ph/src/zpr.rs
+++ b/adapter/ph/src/zpr.rs
@@ -16,6 +16,10 @@ pub const ZPI_0: Zpi = 0;
 /// Proposed value to allow easily distinguishing packets with plaintext payloads.
 pub const ZPI_ENCRYPTED_HEADER_FLAG: Zpi = 0x80;
 
+/// Message sequence numbers.  Note this is the _abstract_ sequence number.
+/// The physical sequence number included in message headers is a suffix of this.
+pub type SeqNum = u64;
+
 /// The Security Association ID must fit no more than 8 bits.  Note that it shares
 /// space with the ZPI.
 pub type SaId = u8;


### PR DESCRIPTION
Imbues SyncReqState with a notion of sequence numbers, which are handed out with each window permit granted.  These sequence numbers are plumbed through the sync request->reply loop and matched up on reception.

I don't love this code, and it should be replaced long-term once we figure out our broader story for sequence numbers.  But it's here for now.

Some follow-on TODOs --

* The two halves of SyncReqState, the window state, and the listener state, are mostly independent and can/should be split out.  The window state can then move up a layer and be used for all management messages and/or implemented as part of a transport layer. This is #398.
* We need to generate sequence numbers for async requests also.  This is #401.
* On receipt, sequence numbers of requests should be validated that they are nondecreasing, to prevent replays and out-of-order execution.  This is #400.
* The synchronous request handlers should be async functions, and the logic to send a reply can then be centralized (rather than stuck in each handler function).  This is #399.
* It would be nice if sequence numbers served as nonces.  This is #358.