### PR TITLE
set ZPI_ENCRYPTED_HEADER_FLAG on ZPIs indicating encrypted data

### DIFF
--- a/.github/workflows/rust-adapter.yml
+++ b/.github/workflows/rust-adapter.yml
@@ -153,6 +153,9 @@ jobs:
       run: |
         cd adapter/ph
         cargo build
+        sudo apt update
+        sudo apt install libpcap-dev
+        cargo build --manifest-path ../ph-debug/Cargo.toml
         ZPR_TEST_VERBOSE=1 test/basic-test.sh
 
   capture-integration-test:

--- a/.github/workflows/rust-adapter.yml
+++ b/.github/workflows/rust-adapter.yml
@@ -145,7 +145,7 @@ jobs:
 
   # Integration tests
   basic-integration-test:
-    needs: [ph-build]
+    needs: [ph-build, ph-debug-build]
     runs-on: ubuntu-latest
     steps: 
     - uses: actions/checkout@v4

--- a/adapter/ph/src/counters_enum.rs
+++ b/adapter/ph/src/counters_enum.rs
@@ -42,6 +42,9 @@ pub enum CounterType {
     UnknownStreamId,
     BadStructure,
     OtherError,
+
+    #[cfg(debug_assertions)]
+    AgentPacketsOutOfOrder,
 }
 
 impl CounterType {
@@ -83,6 +86,9 @@ impl CounterType {
             Self::UnknownStreamId => "Unknown Stream ID",
             Self::BadStructure => "Bad Structure",
             Self::OtherError => "Other Error",
+
+            #[cfg(debug_assertions)]
+            Self::AgentPacketsOutOfOrder => "Agent Packets Out-Of-Order",
         }
     }
 }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -428,9 +428,18 @@ pub async fn substrate_egress_blocking<'pktbuf>(
     }
 }
 
+#[cfg(debug_assertions)]
+/// This table is used to track whether a flow ever switches from one worker
+/// to another (indicating potential for out-of-order packets) -- meaning
+/// our packet steerer isn't steering correctly.  This is used only in debug mode.
+const AGENT_PACKET_FLOW_TRACKER: std::sync::LazyLock<
+    dashmap::DashMap<(zpr::LinkId, zpr::StreamId), usize>,
+> = std::sync::LazyLock::new(|| dashmap::DashMap::new());
+
 /// Process packets ingressing from the specified address.
 pub fn substrate_ingress<'pktbuf>(
     asm: &Assembly<'pktbuf>,
+    #[cfg_attr(not(debug_assertions), allow(unused_variables))] worker_index: usize,
     peer_sa: &zpr::SubstrateAddr,
     mut pkt: Packet<'pktbuf>,
 ) {
@@ -548,9 +557,23 @@ pub fn substrate_ingress<'pktbuf>(
         return drop_and_count(asm, pkt, CounterType::BadStructure);
     };
 
-    pkt.metadata_mut().flow_id = per_flow_hdr.stream_id.into(); // TODO: is this necessary?
+    let stream_id: zpr::StreamId = per_flow_hdr.stream_id.into(); // TODO: is this necessary?
 
-    forward(asm, ingress_link_id, per_flow_hdr.stream_id.into(), pkt);
+    // in debug builds, track which worker this agent traffic came in on
+    // ensure a given flow isn't hopping between workers (potentially
+    // resulting in out-of-order packets)
+    #[cfg(debug_assertions)]
+    if let Some(old_index) =
+        AGENT_PACKET_FLOW_TRACKER.insert((ingress_link_id, stream_id), worker_index)
+    {
+        if old_index != worker_index {
+            asm.counters[CounterType::AgentPacketsOutOfOrder].increment();
+        }
+    }
+
+    pkt.metadata_mut().flow_id = stream_id; // TODO: is this necessary?
+
+    forward(asm, ingress_link_id, stream_id, pkt);
 }
 
 /// Send a compressed agent packet to the agent.

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -366,7 +366,7 @@ fn main() -> ExitCode {
                     private: dock_noise_private_key.to_vec(),
                     public: dock_noise_public_key.to_vec(),
                 };
-                km_multiplexor::add_node_link(asm, peer_id2, ZPIPair::new(1, 2), dock_keypair)
+                km_multiplexor::add_node_link(asm, peer_id2, ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 1, 2), dock_keypair)
                     .unwrap();
             }
         }
@@ -387,7 +387,7 @@ fn main() -> ExitCode {
                 km_multiplexor::add_adapter_link(
                     asm,
                     peer_id,
-                    ZPIPair::new(3, 4),
+                    ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 3, 4),
                     dock_noise_public_key,
                 )
                 .unwrap();
@@ -396,7 +396,7 @@ fn main() -> ExitCode {
                     private: dock_noise_private_key.to_vec(),
                     public: dock_noise_public_key.to_vec(),
                 };
-                km_multiplexor::add_node_link(asm, peer_id, ZPIPair::new(5, 6), dock_keypair)
+                km_multiplexor::add_node_link(asm, peer_id, ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 5, 6), dock_keypair)
                     .unwrap();
             }
         }

