### PR TITLE
Better treatment of IPv6 flowinfo

### DIFF
--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -191,7 +191,10 @@ impl<'a> SubstrateEgress<'a> {
             SocketAddr::V6(dest_sa) => dest_sa.set_flowinfo(packet.flowhash()),
         }
 
-        (self.sockets[packet.flowhash() as usize % self.sockets.len()], dest_sa)
+        (
+            self.sockets[packet.flowhash() as usize % self.sockets.len()],
+            dest_sa,
+        )
     }
 
     #[allow(dead_code)]

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -131,11 +131,11 @@ impl<'a> SubstrateEgress<'a> {
     pub async fn enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>(
         &self,
         packet: P,
-        mut dest_sa: zpr::SubstrateAddr,
+        dest_sa: zpr::SubstrateAddr,
     ) -> Result<(), P> {
-        let socket = self.select_socket_and_set_flowinfo(&*packet, &mut dest_sa);
+        let (socket, dest_sockaddr) = self.select_socket_and_set_flowinfo(&*packet, dest_sa);
 
-        match socket.send_to(packet.body(), dest_sa).await {
+        match socket.send_to(packet.body(), dest_sockaddr).await {
             Ok(_) => Ok(()),
 
             Err(err) => {
@@ -157,11 +157,11 @@ impl<'a> SubstrateEgress<'a> {
     pub fn try_enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>(
         &self,
         packet: P,
-        mut dest_sa: zpr::SubstrateAddr,
+        dest_sa: zpr::SubstrateAddr,
     ) -> Result<(), TryEnqueueError<P>> {
-        let socket = self.select_socket_and_set_flowinfo(&*packet, &mut dest_sa);
+        let (socket, dest_sockaddr) = self.select_socket_and_set_flowinfo(&*packet, dest_sa);
 
-        match socket.try_send_to(packet.body(), dest_sa) {
+        match socket.try_send_to(packet.body(), dest_sockaddr) {
             Ok(_) => Ok(()),
 
             Err(err) => {
@@ -184,14 +184,14 @@ impl<'a> SubstrateEgress<'a> {
     fn select_socket_and_set_flowinfo(
         &self,
         packet: &Packet<'_>,
-        dest_sa: &mut zpr::SubstrateAddr,
-    ) -> &'a UdpSocket {
-        match dest_sa {
+        mut dest_sa: zpr::SubstrateAddr,
+    ) -> (&'a UdpSocket, std::net::SocketAddr) {
+        match &mut dest_sa {
             SocketAddr::V4(_) => (),
             SocketAddr::V6(dest_sa) => dest_sa.set_flowinfo(packet.flowhash()),
         }
 
-        self.sockets[packet.flowhash() as usize % self.sockets.len()]
+        (self.sockets[packet.flowhash() as usize % self.sockets.len()], dest_sa)
     }
 
     #[allow(dead_code)]

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -3,7 +3,9 @@
 use crate::net_defs;
 use crate::packet::Packet;
 use crate::test_packet::*;
+use crate::zpr;
 use std::io::ErrorKind;
+use std::net::SocketAddr;
 use std::result::Result;
 use std::time::SystemTime;
 use tokio::net::UdpSocket;
@@ -129,9 +131,9 @@ impl<'a> SubstrateEgress<'a> {
     pub async fn enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>(
         &self,
         packet: P,
-        dest_sa: std::net::SocketAddr,
+        mut dest_sa: zpr::SubstrateAddr,
     ) -> Result<(), P> {
-        let socket = self.sockets[packet.flowhash() as usize % self.sockets.len()];
+        let socket = self.select_socket_and_set_flowinfo(&*packet, &mut dest_sa);
 
         match socket.send_to(packet.body(), dest_sa).await {
             Ok(_) => Ok(()),
@@ -155,9 +157,9 @@ impl<'a> SubstrateEgress<'a> {
     pub fn try_enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>(
         &self,
         packet: P,
-        dest_sa: std::net::SocketAddr,
+        mut dest_sa: zpr::SubstrateAddr,
     ) -> Result<(), TryEnqueueError<P>> {
-        let socket = self.sockets[packet.flowhash() as usize % self.sockets.len()];
+        let socket = self.select_socket_and_set_flowinfo(&*packet, &mut dest_sa);
 
         match socket.try_send_to(packet.body(), dest_sa) {
             Ok(_) => Ok(()),
@@ -177,6 +179,19 @@ impl<'a> SubstrateEgress<'a> {
                 }
             }
         }
+    }
+
+    fn select_socket_and_set_flowinfo(
+        &self,
+        packet: &Packet<'_>,
+        dest_sa: &mut zpr::SubstrateAddr,
+    ) -> &'a UdpSocket {
+        match dest_sa {
+            SocketAddr::V4(_) => (),
+            SocketAddr::V6(dest_sa) => dest_sa.set_flowinfo(packet.flowhash()),
+        }
+
+        self.sockets[packet.flowhash() as usize % self.sockets.len()]
     }
 
     #[allow(dead_code)]

--- a/adapter/ph/src/substrate_ingress_worker.rs
+++ b/adapter/ph/src/substrate_ingress_worker.rs
@@ -4,6 +4,7 @@ use crate::fastpath;
 use crate::packet::Packet;
 use std::future::Future;
 use std::io::ErrorKind;
+use std::net::SocketAddr;
 use tokio::net::UdpSocket;
 
 #[derive(Copy, Clone)]
@@ -25,7 +26,7 @@ async fn worker<'a>(config: &Config, asm: &Assembly<'a>, socket: &UdpSocket) {
         // TODO: batch receive
         for buf in bufs.drain(..) {
             let mut pkt = Packet::new(buf, config::DEFAULT_MESSAGE_HEADROOM);
-            let sender = loop {
+            let mut sender = loop {
                 match socket.recv_buf_from(&mut pkt).await {
                     Ok((_size, sender)) => break sender,
 
@@ -37,6 +38,13 @@ async fn worker<'a>(config: &Config, asm: &Assembly<'a>, socket: &UdpSocket) {
                     }
                 }
             };
+
+            // SocketAddrV6 distinguishes addresses also by `flowinfo` which
+            // we do not want -- only the 5-tuple.  So clear it.
+            match &mut sender {
+                SocketAddr::V4(_) => (),
+                SocketAddr::V6(sender) => sender.set_flowinfo(0),
+            }
 
             fastpath::substrate_ingress(asm, &sender, pkt);
         }


### PR DESCRIPTION
IPv6 flowinfo should be cleared on substrate ingress (otherwise peer lookup is broken), and set on substrate egress (from the `flowhash` field of a `Packet`).

Setting `Packet.flowhash` to something useful in the first place is out of scope of this PR.  (I've opened #441 to address this.)