### PR TITLE
reserve stream ID 0

### DIFF
--- a/adapter/ph/src/adapter_tables.rs
+++ b/adapter/ph/src/adapter_tables.rs
@@ -126,12 +126,12 @@ impl DockLookupTable {
         inspector: impl FnOnce(&DltPep) -> T,
     ) -> Option<T> {
         self.reader
-            .inspect(|reader| reader.get(tether_id as usize).map(inspector))
+            .inspect(|reader| reader.get((tether_id as usize).wrapping_sub(1)).map(inspector))
     }
 
     pub fn get(&self, tether_id: StreamId) -> Option<DltPepGuard<'_>> {
         let guard = self.reader.get();
-        if guard.get(tether_id as usize).is_none() {
+        if guard.get((tether_id as usize).wrapping_sub(1)).is_none() {
             return None;
         }
         Some(DltPepGuard {
@@ -141,12 +141,12 @@ impl DockLookupTable {
     }
 
     pub fn insert(&self, pep: DltPep) -> Result<StreamId, ()> {
-        Ok(self.table.lock().unwrap().insert(pep)? as StreamId)
+        Ok((self.table.lock().unwrap().insert(pep)? + 1) as StreamId)
     }
 
     pub fn remove(&self, tether_id: StreamId) {
         let mut table = self.table.lock().unwrap();
-        let new_reader = table.remove(tether_id as usize);
+        let new_reader = table.remove((tether_id as usize).wrapping_sub(1));
         std::mem::drop(table);
         self.reader.write(new_reader);
     }

--- a/adapter/ph/src/adapter_tables.rs
+++ b/adapter/ph/src/adapter_tables.rs
@@ -125,8 +125,11 @@ impl DockLookupTable {
         tether_id: StreamId,
         inspector: impl FnOnce(&DltPep) -> T,
     ) -> Option<T> {
-        self.reader
-            .inspect(|reader| reader.get((tether_id as usize).wrapping_sub(1)).map(inspector))
+        self.reader.inspect(|reader| {
+            reader
+                .get((tether_id as usize).wrapping_sub(1))
+                .map(inspector)
+        })
     }
 
     pub fn get(&self, tether_id: StreamId) -> Option<DltPepGuard<'_>> {

--- a/adapter/ph/src/adapter_tables.rs
+++ b/adapter/ph/src/adapter_tables.rs
@@ -139,7 +139,7 @@ impl DockLookupTable {
         }
         Some(DltPepGuard {
             guard,
-            key: tether_id as usize,
+            key: (tether_id as usize).wrapping_sub(1),
         })
     }
 

--- a/adapter/ph/src/dock_tables.rs
+++ b/adapter/ph/src/dock_tables.rs
@@ -59,28 +59,31 @@ impl DockForwardingTable {
         tether_id: StreamId,
         inspector: impl FnOnce(&DftPep) -> T,
     ) -> Option<T> {
-        self.reader
-            .inspect(|reader| reader.get(tether_id as usize).map(inspector))
+        self.reader.inspect(|reader| {
+            reader
+                .get((tether_id as usize).wrapping_sub(1))
+                .map(inspector)
+        })
     }
 
     pub fn get(&self, tether_id: StreamId) -> Option<DftPepGuard<'_>> {
         let guard = self.reader.get();
-        if guard.get(tether_id as usize).is_none() {
+        if guard.get((tether_id as usize).wrapping_sub(1)).is_none() {
             return None;
         }
         Some(DftPepGuard {
             guard,
-            key: tether_id as usize,
+            key: (tether_id as usize).wrapping_sub(1),
         })
     }
 
     pub fn insert(&self, pep: DftPep) -> Result<StreamId, ()> {
-        Ok(self.table.lock().unwrap().insert(pep)? as StreamId)
+        Ok((self.table.lock().unwrap().insert(pep)? + 1) as StreamId)
     }
 
     pub fn remove(&self, tether_id: StreamId) {
         let mut table = self.table.lock().unwrap();
-        let new_reader = table.remove(tether_id as usize);
+        let new_reader = table.remove((tether_id as usize).wrapping_sub(1));
         std::mem::drop(table);
         self.reader.write(new_reader);
     }


### PR DESCRIPTION
Since the DLT is the source of all stream IDs (at the moment), that's the only code I needed to touch.

The `wrapping_sub` is used to map stream ID 0 to usize(-1), which is a guaranteed lookup fail (not possible to allocate such a high stream ID).