### PR TITLE
Fix mgmt deadlock

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "ph"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aarc",
  "arrayref",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ph"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -8,6 +8,7 @@ use crate::queues::AdapterManagerMessage;
 use crate::zpr;
 use std::future::Future;
 use tokio::sync::mpsc;
+use tracing::debug;
 
 async fn worker<'pktbuf>(
     asm: &Assembly<'pktbuf>,
@@ -56,7 +57,7 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
     // compress only IP addresses for now
     let compression_mode: zpr::CompressionMode = 0;
 
-    eprintln!(
+    debug!(
         "{}: Issuing bind request for {}",
         asm.system_name, five_tuple
     );
@@ -73,7 +74,7 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
     {
         Ok(tether_id) => {
             // Bind succeeded; add to ALT.
-            eprintln!(
+            debug!(
                 "{}: Bind of {} succeeded: {}",
                 asm.system_name, five_tuple, tether_id
             );
@@ -90,7 +91,7 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
 
         Err(err) => {
             // Bind failed; remove pending entry from ALT.
-            eprintln!(
+            debug!(
                 "{}: Bind of {} failed: {}",
                 asm.system_name, five_tuple, err
             );

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -43,12 +43,6 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
     let five_tuple = *pkt.metadata().five_tuple();
     fastpath::drop_and_count(asm, pkt, CounterType::DroppedAwaitingBind);
 
-    // VERY HACK: there's some race condition which IPv6's
-    // rapid link-local config traffic exacerbates
-    if five_tuple.l3_type == zpr::L3Type::Ipv6 {
-        return;
-    }
-
     // if there's already an entry, this is a duplicate request
     // (NOTE: we should be the only ones modifying this table!)
     if asm.alt.get(&five_tuple).is_some() {

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -537,7 +537,7 @@ pub fn substrate_ingress<'pktbuf>(
         // TODO: should we peel off the ZDP header here??
         // (instead of this silly code to restore it?)
         *pkt.alloc_zeroed_header() = base_hdr;
-        mgmt::route_mgmt_packet(asm, ingress_link_id, pkt);
+        mgmt::dispatch_mgmt_packet(asm, ingress_link_id, pkt);
         return;
     }
 

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -23,7 +23,7 @@ use crate::{compress, km};
 use blake3;
 use bytes::{Buf, BufMut};
 use std::time::SystemTime;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use zerocopy::FromBytes;
 use zpr_ext::std::mem::{drop_guard, DropGuard};
 use zpr_ext::zerocopy::*;
@@ -35,7 +35,7 @@ pub fn drop_and_count<'pktbuf>(
     reason: impl Into<CounterType>,
 ) {
     let reason = reason.into();
-    eprintln!("{}: dropping packet because {}", asm.system_name, reason);
+    debug!("{}: dropping packet because {}", asm.system_name, reason);
     asm.buffer_stack.put_buffer(pkt.destroy());
     asm.counters[reason.into()].increment();
 }
@@ -432,8 +432,6 @@ pub fn substrate_ingress<'pktbuf>(
     mut pkt: Packet<'pktbuf>,
 ) {
     asm.counters[CounterType::InPacksRec].increment();
-
-    eprintln!("{}: got packet from {}", asm.system_name, peer_sa);
 
     let Some(ingress_link_id) = asm.peer_table.lookup_peer(peer_sa) else {
         drop_and_count(asm, pkt, CounterType::UnknownPeer);

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -11,6 +11,7 @@ use crate::counters_enum::CounterType;
 use crate::defs::Direction;
 use crate::km::Codec;
 use crate::km_noise::NOISE_PADLEN;
+use crate::mgmt;
 use crate::net_defs;
 use crate::packet::Packet;
 use crate::peer_table::PeerState;
@@ -523,9 +524,7 @@ pub fn substrate_ingress<'pktbuf>(
     // In ZPI zero only KM messages are allowed (well, and APR ARP which we don't support yet)
     // Can be overridden (FOR TESTING ONLY) in the flags.
     if !secure && base_hdr.packet_type != zdp::ZdpPacketType::KeyManagement {
-        if asm.flags.allow_insecure_zpi_zero {
-            warn!("operating in insecure mode - allow_insecure_zpi_zero is ENABLED");
-        } else {
+        if !asm.flags.allow_insecure_zpi_zero {
             warn!(
                 "ingress: link {}: ZPI 0 only allows key management messages, not {:?}",
                 ingress_link_id, base_hdr.packet_type
@@ -540,21 +539,7 @@ pub fn substrate_ingress<'pktbuf>(
         // TODO: should we peel off the ZDP header here??
         // (instead of this silly code to restore it?)
         *pkt.alloc_zeroed_header() = base_hdr;
-
-        eprintln!("{}: enqueueing!", asm.system_name);
-
-        let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
-            drop_and_count(asm, pkt, CounterType::PeerRemoved);
-            return;
-        };
-
-        match peer_state.mgmt_processor.try_enqueue_packet(pkt) {
-            Ok(()) => (),
-            Err(TryEnqueueError::Full(pkt)) => {
-                eprintln!("{}: queue backpressure!", asm.system_name);
-                drop_and_count(asm, pkt, CounterType::QueueBackpressure);
-            }
-        }
+        mgmt::route_mgmt_packet(asm, ingress_link_id, pkt);
         return;
     }
 

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -317,6 +317,7 @@ impl KeyManager {
     /// This waits until space available in our KM message queue.
     ///
     /// We copy the payload into our own buffer for processing asynchronously. Caller should free buffer.
+    #[allow(dead_code)]
     pub async fn handle_km_message(&self, message: &[u8]) -> KmResult<()> {
         let tx: mpsc::Sender<Bytes>;
         {
@@ -341,7 +342,6 @@ impl KeyManager {
     /// This will fail if there is no space in queue.
     ///
     /// We copy the payload into our own buffer for processing asynchronously. Caller should free buffer.
-    #[allow(dead_code)]
     pub fn try_handle_km_message(&self, message: &[u8]) -> KmResult<()> {
         let tx: mpsc::Sender<Bytes>;
         {

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -246,7 +246,7 @@ fn add_noise_link(
 /// - [KmMsgProcessingError::EnqueueFailed] if the message could not be enqueued on the state machine.
 /// - [KmMsgProcessingError::LinkUnconfigured] if the link is not configured for Key Management.
 ///
-pub async fn handle_inbound_km_msg<'pktbuf>(
+pub fn handle_inbound_km_msg<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     from_link: zpr::LinkId,
     km_payload: &[u8],
@@ -255,7 +255,7 @@ pub async fn handle_inbound_km_msg<'pktbuf>(
         Some(h) => h,
         None => return Err(KmMsgProcessingError::LinkUnconfigured),
     };
-    match manager.handle_km_message(km_payload).await {
+    match manager.try_handle_km_message(km_payload) {
         Ok(_) => Ok(()),
         Err(e) => match e {
             KmError::InvalidState => Err(KmMsgProcessingError::InvalidState),

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -361,9 +361,7 @@ mod test {
         };
 
         // Now send the reply back into our link.
-        handle_inbound_km_msg(asm, adapter_link_id, &handshake_reply)
-            .await
-            .unwrap();
+        handle_inbound_km_msg(asm, adapter_link_id, &handshake_reply).unwrap();
 
         yield_now().await;
 

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -14,7 +14,7 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_tun::TunBuilder;
-use tracing::warn;
+use tracing::{info, warn};
 use tracing_subscriber;
 use zpr_ext::tokio::net::UdpSocketExt;
 
@@ -445,8 +445,8 @@ fn main() -> ExitCode {
             js.spawn(km_multiplexor::launch_message_worker(&*asm, km_rx));
         }
 
-        eprintln!("{}: connecting...", asm.system_name);
-        eprintln!("{}: connected!", asm.system_name); // FIXME: it's a lie
+        info!("{}: connecting...", asm.system_name);
+        info!("{}: connected!", asm.system_name); // FIXME: it's a lie
         asm.tun_ctl.set_carrier(true).unwrap();
 
         for (worker_index, socket) in sockets.iter().enumerate() {

--- a/adapter/ph/src/mgmt.rs
+++ b/adapter/ph/src/mgmt.rs
@@ -216,7 +216,7 @@ fn match_received<'pktbuf>(
     }
 }
 
-pub fn route_mgmt_packet<'pktbuf>(
+pub fn dispatch_mgmt_packet<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     ingress_link_id: zpr::LinkId,
     pkt: Packet<'pktbuf>,

--- a/adapter/ph/src/mgmt.rs
+++ b/adapter/ph/src/mgmt.rs
@@ -256,7 +256,10 @@ fn handle_response<'pktbuf>(
 
     let packet_type = base_hdr.packet_type;
 
-    debug_assert!(packet_type.is_response(), "stray mgmt request in handle_response()");
+    debug_assert!(
+        packet_type.is_response(),
+        "stray mgmt request in handle_response()"
+    );
 
     // Gets the designated sender, attempts to send the response, if not drops
     // the packet and increments corresponding counter
@@ -272,11 +275,7 @@ fn handle_response<'pktbuf>(
 }
 
 /// send a Report message (RFC 6.5 § 6.3.13)
-pub async fn send_report(
-    asm: &Assembly<'_>,
-    link_id: zpr::LinkId,
-    report: &str,
-) {
+pub async fn send_report(asm: &Assembly<'_>, link_id: zpr::LinkId, report: &str) {
     // TODO this condition will need to be adjusted when we have complete ZPR packets
     // with the information at the end of the packet at well
     if packet::PACKET_BUFFER_MAX_BODY_SIZE - config::DEFAULT_MESSAGE_HEADROOM < report.len() {

--- a/adapter/ph/src/mgmt.rs
+++ b/adapter/ph/src/mgmt.rs
@@ -9,12 +9,14 @@ use crate::dock_tables;
 use crate::fastpath;
 use crate::km_multiplexor;
 use crate::packet::{self, Packet};
+use crate::queues;
 use crate::zdp;
 use crate::zpr;
 use bytes::{Buf, BufMut};
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::error;
+use zerocopy::FromBytes;
 use zpr_ext::std::mem::{drop_guard, DropGuard};
 use zpr_ext::zerocopy::{AsBytesExt, FromBytesExt};
 
@@ -215,9 +217,69 @@ fn match_received<'pktbuf>(
     }
 }
 
+pub fn route_mgmt_packet<'pktbuf>(
+    asm: &Assembly<'pktbuf>,
+    ingress_link_id: zpr::LinkId,
+    pkt: Packet<'pktbuf>,
+) {
+    match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
+        Some(base_hdr) if base_hdr.packet_type.is_response() => {
+            match handle_response(asm, ingress_link_id, pkt) {
+                Ok(()) => (),
+                Err((err, pkt)) => fastpath::drop_and_count(asm, pkt, err),
+            }
+        }
+
+        _ => {
+            eprintln!("{}: enqueueing!", asm.system_name);
+
+            let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
+                fastpath::drop_and_count(asm, pkt, CounterType::PeerRemoved);
+                return;
+            };
+
+            match peer_state.mgmt_processor.try_enqueue_packet(pkt) {
+                Ok(()) => (),
+                Err(queues::TryEnqueueError::Full(pkt)) => {
+                    eprintln!("{}: queue backpressure!", asm.system_name);
+                    fastpath::drop_and_count(asm, pkt, CounterType::QueueBackpressure);
+                }
+            }
+        }
+    }
+}
+
+fn handle_response<'pktbuf>(
+    asm: &Assembly<'pktbuf>,
+    ingress_link_id: zpr::LinkId,
+    mut pkt: Packet<'pktbuf>,
+) -> HandleMgmtResult<'pktbuf> {
+    let Some(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(&mut pkt) else {
+        return Err((HandleMgmtError::BadStructure, pkt));
+    };
+
+    let packet_type = base_hdr.packet_type;
+
+    debug_assert!(packet_type.is_response(), "stray mgmt request in handle_response()");
+
+    eprintln!("{}: got response from {}", asm.system_name, ingress_link_id);
+
+    // Gets the designated sender, attempts to send the response, if not drops
+    // the packet and increments corresponding counter
+    let mut pkt = Some(pkt);
+    asm.peer_table
+        .inspect(ingress_link_id, |peer_state| {
+            peer_state
+                .sync_req_state
+                .forward_response((packet_type, pkt.take().unwrap()))
+                .map_err(|pkt| (HandleMgmtError::UnexpectedMgmtResponse, pkt))
+        })
+        .unwrap_or_else(|| Err((HandleMgmtError::UnexpectedMgmtResponse, pkt.take().unwrap())))
+}
+
 /// send a Report message (RFC 6.5 § 6.3.13)
-pub async fn send_report<'pktbuf>(
-    asm: &'pktbuf Assembly<'pktbuf>,
+pub async fn send_report(
+    asm: &Assembly<'_>,
     link_id: zpr::LinkId,
     report: &str,
 ) {
@@ -235,7 +297,7 @@ pub async fn send_report<'pktbuf>(
 }
 
 /// send a Discard message (RFC 6.5 § 6.3.1)
-pub async fn send_discard<'pktbuf>(asm: &'pktbuf Assembly<'pktbuf>, link_id: zpr::LinkId) {
+pub async fn send_discard(asm: &Assembly<'_>, link_id: zpr::LinkId) {
     let buf = asm.buffer_stack.get_buffer().await;
     let pkt = Packet::new(buf, config::DEFAULT_MESSAGE_HEADROOM);
     send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::Discard, pkt).await;

--- a/adapter/ph/src/mgmt.rs
+++ b/adapter/ph/src/mgmt.rs
@@ -219,9 +219,17 @@ fn match_received<'pktbuf>(
 pub fn dispatch_mgmt_packet<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     ingress_link_id: zpr::LinkId,
-    pkt: Packet<'pktbuf>,
+    mut pkt: Packet<'pktbuf>,
 ) {
     match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
+        Some(base_hdr) if base_hdr.packet_type == zdp::ZdpPacketType::KeyManagement => {
+            pkt.advance(std::mem::size_of::<zdp::ZdpBaseHeader>());
+            match handle_key_management(asm, ingress_link_id, pkt) {
+                Ok(()) => (),
+                Err((err, pkt)) => fastpath::drop_and_count(asm, pkt, err),
+            }
+        }
+
         Some(base_hdr) if base_hdr.packet_type.is_response() => {
             match handle_response(asm, ingress_link_id, pkt) {
                 Ok(()) => (),
@@ -759,7 +767,7 @@ pub async fn send_key_management<'pktbuf>(
 
 // ZPI and Base header is already gone by the time we get here.  So we expect
 // to parse starting from the KeyManagement header.
-pub async fn handle_key_management<'pktbuf>(
+pub fn handle_key_management<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     ingress_link_id: zpr::LinkId,
     mut pkt: Packet<'pktbuf>,
@@ -783,9 +791,7 @@ pub async fn handle_key_management<'pktbuf>(
         error!("KeyManagement packet arrived with truncated payload");
         return Err((HandleMgmtError::BadStructure, pkt));
     }
-    match km_multiplexor::handle_inbound_km_msg(asm, ingress_link_id, &pkt.body()[..km_msg_len])
-        .await
-    {
+    match km_multiplexor::handle_inbound_km_msg(asm, ingress_link_id, &pkt.body()[..km_msg_len]) {
         Ok(()) => (),
         Err(e) => {
             error!(

--- a/adapter/ph/src/mgmt.rs
+++ b/adapter/ph/src/mgmt.rs
@@ -15,7 +15,7 @@ use crate::zpr;
 use bytes::{Buf, BufMut};
 use std::time::Duration;
 use tokio::time::sleep;
-use tracing::error;
+use tracing::{error, info, warn};
 use zerocopy::FromBytes;
 use zpr_ext::std::mem::{drop_guard, DropGuard};
 use zpr_ext::zerocopy::{AsBytesExt, FromBytesExt};
@@ -182,7 +182,6 @@ async fn send_sync_req_helper<'pktbuf>(
         tokio::select! {
             response = &mut response_future => {
                 drop(permit);
-                eprintln!("{}: received response from {} via channel!", asm.system_name, link_id);
                 return match_received(asm, response.ok(), SyncReqError::LinkClosed, zdp_response_type);
             }
             _ = sleep(Duration::from_secs(config::DEFAULT_REQUEST_RETRY_TIMER as u64)) => ()
@@ -231,8 +230,6 @@ pub fn route_mgmt_packet<'pktbuf>(
         }
 
         _ => {
-            eprintln!("{}: enqueueing!", asm.system_name);
-
             let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
                 fastpath::drop_and_count(asm, pkt, CounterType::PeerRemoved);
                 return;
@@ -241,7 +238,6 @@ pub fn route_mgmt_packet<'pktbuf>(
             match peer_state.mgmt_processor.try_enqueue_packet(pkt) {
                 Ok(()) => (),
                 Err(queues::TryEnqueueError::Full(pkt)) => {
-                    eprintln!("{}: queue backpressure!", asm.system_name);
                     fastpath::drop_and_count(asm, pkt, CounterType::QueueBackpressure);
                 }
             }
@@ -261,8 +257,6 @@ fn handle_response<'pktbuf>(
     let packet_type = base_hdr.packet_type;
 
     debug_assert!(packet_type.is_response(), "stray mgmt request in handle_response()");
-
-    eprintln!("{}: got response from {}", asm.system_name, ingress_link_id);
 
     // Gets the designated sender, attempts to send the response, if not drops
     // the packet and increments corresponding counter
@@ -324,13 +318,13 @@ pub async fn send_hello_request<'a, 'pktbuf>(
                 return Err(());
             };
             let status = hdr.status;
-            eprintln!("Received HelloResponse, status: {}", status);
+            info!("Received HelloResponse, status: {}", status);
             asm.buffer_stack.put_buffer(hello_res.destroy());
             Ok(())
         }
 
         Err(err) => {
-            eprintln!("{} error with HelloRequest", err);
+            warn!("{} error with HelloRequest", err);
             Err(())
         }
     }
@@ -359,11 +353,6 @@ pub async fn send_bind_agent_address_request<'a, 'pktbuf>(
     compression_mode: zpr::CompressionMode,
     five_tuple: FiveTuple,
 ) -> Result<zpr::StreamId, BindAgentAddressError> {
-    eprintln!(
-        "{}: sending bind req for {} to {}",
-        asm.system_name, five_tuple, link_id
-    );
-
     let response = send_sync_per_flow_req(
         asm,
         link_id,
@@ -476,8 +465,7 @@ pub async fn handle_report<'pktbuf>(
     let report_data_length: usize = hdr.report_data_length.into();
     pkt.advance(std::mem::size_of::<zdp::ZdpReportHeader>());
     if pkt.body().len() >= report_data_length {
-        // TODO printing to stderr blocks indefinitely, this is just temporary
-        eprintln!(
+        info!(
             "{}: {}",
             ingress_link_id,
             std::str::from_utf8(&pkt.body()[..report_data_length]).unwrap()
@@ -494,7 +482,7 @@ pub async fn handle_discard<'pktbuf>(
     pkt: Packet<'pktbuf>,
 ) -> HandleMgmtResult<'pktbuf> {
     // TODO print to debug log, when implemented
-    eprintln!(
+    info!(
         "{}: Discard message received from {}",
         asm.system_name, ingress_link_id
     );
@@ -512,7 +500,7 @@ pub async fn handle_hello_request<'pktbuf>(
     let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpHelloResponseHeader>();
     hdr.status = 0.into();
 
-    eprintln!("{}: Received HelloRequest", asm.system_name);
+    info!("{}: Received HelloRequest", asm.system_name);
 
     send_non_flow_mgmt(
         asm,
@@ -611,11 +599,6 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
         dst_port,
     );
 
-    eprintln!(
-        "{}: handling bind req for {} from {}",
-        asm.system_name, five_tuple, ingress_link_id
-    );
-
     // recycle request buffer for response
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
 
@@ -704,8 +687,6 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
         }
 
         PhMode::Adapter => {
-            eprintln!("{}: I'm an adapter!", asm.system_name);
-
             // form PEP
             let pep = adapter_tables::DltPep {
                 compression_mode,
@@ -744,11 +725,6 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
             }
         }
     }
-
-    eprintln!(
-        "{}: responding to {} with {} for {}!",
-        asm.system_name, ingress_link_id, ingress_tether_id, five_tuple
-    );
 
     // respond to requestor
     send_per_flow_mgmt(

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -56,7 +56,7 @@ async fn handle_packet<'pktbuf>(
 
     let packet_type = base_hdr.packet_type;
 
-    debug_assert!(
+    assert!(
         !packet_type.is_response(),
         "stray mgmt response in mgmt processor"
     );

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -23,13 +23,17 @@ async fn worker<'pktbuf>(
         match msg {
             MgmtProcessorMessage::Packet(pkt) => {
                 eprintln!(
-                    "{}: dequeued mgmt message from {}",
+                    "{}: ENTER dequeued mgmt message from {}",
                     asm.system_name, config.link_id
                 );
                 match handle_packet(asm, config.link_id, pkt).await {
                     Ok(()) => (),
                     Err((err, pkt)) => fastpath::drop_and_count(asm, pkt, err),
                 }
+                eprintln!(
+                    "{}: LEAVE dequeued mgmt message from {}",
+                    asm.system_name, config.link_id
+                );
             }
 
             MgmtProcessorMessage::TestPacket(pkt) => pkt.acknowledge(queue.len(), 1),
@@ -65,21 +69,9 @@ async fn handle_packet<'pktbuf>(
 
     let packet_type = base_hdr.packet_type;
 
-    if packet_type.is_response() {
-        eprintln!("{}: got response from {}", asm.system_name, ingress_link_id);
+    debug_assert!(!packet_type.is_response(), "stray mgmt response in mgmt processor");
 
-        // Gets the designated sender, attempts to send the response, if not drops
-        // the packet and increments corresponding counter
-        let mut pkt = Some(pkt);
-        asm.peer_table
-            .inspect(ingress_link_id, |peer_state| {
-                peer_state
-                    .sync_req_state
-                    .forward_response((packet_type, pkt.take().unwrap()))
-                    .map_err(|pkt| (HandleMgmtError::UnexpectedMgmtResponse, pkt))
-            })
-            .unwrap_or_else(|| Err((HandleMgmtError::UnexpectedMgmtResponse, pkt.take().unwrap())))
-    } else if base_hdr.packet_type.is_per_flow() {
+    if base_hdr.packet_type.is_per_flow() {
         let Some(per_flow_hdr) = ZdpPerFlowHeader::read_from_buf(&mut pkt) else {
             return Err((HandleMgmtError::BadStructure, pkt));
         };

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -22,18 +22,10 @@ async fn worker<'pktbuf>(
     while let Some(msg) = queue.recv().await {
         match msg {
             MgmtProcessorMessage::Packet(pkt) => {
-                eprintln!(
-                    "{}: ENTER dequeued mgmt message from {}",
-                    asm.system_name, config.link_id
-                );
                 match handle_packet(asm, config.link_id, pkt).await {
                     Ok(()) => (),
                     Err((err, pkt)) => fastpath::drop_and_count(asm, pkt, err),
                 }
-                eprintln!(
-                    "{}: LEAVE dequeued mgmt message from {}",
-                    asm.system_name, config.link_id
-                );
             }
 
             MgmtProcessorMessage::TestPacket(pkt) => pkt.acknowledge(queue.len(), 1),
@@ -58,11 +50,6 @@ async fn handle_packet<'pktbuf>(
     ingress_link_id: zpr::LinkId,
     mut pkt: Packet<'pktbuf>,
 ) -> HandleMgmtResult<'pktbuf> {
-    eprintln!(
-        "{}: handling mgmt message from {}",
-        asm.system_name, ingress_link_id
-    );
-
     let Some(base_hdr) = ZdpBaseHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -56,7 +56,10 @@ async fn handle_packet<'pktbuf>(
 
     let packet_type = base_hdr.packet_type;
 
-    debug_assert!(!packet_type.is_response(), "stray mgmt response in mgmt processor");
+    debug_assert!(
+        !packet_type.is_response(),
+        "stray mgmt response in mgmt processor"
+    );
 
     if base_hdr.packet_type.is_per_flow() {
         let Some(per_flow_hdr) = ZdpPerFlowHeader::read_from_buf(&mut pkt) else {

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -84,7 +84,7 @@ async fn handle_packet<'pktbuf>(
             ZdpPacketType::Discard => mgmt::handle_discard(asm, ingress_link_id, pkt).await,
 
             ZdpPacketType::KeyManagement => {
-                mgmt::handle_key_management(asm, ingress_link_id, pkt).await
+                panic!("unexpected Key Management message in mgmt processor")
             }
 
             ZdpPacketType::HelloRequest => {

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -22,7 +22,7 @@ pub enum MgmtProcessorMessage<'pktbuf> {
     TestPacket(TestPacket),
 }
 
-/// MgmtProcessor processes all inbound management packets
+/// MgmtProcessor processes all inbound management requests.
 /// Unlike other queues, this doesn't live directly in the assembly,
 /// but rather in the peer table, as there is one of these per peer.
 pub struct MgmtProcessor<'pktbuf> {

--- a/adapter/ph/src/rpc_worker.rs
+++ b/adapter/ph/src/rpc_worker.rs
@@ -22,6 +22,7 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::oneshot::error::RecvError;
 use tokio::task::JoinSet;
 use tokio::time::interval;
+use tracing::error;
 use zpr_ext::std::os::unix::net::{AncillaryData, SocketAncillary};
 use zpr_ext::tokio::net::*;
 
@@ -36,8 +37,8 @@ async fn worker(asm: &'static Assembly<'static>, socket: &UnixListener) {
             Some(ret) = set.join_next() =>
                 match ret {
                     Ok(Ok(())) => (),
-                    Ok(Err(err)) => eprintln!("Handle Connection Failed: {err}"),
-                    Err(err) => eprintln!("join_next panicked: {err}")
+                    Ok(Err(err)) => error!("Handle Connection Failed: {err}"),
+                    Err(err) => error!("join_next panicked: {err}")
                 },
             accepted = socket.accept() =>
                 match accepted {
@@ -45,7 +46,7 @@ async fn worker(asm: &'static Assembly<'static>, socket: &UnixListener) {
                         set.spawn(handle_connection(asm, stream));
                     },
                     Err(_e) => {
-                        eprintln!("Connection failed");
+                        error!("Connection failed");
                     }
             }
         }
@@ -56,8 +57,6 @@ async fn handle_connection(
     asm: &'static Assembly<'static>,
     mut stream: UnixStream,
 ) -> std::io::Result<()> {
-    eprintln!("Connection received");
-
     let mut str_message = String::new();
 
     let split_buf = stream.split(); // split stream into read/write streams

--- a/adapter/ph/test/common_funcs.sh
+++ b/adapter/ph/test/common_funcs.sh
@@ -96,8 +96,8 @@ function ping_test() {
   sudo ip netns exec zpr-a ping -q -c 5 -w 5 "$B_ZPR_ADDR" & wait -f $!
   sudo ip netns exec zpr-b ping -q -c 5 -w 5 "$A_ZPR_ADDR" & wait -f $!
 
-#  sudo ip netns exec zpr-a ping -q -c 5 -w 5 "$B_ZPR_ADDR6" & wait -f $!
-#  sudo ip netns exec zpr-b ping -q -c 5 -w 5 "$A_ZPR_ADDR6" & wait -f $!
+  sudo ip netns exec zpr-a ping -q -c 5 -w 5 "$B_ZPR_ADDR6" & wait -f $!
+  sudo ip netns exec zpr-b ping -q -c 5 -w 5 "$A_ZPR_ADDR6" & wait -f $!
 }
 
 function check_carrier() {

--- a/diagrams/substrate_ingress.puml
+++ b/diagrams/substrate_ingress.puml
@@ -36,15 +36,8 @@ endif
 
 if (""TransitPacket"") then (yes)
 else (no)
-    if (try enqueue) then (ok)
-        -[dotted]-> ""mgmt_processor[link_id]"";
-        |""mgmt_processor[link_id]"" worker|
-        :""handle_packet()""; <<procedure>>
-        detach
-    else (queue full)
-        |fastpath|
-        end
-    endif
+    :""dispatch_mgmt_packet()""; <<procedure>>
+    detach
 endif
 
 :parse ""PerFlowHeader"";


### PR DESCRIPTION
We had a deadlock in mgmt processing, due to the fact that the mgmt processor both was routing responses, and also processing requests.

So, rather than enqueue all mgmt packets immediately into the mgmt processor, the fastpath now performs the dispatch of request vs. response packets, sending requests to the mgmt processor queue as before, and responses get routed to the active response listener.

This is a little more heavyweight than I'd like in the fastpath, but at least it's nonblocking.  In the future, we could add a queue to perform this mgmt dispatching.

Also, this patch re-enables IPv6 processing (which now no longer deadlocks!) and removes many of the debug statements I added to track down this issue.  (Notably, there are no eprintlns left in the PH.)

Finally, I also moved KM enqueueing out of the mgmt processor and into the newly created `dispatch_mgmt_packet()`.  Now `mgmt_processor` is dedicated to actually processing mgmt requests.