### PR TITLE
add calls to really do the link-2-link hmac

### DIFF
--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -193,11 +193,13 @@ pub fn encrypt_null<'pktbuf>(pkt: &mut Packet<'pktbuf>) {
     );
 }
 
-pub fn encrypt_hmac<'pktbuf>(_send_hmac_key: [u8; 32], _pkt: &mut Packet<'pktbuf>) {
-    // Run the blake hash key'd with the `send_hmac_key` on the correct parts of the packet
-    // and write the (truncated) hash value to the correct header location.
 
-    info!("encrypt_hmac: not implemented - NOP");
+/// Slap an HMAC onto the end of the packet.
+pub fn encrypt_hmac<'pktbuf>(send_hmac_key: [u8; 32], pkt: &mut Packet<'pktbuf>) {
+    let mut link_mac = [0u8; zdp::ZDP_PACKET_MAC_SIZE];
+    link_mac[..zdp::ZDP_PACKET_MAC_SIZE]
+        .copy_from_slice(&blake3::keyed_hash(&send_hmac_key, pkt.body()).as_bytes()[..zdp::ZDP_PACKET_MAC_SIZE]);
+    pkt.put(&link_mac[..zdp::ZDP_PACKET_MAC_SIZE]);
 }
 
 pub fn encrypt_full<'pktbuf>(
@@ -256,12 +258,25 @@ pub fn decrypt_null<'pktbuf>(pkt: &mut Packet<'pktbuf>) -> Result<(), DecryptErr
     Ok(())
 }
 
-/// Decrypt a ZDP packet according to its ZPI header (which is not removed).
+/// Check and remove the link-2-link HMAC on the (presumed) transit packet.
 pub fn decrypt_hmac<'pktbuf>(
-    _recv_hmac_key: [u8; 32],
-    _pkt: &mut Packet<'pktbuf>,
+    recv_hmac_key: [u8; 32],
+    pkt: &mut Packet<'pktbuf>,
 ) -> Result<(), DecryptError> {
-    info!("decrypt_hmac: not implemented -- NOP");
+
+    if pkt.body().len() < zdp::ZDP_PACKET_MAC_SIZE {
+        return Err(DecryptError::BadStructure);
+    }
+
+    let mut link_mac = [0u8; zdp::ZDP_PACKET_MAC_SIZE];
+
+    link_mac.copy_from_slice(&pkt.body()[pkt.body().len() - zdp::ZDP_PACKET_MAC_SIZE..]);
+    pkt.shrink_by(zdp::ZDP_PACKET_MAC_SIZE);
+
+    if &blake3::keyed_hash(&recv_hmac_key, &pkt.body()).as_bytes()[..zdp::ZDP_PACKET_MAC_SIZE] != &link_mac[..zdp::ZDP_PACKET_MAC_SIZE] {
+        return Err(DecryptError::MicvFailure);
+    }
+
     Ok(())
 }
 
@@ -751,4 +766,47 @@ mod test {
 
         assert!(pkt.body().len() == orig_len); // did remove checksum
     }
+
+    #[test]
+    fn test_add_and_check_hmac() {
+        let mut buf = [0u8; PACKET_BUFFER_SIZE];
+        let mut pkt = Packet::new(&mut buf, 64);
+
+        pkt.put(&b"this is a test of hmac"[..]);
+        let key: [u8; 32] = [6u8; 32];
+
+        let orig_len = pkt.body().len();
+
+        encrypt_hmac(key, &mut pkt);
+
+        assert!(pkt.body().len() == orig_len + zdp::ZDP_PACKET_MAC_SIZE); // did add hmac
+
+
+        let res = decrypt_hmac(key, &mut pkt);
+        assert!(res.is_ok());
+
+        assert!(pkt.body().len() == orig_len); // did remove hmac
+    }
+
+
+    #[test]
+    fn test_add_and_check_hmac_fail() {
+        let mut buf = [0u8; PACKET_BUFFER_SIZE];
+        let mut pkt = Packet::new(&mut buf, 64);
+
+        pkt.put(&b"this is a test of hmac"[..]);
+        let key: [u8; 32] = [6u8; 32];
+
+        let orig_len = pkt.body().len();
+
+        encrypt_hmac(key, &mut pkt);
+
+        assert!(pkt.body().len() == orig_len + zdp::ZDP_PACKET_MAC_SIZE); // did add hmac
+
+        let wrong_key: [u8; 32] = [7u8; 32];
+
+        let res = decrypt_hmac(wrong_key, &mut pkt);
+        assert!(res.is_err());
+    }
+
 }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -193,12 +193,12 @@ pub fn encrypt_null<'pktbuf>(pkt: &mut Packet<'pktbuf>) {
     );
 }
 
