### PR TITLE
more better test script logging

### DIFF
--- a/.github/workflows/rust-adapter.yml
+++ b/.github/workflows/rust-adapter.yml
@@ -153,7 +153,7 @@ jobs:
       run: |
         cd adapter/ph
         cargo build
-        test/basic-test.sh
+        ZPR_TEST_VERBOSE=1 test/basic-test.sh
 
   capture-integration-test:
     needs: [ph-build, ph-debug-build]
@@ -167,4 +167,4 @@ jobs:
         sudo apt update
         sudo apt install libpcap-dev
         cargo build --manifest-path ../ph-debug/Cargo.toml
-        test/capture-test.sh
+        ZPR_TEST_VERBOSE=1 test/capture-test.sh

--- a/adapter/ph/test/basic-test.sh
+++ b/adapter/ph/test/basic-test.sh
@@ -60,7 +60,7 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
      --self-addr 0.0.0.0:12345 --peer-addr1 "$A_SUBSTRATE_ADDR":12345 \
      --peer-addr2 "$B_SUBSTRATE_ADDR":12345 \
      --ca-file ca.crt --certificate-file node.crt --private-key-file node.key \
-     --tun-if tun0 >node.log 2>&1 &
+     --tun-if tun0 2>&1 |tee node.log &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 sleep 2
@@ -69,7 +69,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_A":12345 \
   --ca-file ca.crt --certificate-file adapter1.crt --private-key-file adapter1.key \
-  --tun-if tun0 >zpr-a.log 2>&1 &
+  --tun-if tun0 2>&1 |tee zpr-a.log &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 
@@ -77,7 +77,7 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-b" --control-path "$ADAPTER2_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_B":12345 \
   --ca-file ca.crt --certificate-file adapter2.crt --private-key-file adapter2.key \
-  --tun-if tun0 > zpr-b.log 2>&1 &
+  --tun-if tun0 2>&1 |tee zpr-b.log &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 

--- a/adapter/ph/test/basic-test.sh
+++ b/adapter/ph/test/basic-test.sh
@@ -60,7 +60,7 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
      --self-addr 0.0.0.0:12345 --peer-addr1 "$A_SUBSTRATE_ADDR":12345 \
      --peer-addr2 "$B_SUBSTRATE_ADDR":12345 \
      --ca-file ca.crt --certificate-file node.crt --private-key-file node.key \
-     --tun-if tun0 &
+     --tun-if tun0 >node.log 2>&1 &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 sleep 2
@@ -69,7 +69,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_A":12345 \
   --ca-file ca.crt --certificate-file adapter1.crt --private-key-file adapter1.key \
-  --tun-if tun0 &
+  --tun-if tun0 >zpr-a.log 2>&1 &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 
@@ -77,7 +77,7 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-b" --control-path "$ADAPTER2_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_B":12345 \
   --ca-file ca.crt --certificate-file adapter2.crt --private-key-file adapter2.key \
-  --tun-if tun0 &
+  --tun-if tun0 > zpr-b.log 2>&1 &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 
@@ -95,27 +95,10 @@ echo "Carrier has arrived."
 stty sane || true
 
 
-echo "=========================================================="
-echo "=========================================================="
-echo "=========================================================="
-echo "=========================================================="
 echo "PAUSING FOR KEY MANAGEMENT EXCHANGE ..."
-echo "=========================================================="
-echo "=========================================================="
-echo "=========================================================="
-echo "=========================================================="
-sleep 10
+countdown 10
 
-
-echo "=========================================================="
-echo "=========================================================="
-echo "=========================================================="
-echo "=========================================================="
 echo "TEST STARTING"
-echo "=========================================================="
-echo "=========================================================="
-echo "=========================================================="
-echo "=========================================================="
 
 
 #

--- a/adapter/ph/test/capture-test.sh
+++ b/adapter/ph/test/capture-test.sh
@@ -25,6 +25,8 @@ ADAPTER1_SOCK=adapter1.sock
 ADAPTER2_SOCK=adapter2.sock
 NODE_SOCK=node.sock
 
+SHOW_CAPTURE="${ZPR_TEST_VERBOSE:-no}"
+
 #
 # Helper functions
 #
@@ -76,7 +78,7 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --self-addr 0.0.0.0:12345 --peer-addr1 "$A_SUBSTRATE_ADDR":12345 \
   --peer-addr2 "$B_SUBSTRATE_ADDR":12345 \
   --ca-file ca.crt --certificate-file node.crt --private-key-file node.key \
-  --tun-if tun0 &
+  --tun-if tun0 >node.log 2>&1 &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 sleep 2
@@ -85,14 +87,14 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_A":12345 \
   --ca-file ca.crt --certificate-file adapter1.crt --private-key-file adapter1.key \
-  --tun-if tun0 &
+  --tun-if tun0 >zpr-a.log 2>&1 &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-b" --control-path "$ADAPTER2_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_B":12345 \
   --ca-file ca.crt --certificate-file adapter2.crt --private-key-file adapter2.key \
-  --tun-if tun0 &
+  --tun-if tun0 >zpr-b.log 2>&1 &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 sleep 1 # FIXME: I think we need this b/c DTLS doesn't deal with dropped initial packet well
@@ -121,8 +123,8 @@ stty sane || true
 
 set_program "$ADAPTER2_SOCK" "$TMPDIR/cap_test2.pcap" None
 
