### PR TITLE
store first packet on a new stream until bind completes

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -42,17 +42,23 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
 
     // just extract 5t and drop packet for now, storing & resending it later is a TODO
     let five_tuple = *pkt.metadata().five_tuple();
-    fastpath::drop_and_count(asm, pkt, CounterType::DroppedAwaitingBind);
 
     // if there's already an entry, this is a duplicate request
     // (NOTE: we should be the only ones modifying this table!)
     if asm.alt.get(&five_tuple).is_some() {
+        fastpath::drop_and_count(asm, pkt, CounterType::DroppedAwaitingBind);
         return;
     }
 
     // mark ALT entry as pending to attempt to (i.e. racily) prevent
     // fastpath from issuing multiple requests
-    asm.alt.insert(five_tuple, AltEntry::Pending);
+    asm.alt.insert(
+        five_tuple,
+        AltEntry::Pending {
+            initial_packet: pkt,
+            more_packets_seen: false.into(),
+        },
+    );
 
     // compress only IP addresses for now
     let compression_mode: zpr::CompressionMode = 0;
@@ -78,15 +84,38 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
                 "{}: Bind of {} succeeded: {}",
                 asm.system_name, five_tuple, tether_id
             );
-            asm.alt
+
+            let AltEntry::Pending {
+                initial_packet,
+                more_packets_seen,
+            } = asm
+                .alt
                 .alter(&five_tuple, |entry| {
-                    assert!(matches!(entry, AltEntry::Pending));
-                    *entry = AltEntry::Active(AltPep {
-                        compression_mode,
-                        tether_id,
-                    });
+                    std::mem::replace(
+                        entry,
+                        AltEntry::Active(AltPep {
+                            compression_mode,
+                            tether_id,
+                        }),
+                    )
                 })
-                .unwrap();
+                .unwrap()
+            else {
+                panic!("coding error: race to activate pending ALT entry");
+            };
+
+            if more_packets_seen.into_inner() {
+                // don't bother re-sending this initial packet; it's already out-of-order
+                // and the upper-layer protocol is seemingly chatty & will try again
+                fastpath::drop_and_count(asm, initial_packet, CounterType::DroppedAwaitingBind);
+            } else {
+                // no more packets seen, this initial one is probably important, let's send it on now
+                fastpath::agent_output_post_classify(
+                    asm,
+                    initial_packet,
+                    /* allow_bind_request */ false,
+                );
+            }
         }
 
         Err(err) => {

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -40,15 +40,17 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
         return;
     }
 
-    // just extract 5t and drop packet for now, storing & resending it later is a TODO
-    let five_tuple = *pkt.metadata().five_tuple();
+    let five_tuple = pkt.metadata().five_tuple();
 
     // if there's already an entry, this is a duplicate request
     // (NOTE: we should be the only ones modifying this table!)
