### PR TITLE
Mk addr message

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Core ZPR components
 Here is the general "startup" sequence for milestone 2.
 
  * NODE - the only node
- * V/S ADAPTER - the adapter in front fo the visa service.
+ * V/S ADAPTER - the adapter in front of the visa service.
  * VISASVC - the visa service
  * ADAPTER - one of the "regular" (non-visa service) adapters.
 
@@ -23,20 +23,25 @@ ADAPTER                 NODE                VISASVC
   .         |        kmh2 |---+                |        | association
   .         |<------------+   | node detect    |        |
   .         |             |   | VS CN          |       =/
+  .         |hello(4)     |   |                |
+  .         +------------>|   |                |
+  .         |      hellor |   |                |
+  .         |<------------+   |                |
+  .         |             |   |                |
   .         | raa         |   |                |
   .         +------------>|   |                |       =\
   .         |        raar |   |                |        | ZPR address reg
   .         |<------------+   |                |       =/
   .         .             |<--+                |
   .         .             |                    |
-  |                       | hello              |       =\
+  |                       | vs.hello           |       =\
   |                       +------------------->|        |
-  |                       |         hello-resp |        | node establishes    
+  |                       |      vs.hello-resp |        | node establishes    
   |                       |<-------------------+        | connection to 
   |                       |                    |        | visa service
-  |                       | authenticate       |        |
+  |                       | vs.authenticate    |        |
   |                       +------------------->|        |
-  |                       |           response |        |
+  |                       |        vs.response |        |
   |                       |<-------------------+        |
   .                       .                    .       =/
   .                       .                    .
@@ -46,14 +51,19 @@ ADAPTER                 NODE                VISASVC
   |                  kmh2 |                    |        | association
   |<----------------------+                    |       =/
   |                       |                    |
+  | hello                 |                    |
+  +---------------------->|                    |
+  |                hellor |                    |
+  |<----------------------+                    |
+  |                       |                    |  
   | raa(3)                |                    |
   +---------------------->|                    |       =\
   |                  raar |                    |        | ZPR address reg
   |<----------------------+                    |       =/
   |                       |                    |
-  |                       | auth_connect(1)    |       =\
+  |                       | vs.auth_connect(1) |       =\
   |                       +------------------->|        | node tell
-  |                       |         auth_reply |        | visa service
+  |                       |      vs.auth_reply |        | visa service
   |                       |<-------------------+       =/
   |                       |                    |
   | echo(2)               |                    |       =\
@@ -63,19 +73,22 @@ ADAPTER                 NODE                VISASVC
   |                       |                    |
   .                       .                    .
   . (traffic)             .                    .       =\
-  +---------------------->| visa-req           |        | visa 
+  +---------------------->| vs.visa-req        |        | visa 
   |                       +------------------->|        | request
-  |                       |         visa-resp  |        |
+  |                       |       vs.visa-resp |        |
   |                       |<-------------------+       =/
   |                       |                    |
   .                       .                    .
   .                       .                    .
   | terminate             |                    |       =\
-  +---------------------->| agent_disconnect   |        | polite link down
+  +---------------------->| vs.agent_disconnect|        | polite link down
   |                       +------------------->|       =/
   X                       |                    |
                           .                    .
                           .                    .
+
+  - 'vs.' prefix indicates a visa service API call which runs on top of ZPR.
+    All other messages are ZDP.
 ```
 
 ```
@@ -92,6 +105,9 @@ NOTES:
 (3) "raa" is RegisterAgentAddress in which the agent sends its ZPR address to the
     node. Required since the node includes this in the connect message to the 
     visa service.  "raar" is RegisterAgentAddressResponse.
+    
+(4) The "hello" and "hellor" (hello-response) messages are placeholders and do not
+    transfer any information at the moment.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ ADAPTER                 NODE                VISASVC
   .         |        kmh2 |---+                |        | association
   .         |<------------+   | node detect    |        |
   .         |             |   | VS CN          |       =/
