### PR TITLE
Link State Part 1: Refactor link bringup

### DIFF
--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -5,16 +5,26 @@ use crate::config;
 use crate::counter::*;
 use crate::counters_enum::*;
 use crate::flow_control::FlowControl;
+use crate::km::ZPIPair;
+use crate::km_cert_exchange::KmCertExchange;
+use crate::km_multiplexor;
 use crate::km_multiplexor::KmState;
+use crate::km_noise;
+use crate::link_state::LinkType;
 use crate::mgmt_processor_worker;
 use crate::peer_table;
+use crate::peer_table::PeerInsertError;
 use crate::queues::*;
 use crate::tun_ctl::TunCtl;
 use crate::zpr;
+use crate::zpr::ZPI_ENCRYPTED_HEADER_FLAG;
+use crate::zpr::{LinkId, SubstrateAddr};
 
 use enum_map::EnumMap;
+use km_noise::NoiseKeypair;
 use std::default::Default;
 use std::result::Result;
+use tracing::info;
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum PhMode {
@@ -70,6 +80,10 @@ pub struct Assembly<'pktbuf> {
     pub mgmt_dispatch: MgmtDispatch<'pktbuf>,
     pub adapter_manager: AdapterManager<'pktbuf>,
     pub km_state: KmState,
+
+    pub self_noise_keypair: Option<NoiseKeypair>,
+    pub peer_noise_keypair: Option<NoiseKeypair>,
+    pub certx: Option<KmCertExchange>,
 }
 
 pub struct PhFlags {
@@ -89,29 +103,98 @@ impl Default for PhFlags {
 }
 
 impl Assembly<'_> {
-    pub fn hack_get_adapter_docking_session_id(&self) -> zpr::LinkId {
-        assert!(matches!(self.ph_mode, PhMode::Adapter));
-        let peer_ids = self.peer_ids.lock().unwrap();
-        assert_eq!(peer_ids.len(), 1);
-        peer_ids[0]
+    pub fn is_node(&self) -> bool {
+        self.ph_mode == PhMode::Node
     }
 
-    pub fn hack_add_peer(
+    pub fn is_adapter(&self) -> bool {
+        self.ph_mode == PhMode::Adapter
+    }
+
+    fn add_peer(
         &'static self,
-        peer_type: peer_table::PeerType,
-        substrate_addr: zpr::SubstrateAddr,
-    ) -> Result<zpr::LinkId, peer_table::PeerInsertError> {
+        link_type: LinkType,
+        peer_addr: &SubstrateAddr,
+    ) -> Result<LinkId, PeerInsertError> {
         let entry = self.peer_table.vacant_entry()?;
 
         let worker_config = mgmt_processor_worker::Config {
             link_id: entry.key(),
         };
 
-        let peer_state = peer_table::PeerState::new(peer_type, substrate_addr, |q| {
+        let peer_state = peer_table::PeerState::new(link_type, *peer_addr, |q| {
             mgmt_processor_worker::launch(&worker_config, self, q)
         });
 
         Ok(entry.insert(peer_state))
+    }
+
+    /// Add an adapter to the peer table
+    pub fn accept_tether(
+        &'static self,
+        adapter_addr: &SubstrateAddr,
+    ) -> Result<LinkId, PeerInsertError> {
+        assert!(self.is_node());
+        info!(
+            "{}: Accepting tether from {}",
+            self.system_name, adapter_addr
+        );
+        let peer_id = self.add_peer(LinkType::NodeToAdapter, adapter_addr)?;
+        self.peer_ids.lock().unwrap().push(peer_id);
+
+        km_multiplexor::add_node_link(
+            &self,
+            peer_id,
+            ZPIPair::new(ZPI_ENCRYPTED_HEADER_FLAG | 3, 4),
+            self.self_noise_keypair.clone().unwrap(),
+            self.certx.clone().unwrap(),
+        )
+        .unwrap();
+
+        info!(
+            "{}: Successfully accepted tether from {}.  Assigned ID {}",
+            self.system_name, adapter_addr, peer_id
+        );
+
+        return Ok(peer_id);
+    }
+
+    /// Add a node to the peer table as an adapter
+    pub fn initiate_tether(
+        &'static self,
+        node_addr: &SubstrateAddr,
+    ) -> Result<LinkId, PeerInsertError> {
+        assert!(self.is_adapter());
+        info!(
+            "{}: Initiating tether towards {}",
+            self.system_name, node_addr
+        );
+        let peer_id = self.add_peer(LinkType::AdapterToNode, node_addr)?;
+        self.peer_ids.lock().unwrap().push(peer_id);
+
+        km_multiplexor::add_adapter_link(
+            &self,
+            peer_id,
+            ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 5, 6),
+            self.self_noise_keypair.clone().unwrap(),
+            self.peer_noise_keypair.clone().unwrap().public,
+            self.certx.clone().unwrap(),
+        )
+        .unwrap();
+
+        info!(
+            "{}: Successfully initiated tether to {}.  Assigned ID {}",
+            self.system_name, node_addr, peer_id
+        );
+
+        return Ok(peer_id);
+    }
+
+    pub fn hack_get_adapter_docking_session_id(&self) -> zpr::LinkId {
+        assert!(matches!(self.ph_mode, PhMode::Adapter));
+        let peer_ids = self.peer_ids.lock().unwrap();
+        assert_eq!(peer_ids.len(), 1);
+        peer_ids[0]
     }
 }
 
@@ -231,6 +314,9 @@ pub mod test {
             mgmt_dispatch,
             adapter_manager,
             km_state,
+            self_noise_keypair: None,
+            peer_noise_keypair: None,
+            certx: None,
         }
     }
 }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -142,14 +142,16 @@ impl Assembly<'_> {
         let peer_id = self.add_peer(LinkType::NodeToAdapter, adapter_addr)?;
         self.peer_ids.lock().unwrap().push(peer_id);
 
-        km_multiplexor::add_node_link(
-            &self,
-            peer_id,
-            ZPIPair::new(ZPI_ENCRYPTED_HEADER_FLAG | 3, 4),
-            self.self_noise_keypair.clone().unwrap(),
-            self.certx.clone().unwrap(),
-        )
-        .unwrap();
+        if !self.flags.disable_key_management {
+            km_multiplexor::add_node_link(
+                &self,
+                peer_id,
+                ZPIPair::new(ZPI_ENCRYPTED_HEADER_FLAG | 3, 4),
+                self.self_noise_keypair.clone().unwrap(),
+                self.certx.clone().unwrap(),
+            )
+            .unwrap();
+        }
 
         info!(
             "{}: Successfully accepted tether from {}.  Assigned ID {}",
@@ -172,15 +174,17 @@ impl Assembly<'_> {
         let peer_id = self.add_peer(LinkType::AdapterToNode, node_addr)?;
         self.peer_ids.lock().unwrap().push(peer_id);
 
-        km_multiplexor::add_adapter_link(
-            &self,
-            peer_id,
-            ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 5, 6),
-            self.self_noise_keypair.clone().unwrap(),
-            self.peer_noise_keypair.clone().unwrap().public,
-            self.certx.clone().unwrap(),
-        )
-        .unwrap();
+        if !self.flags.disable_key_management {
+            km_multiplexor::add_adapter_link(
+                &self,
+                peer_id,
+                ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 5, 6),
+                self.self_noise_keypair.clone().unwrap(),
+                self.peer_noise_keypair.clone().unwrap().public,
+                self.certx.clone().unwrap(),
+            )
+            .unwrap();
+        }
 
         info!(
             "{}: Successfully initiated tether to {}.  Assigned ID {}",

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -38,6 +38,10 @@ pub fn drop_and_count<'pktbuf>(
     asm.counters[reason.into()].increment();
 }
 