-
 /// Slap an HMAC onto the end of the packet.
 pub fn encrypt_hmac<'pktbuf>(send_hmac_key: [u8; 32], pkt: &mut Packet<'pktbuf>) {
     let mut link_mac = [0u8; zdp::ZDP_PACKET_MAC_SIZE];
-    link_mac[..zdp::ZDP_PACKET_MAC_SIZE]
-        .copy_from_slice(&blake3::keyed_hash(&send_hmac_key, pkt.body()).as_bytes()[..zdp::ZDP_PACKET_MAC_SIZE]);
+    link_mac[..zdp::ZDP_PACKET_MAC_SIZE].copy_from_slice(
+        &blake3::keyed_hash(&send_hmac_key, pkt.body()).as_bytes()[..zdp::ZDP_PACKET_MAC_SIZE],
+    );
     pkt.put(&link_mac[..zdp::ZDP_PACKET_MAC_SIZE]);
 }
 
@@ -263,7 +263,6 @@ pub fn decrypt_hmac<'pktbuf>(
     recv_hmac_key: [u8; 32],
     pkt: &mut Packet<'pktbuf>,
 ) -> Result<(), DecryptError> {
-
     if pkt.body().len() < zdp::ZDP_PACKET_MAC_SIZE {
         return Err(DecryptError::BadStructure);
     }
@@ -273,7 +272,9 @@ pub fn decrypt_hmac<'pktbuf>(
     link_mac.copy_from_slice(&pkt.body()[pkt.body().len() - zdp::ZDP_PACKET_MAC_SIZE..]);
     pkt.shrink_by(zdp::ZDP_PACKET_MAC_SIZE);
 
-    if &blake3::keyed_hash(&recv_hmac_key, &pkt.body()).as_bytes()[..zdp::ZDP_PACKET_MAC_SIZE] != &link_mac[..zdp::ZDP_PACKET_MAC_SIZE] {
+    if &blake3::keyed_hash(&recv_hmac_key, &pkt.body()).as_bytes()[..zdp::ZDP_PACKET_MAC_SIZE]
+        != &link_mac[..zdp::ZDP_PACKET_MAC_SIZE]
+    {
         return Err(DecryptError::MicvFailure);
     }
 
@@ -781,13 +782,11 @@ mod test {
 
         assert!(pkt.body().len() == orig_len + zdp::ZDP_PACKET_MAC_SIZE); // did add hmac
 
-
         let res = decrypt_hmac(key, &mut pkt);
         assert!(res.is_ok());
 
         assert!(pkt.body().len() == orig_len); // did remove hmac
     }
-
 
     #[test]
     fn test_add_and_check_hmac_fail() {
@@ -808,5 +807,4 @@ mod test {
         let res = decrypt_hmac(wrong_key, &mut pkt);
         assert!(res.is_err());
     }
-
 }

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -106,6 +106,7 @@ pub struct ZdpPerFlowHeader {
     pub stream_id: U32,
 }
 
+
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(packed)]
 pub struct ZdpEchoHeader {
@@ -177,6 +178,11 @@ pub struct ZdpA2aHeader {
 
 /// Config-specified size of A2A MAC.  Algorithm-specified MAC may be smaller (but not larger).
 pub const ZDP_A2A_MAC_SIZE: usize = 8;
+
+
+/// Size of the ZDP "link" HMAC which is set link-by-link for transit packets.
+/// This HMAC is tacked on to the end of the packet (following the A2A HMAC).
+pub const ZDP_PACKET_MAC_SIZE: usize = 8;
 
 const _: () = assert!(core::mem::size_of::<ZdpBaseHeader>() == 4);
 const _: () = assert!(core::mem::size_of::<ZdpPerFlowHeader>() == 4);

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -106,7 +106,6 @@ pub struct ZdpPerFlowHeader {
     pub stream_id: U32,
 }
 
-
 #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
 #[repr(packed)]
 pub struct ZdpEchoHeader {
@@ -178,7 +177,6 @@ pub struct ZdpA2aHeader {
 
 /// Config-specified size of A2A MAC.  Algorithm-specified MAC may be smaller (but not larger).
 pub const ZDP_A2A_MAC_SIZE: usize = 8;
-
 
 /// Size of the ZDP "link" HMAC which is set link-by-link for transit packets.
 /// This HMAC is tacked on to the end of the packet (following the A2A HMAC).


### PR DESCRIPTION
Fill in code for encrypt_hmac and decrypt_hmac.

Puts 8 byte HMAC on end of transit packets.