-    if asm.alt.get(&five_tuple).is_some() {
+    if asm.alt.get(five_tuple).is_some() {
         fastpath::drop_and_count(asm, pkt, CounterType::DroppedAwaitingBind);
         return;
     }
+
+    // copy out five tuple so we can give away packet
+    let five_tuple = *five_tuple;
 
     // mark ALT entry as pending to attempt to (i.e. racily) prevent
     // fastpath from issuing multiple requests
@@ -91,6 +93,8 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
             } = asm
                 .alt
                 .alter(&five_tuple, |entry| {
+                    assert!(matches!(entry, AltEntry::Pending { .. }), "coding error: race to activate pending ALT entry");
+
                     std::mem::replace(
                         entry,
                         AltEntry::Active(AltPep {
@@ -100,9 +104,7 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
                     )
                 })
                 .unwrap()
-            else {
-                panic!("coding error: race to activate pending ALT entry");
-            };
+            else { unreachable!(); };
 
             if more_packets_seen.into_inner() {
                 // don't bother re-sending this initial packet; it's already out-of-order

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -93,7 +93,10 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
             } = asm
                 .alt
                 .alter(&five_tuple, |entry| {
-                    assert!(matches!(entry, AltEntry::Pending { .. }), "coding error: race to activate pending ALT entry");
+                    assert!(
+                        matches!(entry, AltEntry::Pending { .. }),
+                        "coding error: race to activate pending ALT entry"
+                    );
 
                     std::mem::replace(
                         entry,
@@ -104,7 +107,9 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
                     )
                 })
                 .unwrap()
-            else { unreachable!(); };
+            else {
+                unreachable!();
+            };
 
             if more_packets_seen.into_inner() {
                 // don't bother re-sending this initial packet; it's already out-of-order

--- a/adapter/ph/src/adapter_tables.rs
+++ b/adapter/ph/src/adapter_tables.rs
@@ -5,12 +5,13 @@
 #![allow(dead_code)]
 
 use crate::defs::FiveTuple;
+use crate::packet::Packet;
 use crate::rcu::{RcuBox, RcuGuard};
 use crate::zpr::{CompressionMode, StreamId};
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::mapref::one::Ref as DashMapRef;
 use dashmap::DashMap;
-use std::sync::Mutex;
+use std::sync::{atomic, Mutex};
 
 const DOCK_LOOKUP_TABLE_SIZE: usize = 1 << 20; // 1 million
 
@@ -20,27 +21,29 @@ pub struct AltPep {
     pub tether_id: StreamId,
 }
 
-#[derive(Clone, Copy)]
-pub enum AltEntry {
+pub enum AltEntry<'pktbuf> {
     Active(AltPep),
-    Pending,
+    Pending {
+        initial_packet: Packet<'pktbuf>,
+        more_packets_seen: atomic::AtomicBool,
+    },
 }
 
-pub struct AgentLookupTable {
-    table: DashMap<FiveTuple, AltEntry>,
+pub struct AgentLookupTable<'pktbuf> {
+    table: DashMap<FiveTuple, AltEntry<'pktbuf>>,
 }
 
-pub struct AltEntryGuard<'a>(DashMapRef<'a, FiveTuple, AltEntry>);
+pub struct AltEntryGuard<'a, 'pktbuf>(DashMapRef<'a, FiveTuple, AltEntry<'pktbuf>>);
 
-impl std::ops::Deref for AltEntryGuard<'_> {
-    type Target = AltEntry;
+impl<'pktbuf> std::ops::Deref for AltEntryGuard<'_, 'pktbuf> {
+    type Target = AltEntry<'pktbuf>;
 
     fn deref(&self) -> &Self::Target {
         self.0.deref()
     }
 }
 
-impl AgentLookupTable {
+impl<'pktbuf> AgentLookupTable<'pktbuf> {
     pub fn new() -> Self {
         Self {
             table: DashMap::new(),
@@ -51,17 +54,17 @@ impl AgentLookupTable {
     pub fn inspect<T>(
         &self,
         five_tuple: &FiveTuple,
-        inspector: impl FnOnce(&AltEntry) -> T,
+        inspector: impl FnOnce(&AltEntry<'pktbuf>) -> T,
     ) -> Option<T> {
         self.table.get(five_tuple).map(|entry| inspector(&*entry))
     }
 
-    pub fn get(&self, five_tuple: &FiveTuple) -> Option<AltEntryGuard<'_>> {
+    pub fn get(&self, five_tuple: &FiveTuple) -> Option<AltEntryGuard<'_, 'pktbuf>> {
         self.table.get(five_tuple).map(AltEntryGuard)
     }
 
     // FIXME: ideally we want `try_insert()` but dashmap doesn't support that…
-    pub fn insert(&self, five_tuple: FiveTuple, entry: AltEntry) {
+    pub fn insert(&self, five_tuple: FiveTuple, entry: AltEntry<'pktbuf>) {
         self.table.insert(five_tuple, entry);
     }
 
@@ -73,7 +76,7 @@ impl AgentLookupTable {
     pub fn alter<T>(
         &self,
         five_tuple: &FiveTuple,
-        alterer: impl FnOnce(&mut AltEntry) -> T,
+        alterer: impl FnOnce(&mut AltEntry<'pktbuf>) -> T,
     ) -> Result<T, ()> {
         match self.table.get_mut(five_tuple) {
             Some(mut ref_) => Ok(alterer(ref_.value_mut())),

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -64,7 +64,7 @@ pub struct Assembly<'pktbuf> {
 
     // Adapter tables
     // NOTE: only adapter_manager_worker should modify these tables!
-    pub alt: adapter_tables::AgentLookupTable,
+    pub alt: adapter_tables::AgentLookupTable<'pktbuf>,
     pub dlt: adapter_tables::DockLookupTable,
 
     pub adapter_manager: AdapterManager<'pktbuf>,
@@ -136,7 +136,7 @@ pub mod test {
         pub tun_ctl: Option<Box<dyn TunCtl + 'a>>,
         pub peer_table: Option<peer_table::PeerTable<'a>>,
         pub peer_ids: Option<Vec<zpr::LinkId>>,
-        pub alt: Option<adapter_tables::AgentLookupTable>,
+        pub alt: Option<adapter_tables::AgentLookupTable<'a>>,
         pub dlt: Option<adapter_tables::DockLookupTable>,
         pub adapter_manager: Option<AdapterManager<'a>>,
         pub km_state: Option<KmState>,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -22,6 +22,7 @@ use crate::zpr;
 use crate::{compress, km};
 use blake3;
 use bytes::{Buf, BufMut};
+use std::sync::atomic;
 use std::time::SystemTime;
 use tracing::{debug, error, info, warn};
 use zerocopy::FromBytes;
@@ -646,42 +647,72 @@ pub fn agent_output<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) 
         }
     }
 
+    agent_output_post_classify(asm, pkt, /* allow_bind_request */ true);
+}
+
+/// Post-classification portion of `agent_output` function.  Used for
+/// re-injecting already-classified packets e.g.  which were held awaiting
+/// bind.  `allow_bind_request` should be true for "real" packets; false for
+/// packets re-injected from mgmt plane after fulfilling a bind request (so
+/// as to prevent the theoretical possibility of a packet loop).
+pub fn agent_output_post_classify<'pktbuf>(
+    asm: &Assembly<'pktbuf>,
+    mut pkt: Packet<'pktbuf>,
+    allow_bind_request: bool,
+) {
     let five_tuple = *pkt.metadata().five_tuple(); // TODO: convince borrow checker we don't need to copy this out
 
     // lookup five tuple in ALT
-    match asm.alt.inspect(&five_tuple, |entry| *entry) {
-        Some(AltEntry::Active(pep)) => {
-            // compute A2A MAC
-            // TODO: use actual A2A SAID & keyed hash
-            let a2a_said: zpr::A2aSaid = 0;
-            let a2a_mac_size = zdp::ZDP_A2A_MAC_SIZE; // TODO: may be smaller depending on A2A SAID
-            let mut a2a_mac = [0u8; zdp::ZDP_A2A_MAC_SIZE];
-            // SECURITY: truncating BLAKE3 is safe
-            a2a_mac[..a2a_mac_size]
-                .copy_from_slice(&blake3::hash(pkt.body()).as_bytes()[..a2a_mac_size]);
+    match asm.alt.get(&five_tuple) {
+        Some(entry) => match &*entry {
+            AltEntry::Active(pep) => {
+                // compute A2A MAC
+                // TODO: use actual A2A SAID & keyed hash
+                let a2a_said: zpr::A2aSaid = 0;
+                let a2a_mac_size = zdp::ZDP_A2A_MAC_SIZE; // TODO: may be smaller depending on A2A SAID
+                let mut a2a_mac = [0u8; zdp::ZDP_A2A_MAC_SIZE];
+                // SECURITY: truncating BLAKE3 is safe
+                a2a_mac[..a2a_mac_size]
+                    .copy_from_slice(&blake3::hash(pkt.body()).as_bytes()[..a2a_mac_size]);
 
-            // compress packet
-            compress::compress(
-                pep.compression_mode,
-                five_tuple.l3_type,
-                five_tuple.l4_protocol,
-                &mut pkt,
-            );
+                // compress packet
+                compress::compress(
+                    pep.compression_mode,
+                    five_tuple.l3_type,
+                    five_tuple.l4_protocol,
+                    &mut pkt,
+                );
 
-            // append A2A MAC
-            pkt.put(&a2a_mac[..a2a_mac_size]);
-            pkt.alloc_zeroed_header::<zdp::ZdpA2aHeader>().a2a_said = a2a_said;
+                // append A2A MAC
+                pkt.put(&a2a_mac[..a2a_mac_size]);
+                pkt.alloc_zeroed_header::<zdp::ZdpA2aHeader>().a2a_said = a2a_said;
 
-            // forward packet on
-            forward(asm, zpr::AGENT_LINK_ID, pep.tether_id, pkt);
-        }
+                // forward packet on
+                forward(asm, zpr::AGENT_LINK_ID, pep.tether_id, pkt);
+            }
 
-        Some(AltEntry::Pending) => {
-            // bind request pending; drop this packet
-            drop_and_count(asm, pkt, CounterType::DroppedAwaitingBind);
-        }
+            AltEntry::Pending {
+                more_packets_seen, ..
+            } => {
+                // Bind request pending; mark that the first packet
+                // is no longer important (and therefore shouldn't be re-sent)
+                // and also drop this packet.
+                // NOTE: the atomic ordering here is unimportant, as this
+                // is a best-effort mechanism.  Our behavior is still correct
+                // if this flag is racily read as false.
+                more_packets_seen.store(true, atomic::Ordering::Relaxed);
+                drop_and_count(asm, pkt, CounterType::DroppedAwaitingBind);
+            }
+        },
 
         None => {
+            if !allow_bind_request {
+                // avoid the (all-but purely theoretical) chance of a packet loop,
+                // when this is called from bind setup code
+                drop_and_count(asm, pkt, CounterType::OtherError);
+                return;
+            }
+
             // issue bind request
             match asm.adapter_manager.try_request_tether_id(pkt) {
                 Ok(()) => (),


### PR DESCRIPTION
This solves the "first packet" problem, which, beside categorically slowing down TCP (due to long ACK timeouts), also completely broke DNS over UDP (since each retry uses a fresh source port).

The solution is simple -- store the first packet with the "pending" entry in the ALT, and send it once the bind completes.

As an extra nicety, if another packet is seen in the interim, the initial packet is flagged as no longer needed, causing it to be dropped rather than sent when the bind completes.  (It's not dropped immediately to avoid the extra overhead of synchronizing with the mgmt plane.)  This is a trivial mechanism which avoids sending a now out-of-order packet which apparently is not missed anyway.

Basic test shows all packets passing now.  (Haven't tested with DNS yet but I expect it to work.)