-  .         | ???         |   |                |
+  .         | raa         |   |                |
   .         +------------>|   |                |       =\
-  .         |         ??? |   |                |        | ZPR address reg
+  .         |        raar |   |                |        | ZPR address reg
   .         |<------------+   |                |       =/
   .         .             |<--+                |
   .         .             |                    |
@@ -46,10 +46,10 @@ ADAPTER                 NODE                VISASVC
   |                  kmh2 |                    |        | association
   |<----------------------+                    |       =/
   |                       |                    |
-  | ??? (addr)            |                    |
+  | raa(3)                |                    |
   +---------------------->|                    |       =\
-  |           ??? (empty) |                    |        | ZPR address reg
-  |<----------------------|                    |       =/
+  |                  raar |                    |        | ZPR address reg
+  |<----------------------+                    |       =/
   |                       |                    |
   |                       | auth_connect(1)    |       =\
   |                       +------------------->|        | node tell
@@ -72,7 +72,7 @@ ADAPTER                 NODE                VISASVC
   .                       .                    .
   | terminate             |                    |       =\
   +---------------------->| agent_disconnect   |        | polite link down
-  |                       |------------------->|       =/
+  |                       +------------------->|       =/
   X                       |                    |
                           .                    .
                           .                    .
@@ -88,6 +88,10 @@ NOTES:
     ZDP messages we will use.  Note that we may want to establish liveness before
     calling auth_connect.  It is possible for the key management handshake to
     fail and one side not realize it.
+    
+(3) "raa" is RegisterAgentAddress in which the agent sends its ZPR address to the
+    node. Required since the node includes this in the connect message to the 
+    visa service.  "raar" is RegisterAgentAddressResponse.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ ADAPTER                 NODE                VISASVC
   |                  kmh2 |                    |        | association
   |<----------------------+                    |       =/
   |                       |                    |
+  | ??? (addr)            |                    |
+  +---------------------->|--+ node know knows |
+  |           ??? (empty) |  | adapters ZPR    |
+  |<----------------------|<-+ address         |
+  |                       |                    |
   |                       | auth_connect(1)    |       =\
   |                       +------------------->|        | node tell
   |                       |         auth_reply |        | visa service

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ ADAPTER                 NODE                VISASVC
   .         |        kmh2 |---+                |        | association
   .         |<------------+   | node detect    |        |
   .         |             |   | VS CN          |       =/
+  .         | ???         |   |                |
+  .         +------------>|   |                |       =\
+  .         |         ??? |   |                |        | ZPR address reg
+  .         |<------------+   |                |       =/
   .         .             |<--+                |
   .         .             |                    |
   |                       | hello              |       =\
@@ -43,9 +47,9 @@ ADAPTER                 NODE                VISASVC
   |<----------------------+                    |       =/
   |                       |                    |
   | ??? (addr)            |                    |
-  +---------------------->|--+ node know knows |
-  |           ??? (empty) |  | adapters ZPR    |
-  |<----------------------|<-+ address         |
+  +---------------------->|                    |       =\
+  |           ??? (empty) |                    |        | ZPR address reg
+  |<----------------------|                    |       =/
   |                       |                    |
   |                       | auth_connect(1)    |       =\
   |                       +------------------->|        | node tell


### PR DESCRIPTION
I believe we need an extra message from adapter to node following the key exchange.  I have doctored up the README diagram to illustrate.

Purpose of the message is to tell the node the ZPR address that the adapter is using.  

Normally this would get sorted out during a real authentication of the agent with the visa service.  Either the adapter would be permitted to use a ZPR address in its configuration or it would be given a dynamic one -- depending on policy.

We are not doing real authentication for m2.  Instead, just using the CN in the noise cert and having the node send a connect message to the visa service that says, "adapter with CN=x is at ZPR addr y".

Not sure what message type to hijack.  I would say either HelloRequest/Response or ConfigurationRequest/Response.  The response can just be a simple "ACK".  The request just needs to contain an IP address.

I'll update the diagram here when we figure it out.