### PR TITLE
Zerocopy upgrade to v0.8

### DIFF
--- a/adapter/cd/Cargo.lock
+++ b/adapter/cd/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -282,7 +282,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "zerocopy",
+ "zerocopy 0.8.3",
 ]
 
 [[package]]
@@ -1060,7 +1060,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "zerocopy",
+ "zerocopy 0.8.3",
  "zpr-ext",
 ]
 
@@ -1111,7 +1111,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1854,7 +1854,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199837a02c176ffe66ac6e3f6195ff49ed0ae9c0fc9c905970f924909812aba6"
+dependencies = [
+ "zerocopy-derive 0.8.3",
 ]
 
 [[package]]
@@ -1869,6 +1878,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy-derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c76c8bc3d9d3594dabe11d4ffab6cd71cc2c3ce38526c6de5a0d81dd0039627"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,12 +1896,12 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zpr-ext"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "libc",
  "nix",
  "tokio",
  "tokio-tun",
- "zerocopy",
+ "zerocopy 0.8.3",
 ]

--- a/adapter/cd/Cargo.toml
+++ b/adapter/cd/Cargo.toml
@@ -24,7 +24,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 ph = { path = "../ph" }
 bytes = "1"
-zerocopy = "0.7.35"
+zerocopy = "0.8.3"
 snow = "0.9.6"
 
 [features]

--- a/adapter/cd/src/zdp/client.rs
+++ b/adapter/cd/src/zdp/client.rs
@@ -141,12 +141,11 @@ impl ZDPClient {
                         Ok(input_len) => {
                             info!("zdp/client - read {} bytes", input_len);
 
-                            let zpi_hdr = ZdpZpiHeader::ref_from_prefix(&buf[0..input_len]);
-                            if zpi_hdr.is_none() {
+                            let Ok((zpi_hdr, _)) = ZdpZpiHeader::ref_from_prefix(&buf[0..input_len]) else {
                                 info!("zdp/server - error parsing ZPI header");
                                 continue;
-                            }
-                            let zpi_hdr = zpi_hdr.unwrap();
+                            };
+
                             match zpi_hdr.zpi {
                                 0 => {
                                     info!("zdp/client - received ZPI=0 message");

--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -940,7 +940,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "zerocopy",
+ "zerocopy 0.8.3",
  "zpr-ext",
 ]
 
@@ -1567,8 +1567,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199837a02c176ffe66ac6e3f6195ff49ed0ae9c0fc9c905970f924909812aba6"
+dependencies = [
+ "zerocopy-derive 0.8.3",
 ]
 
 [[package]]
@@ -1583,6 +1591,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy-derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c76c8bc3d9d3594dabe11d4ffab6cd71cc2c3ce38526c6de5a0d81dd0039627"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,12 +1609,12 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zpr-ext"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "libc",
  "nix",
  "tokio",
  "tokio-tun",
- "zerocopy",
+ "zerocopy 0.8.3",
 ]

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -28,7 +28,7 @@ tokio-util = { version = "0.7.11", features = ["rt"] }
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
-zerocopy = { version = "0.7.34", features = ["byteorder", "derive"] }
+zerocopy = { version = "0.8.3", features = ["derive", "std"] }
 zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "tokio-tun", "zerocopy"] }
 
 [dev-dependencies]

--- a/adapter/ph/src/classifier.rs
+++ b/adapter/ph/src/classifier.rs
@@ -2,9 +2,10 @@
 use crate::net_defs::*;
 use crate::packet;
 use crate::zpr::L3Type;
+use arrayref::array_ref;
 use std::mem::size_of;
