### PR TITLE
fix the --disable-km flag

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -62,7 +62,9 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
 
     // NOPE ! not if the link is not ready.
     let link_id = asm.hack_get_adapter_docking_session_id();
-    if !asm.flags.disable_key_management  && !asm.peer_table.is_security_assocaition_established(link_id) {
+    if !asm.flags.disable_key_management
+        && !asm.peer_table.is_security_assocaition_established(link_id)
+    {
         error!(
             "{}: Link {} has no security association, aborting bind request operation",
             asm.system_name, link_id

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -62,7 +62,7 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
 
     // NOPE ! not if the link is not ready.
     let link_id = asm.hack_get_adapter_docking_session_id();
-    if !asm.peer_table.is_security_assocaition_established(link_id) {
+    if !asm.flags.disable_key_management  && !asm.peer_table.is_security_assocaition_established(link_id) {
         error!(
             "{}: Link {} has no security association, aborting bind request operation",
             asm.system_name, link_id

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -74,6 +74,7 @@ pub struct Assembly<'pktbuf> {
 pub struct PhFlags {
     /// If set TRUE this allows any messages on ZPI 0.  VERY INSECURE!!
     pub allow_insecure_zpi_zero: bool,
+    pub disable_key_management: bool,
 }
 
 impl Default for PhFlags {
@@ -81,6 +82,7 @@ impl Default for PhFlags {
     fn default() -> Self {
         Self {
             allow_insecure_zpi_zero: false,
+            disable_key_management: false,
         }
     }
 }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -134,7 +134,11 @@ fn main() -> ExitCode {
     let _cert_file = cmd_line.certificate_file;
     let _priv_key_file = cmd_line.private_key_file;
     let disable_km = cmd_line.disable_km;
-    let allow_insecure_zpi_zero = if disable_km { true } else { cmd_line.allow_insecure_zpi_zero };
+    let allow_insecure_zpi_zero = if disable_km {
+        true
+    } else {
+        cmd_line.allow_insecure_zpi_zero
+    };
     if allow_insecure_zpi_zero {
         warn!(
             "Insecure ZPI ZERO is enabled.  This is insecure and should only be used for testing."

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -134,7 +134,7 @@ fn main() -> ExitCode {
     let _cert_file = cmd_line.certificate_file;
     let _priv_key_file = cmd_line.private_key_file;
     let disable_km = cmd_line.disable_km;
-    let allow_insecure_zpi_zero = cmd_line.allow_insecure_zpi_zero;
+    let allow_insecure_zpi_zero = if disable_km { true } else { cmd_line.allow_insecure_zpi_zero };
     if allow_insecure_zpi_zero {
         warn!(
             "Insecure ZPI ZERO is enabled.  This is insecure and should only be used for testing."
@@ -316,6 +316,7 @@ fn main() -> ExitCode {
 
     let mut flags: PhFlags = Default::default();
     flags.allow_insecure_zpi_zero = allow_insecure_zpi_zero;
+    flags.disable_key_management = disable_km;
 
     // TEMP HACK to statically install peers
     let asm = Box::leak(Box::new(Assembly {
@@ -473,23 +474,25 @@ fn main() -> ExitCode {
 
         if matches!(ph_mode, PhMode::Adapter) {
             let dsid = asm.hack_get_adapter_docking_session_id();
-            info!(
-                "{}: waiting on security assocaition establishment on link {}",
-                asm.system_name, dsid
-            );
-            while !asm.peer_table.is_security_assocaition_established(dsid) {
-                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            }
-            info!(
-                "{}: security assocaition established successfully on link {}",
-                asm.system_name, dsid
-            );
+            if !disable_km {
+                info!(
+                    "{}: waiting on security assocaition establishment on link {}",
+                    asm.system_name, dsid
+                );
+                while !asm.peer_table.is_security_assocaition_established(dsid) {
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                }
+                info!(
+                    "{}: security assocaition established successfully on link {}",
+                    asm.system_name, dsid
+                );
 
-            // HACK - In our tests we need to send from adapter through the node to the adapter.
-            // We do not know when the other adapter has setup its association. So lets give
-            // it a little time here.
-            info!("{}: waiting for the other adapter to (hopfully) establish its security association...", asm.system_name);
-            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                // HACK - In our tests we need to send from adapter through the node to the adapter.
+                // We do not know when the other adapter has setup its association. So lets give
+                // it a little time here.
+                info!("{}: waiting for the other adapter to (hopfully) establish its security association...", asm.system_name);
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            }
 
 
             mgmt::send_report(asm, dsid, "Reporting for Duty!").await;


### PR DESCRIPTION
If you want to disable key management you can use this flag. No need to also use the allow-insecure-zpi-0 flag since that is now implied.