--- a/adapter/ph/src/substrate_ingress_worker.rs
+++ b/adapter/ph/src/substrate_ingress_worker.rs
@@ -8,7 +8,6 @@ use tokio::net::UdpSocket;
 
 #[derive(Copy, Clone)]
 pub struct Config {
-    #[allow(dead_code)]
     pub worker_index: usize,
     pub batch_size: usize,
 }
@@ -38,7 +37,7 @@ async fn worker<'a>(config: &Config, asm: &Assembly<'a>, socket: &UdpSocket) {
                 }
             };
 
-            fastpath::substrate_ingress(asm, &sender, pkt);
+            fastpath::substrate_ingress(asm, config.worker_index, &sender, pkt);
         }
     }
 }

--- a/adapter/ph/test/basic-test.sh
+++ b/adapter/ph/test/basic-test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 PH_BIN=$(realpath "$(dirname $0)/../target/debug/ph")
+PH_DEBUG_BIN=$(realpath "$(dirname $0)/../../ph-debug/target/debug/ph-debug")
 
 source "$(dirname $0)/common_funcs.sh"
 
@@ -24,6 +25,12 @@ ADAPTER1_SOCK=adapter1.sock
 ADAPTER2_SOCK=adapter2.sock
 NODE_SOCK=node.sock
 
+function counters() {
+  SOCKET=$1
+  "$PH_DEBUG_BIN" -c COUNTERS -p "$SOCKET"
+}
+
+
 #
 # Set up automatic cleanup
 #
@@ -36,6 +43,7 @@ TMPDIR=$(mktemp -d)
 pushd "$TMPDIR" > /dev/null
 
 echo "Setting up network"
+
 
 #
 # Prepare for test
@@ -51,6 +59,7 @@ create_agent_key_and_cert ca adapter2
 create_agent_key_and_cert ca node
 
 echo "Launching DUTs"
+
 
 #
 # Launch PHs
@@ -69,7 +78,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_A":12345 \
   --ca-file ca.crt --certificate-file adapter1.crt --private-key-file adapter1.key \
-  --tun-if tun0 2>&1 |tee zpr-a.log &
+  --tun-if tun0 2>&1 |tee adapter1.log &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 
@@ -77,9 +86,8 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-b" --control-path "$ADAPTER2_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_B":12345 \
   --ca-file ca.crt --certificate-file adapter2.crt --private-key-file adapter2.key \
-  --tun-if tun0 2>&1 |tee zpr-b.log &
+  --tun-if tun0 2>&1 |tee adapter2.log &
 CHILDREN=(${CHILDREN[@]} "$!")
-
 
 
 #
@@ -109,6 +117,22 @@ PASS=0
 if ! ping_test
 then PASS=1
 fi
+
+
+#
+# Check stats
+#
+
+for SOCK in "$ADAPTER1_SOCK" "$ADAPTER2_SOCK" "$NODE_SOCK"
+do
+	# TODO: test also with encrypted agent traffic
+	APOOO=$(counters "$SOCK" | awk -F': ' '$1 == "Agent Packets Out-Of-Order" { print $2 }')
+	if (( APOOO != 0 ))
+	then
+		echo "$(basename "$SOCK"): ERROR: found agent packets out-of-order: $APOOO"
+		PASS=1
+	fi
+done
 
 
 #

--- a/adapter/ph/test/capture-test.sh
+++ b/adapter/ph/test/capture-test.sh
@@ -87,14 +87,14 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_A":12345 \
   --ca-file ca.crt --certificate-file adapter1.crt --private-key-file adapter1.key \
-  --tun-if tun0 2>&1 |tee zpr-a.log &
+  --tun-if tun0 2>&1 |tee adapter1.log &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-b" --control-path "$ADAPTER2_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_B":12345 \
   --ca-file ca.crt --certificate-file adapter2.crt --private-key-file adapter2.key \
-  --tun-if tun0 2>&1 |tee zpr-b.log &
+  --tun-if tun0 2>&1 |tee adapter2.log &
 CHILDREN=(${CHILDREN[@]} "$!")
 
 sleep 1 # FIXME: I think we need this b/c DTLS doesn't deal with dropped initial packet well

--- a/adapter/ph/test/common_funcs.sh
+++ b/adapter/ph/test/common_funcs.sh
@@ -145,8 +145,8 @@ function cleanup() {
   if [ "$SHOW_LOGS" != "no" ]
      then
          emitlog "node.log"
-         emitlog "zpr-a.log"
-         emitlog "zpr-b.log"
+         emitlog "adapter1.log"
+         emitlog "adapter2.log"
   fi
 
   popd > /dev/null


### PR DESCRIPTION
This way the packet steerer correctly ignores the stream ID field on encrypted packets.

Also, added a debug code which checks for out-of-order agent traffic packets which is checked by the integration test.

(Note that these two things don't actually affect each other right now, since agent traffic isn't encrypted by default.  Added a TODO to do this later.)