+fn format_link_id(link_id: Option<zpr::LinkId>) -> String {
+    link_id.map_or(format!("unknown link"), |id| format!("link {}", id))
+}
+
 /// Add the ZPI header to a packet.
 pub fn encap_zpi<'pktbuf>(
     _asm: &Assembly<'pktbuf>,
@@ -440,10 +444,7 @@ pub fn substrate_ingress<'pktbuf>(
 ) {
     asm.counters[CounterType::InPacksRec].increment();
 
-    let Some(ingress_link_id) = asm.peer_table.lookup_peer(peer_sa) else {
-        drop_and_count(asm, pkt, CounterType::UnknownPeer);
-        return;
-    };
+    let ingress_link_id = asm.peer_table.lookup_peer(peer_sa);
 
     // Read, but do not remove the ZPI header
     let Some(zpi_hdr) = zdp::ZdpZpiHeader::read_from_prefix(&pkt.body()) else {
@@ -451,45 +452,51 @@ pub fn substrate_ingress<'pktbuf>(
         return;
     };
 
-    let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
-        drop_and_count(asm, pkt, CounterType::UnknownPeer);
-        return;
-    };
+    let peer_state = ingress_link_id.and_then(|link_id| asm.peer_table.get(link_id));
 
     // If a ZPI is setup on this link, then we expect the message to use one of the valid
     // ZPI values.
     let secure;
