### PR TITLE
Better integrate key management state into peer table

### DIFF
--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -28,6 +28,7 @@ pub enum KmMsgProcessingError {
 #[derive(Debug)]
 pub enum KmSetupError {
     InitializationError(KmError),
+    LinkNotFound,
 }
 
 /// Global state for the KM system.
@@ -204,6 +205,8 @@ where
 ///
 /// - `link_id` is the link to the peer, in this case better be a link to a node.
 /// - `peer_noise_key` is the public noise key for the node/dock.
+///
+/// Note that the link must already have a peer_table entry.
 pub fn add_adapter_link(
     asm: &'static Assembly,
     link_id: zpr::LinkId,
@@ -230,6 +233,8 @@ pub fn add_adapter_link(
 ///
 /// - `link_id` is the link to the peer, in this case better be a link to an adapter.
 /// - `local_noise_key` is the local noise key for the dock (public part of this key must be shared out of band with adapters).
+///
+/// Note that the link must already have a peer_table entry.
 #[allow(dead_code)]
 pub fn add_node_link(
     asm: &'static Assembly,
@@ -279,7 +284,11 @@ fn add_noise_link(
 ) -> Result<(), KmSetupError> {
     let mgr = KeyManager::new(link_id, Box::new(noise));
 
-    asm.peer_table.init_security_association(link_id);
+    // Link must already have a table entry
+    assert!(
+        asm.peer_table.get(link_id).is_some(),
+        "link_id must be in peer_table before adding key management"
+    );
 
     let mut spawn_mgr = mgr.clone();
     let child_ctok = asm.km_state.ctok.child_token();
@@ -305,9 +314,9 @@ fn add_noise_link(
         mgr,
     };
 
-    asm.peer_table.set_km_handle(link_id, handle);
-
-    Ok(())
+    asm.peer_table
+        .set_km_handle(link_id, handle)
+        .or(Err(KmSetupError::LinkNotFound))
 }
 
 /// When an inbound key management ZDP message arrives on a link, send it here after parsing.
@@ -350,9 +359,12 @@ mod test {
     use crate::config;
     use crate::km::KmLinkMsg;
     use crate::km_noise;
+    use crate::mgmt_processor_worker;
+    use crate::peer_table;
     use base64::prelude::*;
+    use std::net::{IpAddr, Ipv4Addr};
     use std::time::Duration;
-    use tokio::task::yield_now;
+    use tokio::task::{self, yield_now};
     use tokio::time::timeout;
 
     #[tokio::test]
@@ -383,74 +395,101 @@ mod test {
 
         let asm = Box::leak(Box::new(create_assembly(builder)));
 
-        // add a fake adapter.
-        let adapter_link_id = 27;
+        // Create this local "taskset" becuase adding an entry to the peer table ends up
+        // calling `spawn_local`.  Not sure I need the whole rest of this unit test in here
+        // but does appear to work.  Note that default tokio unit test runtime is
+        // single-threaded.
 
-        // Adding a link starts a KM
-        add_adapter_link(asm, adapter_link_id, ZPIPair::new(1, 2), nk_public).unwrap();
+        let local = task::LocalSet::new();
+        local
+            .run_until(async move {
+                // add a fake adapter.
+                let adapter_link_id: zpr::LinkId;
+                {
+                    let entry = asm.peer_table.vacant_entry().unwrap();
 
-        yield_now().await;
+                    let worker_config = mgmt_processor_worker::Config {
+                        link_id: entry.key(),
+                    };
 
-        // Start our multiplexor worker
-        tokio::spawn(launch_signal_worker(&*asm, km_sig_rx));
-        yield_now().await;
+                    let fake_sa =
+                        zpr::SubstrateAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9000);
 
-        // An adapter should send a KM message over link 1.
-        let handshake_req: Bytes;
-        match timeout(Duration::from_secs(2), km_rx.recv()).await {
-            Ok(resp) => match resp {
-                Some(KmLinkMsg { link_id, msg }) => {
-                    assert_eq!(link_id, adapter_link_id);
-                    assert_eq!(msg.len(), 130); // should be a KM payload
-                    handshake_req = msg;
+                    let peer_state =
+                        peer_table::PeerState::new(peer_table::PeerType::Adapter, fake_sa, |q| {
+                            mgmt_processor_worker::launch(&worker_config, &*asm, q)
+                        });
+
+                    adapter_link_id = entry.insert(peer_state);
                 }
-                None => panic!("Expected KMLinkMessage message"),
-            },
-            Err(_) => panic!("Timed out waiting for KM message"),
-        }
 
-        // Check that initially, our state is not established.
-        {
-            assert!(!asm
-                .peer_table
-                .is_security_assocaition_established(adapter_link_id))
-        }
+                // Adding a link starts a KM
+                add_adapter_link(asm, adapter_link_id, ZPIPair::new(1, 2), nk_public).unwrap();
 
-        // Pretend to be a node and send back a valid reply.
-        let mut responder = KmNoise::new(false, None, Some(node_kp), 3, 4).unwrap();
-        match responder.reset() {
-            Ok(Some(_m)) => panic!("unexpected message from responder.reset!"),
-            Ok(None) => {} // good
-            Err(e) => {
-                panic!("error resetting responder: {:?}", e);
-            }
-        };
+                yield_now().await;
 
-        // Since we have a "raw" responder, we can just pass the payload (no ZDP headers have been added).
-        let handshake_reply = match responder.handle_message(&handshake_req) {
-            Ok(Some(m)) => m,
-            Ok(None) => {
-                panic!("expected handshake-1 message, got nothing!");
-            }
-            Err(e) => {
-                panic!("responder handle_message failed on handshake-req: {:?}", e);
-            }
-        };
+                // Start our multiplexor worker
+                tokio::spawn(launch_signal_worker(&*asm, km_sig_rx));
+                yield_now().await;
 
-        // Now send the reply back into our link.
-        handle_inbound_km_msg(asm, adapter_link_id, &handshake_reply).unwrap();
+                // An adapter should send a KM message over link 1.
+                let handshake_req: Bytes;
+                match timeout(Duration::from_secs(2), km_rx.recv()).await {
+                    Ok(resp) => match resp {
+                        Some(KmLinkMsg { link_id, msg }) => {
+                            assert_eq!(link_id, adapter_link_id);
+                            assert_eq!(msg.len(), 130); // should be a KM payload
+                            handshake_req = msg;
+                        }
+                        None => panic!("Expected KMLinkMessage message"),
+                    },
+                    Err(_) => panic!("Timed out waiting for KM message"),
+                }
 
-        yield_now().await;
+                // Check that initially, our state is not established.
+                {
+                    assert!(!asm
+                        .peer_table
+                        .is_security_assocaition_established(adapter_link_id))
+                }
 
-        // The KM on the link will process the message and transition to established-state.
-        // It will send two signals - SaIdChange followed by SaEstablished.  Both signals
-        // are picked up by our multiplexor worker.  The second one triggers a state update.
-        {
-            assert!(asm
-                .peer_table
-                .is_security_assocaition_established(adapter_link_id))
-        }
+                // Pretend to be a node and send back a valid reply.
+                let mut responder = KmNoise::new(false, None, Some(node_kp), 3, 4).unwrap();
+                match responder.reset() {
+                    Ok(Some(_m)) => panic!("unexpected message from responder.reset!"),
+                    Ok(None) => {} // good
+                    Err(e) => {
+                        panic!("error resetting responder: {:?}", e);
+                    }
+                };
 
-        drop_link(asm, adapter_link_id).await;
+                // Since we have a "raw" responder, we can just pass the payload (no ZDP headers have been added).
+                let handshake_reply = match responder.handle_message(&handshake_req) {
+                    Ok(Some(m)) => m,
+                    Ok(None) => {
+                        panic!("expected handshake-1 message, got nothing!");
+                    }
+                    Err(e) => {
+                        panic!("responder handle_message failed on handshake-req: {:?}", e);
+                    }
+                };
+
+                // Now send the reply back into our link.
+                handle_inbound_km_msg(asm, adapter_link_id, &handshake_reply).unwrap();
+
+                yield_now().await;
+
+                // The KM on the link will process the message and transition to established-state.
+                // It will send two signals - SaIdChange followed by SaEstablished.  Both signals
+                // are picked up by our multiplexor worker.  The second one triggers a state update.
+                {
+                    assert!(asm
+                        .peer_table
+                        .is_security_assocaition_established(adapter_link_id))
+                }
+
+                drop_link(asm, adapter_link_id).await;
+            })
+            .await;
     }
 }

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use crate::dock_tables::DockForwardingTable;
-use crate::km::{KeyManager, KmTransportSA, UnimplCodec, ZPIPair};
+use crate::km::{KeyManager, KmTransportSA};
 use crate::queues;
 use crate::rcu::{RcuBox, RcuGuard};
 use crate::sync_req;
@@ -8,9 +8,6 @@ use crate::zpr::{LinkId, SubstrateAddr};
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::DashMap;
 use std::future::Future;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
 use tokio::sync::mpsc;
@@ -44,8 +41,7 @@ pub struct PeerState<'pktbuf> {
 // Key Management state per peer.
 struct PeerKmState {
     handle: Mutex<Option<KmHandle>>, // Once the KM state machine starts, it's join handle and related info is stashed here.
-    sa_established: AtomicBool,      // if TRUE then `transport_sa` is valid
-    transport_sa: RcuBox<KmTransportSA>,
+    transport_sa: RcuBox<Option<KmTransportSA>>,
 }
 
 /// The Key Management "handle" is used by the km_multiplexor to hold per-link
@@ -61,15 +57,7 @@ impl PeerKmState {
     fn new() -> Self {
         Self {
             handle: Mutex::new(None),
-            sa_established: AtomicBool::new(false),
-            transport_sa: RcuBox::new(KmTransportSA {
-                sa_id: 0,
-                recv_zpis: ZPIPair::new_zero(),
-                send_zpis: ZPIPair::new_zero(),
-                send_hmac_key: [0; 32],
-                recv_hmac_key: [0; 32],
-                codec: Arc::new(UnimplCodec::new()),
-            }),
+            transport_sa: RcuBox::new(None),
         }
     }
 }
@@ -219,8 +207,7 @@ impl<'pktbuf> PeerTable<'pktbuf> {
         let entry = self
             .get(link_id)
             .ok_or(SecurityAssocaitionStateError::NoAssociationForLink)?;
-        entry.km_state.transport_sa.write(sa);
-        entry.km_state.sa_established.store(true, Ordering::Release);
+        entry.km_state.transport_sa.write(Some(sa));
         Ok(())
     }
 
@@ -249,10 +236,7 @@ impl<'pktbuf> PeerTable<'pktbuf> {
         let entry = self
             .get(link_id)
             .ok_or(SecurityAssocaitionStateError::NoAssociationForLink)?;
-        entry
-            .km_state
-            .sa_established
-            .store(false, Ordering::Release);
+        entry.km_state.transport_sa.write(None);
         Ok(())
     }
 
@@ -261,7 +245,7 @@ impl<'pktbuf> PeerTable<'pktbuf> {
     /// that there is no link found under the ID.
     pub fn is_security_assocaition_established(&self, link_id: LinkId) -> bool {
         if let Some(entry) = self.get(link_id) {
-            return entry.km_state.sa_established.load(Ordering::Acquire);
+            return entry.km_state.transport_sa.get().is_some();
         }
         false
     }
@@ -272,10 +256,11 @@ impl<'pktbuf> PeerTable<'pktbuf> {
         link_id: LinkId,
     ) -> Option<KmTransportSA> {
         let entry = self.get(link_id)?;
-        if entry.km_state.sa_established.load(Ordering::Acquire) {
-            return Some(entry.km_state.transport_sa.get().clone());
+        let tsa = entry.km_state.transport_sa.get();
+        if tsa.is_none() {
+            return None;
         }
-        None
+        tsa.clone()
     }
 
     /// Clone the Key Manager on the link if link exists, and if there is a handle set.
@@ -290,15 +275,10 @@ impl<'pktbuf> PeerTable<'pktbuf> {
     /// Doesn't really _remove_ the state, but does invalidate the security assocation and wipes
     /// the reference to the handle.
     pub fn remove_km_state(&self, link_id: LinkId) -> Option<KmHandle> {
-        let entry = self.get(link_id)?;
+        // If SA is set, un-set it - don't care about errors.
+        let _ = self.clear_security_association(link_id);
 
-        // If SA is set, un-set it.
-        if entry.km_state.sa_established.load(Ordering::Acquire) {
-            entry
-                .km_state
-                .sa_established
-                .store(false, Ordering::Release);
-        }
+        let entry = self.get(link_id)?;
 
         // If there is a handle, remove it and return it.
         let mut handle = entry.km_state.handle.lock().unwrap();

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -38,12 +38,14 @@ pub struct PeerState<'pktbuf> {
     pub dft: DockForwardingTable,
     pub mgmt_processor: queues::MgmtProcessor<'pktbuf>,
     pub mgmt_processor_worker: task::JoinHandle<()>,
+    km_state: PeerKmState,
 }
 
+// Key Management state per peer.
 struct PeerKmState {
-    handle: Option<KmHandle>,
-    sa_established: AtomicBool, // if TRUE then `transport_sa` is valid
-    transport_sa: KmTransportSA,
+    handle: Mutex<Option<KmHandle>>, // Once the KM state machine starts, it's join handle and related info is stashed here.
+    sa_established: AtomicBool,      // if TRUE then `transport_sa` is valid
+    transport_sa: RcuBox<KmTransportSA>,
 }
 
 /// The Key Management "handle" is used by the km_multiplexor to hold per-link
@@ -55,19 +57,19 @@ pub struct KmHandle {
 }
 
 impl PeerKmState {
-    /// Create a new, empty state.
+    /// Create a new, empty state.  This is what is attached to a new PeerTable entry.
     fn new() -> Self {
         Self {
-            handle: None,
+            handle: Mutex::new(None),
             sa_established: AtomicBool::new(false),
-            transport_sa: KmTransportSA {
+            transport_sa: RcuBox::new(KmTransportSA {
                 sa_id: 0,
                 recv_zpis: ZPIPair::new_zero(),
                 send_zpis: ZPIPair::new_zero(),
                 send_hmac_key: [0; 32],
                 recv_hmac_key: [0; 32],
                 codec: Arc::new(UnimplCodec::new()),
-            },
+            }),
         }
     }
 }
@@ -98,6 +100,7 @@ impl PeerState<'static> {
             sync_req_state: sync_req::SyncReqState::new(),
             mgmt_processor,
             mgmt_processor_worker,
+            km_state: PeerKmState::new(),
         }
     }
 }
@@ -106,9 +109,6 @@ pub struct PeerTable<'pktbuf> {
     peer_slab: Mutex<RcuCslab<PeerState<'pktbuf>>>,
     peer_slab_reader: RcuBox<RcuCslabReader<PeerState<'pktbuf>>>,
     sa_to_link: DashMap<SubstrateAddr, LinkId>,
-
-    // TODO: put this into the "peer_state" slab! (https://github.com/org-zpr/zpr-core/issues/388)
-    link_to_km_state: DashMap<LinkId, PeerKmState>,
 }
 
 pub struct PeerStateGuard<'a, 'pktbuf> {
@@ -139,15 +139,10 @@ impl<'pktbuf> PeerTable<'pktbuf> {
         let peer_slab = RcuCslab::with_fixed_capacity(PEER_TABLE_SIZE);
         let peer_slab_reader = RcuBox::new(peer_slab.reader());
         let sa_to_link = DashMap::with_capacity(PEER_TABLE_SIZE);
-        //let link_to_sec_assoc = DashMap::with_capacity(PEER_TABLE_SIZE);
-        //let link_to_km_handle = DashMap::with_capacity(PEER_TABLE_SIZE);
-        let link_to_km_state = DashMap::with_capacity(PEER_TABLE_SIZE);
-
         Self {
             peer_slab: Mutex::new(peer_slab),
             peer_slab_reader,
             sa_to_link,
-            link_to_km_state,
         }
     }
 
@@ -215,37 +210,34 @@ impl<'pktbuf> PeerTable<'pktbuf> {
         })
     }
 
-    /// Initialize state for the security association on the link.  The security association starts out as
-    /// not established.
-    pub fn init_security_association(&self, link_id: LinkId) {
-        if let Some(_) = self.link_to_km_state.insert(link_id, PeerKmState::new()) {
-            panic!("duplicate security association");
-        }
-    }
-
     /// Sets an established security association on the link.
     pub fn set_security_association(
         &self,
         link_id: LinkId,
         sa: KmTransportSA,
     ) -> Result<(), SecurityAssocaitionStateError> {
-        if let Some(mut km_state) = self.link_to_km_state.get_mut(&link_id) {
-            km_state.transport_sa = sa;
-            km_state.sa_established.store(true, Ordering::Release);
-            Ok(())
-        } else {
-            Err(SecurityAssocaitionStateError::NoAssociationForLink)
-        }
+        let entry = self
+            .get(link_id)
+            .ok_or(SecurityAssocaitionStateError::NoAssociationForLink)?;
+        entry.km_state.transport_sa.write(sa);
+        entry.km_state.sa_established.store(true, Ordering::Release);
+        Ok(())
     }
 
     /// At some point shortly after the link security assocaition is initialized, the [km_multiplexor] will
     /// stash its handle in here.
-    pub fn set_km_handle(&self, link_id: LinkId, handle: KmHandle) {
-        if let Some(mut km_state) = self.link_to_km_state.get_mut(&link_id) {
-            km_state.handle = Some(handle);
-        } else {
-            panic!("no security association for link");
-        }
+    ///
+    /// Only possible error is if there is no entry in the table under the `link_id`.
+    pub fn set_km_handle(
+        &self,
+        link_id: LinkId,
+        handle: KmHandle,
+    ) -> Result<(), SecurityAssocaitionStateError> {
+        let entry = self
+            .get(link_id)
+            .ok_or(SecurityAssocaitionStateError::NoAssociationForLink)?;
+        entry.km_state.handle.lock().unwrap().replace(handle);
+        Ok(())
     }
 
     /// After this, [PeerTable::is_security_assocaition_established] will return false for the link until
@@ -254,51 +246,66 @@ impl<'pktbuf> PeerTable<'pktbuf> {
         &self,
         link_id: LinkId,
     ) -> Result<(), SecurityAssocaitionStateError> {
-        if let Some(km_state) = self.link_to_km_state.get_mut(&link_id) {
-            km_state.sa_established.store(false, Ordering::Release);
-            Ok(())
-        } else {
-            Err(SecurityAssocaitionStateError::NoAssociationForLink)
-        }
+        let entry = self
+            .get(link_id)
+            .ok_or(SecurityAssocaitionStateError::NoAssociationForLink)?;
+        entry
+            .km_state
+            .sa_established
+            .store(false, Ordering::Release);
+        Ok(())
     }
 
+    /// Check if a security assocaition is estabolished for the link.
+    /// False returned here means that either the assocaition is not established, or
+    /// that there is no link found under the ID.
     pub fn is_security_assocaition_established(&self, link_id: LinkId) -> bool {
-        if let Some(km_state) = self.link_to_km_state.get(&link_id) {
-            km_state.sa_established.load(Ordering::Acquire)
-        } else {
-            false
+        if let Some(entry) = self.get(link_id) {
+            return entry.km_state.sa_established.load(Ordering::Acquire);
         }
+        false
     }
 
-    /// Return a clone of the transport SA if there is an SA on the link, and it is established.
+    /// Return a clone of the transport SA if there is an SA on the link, and if it is established.
     pub fn clone_established_transport_association(
         &self,
         link_id: LinkId,
     ) -> Option<KmTransportSA> {
-        match self.link_to_km_state.get(&link_id) {
-            Some(km_state) if km_state.sa_established.load(Ordering::Acquire) => {
-                Some(km_state.transport_sa.clone())
-            }
-            _ => None, // either not found or not established
+        let entry = self.get(link_id)?;
+        if entry.km_state.sa_established.load(Ordering::Acquire) {
+            return Some(entry.km_state.transport_sa.get().clone());
         }
+        None
     }
 
+    /// Clone the Key Manager on the link if link exists, and if there is a handle set.
+    /// See [PeerTable::set_km_handle].
     pub fn clone_km_manager(&self, link_id: LinkId) -> Option<KeyManager> {
-        match self.link_to_km_state.get(&link_id) {
-            Some(km_state) if km_state.handle.is_some() => {
-                Some(km_state.handle.as_ref().unwrap().mgr.clone())
-            }
-            _ => None,
-        }
+        let entry = self.get(link_id)?;
+        let handle = entry.km_state.handle.lock().unwrap();
+        handle.as_ref().map(|h| h.mgr.clone())
     }
 
     /// Remove the key manager state from the link, returning the optional KmHandle that was set.
+    /// Doesn't really _remove_ the state, but does invalidate the security assocation and wipes
+    /// the reference to the handle.
     pub fn remove_km_state(&self, link_id: LinkId) -> Option<KmHandle> {
-        if let Some((_, state)) = self.link_to_km_state.remove(&link_id) {
-            state.handle
-        } else {
-            None
+        let entry = self.get(link_id)?;
+
+        // If SA is set, un-set it.
+        if entry.km_state.sa_established.load(Ordering::Acquire) {
+            entry
+                .km_state
+                .sa_established
+                .store(false, Ordering::Release);
         }
+
+        // If there is a handle, remove it and return it.
+        let mut handle = entry.km_state.handle.lock().unwrap();
+        if handle.is_none() {
+            return None;
+        }
+        handle.take()
     }
 }
 


### PR DESCRIPTION
Remove the parallel dashmap thing that was tracking link_id->KmState.  Instead, the KmState is directly the PeerState which is stored as a peer table entry.

Note it is private since it is manipulated exclusively though methods on the table.

The TransportSA, which is used in fastpath is now stored in a RcuBox which presumably is better performing than a mutex.  Not sure I've used that correctly.

The KmHandle -- which is state that the KeyManager uses for management activities is behind a regular mutex but is only used in management path I believe.