-echo "wait for KM"
-sleep 7
+echo "pausing for key management exchange..."
+countdown 7
 
 echo "starting PING test..."
 
@@ -142,10 +144,11 @@ tcpdump -r "$TMPDIR/cap_test1.pcap" 'link[0] = 1 or link[0] == 0' >"$TMPDIR/chec
 MGMT_PACKET_COUNT="$(grep -c '0x0105: ' "$TMPDIR/checker.txt" || echo 0)"
 AGENT_PACKET_COUNT="$(grep -c '0x0106: ' "$TMPDIR/checker.txt" || echo 0)"
 
-echo "============================= CHECKER"
-cat "$TMPDIR/checker.txt"
-
-echo
+if [ "$SHOW_CAPTURE" != "no" ]; then
+  echo -e "\n============================= CHECKER\n"
+  cat "$TMPDIR/checker.txt"
+  echo
+fi
 
 if [[ MGMT_PACKET_COUNT == 0 || AGENT_PACKET_COUNT == 0 ]]; then
   PASS=1

--- a/adapter/ph/test/capture-test.sh
+++ b/adapter/ph/test/capture-test.sh
@@ -124,7 +124,7 @@ stty sane || true
 set_program "$ADAPTER2_SOCK" "$TMPDIR/cap_test2.pcap" None
 
 echo "pausing for key management exchange..."
-countdown 7
+countdown 10
 
 echo "starting PING test..."
 

--- a/adapter/ph/test/capture-test.sh
+++ b/adapter/ph/test/capture-test.sh
@@ -78,7 +78,7 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --self-addr 0.0.0.0:12345 --peer-addr1 "$A_SUBSTRATE_ADDR":12345 \
   --peer-addr2 "$B_SUBSTRATE_ADDR":12345 \
   --ca-file ca.crt --certificate-file node.crt --private-key-file node.key \
-  --tun-if tun0 >node.log 2>&1 &
+  --tun-if tun0 2>&1 |tee node.log &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 sleep 2
@@ -87,14 +87,14 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_A":12345 \
   --ca-file ca.crt --certificate-file adapter1.crt --private-key-file adapter1.key \
-  --tun-if tun0 >zpr-a.log 2>&1 &
+  --tun-if tun0 2>&1 |tee zpr-a.log &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-b" --control-path "$ADAPTER2_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_B":12345 \
   --ca-file ca.crt --certificate-file adapter2.crt --private-key-file adapter2.key \
-  --tun-if tun0 >zpr-b.log 2>&1 &
+  --tun-if tun0 2>&1 |tee zpr-b.log &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 sleep 1 # FIXME: I think we need this b/c DTLS doesn't deal with dropped initial packet well

--- a/adapter/ph/test/common_funcs.sh
+++ b/adapter/ph/test/common_funcs.sh
@@ -107,6 +107,7 @@ function check_carrier() {
   return $(( ! $(sudo ip netns exec "$NETNS" cat "/sys/class/net/$IF/carrier") ))
 }
 
+# Visible sleep for n seconds.  Takes one arg: number of seconds.
 function countdown() {
     count=$1
     (( ++count ))

--- a/adapter/ph/test/common_funcs.sh
+++ b/adapter/ph/test/common_funcs.sh
@@ -107,6 +107,29 @@ function check_carrier() {
   return $(( ! $(sudo ip netns exec "$NETNS" cat "/sys/class/net/$IF/carrier") ))
 }
 
+function countdown() {
+    count=$1
+    (( ++count ))
+    while (( --count > 0 )); do
+        echo -n "$count...   "
+        sleep 1
+    done
+    echo
+}
+
+
+# Takes one arg- filepath relative to TMPDIR
+function emitlog() {
+    echo -e "\n\n==== $1 ====\n"
+    if [ -e "$TMPDIR/$1" ]
+        then
+            cat "$TMPDIR/$1"
+        else
+            echo "(MISSING)"
+    fi
+}
+
+
 function cleanup() {
   for child in $(jobs -p)
   do kill -9 "$child" 2> /dev/null || true
@@ -115,6 +138,15 @@ function cleanup() {
   wait -f
 
   destroy_network || true
+
+  SHOW_LOGS="${ZPR_TEST_VERBOSE:-no}"
+
+  if [ "$SHOW_LOGS" != "no" ]
+     then
+         emitlog "node.log"
+         emitlog "zpr-a.log"
+         emitlog "zpr-b.log"
+  fi
 
   popd > /dev/null
   rm -r "$TMPDIR" || true


### PR DESCRIPTION
This routes the stdout/stderr from the PH instances in the tests into their own files.  If you want to see the output (which happens at the end) you must pass ZPR_TEST_VERBOSE=1 when you run the script.

Eg,
`sudo ZPR_TEST_VERBOSE=1 ./basic-test.sh`

I think this is far clearer than just mushing all the output together.