-    match peer_state.get_established_transport_association() {
-        Some(ref transport_sa) => {
-            if zpi_hdr.zpi == transport_sa.recv_zpis.hmac {
-                match decrypt_hmac(transport_sa.recv_hmac_key, &mut pkt) {
-                    Ok(()) => secure = true,
-                    Err(err) => {
-                        drop_and_count(asm, pkt, err);
-                        return;
+    match peer_state {
+        Some(state) => match state.get_established_transport_association() {
+            Some(ref transport_sa) => {
+                if zpi_hdr.zpi == transport_sa.recv_zpis.hmac {
+                    match decrypt_hmac(transport_sa.recv_hmac_key, &mut pkt) {
+                        Ok(()) => secure = true,
+                        Err(err) => {
+                            drop_and_count(asm, pkt, err);
+                            return;
+                        }
                     }
-                }
-            } else if zpi_hdr.zpi == transport_sa.recv_zpis.encr {
-                // TODO: Put padlen in state somewhere too
-                match decrypt_full(asm, &*transport_sa.codec, NOISE_PADLEN, &mut pkt) {
-                    Ok(()) => secure = true,
-                    Err(err) => {
-                        drop_and_count(asm, pkt, err);
-                        return;
+                } else if zpi_hdr.zpi == transport_sa.recv_zpis.encr {
+                    // TODO: Put padlen in state somewhere too
+                    match decrypt_full(asm, &*transport_sa.codec, NOISE_PADLEN, &mut pkt) {
+                        Ok(()) => secure = true,
+                        Err(err) => {
+                            drop_and_count(asm, pkt, err);
+                            return;
+                        }
                     }
+                } else {
+                    // We have an SA and ZPI does not match.
+                    info!(
+                        "{}: ingress: link {}: unexpected ZPI value {} (expected {:?})",
+                        asm.system_name,
+                        format_link_id(ingress_link_id),
+                        zpi_hdr.zpi,
+                        transport_sa.recv_zpis
+                    );
+                    drop_and_count(asm, pkt, CounterType::UnknownZpi);
+                    return;
                 }
-            } else {
-                // We have an SA and ZPI does not match.
-                info!(
-                    "{}: ingress: link {}: unexpected ZPI value {} (expected {:?})",
-                    asm.system_name, ingress_link_id, zpi_hdr.zpi, transport_sa.recv_zpis
-                );
-                drop_and_count(asm, pkt, CounterType::UnknownZpi);
-                return;
             }
-        }
+            None => {
+                // Either no security association on link, or it is not yet established.
+                secure = false;
+            }
+        },
         None => {
-            // Either no security associatio on link, or it is not yet established.
+            // No link in peer table
             secure = false;
         }
     };
@@ -498,8 +505,10 @@ pub fn substrate_ingress<'pktbuf>(
         // Not under a security assocation  which means only ZPI 0 is allowed.
         if zpi_hdr.zpi != zpr::ZPI_0 {
             info!(
-                "{}: ingress: link {}: ZPI {} not allowed on unestablished SA",
-                asm.system_name, ingress_link_id, zpi_hdr.zpi
+                "{}: ingress: {}: ZPI {} not allowed on unestablished SA",
+                asm.system_name,
+                format_link_id(ingress_link_id),
+                zpi_hdr.zpi
             );
             drop_and_count(asm, pkt, CounterType::UnknownZpi);
             return;
@@ -535,7 +544,9 @@ pub fn substrate_ingress<'pktbuf>(
         if !asm.flags.allow_insecure_zpi_zero {
             warn!(
                 "{}: ingress: link {}: ZPI 0 only allows key management messages, not {:?}",
-                asm.system_name, ingress_link_id, base_hdr.packet_type
+                asm.system_name,
+                format_link_id(ingress_link_id),
+                base_hdr.packet_type
             );
             drop_and_count(asm, pkt, CounterType::OtherError);
             return;
@@ -549,7 +560,7 @@ pub fn substrate_ingress<'pktbuf>(
         *pkt.alloc_zeroed_header() = base_hdr;
         match asm
             .mgmt_dispatch
-            .try_dispatch_mgmt_packet(ingress_link_id, pkt)
+            .try_dispatch_mgmt_packet(ingress_link_id, peer_sa, pkt)
         {
             Ok(()) => (),
             Err(TryEnqueueError::Full(pkt)) => {
@@ -558,6 +569,10 @@ pub fn substrate_ingress<'pktbuf>(
         }
         return;
     }
+
+    let Some(ingress_link_id) = ingress_link_id else {
+        return drop_and_count(asm, pkt, CounterType::UnknownPeer);
+    };
 
     let Some(per_flow_hdr) = zdp::ZdpPerFlowHeader::read_from_buf(&mut pkt) else {
         return drop_and_count(asm, pkt, CounterType::BadStructure);

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -502,8 +502,8 @@ pub fn substrate_ingress<'pktbuf>(
     };
 
     if !secure {
-        // Not under a security assocation  which means only ZPI 0 is allowed.
-        if zpi_hdr.zpi != zpr::ZPI_0 {
+        // Not under a security assocation, which means only ZPI 0 is allowed.
+        if zpi_hdr.zpi != zpr::ZPI_0 && ingress_link_id.is_some() {
             info!(
                 "{}: ingress: {}: ZPI {} not allowed on unestablished SA",
                 asm.system_name,
@@ -534,6 +534,19 @@ pub fn substrate_ingress<'pktbuf>(
         }
     }
 
+    let Some(ingress_link_id) = ingress_link_id else {
+        match asm
+            .mgmt_dispatch
+            .try_dispatch_mgmt_packet_with_addr(peer_sa, pkt)
+        {
+            Ok(()) => (),
+            Err(TryEnqueueError::Full(pkt)) => {
+                drop_and_count(asm, pkt, CounterType::QueueBackpressure)
+            }
+        }
+        return;
+    };
+
     let Some(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(&mut pkt) else {
         return drop_and_count(asm, pkt, CounterType::BadStructure);
     };
@@ -544,9 +557,7 @@ pub fn substrate_ingress<'pktbuf>(
         if !asm.flags.allow_insecure_zpi_zero {
             warn!(
                 "{}: ingress: link {}: ZPI 0 only allows key management messages, not {:?}",
-                asm.system_name,
-                format_link_id(ingress_link_id),
-                base_hdr.packet_type
+                asm.system_name, ingress_link_id, base_hdr.packet_type
             );
             drop_and_count(asm, pkt, CounterType::OtherError);
             return;
@@ -560,7 +571,7 @@ pub fn substrate_ingress<'pktbuf>(
         *pkt.alloc_zeroed_header() = base_hdr;
         match asm
             .mgmt_dispatch
-            .try_dispatch_mgmt_packet(ingress_link_id, peer_sa, pkt)
+            .try_dispatch_mgmt_packet_with_link(ingress_link_id, pkt)
         {
             Ok(()) => (),
             Err(TryEnqueueError::Full(pkt)) => {
@@ -569,10 +580,6 @@ pub fn substrate_ingress<'pktbuf>(
         }
         return;
     }
-
-    let Some(ingress_link_id) = ingress_link_id else {
-        return drop_and_count(asm, pkt, CounterType::UnknownPeer);
-    };
 
     let Some(per_flow_hdr) = zdp::ZdpPerFlowHeader::read_from_buf(&mut pkt) else {
         return drop_and_count(asm, pkt, CounterType::BadStructure);

--- a/adapter/ph/src/km_cert_exchange.rs
+++ b/adapter/ph/src/km_cert_exchange.rs
@@ -70,6 +70,7 @@ struct CertExchgHdr {
 
 /// The Certificate Exchange object holds the local certificate (which includes the noise public key)
 /// and the certificate for our trusted signing authority.
+#[derive(Clone)]
 pub struct KmCertExchange {
     local_cert: X509,
     authority_cert: X509,

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -357,6 +357,7 @@ mod test {
     use crate::config;
     use crate::km::KmLinkMsg;
     use crate::km_testdata::test::*;
+    use crate::link_state::LinkType;
     use crate::mgmt_processor_worker;
     use crate::peer_table;
     use base64::prelude::*;
@@ -420,7 +421,7 @@ mod test {
                         zpr::SubstrateAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9000);
 
                     let peer_state =
-                        peer_table::PeerState::new(peer_table::PeerType::Adapter, fake_sa, |q| {
+                        peer_table::PeerState::new(LinkType::NodeToAdapter, fake_sa, |q| {
                             mgmt_processor_worker::launch(&worker_config, &*asm, q)
                         });
 

--- a/adapter/ph/src/lib.rs
+++ b/adapter/ph/src/lib.rs
@@ -19,6 +19,7 @@ pub mod km_demo;
 pub mod km_multiplexor;
 pub mod km_noise;
 pub mod km_xor;
+pub mod link_state;
 pub mod mgmt;
 pub mod mgmt_dispatch_worker;
 pub mod mgmt_processor_worker;

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1,4 +1,4 @@
-use crate::zpr::LinkId;
+use crate::zpr::{LinkId, LINK_ID_UNKNOWN};
 
 /// State machine for links and docking sessions
 
@@ -43,7 +43,7 @@ pub struct LinkStateMachine {
 impl LinkStateMachine {
     pub fn new(new_link_type: LinkType) -> Self {
         Self {
-            link_id: 0, // Invalid link ID
+            link_id: LINK_ID_UNKNOWN,
             link_type: new_link_type,
             link_state: LinkState::Initial,
             link_status: LinkStatus::Down,

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1,0 +1,53 @@
+use crate::zpr::LinkId;
+
+/// State machine for links and docking sessions
+
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub enum LinkType {
+    AdapterToNode,
+    NodeToNode,
+    NodeToAdapter,
+}
+
+#[allow(dead_code)]
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum LinkState {
+    Initial,
+    Inactive,
+    Keying,
+    Helloing,
+    Closing,
+    Active,
+    Listening,
+    RegisterAA,
+    Error,
+}
+
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug)]
+pub enum LinkStatus {
+    Up,
+    Down,
+}
+
+#[allow(dead_code)]
+pub struct LinkStateMachine {
+    link_id: LinkId,
+    link_type: LinkType,
+    link_state: LinkState,
+    link_status: LinkStatus,
+    silent: bool,
+}
+
+impl LinkStateMachine {
+    pub fn new(new_link_type: LinkType) -> Self {
+        Self {
+            link_id: 0, // Invalid link ID
+            link_type: new_link_type,
+            link_state: LinkState::Initial,
+            link_status: LinkStatus::Down,
+            silent: false,
+        }
+    }
+}

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -16,7 +16,7 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_tun::TunBuilder;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 use tracing_subscriber;
 use zpr_ext::tokio::net::UdpSocketExt;
 
@@ -39,6 +39,7 @@ mod km;
 mod km_cert_exchange;
 mod km_multiplexor;
 mod km_noise;
+mod link_state;
 mod mgmt;
 mod mgmt_dispatch_worker;
 mod mgmt_processor_worker;
@@ -67,7 +68,6 @@ use capture_worker::CaptureWorker;
 use counter::*;
 use counters_enum::*;
 use flow_control::FlowControl;
-use km::ZPIPair;
 use km_multiplexor::KmState;
 use km_noise::NoiseKeypair;
 use queues::*;
@@ -86,10 +86,7 @@ struct CmdLine {
     self_addr: SocketAddr,
 
     #[arg(long)]
-    peer_addr1: SocketAddr,
-
-    #[arg(long)]
-    peer_addr2: Option<SocketAddr>,
+    node_addr: Option<SocketAddr>,
 
     #[arg(long)]
     ca_file: Option<String>,
@@ -138,8 +135,7 @@ fn main() -> ExitCode {
     let system_name = cmd_line.name;
     let sock_path = cmd_line.control_path;
     let self_addr = cmd_line.self_addr;
-    let peer_addr1 = cmd_line.peer_addr1;
-    let peer_addr2 = cmd_line.peer_addr2;
+    let node_addr = cmd_line.node_addr;
     let ca_file = cmd_line.ca_file;
     let cert_file = cmd_line.certificate_file;
     let priv_key_file = cmd_line.private_key_file;
@@ -203,13 +199,13 @@ fn main() -> ExitCode {
     let (km_tx, km_rx) = mpsc::channel(km_message_queue_size);
     let km_state = KmState::new(km_tx, km_sig_tx);
 
-    if peer_addr2.is_some() {
-        ph_mode = PhMode::Node;
-    } else {
+    if node_addr.is_some() {
         ph_mode = PhMode::Adapter;
         if !disable_km && node_pubkey_file.is_none() {
             panic!("Node public key file must be specified when starting an adapter");
         }
+    } else {
+        ph_mode = PhMode::Node;
     }
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -349,95 +345,39 @@ fn main() -> ExitCode {
         mgmt_dispatch,
         adapter_manager,
         km_state,
+        self_noise_keypair: None,
+        peer_noise_keypair: None,
+        certx: None,
     }));
 
     tokio::task::LocalSet::new().block_on(&runtime, async {
-        // TEMP HACK to statically install peers
-
-        // If we are running as adapter, we only have the node public key.
-        // If we are running as node then we have a private key (and can derive public).
-        let dock_noise_kp: NoiseKeypair;
-        let adapter_noise_kp: NoiseKeypair;
         if !disable_km {
             let private_key = km_cert_exchange::load_private_key(&Path::new(&priv_key_file.unwrap())).unwrap();
             if ph_mode == PhMode::Node {
-                dock_noise_kp = NoiseKeypair::new(private_key);
-                adapter_noise_kp = NoiseKeypair::new_zeroed(); // not used
+                asm.self_noise_keypair = Some(NoiseKeypair::new(private_key));
             } else {
                 let public_key = km_cert_exchange::load_public_key(&Path::new(&node_pubkey_file.unwrap())).unwrap();
-                dock_noise_kp = NoiseKeypair {
+                asm.peer_noise_keypair = Some(NoiseKeypair {
                     public: public_key,
                     private: [0u8; 32], // unknown
-                };
-                adapter_noise_kp = NoiseKeypair::new(private_key);
+                });
+                asm.self_noise_keypair = Some(NoiseKeypair::new(private_key));
             }
-        } else {
-            dock_noise_kp = NoiseKeypair::new_zeroed(); // not used
-            adapter_noise_kp = NoiseKeypair::new_zeroed(); // not used
+
+            asm.certx = Some(KmCertExchange::new_from_paths(
+                &Path::new(&cert_file.as_ref().unwrap()),
+                &Path::new(&ca_file.as_ref().unwrap())
+                ).unwrap());
         }
 
-        // Presence of peer2 means we are a node.
-        if let Some(pa2) = peer_addr2 {
-            let peer_id2 = asm
-                .hack_add_peer(peer_table::PeerType::Adapter, pa2)
-                .unwrap();
 
-            asm.peer_ids.lock().unwrap().push(peer_id2);
-
-            if !disable_km {
-                let certx = KmCertExchange::new_from_paths(
-                    &Path::new(&cert_file.as_ref().unwrap()),
-                    &Path::new(&ca_file.as_ref().unwrap())
-                    ).unwrap();
-                km_multiplexor::add_node_link(
-                    asm,
-                    peer_id2,
-                     ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 1, 2),
-                    dock_noise_kp.clone(),
-                    certx
-                )
-                .unwrap();
-            }
-        }
-
-        let peer_id = asm
-            .hack_add_peer(
-                match ph_mode {
-                    PhMode::Node => peer_table::PeerType::Adapter,
-                    PhMode::Adapter => peer_table::PeerType::Node,
-                },
-                peer_addr1,
-            )
-            .unwrap();
-
-        asm.peer_ids.lock().unwrap().push(peer_id);
-        if !disable_km {
-            let certx = KmCertExchange::new_from_paths(
-                &Path::new(&cert_file.unwrap()),
-                &Path::new(&ca_file.unwrap())
-            ).unwrap();
-            if ph_mode == PhMode::Adapter {
-                km_multiplexor::add_adapter_link(
-                    asm,
-                    peer_id,
-                    ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 3, 4),
-                    adapter_noise_kp.clone(),
-                    dock_noise_kp.public.clone(),
-                    certx
-                )
-                .unwrap();
-            } else {
-                km_multiplexor::add_node_link(
-                    asm,
-                    peer_id,
-                    ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 5, 6),
-                    dock_noise_kp.clone(),
-                    certx
-                )
-                .unwrap();
-            }
-        }
-        // END HACK
+        let dsid = match ph_mode {
+            PhMode::Adapter => match asm.initiate_tether(node_addr.as_ref().unwrap()) {
+                Ok(dsid) => Some(dsid),
+                Err(_) => None
+            },
+            PhMode::Node => None
+        };
 
         // TODO signal handler goes here
 
@@ -500,10 +440,7 @@ fn main() -> ExitCode {
             js.spawn(km_multiplexor::launch_message_worker(&*asm, km_rx));
         }
 
-        info!("{}: connecting...", asm.system_name);
-        info!("{}: connected!", asm.system_name); // FIXME: it's a lie
-        asm.tun_ctl.set_carrier(true).unwrap();
-
+        info!("{}: Starting substrate ingress workers", asm.system_name);
         for (worker_index, socket) in sockets.iter().enumerate() {
             js.spawn(substrate_ingress_worker::launch(
                 &substrate_ingress_worker::Config {
@@ -514,20 +451,23 @@ fn main() -> ExitCode {
                 socket,
             ));
         }
+        //if asm.is_node() {
+            asm.tun_ctl.set_carrier(true).unwrap();
+        //}
+
 
         if matches!(ph_mode, PhMode::Adapter) {
-            let dsid = asm.hack_get_adapter_docking_session_id();
-            if !disable_km {
+            if !disable_km && dsid.is_some() {
                 info!(
                     "{}: waiting on security assocaition establishment on link {}",
-                    asm.system_name, dsid
+                    asm.system_name, dsid.unwrap()
                 );
-                while !asm.peer_table.is_security_assocaition_established(dsid) {
+                while !asm.peer_table.is_security_assocaition_established(dsid.unwrap()) {
                     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                 }
                 info!(
                     "{}: security assocaition established successfully on link {}",
-                    asm.system_name, dsid
+                    asm.system_name, dsid.unwrap()
                 );
 
                 // HACK - In our tests we need to send from adapter through the node to the adapter.
@@ -538,18 +478,8 @@ fn main() -> ExitCode {
             }
 
 
-            mgmt::requests::send_report(asm, dsid, "Reporting for Duty!").await;
-            mgmt::requests::send_discard(asm, dsid).await;
-            match mgmt::requests::send_hello_request(asm, dsid).await {
-                Ok(_) => info!(
-                    "{}: hello request sent successfully on link {}",
-                    asm.system_name, dsid
-                ),
-                Err(e) => error!(
-                    "{}: hello request failed on link {}: {:?}",
-                    asm.system_name, dsid, e
-                ),
-            }
+            mgmt::requests::send_report(asm, dsid.unwrap(), "Reporting for Duty!").await;
+            mgmt::requests::send_discard(asm, dsid.unwrap()).await;
         }
 
         while let Some(res) = js.join_next().await {

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -19,13 +19,23 @@ use zpr_ext::zerocopy::FromBytesExt;
 /// This function does not block, and does not perform significant processing.
 /// It merely dispatches the management packet to the correct queue.
 pub fn dispatch_mgmt_packet<'pktbuf>(
-    asm: &Assembly<'pktbuf>,
-    ingress_link_id: zpr::LinkId,
+    asm: &'static Assembly<'pktbuf>,
+    ingress_link_id: Option<zpr::LinkId>,
+    peer_sa: zpr::SubstrateAddr,
     mut pkt: Packet<'pktbuf>,
 ) {
     match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
         Some(base_hdr) if base_hdr.packet_type == zdp::ZdpPacketType::KeyManagement => {
             pkt.advance(std::mem::size_of::<zdp::ZdpBaseHeader>());
+
+            // TODO: once we have multi-node, how do we know whether this is a link or a
+            // tether?
+            let Some(ingress_link_id) =
+                ingress_link_id.or_else(|| asm.accept_tether(&peer_sa).ok())
+            else {
+                return fastpath::drop_and_count(asm, pkt, CounterType::UnknownPeer);
+            };
+
             match handle_key_management(asm, ingress_link_id, pkt) {
                 Ok(()) => (),
                 Err((err, pkt)) => fastpath::drop_and_count(asm, pkt, err),
@@ -33,6 +43,10 @@ pub fn dispatch_mgmt_packet<'pktbuf>(
         }
 
         Some(base_hdr) if base_hdr.packet_type.is_response() => {
+            let Some(ingress_link_id) = ingress_link_id else {
+                return fastpath::drop_and_count(asm, pkt, CounterType::UnknownPeer);
+            };
+
             match handle_response(asm, ingress_link_id, pkt) {
                 Ok(()) => (),
                 Err((err, pkt)) => fastpath::drop_and_count(asm, pkt, err),
@@ -40,6 +54,10 @@ pub fn dispatch_mgmt_packet<'pktbuf>(
         }
 
         _ => {
+            let Some(ingress_link_id) = ingress_link_id else {
+                return fastpath::drop_and_count(asm, pkt, CounterType::UnknownPeer);
+            };
+
             let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
                 fastpath::drop_and_count(asm, pkt, CounterType::PeerRemoved);
                 return;
@@ -87,7 +105,7 @@ fn handle_response<'pktbuf>(
 // ZPI and Base header is already gone by the time we get here.  So we expect
 // to parse starting from the KeyManagement header.
 fn handle_key_management<'pktbuf>(
-    asm: &Assembly<'pktbuf>,
+    asm: &'static Assembly<'pktbuf>,
     ingress_link_id: zpr::LinkId,
     mut pkt: Packet<'pktbuf>,
 ) -> HandleMgmtResult<'pktbuf> {
@@ -110,6 +128,7 @@ fn handle_key_management<'pktbuf>(
         error!("KeyManagement packet arrived with truncated payload");
         return Err((HandleMgmtError::BadStructure, pkt));
     }
+
     match km_multiplexor::handle_inbound_km_msg(asm, ingress_link_id, &pkt.body()[..km_msg_len]) {
         Ok(()) => (),
         Err(e) => {

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -14,13 +14,12 @@ use tracing::error;
 use zerocopy::FromBytes;
 use zpr_ext::zerocopy::FromBytesExt;
 
-/// Dispatch the given management packet.
+/// Dispatch a management packet for a link that hasn't been established yet
 ///
 /// This function does not block, and does not perform significant processing.
 /// It merely dispatches the management packet to the correct queue.
-pub fn dispatch_mgmt_packet<'pktbuf>(
+pub fn dispatch_mgmt_packet_with_addr<'pktbuf>(
     asm: &'static Assembly<'pktbuf>,
-    ingress_link_id: Option<zpr::LinkId>,
     peer_sa: zpr::SubstrateAddr,
     mut pkt: Packet<'pktbuf>,
 ) {
@@ -30,9 +29,7 @@ pub fn dispatch_mgmt_packet<'pktbuf>(
 
             // TODO: once we have multi-node, how do we know whether this is a link or a
             // tether?
-            let Some(ingress_link_id) =
-                ingress_link_id.or_else(|| asm.accept_tether(&peer_sa).ok())
-            else {
+            let Some(ingress_link_id) = asm.accept_tether(&peer_sa).ok() else {
                 return fastpath::drop_and_count(asm, pkt, CounterType::UnknownPeer);
             };
 
@@ -41,12 +38,32 @@ pub fn dispatch_mgmt_packet<'pktbuf>(
                 Err((err, pkt)) => fastpath::drop_and_count(asm, pkt, err),
             }
         }
+        _ => {
+            return fastpath::drop_and_count(asm, pkt, CounterType::UnknownPeer);
+        }
+    }
+}
+
+/// Dispatch the given management packet.
+///
+/// This function does not block, and does not perform significant processing.
+/// It merely dispatches the management packet to the correct queue.
+pub fn dispatch_mgmt_packet_with_link<'pktbuf>(
+    asm: &'static Assembly<'pktbuf>,
+    ingress_link_id: zpr::LinkId,
+    mut pkt: Packet<'pktbuf>,
+) {
+    match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
+        Some(base_hdr) if base_hdr.packet_type == zdp::ZdpPacketType::KeyManagement => {
+            pkt.advance(std::mem::size_of::<zdp::ZdpBaseHeader>());
+
+            match handle_key_management(asm, ingress_link_id, pkt) {
+                Ok(()) => (),
+                Err((err, pkt)) => fastpath::drop_and_count(asm, pkt, err),
+            }
+        }
 
         Some(base_hdr) if base_hdr.packet_type.is_response() => {
-            let Some(ingress_link_id) = ingress_link_id else {
-                return fastpath::drop_and_count(asm, pkt, CounterType::UnknownPeer);
-            };
-
             match handle_response(asm, ingress_link_id, pkt) {
                 Ok(()) => (),
                 Err((err, pkt)) => fastpath::drop_and_count(asm, pkt, err),
@@ -54,10 +71,6 @@ pub fn dispatch_mgmt_packet<'pktbuf>(
         }
 
         _ => {
-            let Some(ingress_link_id) = ingress_link_id else {
-                return fastpath::drop_and_count(asm, pkt, CounterType::UnknownPeer);
-            };
-
             let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
                 fastpath::drop_and_count(asm, pkt, CounterType::PeerRemoved);
                 return;

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -39,6 +39,7 @@ pub async fn send_discard(asm: &Assembly<'_>, link_id: zpr::LinkId) {
     core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::Discard, pkt).await;
 }
 
+#[allow(dead_code)]
 /// send a Hello Request and wait for the Response (RFC 6.5 § 6.3.4)
 pub async fn send_hello_request<'a, 'pktbuf>(
     asm: &'a Assembly<'pktbuf>,

--- a/adapter/ph/src/mgmt_dispatch_worker.rs
+++ b/adapter/ph/src/mgmt_dispatch_worker.rs
@@ -6,22 +6,22 @@ use crate::queues::MgmtDispatchMessage;
 use std::future::Future;
 use tokio::sync::mpsc;
 
-async fn worker<'pktbuf>(
-    asm: &Assembly<'pktbuf>,
-    queue: &mut mpsc::Receiver<MgmtDispatchMessage<'pktbuf>>,
+async fn worker(
+    asm: &'static Assembly<'_>,
+    queue: &mut mpsc::Receiver<MgmtDispatchMessage<'static>>,
 ) {
     while let Some(msg) = queue.recv().await {
         match msg {
-            MgmtDispatchMessage::Packet(ingress_link_id, pkt) => {
-                dispatch::dispatch_mgmt_packet(asm, ingress_link_id, pkt);
+            MgmtDispatchMessage::Packet(ingress_link_id, peer_sa, pkt) => {
+                dispatch::dispatch_mgmt_packet(asm, ingress_link_id, peer_sa, pkt);
             }
         }
     }
 }
 
-pub fn launch<'pktbuf>(
-    asm: impl std::ops::Deref<Target = Assembly<'pktbuf>> + Send + Sync + 'pktbuf,
-    mut queue: mpsc::Receiver<MgmtDispatchMessage<'pktbuf>>,
-) -> impl Future<Output = ()> + 'pktbuf {
+pub fn launch(
+    asm: &'static Assembly,
+    mut queue: mpsc::Receiver<MgmtDispatchMessage<'static>>,
+) -> impl Future<Output = ()> + 'static {
     async move { worker(&*asm, &mut queue).await }
 }

--- a/adapter/ph/src/mgmt_dispatch_worker.rs
+++ b/adapter/ph/src/mgmt_dispatch_worker.rs
@@ -12,8 +12,11 @@ async fn worker(
 ) {
     while let Some(msg) = queue.recv().await {
         match msg {
-            MgmtDispatchMessage::Packet(ingress_link_id, peer_sa, pkt) => {
-                dispatch::dispatch_mgmt_packet(asm, ingress_link_id, peer_sa, pkt);
+            MgmtDispatchMessage::WithLink(ingress_link_id, pkt) => {
+                dispatch::dispatch_mgmt_packet_with_link(asm, ingress_link_id, pkt);
+            }
+            MgmtDispatchMessage::WithAddr(peer_sa, pkt) => {
+                dispatch::dispatch_mgmt_packet_with_addr(asm, peer_sa, pkt);
             }
         }
     }

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use crate::dock_tables::DockForwardingTable;
 use crate::km::{KeyManager, KmTransportSA};
+use crate::link_state::{LinkStateMachine, LinkType};
 use crate::queues;
 use crate::rcu::{RcuBox, RcuCslabEntryGuard, RcuOptionGuard};
 use crate::sync_req;
@@ -17,11 +18,6 @@ use tokio_util::sync::CancellationToken;
 
 const PEER_TABLE_SIZE: usize = 1024;
 
-pub enum PeerType {
-    Node,
-    Adapter,
-}
-
 // FIXME TODO:
 // nodes and adapters have different state requirements.
 // rather than indirecting through an enum, we could/should
@@ -29,8 +25,8 @@ pub enum PeerType {
 // this matches the RFC model of separate docks and forwarders.
 // for now, everyone has a DFT.......
 pub struct PeerState<'pktbuf> {
-    pub peer_type: PeerType,
     pub substrate_addr: SubstrateAddr,
+    pub link_state_machine: Mutex<LinkStateMachine>,
     pub sync_req_state: sync_req::SyncReqState<'pktbuf>,
     pub dft: DockForwardingTable,
     pub mgmt_processor: queues::MgmtProcessor<'pktbuf>,
@@ -67,7 +63,7 @@ const MGMT_PROCESSOR_QUEUE_SIZE: usize = 16;
 // FIXME: can we eliminate the reliance on `'static` herein?
 impl PeerState<'static> {
     pub fn new<Worker>(
-        peer_type: PeerType,
+        link_type: LinkType,
         substrate_addr: SubstrateAddr,
         launch_mgmt_processor_worker: impl FnOnce(
             mpsc::Receiver<queues::MgmtProcessorMessage<'static>>,
@@ -82,8 +78,8 @@ impl PeerState<'static> {
         let mgmt_processor_worker = task::spawn_local(launch_mgmt_processor_worker(mp_outq));
 
         Self {
-            peer_type,
             substrate_addr,
+            link_state_machine: Mutex::new(LinkStateMachine::new(link_type)),
             dft: DockForwardingTable::new(),
             sync_req_state: sync_req::SyncReqState::new(),
             mgmt_processor,
@@ -199,6 +195,7 @@ impl<'pktbuf> PeerTable<'pktbuf> {
             .get(link_id)
             .ok_or(SecurityAssocaitionStateError::NoAssociationForLink)?;
         entry.km_state.transport_sa.write(Some(sa));
+        //entry.link_state_machine.lock().unwrap().keying_done();
         Ok(())
     }
 

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -256,7 +256,7 @@ impl<'pktbuf> Capture<'pktbuf> {
 }
 
 pub enum MgmtDispatchMessage<'pktbuf> {
-    Packet(zpr::LinkId, Packet<'pktbuf>), // FIXME: reserve link ID 0, store link ID in packet
+    Packet(Option<zpr::LinkId>, zpr::SubstrateAddr, Packet<'pktbuf>), // FIXME: reserve link ID 0, store link ID in packet
 }
 
 pub struct MgmtDispatch<'pktbuf> {
@@ -270,19 +270,21 @@ impl<'pktbuf> MgmtDispatch<'pktbuf> {
 
     pub fn try_dispatch_mgmt_packet(
         &self,
-        ingress_link_id: zpr::LinkId,
+        ingress_link_id: Option<zpr::LinkId>,
+        peer_sa: &zpr::SubstrateAddr,
         packet: Packet<'pktbuf>,
     ) -> Result<(), TryEnqueueError<Packet<'pktbuf>>> {
-        match self
-            .sender
-            .try_send(MgmtDispatchMessage::Packet(ingress_link_id, packet))
-        {
+        match self.sender.try_send(MgmtDispatchMessage::Packet(
+            ingress_link_id,
+            *peer_sa,
+            packet,
+        )) {
             Ok(()) => Ok(()),
 
             Err(TrySendError::Closed(_)) => panic!("mgmt dispatch channel closed"),
 
             Err(TrySendError::Full(msg)) => match msg {
-                MgmtDispatchMessage::Packet(_, packet) => Err(TryEnqueueError::Full(packet)),
+                MgmtDispatchMessage::Packet(_, _, packet) => Err(TryEnqueueError::Full(packet)),
             },
         }
     }

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -256,7 +256,8 @@ impl<'pktbuf> Capture<'pktbuf> {
 }
 
 pub enum MgmtDispatchMessage<'pktbuf> {
-    Packet(Option<zpr::LinkId>, zpr::SubstrateAddr, Packet<'pktbuf>), // FIXME: reserve link ID 0, store link ID in packet
+    WithLink(zpr::LinkId, Packet<'pktbuf>), // FIXME: store link ID in packet
+    WithAddr(zpr::SubstrateAddr, Packet<'pktbuf>),
 }
 
 pub struct MgmtDispatch<'pktbuf> {
@@ -268,24 +269,47 @@ impl<'pktbuf> MgmtDispatch<'pktbuf> {
         Self { sender }
     }
 
-    pub fn try_dispatch_mgmt_packet(
+    pub fn try_dispatch_mgmt_packet_with_link(
         &self,
-        ingress_link_id: Option<zpr::LinkId>,
-        peer_sa: &zpr::SubstrateAddr,
+        ingress_link_id: zpr::LinkId,
         packet: Packet<'pktbuf>,
     ) -> Result<(), TryEnqueueError<Packet<'pktbuf>>> {
-        match self.sender.try_send(MgmtDispatchMessage::Packet(
-            ingress_link_id,
-            *peer_sa,
-            packet,
-        )) {
+        match self
+            .sender
+            .try_send(MgmtDispatchMessage::WithLink(ingress_link_id, packet))
+        {
             Ok(()) => Ok(()),
 
             Err(TrySendError::Closed(_)) => panic!("mgmt dispatch channel closed"),
 
-            Err(TrySendError::Full(msg)) => match msg {
-                MgmtDispatchMessage::Packet(_, _, packet) => Err(TryEnqueueError::Full(packet)),
-            },
+            Err(TrySendError::Full(msg)) => {
+                let MgmtDispatchMessage::WithLink(_, pkt) = msg else {
+                    unreachable!()
+                };
+                Err(TryEnqueueError::Full(pkt))
+            }
+        }
+    }
+
+    pub fn try_dispatch_mgmt_packet_with_addr(
+        &self,
+        peer_sa: &zpr::SubstrateAddr,
+        packet: Packet<'pktbuf>,
+    ) -> Result<(), TryEnqueueError<Packet<'pktbuf>>> {
+        match self
+            .sender
+            .try_send(MgmtDispatchMessage::WithAddr(*peer_sa, packet))
+        {
+            Ok(()) => Ok(()),
+
+            Err(TrySendError::Closed(_)) => panic!("mgmt dispatch channel closed"),
+
+            Err(TrySendError::Full(msg)) => {
+                let MgmtDispatchMessage::WithLink(_, pkt) = msg else {
+                    unreachable!()
+                };
+                Err(TryEnqueueError::Full(pkt))
+            }
         }
     }
 }

--- a/adapter/ph/test/basic-test.sh
+++ b/adapter/ph/test/basic-test.sh
@@ -66,8 +66,7 @@ echo "Launching DUTs"
 #
 sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
      --name "zpr-node" --control-path "$NODE_SOCK" \
-     --self-addr 0.0.0.0:12345 --peer-addr1 "$A_SUBSTRATE_ADDR":12345 \
-     --peer-addr2 "$B_SUBSTRATE_ADDR":12345 \
+     --self-addr 0.0.0.0:12345 \
      --ca-file ca.crt --certificate-file node.crt --private-key-file node.key \
      --tun-if tun0 2>&1 |tee node.log &
 CHILDREN=(${CHILDREN[@]} "$!")
@@ -76,7 +75,7 @@ sleep 2
 
 sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \
-  --self-addr "$A_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_A":12345 \
+  --self-addr "$A_SUBSTRATE_ADDR":12345 --node-addr "$NODE_SUBSTRATE_ADDR_A":12345 \
   --ca-file ca.crt --certificate-file adapter1.crt --private-key-file adapter1.key \
   --node-public-key-file node.pubkey \
   --tun-if tun0 2>&1 |tee adapter1.log &
@@ -85,7 +84,7 @@ CHILDREN=(${CHILDREN[@]} "$!")
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-b" --control-path "$ADAPTER2_SOCK" \
-  --self-addr "$B_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_B":12345 \
+  --self-addr "$B_SUBSTRATE_ADDR":12345 --node-addr "$NODE_SUBSTRATE_ADDR_B":12345 \
   --ca-file ca.crt --certificate-file adapter2.crt --private-key-file adapter2.key \
   --node-public-key-file node.pubkey \
   --tun-if tun0 2>&1 |tee adapter2.log &
@@ -141,7 +140,7 @@ done
 # Cleanup
 #
 
-sudo kill "${CHILDREN[@]}" 2> /dev/null || true
+sudo kill -SIGUSR1 "${CHILDREN[@]}" 2> /dev/null || true
 sleep 1  # FIXME: let's do something better here
 stty sane || true
 

--- a/adapter/ph/test/capture-test.sh
+++ b/adapter/ph/test/capture-test.sh
@@ -76,8 +76,7 @@ create_agent_key_and_cert ca node
 #
 sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-node" --control-path "$NODE_SOCK" \
-  --self-addr 0.0.0.0:12345 --peer-addr1 "$A_SUBSTRATE_ADDR":12345 \
-  --peer-addr2 "$B_SUBSTRATE_ADDR":12345 \
+  --self-addr 0.0.0.0:12345 \
   --ca-file ca.crt --certificate-file node.crt --private-key-file node.key \
   --tun-if tun0 2>&1 |tee node.log &
 CHILDREN=(${CHILDREN[@]} "$!")
@@ -86,7 +85,7 @@ sleep 2
 
 sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-a" --control-path "$ADAPTER1_SOCK" \
-  --self-addr "$A_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_A":12345 \
+  --self-addr "$A_SUBSTRATE_ADDR":12345 --node-addr "$NODE_SUBSTRATE_ADDR_A":12345 \
   --ca-file ca.crt --certificate-file adapter1.crt --private-key-file adapter1.key \
   --node-public-key-file node.pubkey \
   --tun-if tun0 2>&1 |tee adapter1.log &
@@ -94,7 +93,7 @@ CHILDREN=(${CHILDREN[@]} "$!")
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --name "zpr-b" --control-path "$ADAPTER2_SOCK" \
-  --self-addr "$B_SUBSTRATE_ADDR":12345 --peer-addr1 "$NODE_SUBSTRATE_ADDR_B":12345 \
+  --self-addr "$B_SUBSTRATE_ADDR":12345 --node-addr "$NODE_SUBSTRATE_ADDR_B":12345 \
   --ca-file ca.crt --certificate-file adapter2.crt --private-key-file adapter2.key \
   --node-public-key-file node.pubkey \
   --tun-if tun0 2>&1 |tee adapter2.log &


### PR DESCRIPTION
- Move most of link bringup out of main (some pending)
- Initial add of LinkState data structures (mostly unused in this PR)
- Dynamic link bringup based on key management messages
- Remove now-extraneous peer IPs from node command line args