-use zerocopy::{AsBytes, FromZeroes, KnownLayout, Unaligned};
-use zerocopy::{ByteOrder, FromBytes, NetworkEndian};
+use zerocopy::byteorder::network_endian::*;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 #[derive(Debug, PartialEq)]
 pub enum ClassifierResult {
@@ -18,14 +19,14 @@ pub enum ClassifierResult {
 pub const IP_VERSION_MASK: u8 = 0xF0;
 pub const IPV4_HEADER_LENGTH_MASK: u8 = 0x0F;
 
-#[derive(AsBytes, FromZeroes, FromBytes, KnownLayout, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 pub struct IPv4Header {
     pub vhl: u8,
     pub dscp: u8,
-    pub total_length: [u8; 2],
+    pub total_length: U16,
     pub frag_id: [u8; 2],
-    pub frag_offset: [u8; 2],
+    pub frag_offset: U16,
     pub ttl: u8,
     pub proto: u8,
     pub header_checksum: [u8; 2],
@@ -33,7 +34,7 @@ pub struct IPv4Header {
     pub dst_address: [u8; 4],
 }
 
-#[derive(AsBytes, FromZeroes, FromBytes, KnownLayout, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 pub struct IPv6Header {
     pub version_and_tc_upper: u8,
@@ -48,11 +49,11 @@ pub struct IPv6Header {
 
 const NO_NEXT_HEADER: u8 = 59;
 
-#[derive(FromZeroes, FromBytes, KnownLayout, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 struct TCPHeader {
-    pub src_port: [u8; 2],
-    pub dst_port: [u8; 2],
+    pub src_port: U16,
+    pub dst_port: U16,
     pub sequence_number: [u8; 4],
     pub acknowledgement_number: [u8; 4],
     pub data_offset_and_reserved: u8,
@@ -62,11 +63,11 @@ struct TCPHeader {
     pub urgent_pointer: [u8; 2],
 }
 
-#[derive(FromZeroes, FromBytes, KnownLayout, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 struct UDPHeader {
-    pub src_port: [u8; 2],
-    pub dst_port: [u8; 2],
+    pub src_port: U16,
+    pub dst_port: U16,
     pub length: [u8; 2],
     pub checksum: [u8; 2],
 }
@@ -112,11 +113,11 @@ fn classify_ipv4(
     }
 
     let header_bytes = &body[..size_of::<IPv4Header>()];
-    let ipv4_header = IPv4Header::ref_from(header_bytes).unwrap();
+    let ipv4_header = IPv4Header::ref_from_bytes(header_bytes).unwrap();
 
     let header_length = ipv4_header.vhl & IPV4_HEADER_LENGTH_MASK;
-    let total_length = NetworkEndian::read_u16(&ipv4_header.total_length);
-    if usize::from(total_length) != body.len()
+    let total_length = ipv4_header.total_length.get();
+    if total_length as usize != body.len()
         || header_length < 5
         || u16::from(header_length * 4) > total_length
     {
@@ -130,7 +131,7 @@ fn classify_ipv4(
 
     const FRAGMENT_OFFSET_MASK: u16 = 0x1FFF;
     const MORE_FRAGMENTS_MASK: u16 = 0x2000;
-    let frag_offset = NetworkEndian::read_u16(&ipv4_header.frag_offset);
+    let frag_offset = ipv4_header.frag_offset.get();
     if frag_offset & FRAGMENT_OFFSET_MASK != 0 {
         metadata.set_l4_protocol(ipv4_header.proto);
         return Ok(ClassifierResult::SubsequentFragment);
@@ -158,7 +159,7 @@ fn classify_ipv6(
     }
 
     let header_bytes = &body[..size_of::<IPv6Header>()];
-    let ipv6_header = IPv6Header::ref_from(header_bytes).unwrap();
+    let ipv6_header = IPv6Header::ref_from_bytes(header_bytes).unwrap();
 
     metadata.set_addresses(ipv6_header.src_address, ipv6_header.dst_address);
 
@@ -241,7 +242,7 @@ fn classify_frag(
     }
 
     const FRAG_OFFSET_MASK: u16 = 0xFFF8;
-    let frag_offset = NetworkEndian::read_u16(&body[2..4]);
+    let frag_offset = U16::from_bytes(*array_ref!(body, 2, 2)).get();
     if frag_offset & FRAG_OFFSET_MASK != 0 {
         // Subsequent fragments can't be parsed further
         return Ok(ClassifierResult::SubsequentFragment);
@@ -256,8 +257,8 @@ fn classify_icmp(
     _body: &[u8],
 ) -> Result<ClassifierResult, &'static str> {
     // TODO: check type and code
-    metadata.set_src_port([0u8; 2]);
-    metadata.set_dst_port([0u8; 2]);
+    metadata.set_src_port(0);
+    metadata.set_dst_port(0);
     Ok(ClassifierResult::OK)
 }
 
@@ -271,15 +272,15 @@ fn classify_tcp(
     }
 
     let header_bytes = &body[..size_of::<TCPHeader>()];
-    let tcp_header = TCPHeader::ref_from(header_bytes).unwrap();
+    let tcp_header = TCPHeader::ref_from_bytes(header_bytes).unwrap();
 
     let data_offset = (tcp_header.data_offset_and_reserved >> 4) * 4;
     if data_offset < 20 || data_offset as usize > body.len() {
         return Err("Packet length error");
     }
 
-    metadata.set_src_port(tcp_header.src_port);
-    metadata.set_dst_port(tcp_header.dst_port);
+    metadata.set_src_port(tcp_header.src_port.get());
+    metadata.set_dst_port(tcp_header.dst_port.get());
 
     Ok(ClassifierResult::OK)
 }
@@ -293,10 +294,10 @@ fn classify_udp(
     }
 
     let header_bytes = &body[..size_of::<UDPHeader>()];
-    let udp_header = UDPHeader::ref_from(header_bytes).unwrap();
+    let udp_header = UDPHeader::ref_from_bytes(header_bytes).unwrap();
 
-    metadata.set_src_port(udp_header.src_port);
-    metadata.set_dst_port(udp_header.dst_port);
+    metadata.set_src_port(udp_header.src_port.get());
+    metadata.set_dst_port(udp_header.dst_port.get());
 
     Ok(ClassifierResult::OK)
 }
@@ -304,8 +305,8 @@ fn classify_udp(
 fn classify_unclassified(
     metadata: &mut packet::PacketMetadata,
 ) -> Result<ClassifierResult, &'static str> {
-    metadata.set_src_port([0u8; 2]);
-    metadata.set_dst_port([0u8; 2]);
+    metadata.set_src_port(0);
+    metadata.set_dst_port(0);
     Ok(ClassifierResult::UnclassifiedL4)
 }
 
@@ -313,7 +314,7 @@ fn classify_unclassified(
 mod tests {
     use super::*;
     use crate::config;
-    use zerocopy::FromZeroes;
+    use zerocopy::FromZeros;
 
     #[test]
     fn test_non_ip() {

--- a/adapter/ph/src/compress.rs
+++ b/adapter/ph/src/compress.rs
@@ -5,16 +5,14 @@ use crate::defs::FiveTuple;
 use crate::net_defs;
 use crate::packet::Packet;
 use crate::zpr::{CompressionMode, L3Type};
-use arrayref::array_ref;
 use bytes::Buf;
 use std::net::{Ipv4Addr, Ipv6Addr};
-use zerocopy::FromBytes;
-use zerocopy::{AsBytes, FromZeroes, Unaligned};
+use zerocopy::*;
 use zpr_ext::bytes::BufExt;
 
 const ZDP_V4_FRAG_INFO_PRESENT: u8 = 0b00001000;
 
-#[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 struct CompressedIPv6Header {
     pub version_and_tc_upper: u8,
@@ -24,27 +22,26 @@ struct CompressedIPv6Header {
 }
 
 fn compress_addrs_v4(pkt: &mut Packet) {
-    let hdr = classifier::IPv4Header::ref_from_prefix(pkt.body()).unwrap();
+    let hdr = classifier::IPv4Header::ref_from_prefix(pkt.body())
+        .unwrap()
+        .0;
     let hl = hdr.vhl & classifier::IPV4_HEADER_LENGTH_MASK;
     let dscp = hdr.dscp;
-    let frag_flags = hdr.frag_offset[0] >> 5; // fragmentation flags
-    let frag_info = [
-        hdr.frag_id[0],
-        hdr.frag_id[1],
-        hdr.frag_offset[0] & 0x1f, // ignores fragmentation flags; NOTE/TODO: spec deviation
-        hdr.frag_offset[1],
-    ];
+    let frag_flags = hdr.frag_offset.get() >> 13; // fragmentation flags
+    let frag_id = hdr.frag_id;
+    let frag_offset = hdr.frag_offset & 0x1fff; // ignores fragmentation flags; NOTE/TODO: spec deviation
     let ttl = hdr.ttl;
 
     pkt.advance(std::mem::size_of::<classifier::IPv4Header>());
 
     pkt.push_header(&ttl);
 
-    let frag_info_present = frag_info != [0u8; 4];
+    let frag_info_present = frag_id != [0u8; 2] || frag_offset.get() != 0;
     // NOTE/TODO: this differs slightly from the spec, in that the ID field
     // is also optional.  I have an ask out to Frank to change this in the spec.
     if frag_info_present {
-        pkt.push_header(&frag_info);
+        pkt.push_header(&frag_offset);
+        pkt.push_header(&frag_id);
     }
 
     let hl_zdpflags = (hl << 4)
@@ -53,7 +50,7 @@ fn compress_addrs_v4(pkt: &mut Packet) {
         } else {
             0
         })
-        | frag_flags;
+        | (frag_flags as u8);
 
     pkt.push_header(&[hl_zdpflags, dscp]);
 }
@@ -67,13 +64,16 @@ fn expand_addrs_v4(pkt: &mut Packet, proto: u8, src_address: Ipv4Addr, dst_addre
     let frag_info_present = (hl_zdpflags & ZDP_V4_FRAG_INFO_PRESENT) != 0;
     let frag_flags = hl_zdpflags & 0x07;
 
-    let mut frag_info;
+    let frag_id;
+    let mut frag_offset;
     if frag_info_present {
-        frag_info = pkt.get_array::<4>();
+        frag_id = pkt.get_array::<2>();
+        frag_offset = pkt.get_u16();
     } else {
-        frag_info = [0u8; 4];
+        frag_id = [0u8; 2];
+        frag_offset = 0u16;
     }
-    frag_info[2] |= frag_flags << 5; // NOTE/TODO: spec deviation
+    frag_offset |= (frag_flags as u16) << 13; // NOTE/TODO: spec deviation
 
     let ttl = pkt.get_u8();
 
@@ -82,10 +82,9 @@ fn expand_addrs_v4(pkt: &mut Packet, proto: u8, src_address: Ipv4Addr, dst_addre
     let hdr = pkt.alloc_zeroed_header::<classifier::IPv4Header>();
     hdr.vhl = (4 << 4) | hl;
     hdr.dscp = tos;
-    hdr.total_length =
-        ((body_len + std::mem::size_of::<classifier::IPv4Header>()) as u16).to_be_bytes();
-    hdr.frag_id = *array_ref!(frag_info, 0, 2);
-    hdr.frag_offset = *array_ref!(frag_info, 2, 2);
+    hdr.total_length = ((body_len + std::mem::size_of::<classifier::IPv4Header>()) as u16).into();
+    hdr.frag_id = frag_id;
+    hdr.frag_offset = frag_offset.into();
     hdr.ttl = ttl;
     hdr.proto = proto;
     hdr.src_address = src_address.octets();
@@ -95,11 +94,14 @@ fn expand_addrs_v4(pkt: &mut Packet, proto: u8, src_address: Ipv4Addr, dst_addre
     let csum = net_defs::inet_checksum(&pkt.body()[..header_len]);
     classifier::IPv4Header::mut_from_prefix(pkt.body_mut())
         .unwrap()
+        .0
         .header_checksum = csum;
 }
 
 fn compress_addrs_v6(pkt: &mut Packet) {
-    let hdr = classifier::IPv6Header::ref_from_prefix(pkt.body()).unwrap();
+    let hdr = classifier::IPv6Header::ref_from_prefix(pkt.body())
+        .unwrap()
+        .0;
     let version_and_tc_upper = hdr.version_and_tc_upper;
     let tc_lower_and_fl_upper = hdr.tc_lower_and_fl_upper;
     let fl_lower = hdr.fl_lower;
@@ -120,7 +122,7 @@ fn expand_addrs_v6(
     src_address: Ipv6Addr,
     dst_address: Ipv6Addr,
 ) {
-    let chdr = CompressedIPv6Header::ref_from_prefix(pkt.body()).unwrap();
+    let chdr = CompressedIPv6Header::ref_from_prefix(pkt.body()).unwrap().0;
     let version_and_tc_upper = chdr.version_and_tc_upper;
     let tc_lower_and_fl_upper = chdr.tc_lower_and_fl_upper;
     let fl_lower = chdr.fl_lower;

--- a/adapter/ph/src/defs.rs
+++ b/adapter/ph/src/defs.rs
@@ -2,7 +2,7 @@
 
 use crate::net_defs;
 use crate::zpr;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::*;
 
 /// Packet direction with respect to an interface.
 /// Primary use is for constructing libpcap link-layer header.
@@ -14,7 +14,7 @@ pub enum Direction {
 }
 
 /// IP 5-tuple used for hashing.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, AsBytes, FromBytes, FromZeroes)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, FromBytes, IntoBytes, Immutable, KnownLayout)]
 #[repr(C)]
 pub struct FiveTuple {
     pub src_address: net_defs::IpAddress,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -287,8 +287,8 @@ fn substrate_egress_common<'pktbuf>(
     // TODO: should we add ZDP header here also??
 
     let zdp_hdr = match zdp::ZdpBaseHeader::ref_from_prefix(&pkt.body()) {
-        Some(zdp_hdr) => zdp_hdr,
-        None => {
+        Ok((zdp_hdr, _)) => zdp_hdr,
+        Err(_) => {
             error!("egress: link {}: failed to parse the ZDP header", link_id);
             return Err(km::EncryptionError::ParseError);
         }
@@ -446,7 +446,7 @@ pub fn substrate_ingress<'pktbuf>(
     };
 
     // Read, but do not remove the ZPI header
-    let Some(zpi_hdr) = zdp::ZdpZpiHeader::read_from_prefix(&pkt.body()) else {
+    let Ok((zpi_hdr, _)) = zdp::ZdpZpiHeader::read_from_prefix(&pkt.body()) else {
         drop_and_count(asm, pkt, CounterType::BadStructure);
         return;
     };
@@ -517,15 +517,12 @@ pub fn substrate_ingress<'pktbuf>(
     maybe_capture(asm, Direction::Inbound, &mut pkt);
 
     // now pop the ZPI off the packet. We've already checked it.
-    match zdp::ZdpZpiHeader::read_from_buf(&mut pkt) {
-        Some(_) => (),
-        None => {
-            drop_and_count(asm, pkt, CounterType::BadStructure);
-            return;
-        }
+    if zdp::ZdpZpiHeader::read_from_buf(&mut pkt).is_err() {
+        drop_and_count(asm, pkt, CounterType::BadStructure);
+        return;
     }
 
-    let Some(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(&mut pkt) else {
+    let Ok(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(&mut pkt) else {
         return drop_and_count(asm, pkt, CounterType::BadStructure);
     };
 
@@ -559,7 +556,7 @@ pub fn substrate_ingress<'pktbuf>(
         return;
     }
 
-    let Some(per_flow_hdr) = zdp::ZdpPerFlowHeader::read_from_buf(&mut pkt) else {
+    let Ok(per_flow_hdr) = zdp::ZdpPerFlowHeader::read_from_buf(&mut pkt) else {
         return drop_and_count(asm, pkt, CounterType::BadStructure);
     };
 
@@ -590,7 +587,7 @@ pub fn agent_input<'pktbuf>(
     mut pkt: Packet<'pktbuf>,
 ) {
     // extract A2A MAC
-    let Some(a2a_hdr) = zdp::ZdpA2aHeader::read_from_buf(&mut pkt) else {
+    let Ok(a2a_hdr) = zdp::ZdpA2aHeader::read_from_buf(&mut pkt) else {
         drop_and_count(asm, pkt, CounterType::BadStructure);
         return;
     };

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -826,7 +826,7 @@ pub fn encrypt_transport_zdp(message: &mut Packet, codec: Arc<dyn Codec>) -> KmR
     {
         return Err(KmError::ShortPacket);
     }
-    let base_hdr =
+    let (base_hdr, _) =
         ZdpBaseHeader::ref_from_prefix(&message.body()[1..]).expect("too-short ZDP message");
 
     let encr_len: usize = match base_hdr.packet_type {
@@ -1214,7 +1214,7 @@ mod test {
         let mut pkt = Packet::new(&mut buf, 64);
         //let hbytes = hdr.as_bytes();
         //pkt.body_mut()[0..hbytes.len()].copy_from_slice(&hbytes);
-        hdr.write_to_buf(&mut pkt);
+        hdr.write_to_buf(&mut pkt).unwrap();
         pkt.alloc_zeroed_header::<ZdpZpiHeader>().zpi = 0x33;
         let orig_len = pkt.body().len();
         assert!(orig_len == 1 + std::mem::size_of::<ZdpBaseHeader>());
@@ -1232,8 +1232,9 @@ mod test {
             orig_len,
             pkt.body().len()
         );
-        let encr_hdr =
-            ZdpBaseHeader::ref_from_prefix(&pkt.body()[1..]).expect("failed to read back header");
+        let encr_hdr = ZdpBaseHeader::ref_from_prefix(&pkt.body()[1..])
+            .expect("failed to read back header")
+            .0;
 
         assert!(encr_hdr.packet_type == hdr.packet_type);
         assert!(encr_hdr.excess_length == hdr.excess_length);
@@ -1254,7 +1255,7 @@ mod test {
         };
         //let hbytes = hdr.as_bytes();
         //pkt.body_mut()[0..hbytes.len()].copy_from_slice(&hbytes);
-        hdr.write_to_buf(&mut pkt);
+        hdr.write_to_buf(&mut pkt).unwrap();
         pkt.alloc_zeroed_header::<ZdpZpiHeader>().zpi = 33;
         let orig_len = pkt.body().len();
         assert!(orig_len == 1 + std::mem::size_of::<ZdpBaseHeader>());
@@ -1280,8 +1281,9 @@ mod test {
             pkt.body().len()
         );
 
-        let encr_hdr =
-            ZdpBaseHeader::ref_from_prefix(&pkt.body()[1..]).expect("failed to read back header");
+        let encr_hdr = ZdpBaseHeader::ref_from_prefix(&pkt.body()[1..])
+            .expect("failed to read back header")
+            .0;
 
         assert!(encr_hdr.packet_type == hdr.packet_type);
         assert!(encr_hdr.excess_length == hdr.excess_length);

--- a/adapter/ph/src/km_cert_exchange.rs
+++ b/adapter/ph/src/km_cert_exchange.rs
@@ -24,7 +24,7 @@ use std::fs;
 use std::path::Path;
 use tracing::error;
 use zerocopy::byteorder::network_endian::*;
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::km_noise::NOISE_KEY_LEN;
 
@@ -61,7 +61,7 @@ impl fmt::Debug for ParseError {
     }
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 struct CertExchgHdr {
     pub cert_len: U16,
@@ -159,8 +159,8 @@ impl KmCertExchange {
             return Err(CertExchangeError::ShortPayloadError);
         }
         let msg = match CertExchgHdr::ref_from_prefix(&payload) {
-            Some(k) => k,
-            None => {
+            Ok((k, _)) => k,
+            Err(_) => {
                 return Err(CertExchangeError::InvalidPayloadError);
             }
         };

--- a/adapter/ph/src/km_demo.rs
+++ b/adapter/ph/src/km_demo.rs
@@ -74,32 +74,34 @@ pub fn build_zdp_km_noise_packet<'buf>(
 /// Parse a full ZDP packet as a ZDP Report Message, expecting the payload of that message
 /// to be a string which is returned.
 pub fn parse_zdp_report_pkt(pkt: &Packet) -> Result<String, String> {
-    let zpi_hdr = ZdpZpiHeader::ref_from_prefix(&pkt.body());
-    if zpi_hdr.is_none() {
+    let Ok((_zpi_hdr, _)) = ZdpZpiHeader::ref_from_prefix(&pkt.body()) else {
         return Err(String::from(
             "error parsing ZPI header from decrypted payload",
         ));
-    }
-    let zdp_hdr = ZdpBaseHeader::ref_from_prefix(&pkt.body()[ZDP_BASE_HEADER_OFFSET..]);
-    if zdp_hdr.is_none() {
+    };
+
+    let Ok((zdp_hdr, _)) = ZdpBaseHeader::ref_from_prefix(&pkt.body()[ZDP_BASE_HEADER_OFFSET..])
+    else {
         return Err(String::from(
             "parse report msg - error parsing ZDP header from decrypted payload",
         ));
-    }
-    let zdp_hdr = zdp_hdr.unwrap();
+    };
+
     if zdp_hdr.packet_type != ZdpPacketType::Report {
         return Err(String::from(format!(
             "parse report msg - expected REPORT packet, got {:?}",
             zdp_hdr.packet_type
         )));
     }
-    let report_hdr = ZdpReportHeader::ref_from_prefix(&pkt.body()[ZDP_REPORT_HDR_OFFSET..]);
-    if report_hdr.is_none() {
+
+    let Ok((report_hdr, _)) =
+        ZdpReportHeader::ref_from_prefix(&pkt.body()[ZDP_REPORT_HDR_OFFSET..])
+    else {
         return Err(String::from(
             "parse report msg - error parsing REPORT header from decrypted payload",
         ));
-    }
-    let report_hdr = report_hdr.unwrap();
+    };
+
     let strlen = usize::from(report_hdr.report_data_length);
     if ZDP_REPORT_DATA_OFFSET + strlen > pkt.body().len() {
         return Err(String::from(
@@ -121,32 +123,34 @@ pub fn parse_zdp_report_pkt(pkt: &Packet) -> Result<String, String> {
 /// Parse a ZDP packet as a ZDP Key Management Message.  Return a reference to
 /// the KM payload (which can then be passed to the KM system).
 pub fn parse_km_payload<'buf>(msg_buf: &'buf [u8]) -> Result<&'buf [u8], String> {
-    let zdp_hdr = ZdpBaseHeader::ref_from_prefix(&msg_buf[ZDP_BASE_HEADER_OFFSET..]);
-    if zdp_hdr.is_none() {
+    let Ok((zdp_hdr, _)) = ZdpBaseHeader::ref_from_prefix(&msg_buf[ZDP_BASE_HEADER_OFFSET..])
+    else {
         return Err(String::from(
             "zdp/server - error parsing ZDP header from ZPI=0 message",
         ));
-    }
-    let zdp_hdr = zdp_hdr.unwrap();
+    };
+
     if zdp_hdr.packet_type != ZdpPacketType::KeyManagement {
         return Err(String::from(format!(
             "zdp/server - expected KM packet, got {:?}",
             zdp_hdr.packet_type
         )));
     }
-    let km_hdr = ZdpKeyManagementHeader::ref_from_prefix(&msg_buf[ZDP_KM_HDR_OFFSET..]);
-    if km_hdr.is_none() {
+
+    let Ok((km_hdr, _)) = ZdpKeyManagementHeader::ref_from_prefix(&msg_buf[ZDP_KM_HDR_OFFSET..])
+    else {
         return Err(String::from(
             "zdp/server - error parsing KM header from ZPI=0 message",
         ));
-    }
-    let km_hdr = km_hdr.unwrap();
+    };
+
     if !km_hdr.is_noise() {
         return Err(String::from(format!(
             "zdp/server - expected NOISE KM message, got {:?}",
             km_hdr.message_type.get()
         )));
     }
+
     let km_msg_len = usize::from(km_hdr.message_length);
     if msg_buf.len() < ZDP_KM_DATA_OFFSET + km_msg_len {
         return Err(String::from(format!(

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -45,7 +45,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::{error, warn};
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 static PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
 
@@ -157,7 +157,7 @@ impl Display for NoiseKeypair {
     }
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 struct KeyMsg {
     pub zpi_full_encr: u8,
@@ -257,13 +257,12 @@ impl KmNoise {
             error!("noise: handshake payload is too short: {}", payload.len());
             return Err(KmError::HandshakeError);
         }
-        let km = match KeyMsg::ref_from_prefix(&payload) {
-            Some(k) => k,
-            None => {
-                error!("noise: error parsing KeyMsg handshake payload");
-                return Err(KmError::HandshakeError);
-            }
+
+        let Ok((km, _)) = KeyMsg::ref_from_prefix(&payload) else {
+            error!("noise: error parsing KeyMsg handshake payload");
+            return Err(KmError::HandshakeError);
         };
+
         self.send_zpis = Some(ZPIPair {
             encr: km.zpi_full_encr,
             hmac: km.zpi_transit_hmac,

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -24,7 +24,7 @@ pub fn dispatch_mgmt_packet<'pktbuf>(
     mut pkt: Packet<'pktbuf>,
 ) {
     match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
-        Some(base_hdr) if base_hdr.packet_type == zdp::ZdpPacketType::KeyManagement => {
+        Ok((base_hdr, _)) if base_hdr.packet_type == zdp::ZdpPacketType::KeyManagement => {
             pkt.advance(std::mem::size_of::<zdp::ZdpBaseHeader>());
             match handle_key_management(asm, ingress_link_id, pkt) {
                 Ok(()) => (),
@@ -32,7 +32,7 @@ pub fn dispatch_mgmt_packet<'pktbuf>(
             }
         }
 
-        Some(base_hdr) if base_hdr.packet_type.is_response() => {
+        Ok((base_hdr, _)) if base_hdr.packet_type.is_response() => {
             match handle_response(asm, ingress_link_id, pkt) {
                 Ok(()) => (),
                 Err((err, pkt)) => fastpath::drop_and_count(asm, pkt, err),
@@ -60,7 +60,7 @@ fn handle_response<'pktbuf>(
     ingress_link_id: zpr::LinkId,
     mut pkt: Packet<'pktbuf>,
 ) -> HandleMgmtResult<'pktbuf> {
-    let Some(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(&mut pkt) else {
+    let Ok(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };
 
@@ -91,10 +91,11 @@ fn handle_key_management<'pktbuf>(
     ingress_link_id: zpr::LinkId,
     mut pkt: Packet<'pktbuf>,
 ) -> HandleMgmtResult<'pktbuf> {
-    let Some(km_hdr) = zdp::ZdpKeyManagementHeader::read_from_buf(&mut pkt) else {
+    let Ok(km_hdr) = zdp::ZdpKeyManagementHeader::read_from_buf(&mut pkt) else {
         error!("KeyManagement packet arrived with unparseable header");
         return Err((HandleMgmtError::BadStructure, pkt));
     };
+
     if !km_hdr.is_noise() {
         error!(
             "KeyManagement packet not using NOISE - type is {}",
@@ -105,6 +106,7 @@ fn handle_key_management<'pktbuf>(
             pkt,
         ));
     }
+
     let km_msg_len = usize::from(km_hdr.message_length);
     if pkt.remaining() < km_msg_len {
         error!("KeyManagement packet arrived with truncated payload");

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -11,7 +11,7 @@ use crate::zdp;
 use crate::zpr;
 use bytes::{Buf, BufMut};
 use tracing::info;
-use zpr_ext::zerocopy::{AsBytesExt, FromBytesExt};
+use zpr_ext::zerocopy::{FromBytesExt, IntoBytesExt};
 
 pub enum HandleMgmtError {
     UnknownType(u8),
@@ -41,7 +41,7 @@ pub async fn handle_report<'pktbuf>(
     ingress_link_id: zpr::LinkId,
     mut pkt: Packet<'pktbuf>,
 ) -> HandleMgmtResult<'pktbuf> {
-    let Some(hdr) = zdp::ZdpReportHeader::read_from_buf(&mut pkt) else {
+    let Ok(hdr) = zdp::ZdpReportHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };
 
@@ -107,7 +107,7 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
     seq_num: zpr::SeqNum,
     mut pkt: Packet<'pktbuf>,
 ) -> HandleMgmtResult<'pktbuf> {
-    let Some(hdr) = zdp::ZdpBindAgentAddressRequestHeader::read_from_buf(&mut pkt) else {
+    let Ok(hdr) = zdp::ZdpBindAgentAddressRequestHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };
 
@@ -119,24 +119,24 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
     let dst_address;
     match hdr.ip_version {
         zpr::L3Type::Ipv4 => {
-            let Some(src_addr) = <[u8; 4]>::read_from_buf(&mut pkt) else {
+            let Ok(src_addr) = <[u8; 4]>::read_from_buf(&mut pkt) else {
                 return Err((HandleMgmtError::BadStructure, pkt));
             };
             src_address = src_addr.into();
 
-            let Some(dst_addr) = <[u8; 4]>::read_from_buf(&mut pkt) else {
+            let Ok(dst_addr) = <[u8; 4]>::read_from_buf(&mut pkt) else {
                 return Err((HandleMgmtError::BadStructure, pkt));
             };
             dst_address = dst_addr.into();
         }
 
         zpr::L3Type::Ipv6 => {
-            let Some(src_addr) = <[u8; 16]>::read_from_buf(&mut pkt) else {
+            let Ok(src_addr) = <[u8; 16]>::read_from_buf(&mut pkt) else {
                 return Err((HandleMgmtError::BadStructure, pkt));
             };
             src_address = src_addr.into();
 
-            let Some(dst_addr) = <[u8; 16]>::read_from_buf(&mut pkt) else {
+            let Ok(dst_addr) = <[u8; 16]>::read_from_buf(&mut pkt) else {
                 return Err((HandleMgmtError::BadStructure, pkt));
             };
             dst_address = dst_addr.into();
@@ -225,7 +225,8 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
                                         zdp::ZdpBindAgentAddressResponseHeader::STATUS_CODE_SUCCESS,
                                     info_len: 0,
                                 }
-                                .write_to_buf(&mut rsp_pkt);
+                                .write_to_buf(&mut rsp_pkt)
+                                .unwrap();
 
                                 tid
                             }
@@ -240,7 +241,8 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
                                         zdp::ZdpBindAgentAddressResponseHeader::STATUS_CODE_OTHER,
                                     info_len: message.len() as u8,
                                 }
-                                .write_to_buf(&mut rsp_pkt);
+                                .write_to_buf(&mut rsp_pkt)
+                                .unwrap();
 
                                 rsp_pkt.put(message.as_bytes());
 
@@ -269,7 +271,8 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
                         status_code: zdp::ZdpBindAgentAddressResponseHeader::STATUS_CODE_OTHER,
                         info_len: message.len() as u8,
                     }
-                    .write_to_buf(&mut rsp_pkt);
+                    .write_to_buf(&mut rsp_pkt)
+                    .unwrap();
 
                     rsp_pkt.put(message.as_bytes());
 
@@ -294,7 +297,8 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
                         status_code: zdp::ZdpBindAgentAddressResponseHeader::STATUS_CODE_SUCCESS,
                         info_len: 0,
                     }
-                    .write_to_buf(&mut rsp_pkt);
+                    .write_to_buf(&mut rsp_pkt)
+                    .unwrap();
 
                     ingress_tether_id = tid;
                 }
@@ -308,7 +312,8 @@ pub async fn handle_bind_agent_address_request<'pktbuf>(
                         status_code: zdp::ZdpBindAgentAddressResponseHeader::STATUS_CODE_OTHER,
                         info_len: message.len() as u8,
                     }
-                    .write_to_buf(&mut rsp_pkt);
+                    .write_to_buf(&mut rsp_pkt)
+                    .unwrap();
 
                     rsp_pkt.put(message.as_bytes());
 

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -11,7 +11,7 @@ use crate::zdp;
 use crate::zpr;
 use bytes::{Buf, BufMut};
 use tracing::{info, warn};
-use zpr_ext::zerocopy::{AsBytesExt, FromBytesExt};
+use zpr_ext::zerocopy::{FromBytesExt, IntoBytesExt};
 
 /// send a Key Management message (RFC 6.5 § 6.2.8)
 pub async fn send_key_management<'pktbuf>(
@@ -55,7 +55,7 @@ pub async fn send_hello_request<'a, 'pktbuf>(
 
     match response {
         Ok(mut hello_res) => {
-            let Some(hdr) = zdp::ZdpHelloResponseHeader::read_from_buf(&mut hello_res) else {
+            let Ok(hdr) = zdp::ZdpHelloResponseHeader::read_from_buf(&mut hello_res) else {
                 fastpath::drop_and_count(asm, hello_res, CounterType::BadStructure);
                 return Err(());
             };
@@ -106,7 +106,8 @@ pub async fn send_bind_agent_address_request<'a, 'pktbuf>(
                 ip_version: five_tuple.l3_type,
                 compression_mode,
             }
-            .write_to_buf(&mut req);
+            .write_to_buf(&mut req)
+            .unwrap();
 
             match five_tuple.l3_type {
                 zpr::L3Type::Ipv4 => {
@@ -133,7 +134,7 @@ pub async fn send_bind_agent_address_request<'a, 'pktbuf>(
 
     match response {
         Ok((tether_id, mut resp)) => {
-            let Some(hdr) = zdp::ZdpBindAgentAddressResponseHeader::read_from_buf(&mut resp) else {
+            let Ok(hdr) = zdp::ZdpBindAgentAddressResponseHeader::read_from_buf(&mut resp) else {
                 fastpath::drop_and_count(asm, resp, CounterType::BadStructure);
                 return Err(BindAgentAddressError::BadStructure);
             };

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -51,7 +51,7 @@ async fn handle_packet<'pktbuf>(
     ingress_link_id: zpr::LinkId,
     mut pkt: Packet<'pktbuf>,
 ) -> HandleMgmtResult<'pktbuf> {
-    let Some(base_hdr) = ZdpBaseHeader::read_from_buf(&mut pkt) else {
+    let Ok(base_hdr) = ZdpBaseHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };
 
@@ -68,7 +68,7 @@ async fn handle_packet<'pktbuf>(
     let seq_num = base_hdr.sequence_number.get() as u64; // TODO: reconstitute full seq num given expected seq num state
 
     if base_hdr.packet_type.is_per_flow() {
-        let Some(per_flow_hdr) = ZdpPerFlowHeader::read_from_buf(&mut pkt) else {
+        let Ok(per_flow_hdr) = ZdpPerFlowHeader::read_from_buf(&mut pkt) else {
             return Err((HandleMgmtError::BadStructure, pkt));
         };
 

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -2,8 +2,7 @@
 
 use arrayref::array_ref;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use zerocopy::FromZeroes;
-use zerocopy::{AsBytes, FromBytes, KnownLayout, Unaligned};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 pub mod ethertype {
     //! Ethertype / IEEE 802 numbers
@@ -15,7 +14,7 @@ pub mod ethertype {
 pub const IPV6_ADDRESS_SIZE: usize = 16;
 
 #[derive(
-    AsBytes, FromZeroes, FromBytes, KnownLayout, Unaligned, Copy, Clone, Hash, Debug, PartialEq, Eq,
+    FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Hash, Debug, PartialEq, Eq,
 )]
 #[repr(transparent)]
 pub struct IpAddress {

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -13,7 +13,7 @@ use crate::zpr;
 use crate::zpr::L3Type;
 use bytes::buf;
 use std::mem::{size_of, size_of_val};
-use zerocopy::{AsBytes, ByteOrder, FromBytes, FromZeroes, NetworkEndian};
+use zerocopy::*;
 use zpr_ext::std::mem::DropGuard;
 
 /// Exclusive handle to an in-use packet buffer.
@@ -150,7 +150,7 @@ pub struct Packet<'buf> {
     buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE],
 }
 
-#[derive(AsBytes, FromZeroes, FromBytes)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout)]
 #[repr(C)]
 pub struct PacketMetadata {
     offset: usize,    // packet offset (must be >= PACKET_BODY_BUFFER_MIN_OFFSET)
@@ -172,12 +172,12 @@ impl PacketMetadata {
         self.five_tuple.dst_address = dst_addr;
     }
 
-    pub fn set_src_port(&mut self, sport: [u8; 2]) {
-        self.five_tuple.src_port = NetworkEndian::read_u16(&sport)
+    pub fn set_src_port(&mut self, sport: u16) {
+        self.five_tuple.src_port = sport;
     }
 
-    pub fn set_dst_port(&mut self, dport: [u8; 2]) {
-        self.five_tuple.dst_port = NetworkEndian::read_u16(&dport)
+    pub fn set_dst_port(&mut self, dport: u16) {
+        self.five_tuple.dst_port = dport;
     }
 
     pub fn set_l4_protocol(&mut self, proto: IpProtocol) {
@@ -335,7 +335,7 @@ impl<'buf> Packet<'buf> {
 
     /// Returns a reference to the packet metadata.
     pub fn metadata(&self) -> &PacketMetadata {
-        let opt = PacketMetadata::ref_from(&self.buf[..size_of::<PacketMetadata>()]);
+        let opt = PacketMetadata::ref_from_bytes(&self.buf[..size_of::<PacketMetadata>()]);
         unsafe {
             // SAFETY: we know this fits in PACKET_BUFFER_SIZE
             opt.unwrap_unchecked()
@@ -344,7 +344,7 @@ impl<'buf> Packet<'buf> {
 
     /// Returns a mutable reference to the packet metadata.
     pub fn metadata_mut(&mut self) -> &mut PacketMetadata {
-        let opt = PacketMetadata::mut_from(&mut self.buf[..size_of::<PacketMetadata>()]);
+        let opt = PacketMetadata::mut_from_bytes(&mut self.buf[..size_of::<PacketMetadata>()]);
         unsafe {
             // SAFETY: we know this fits in PACKET_BUFFER_SIZE
             opt.unwrap_unchecked()
@@ -368,7 +368,7 @@ impl<'buf> Packet<'buf> {
     /// Returns mutable references to both the packet metadata and body.
     pub fn metadata_mut_and_body_mut(&mut self) -> (&mut PacketMetadata, &mut [u8]) {
         let (md, bd) = self.buf.split_at_mut(size_of::<PacketMetadata>());
-        let opt = PacketMetadata::mut_from(md);
+        let opt = PacketMetadata::mut_from_bytes(md);
         let md = unsafe {
             // SAFETY: we know this fits in PACKET_BUFFER_SIZE
             opt.unwrap_unchecked()
@@ -398,13 +398,20 @@ impl<'buf> Packet<'buf> {
     /// Extend the start of the packet into available headroom enough to
     /// hold a structure of the given type, and return a reference to the space.
     /// The structure allocated will be zeroed.
-    pub fn alloc_zeroed_header<T: AsBytes + FromBytes + FromZeroes>(&mut self) -> &mut T {
-        T::mut_from(self.alloc_zeroed_headroom(size_of::<T>())).unwrap()
+    pub fn alloc_zeroed_header<T: FromBytes + IntoBytes + KnownLayout + Unaligned>(
+        &mut self,
+    ) -> &mut T {
+        let res = T::mut_from_bytes(self.alloc_zeroed_headroom(size_of::<T>()))
+            .map_err(Into::<SizeError<_, _>>::into);
+        unsafe {
+            // SAFETY: we know we've allocated exactly the right number of bytes
+            res.unwrap_unchecked()
+        }
     }
 
     /// Copy the given data as a header into the packet's headroom.
     /// (Avoids needlessly zeroing the allocated headroom.)
-    pub fn push_header<T: AsBytes + FromBytes + FromZeroes>(&mut self, header: &T) {
+    pub fn push_header<T: IntoBytes + Immutable>(&mut self, header: &T) {
         let cnt = size_of::<T>();
         assert!(cnt <= self.headroom_available());
         let md = self.metadata_mut();

--- a/adapter/ph/src/pcap_writer.rs
+++ b/adapter/ph/src/pcap_writer.rs
@@ -6,7 +6,7 @@
 use std::io;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
-use zerocopy::AsBytes;
+use zerocopy::{Immutable, IntoBytes, KnownLayout};
 
 /// Represents an open PCAP writer.
 pub struct PcapWriter<W: AsyncWrite> {
@@ -22,7 +22,7 @@ const PCAP_HDR_VERSION_MINOR: u16 = 4;
 /// Maximum size packet which may be captured.
 pub const MAX_SNAPLEN: usize = 1 << 18;
 
-#[derive(AsBytes)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
 #[repr(C)]
 struct PcapHdr {
     magic_number: u32,
@@ -34,7 +34,7 @@ struct PcapHdr {
     network: u32,
 }
 
-#[derive(AsBytes)]
+#[derive(IntoBytes, Immutable, KnownLayout)]
 #[repr(C)]
 struct PcaprecHdr {
     ts_sec: u32,

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -2,12 +2,12 @@
 
 use open_enum::open_enum;
 use zerocopy::byteorder::network_endian::*;
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::zpr;
 
 #[open_enum]
-#[derive(Copy, Clone, Debug, FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(u8)]
 pub enum ZdpPacketType {
     // Flow-based
@@ -79,13 +79,13 @@ impl ZdpPacketType {
     }
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpZpiHeader {
     pub zpi: u8,
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpBaseHeader {
     pub packet_type: ZdpPacketType,
@@ -100,13 +100,13 @@ pub const ZDP_BASE_HEADER_OFFSET: usize = std::mem::size_of::<ZdpZpiHeader>();
 pub const ZDP_NON_PER_FLOW_MGMT_HEADER_OFFSET: usize =
     ZDP_BASE_HEADER_OFFSET + std::mem::size_of::<ZdpBaseHeader>();
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpPerFlowHeader {
     pub stream_id: U32,
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpEchoHeader {
     pub base_header: ZdpBaseHeader,
@@ -114,20 +114,20 @@ pub struct ZdpEchoHeader {
     pub additional_length: U16,
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpReportHeader {
     pub report_data_length: U16,
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpHelloResponseHeader {
     pub status: U16,
 }
 
 /// Bind Agent Address request (§ 6.3.11)
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpBindAgentAddressRequestHeader {
     pub ip_version: zpr::L3Type,
@@ -135,7 +135,7 @@ pub struct ZdpBindAgentAddressRequestHeader {
 }
 
 /// Bind Agent Address response (§ 6.3.11)
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpBindAgentAddressResponseHeader {
     pub status_code: u8,
@@ -147,7 +147,7 @@ impl ZdpBindAgentAddressResponseHeader {
     pub const STATUS_CODE_OTHER: u8 = 1;
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpKeyManagementHeader {
     pub message_type: U16,
@@ -169,7 +169,7 @@ impl ZdpKeyManagementHeader {
     }
 }
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpA2aHeader {
     pub a2a_said: zpr::A2aSaid,

--- a/adapter/ph/src/zdp_ll.rs
+++ b/adapter/ph/src/zdp_ll.rs
@@ -1,9 +1,9 @@
 //! ZDP libpcap link-layer
 
 use crate::defs::*;
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
-#[derive(AsBytes, FromBytes, FromZeroes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpLinkP2P {
     pub direction: u8,

--- a/adapter/ph/src/zpr.rs
+++ b/adapter/ph/src/zpr.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 
 use open_enum::open_enum;
-use zerocopy::{AsBytes, FromBytes, FromZeroes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 /// Substrate Address
 pub type SubstrateAddr = std::net::SocketAddr;
@@ -53,7 +53,7 @@ pub const KM_ID_NOISE: KmId = 2;
 
 /// ZPR agent packet L3 type (RFC 6.5 § 6.3.11)
 #[open_enum]
-#[derive(Clone, Copy, Debug, Hash, AsBytes, FromBytes, FromZeroes)]
+#[derive(Copy, Clone, Debug, FromBytes, Hash, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(u8)]
 pub enum L3Type {
     Ipv4 = 4,

--- a/libnode/Cargo.lock
+++ b/libnode/Cargo.lock
@@ -938,7 +938,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "zerocopy",
+ "zerocopy 0.8.3",
  "zpr-ext",
 ]
 
@@ -995,7 +995,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1624,7 +1624,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199837a02c176ffe66ac6e3f6195ff49ed0ae9c0fc9c905970f924909812aba6"
+dependencies = [
+ "zerocopy-derive 0.8.3",
 ]
 
 [[package]]
@@ -1639,6 +1648,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy-derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c76c8bc3d9d3594dabe11d4ffab6cd71cc2c3ce38526c6de5a0d81dd0039627"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,12 +1666,12 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zpr-ext"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "libc",
  "nix",
  "tokio",
  "tokio-tun",
- "zerocopy",
+ "zerocopy 0.8.3",
 ]

--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -878,7 +878,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "zerocopy",
+ "zerocopy 0.8.3",
 ]
 
 [[package]]
@@ -1067,7 +1067,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "zerocopy",
+ "zerocopy 0.8.3",
  "zpr-ext",
 ]
 
@@ -1124,7 +1124,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1889,7 +1889,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199837a02c176ffe66ac6e3f6195ff49ed0ae9c0fc9c905970f924909812aba6"
+dependencies = [
+ "zerocopy-derive 0.8.3",
 ]
 
 [[package]]
@@ -1904,6 +1913,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy-derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c76c8bc3d9d3594dabe11d4ffab6cd71cc2c3ce38526c6de5a0d81dd0039627"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,12 +1931,12 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zpr-ext"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "libc",
  "nix",
  "tokio",
  "tokio-tun",
- "zerocopy",
+ "zerocopy 0.8.3",
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,9 +20,8 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 ph = { path = "../adapter/ph" }
 libnode = { path = "../libnode" }
-zerocopy = "0.7.35"
+zerocopy = "0.8.3"
 bytes = "1.7.1"
 snow = "0.9.6"
 curve25519-dalek = "4.1.3"
 base64 = "0.22.1"
-

--- a/node/src/zdp/server.rs
+++ b/node/src/zdp/server.rs
@@ -199,12 +199,10 @@ impl ZDPServer {
                                 continue;
                             }
 
-                            let zpi_hdr = ZdpZpiHeader::ref_from_prefix(&input_buf[0..read_len]);
-                            if zpi_hdr.is_none() {
+                            let Ok((zpi_hdr, _)) = ZdpZpiHeader::ref_from_prefix(&input_buf[0..read_len]) else {
                                 info!("zdp/server - error parsing ZPI header");
                                 continue;
-                            }
-            ;                let zpi_hdr = zpi_hdr.unwrap();
+                            };
 
                             // If ZPI is 0 then it may be a KM message. Else it's transport.
                             match zpi_hdr.zpi {

--- a/zpr-ext/Cargo.lock
+++ b/zpr-ext/Cargo.lock
@@ -45,12 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,19 +340,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "199837a02c176ffe66ac6e3f6195ff49ed0ae9c0fc9c905970f924909812aba6"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "8c76c8bc3d9d3594dabe11d4ffab6cd71cc2c3ce38526c6de5a0d81dd0039627"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -367,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "zpr-ext"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "libc",

--- a/zpr-ext/Cargo.toml
+++ b/zpr-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zpr-ext"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]
@@ -9,7 +9,7 @@ libc = { version = "0.2.155" }
 nix = { version = "0.29.0", features = ["ioctl", "net"], optional = true }
 tokio-tun = { version = "0.11.5", optional = true }
 tokio = { version = "1.37.0", features = ["net"], optional = true }
-zerocopy = { version = "0.7.34", optional = true }
+zerocopy = { version = "0.8.3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.37.0", features = ["macros", "time", "rt"] }

--- a/zpr-ext/src/zerocopy.rs
+++ b/zpr-ext/src/zerocopy.rs
@@ -1,3 +1,27 @@
+pub mod error {
+    use std::marker::PhantomData;
+
+    /// NOTE: zerocopy currently provides no way to construct a
+    /// SizeError, so we must return an opaque error type.
+    #[non_exhaustive]
+    pub struct SizeError<Src, Dst: ?Sized>(PhantomData<zerocopy::error::SizeError<Src, Dst>>);
+
+    impl<Src, Dst: ?Sized> SizeError<Src, Dst> {
+        #[allow(dead_code)]
+        pub(super) fn new() -> Self {
+            Self(PhantomData)
+        }
+    }
+
+    impl<Src, Dst: ?Sized> std::fmt::Debug for SizeError<Src, Dst> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "SizeError")
+        }
+    }
+}
+
+pub use error::*;
+
 #[cfg(feature = "bytes")]
 mod zerocopy_bytes {
     use crate::bytes::BufExt;
@@ -5,9 +29,14 @@ mod zerocopy_bytes {
     use std::mem::MaybeUninit;
     use zerocopy::*;
 
-    pub trait AsBytesExt {
+    pub trait IntoBytesExt {
         /// Like `write_to()`, but writes to a `BufMut`.
-        fn write_to_buf(&self, buf: &mut impl BufMut) -> Option<()>;
+        fn write_to_buf<B: BufMut>(
+            &self,
+            buf: &mut B,
+        ) -> Result<(), super::SizeError<&Self, &mut B>>
+        where
+            Self: Immutable;
     }
 
     pub trait FromBytesExt {
@@ -15,19 +44,25 @@ mod zerocopy_bytes {
         fn as_uninit_bytes_mut(&mut self) -> &mut [MaybeUninit<u8>];
 
         /// Like `read_from_prefix()`, but reads from a `Buf`.
-        fn read_from_buf(buf: &mut impl Buf) -> Option<Self>
+        fn read_from_buf<B: Buf>(buf: &mut B) -> Result<Self, super::SizeError<&mut B, Self>>
         where
             Self: Sized;
     }
 
-    impl<T: AsBytes> AsBytesExt for T {
-        fn write_to_buf(&self, buf: &mut impl BufMut) -> Option<()> {
+    impl<T: IntoBytes> IntoBytesExt for T {
+        fn write_to_buf<B: BufMut>(
+            &self,
+            buf: &mut B,
+        ) -> Result<(), super::SizeError<&Self, &mut B>>
+        where
+            Self: Immutable,
+        {
             let bytes = self.as_bytes();
             if buf.remaining_mut() < bytes.len() {
-                None
+                Err(super::SizeError::new())
             } else {
                 buf.put(bytes);
-                Some(())
+                Ok(())
             }
         }
     }
@@ -45,16 +80,16 @@ mod zerocopy_bytes {
             }
         }
 
-        fn read_from_buf(buf: &mut impl Buf) -> Option<Self>
+        fn read_from_buf<B: Buf>(buf: &mut B) -> Result<Self, super::SizeError<&mut B, Self>>
         where
             Self: Sized,
         {
             if buf.remaining() < std::mem::size_of::<Self>() {
-                None
+                Err(super::SizeError::new())
             } else {
                 let mut ret = T::new_zeroed();
                 buf.copy_to_maybe_uninit_slice_mut(ret.as_uninit_bytes_mut());
-                Some(ret)
+                Ok(ret)
             }
         }
     }


### PR DESCRIPTION
No actual code changes in here (except for some necessary modifications to `zpr_ext::zerocopy`).  All just migrating to zerocopy 0.8.