### PR TITLE
remove old insecure flags

### DIFF
--- a/adapter/ph-debug/Cargo.lock
+++ b/adapter/ph-debug/Cargo.lock
@@ -109,12 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,19 +654,18 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "bb3da5f7220f919a6c7af7c856435a68ee1582fd7a77aa72936257d8335bd6f6"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "2e5f54f3cc93cd80745404626681b4b9fca9a867bad5a8424b618eb0db1ae6ea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -681,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "zpr-ext"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "libc",

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -62,8 +62,7 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
 
     // NOPE ! not if the link is not ready.
     let link_id = asm.hack_get_adapter_docking_session_id();
-    if !asm.flags.disable_key_management
-        && !asm.peer_table.is_security_assocaition_established(link_id)
+    if !asm.peer_table.is_security_assocaition_established(link_id)
     {
         error!(
             "{}: Link {} has no security association, aborting bind request operation",

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -62,8 +62,7 @@ async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pkt
 
     // NOPE ! not if the link is not ready.
     let link_id = asm.hack_get_adapter_docking_session_id();
-    if !asm.peer_table.is_security_assocaition_established(link_id)
-    {
+    if !asm.peer_table.is_security_assocaition_established(link_id) {
         error!(
             "{}: Link {} has no security association, aborting bind request operation",
             asm.system_name, link_id

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -21,7 +21,6 @@ use zpr::{LinkId, SubstrateAddr};
 
 use enum_map::EnumMap;
 use km_noise::NoiseKeypair;
-use std::default::Default;
 use std::result::Result;
 use tracing::info;
 
@@ -48,7 +47,6 @@ pub enum PhMode {
 /// visible queue becoming full.
 
 pub struct Assembly<'pktbuf> {
-    pub flags: PhFlags,
     pub ph_mode: PhMode,
     pub topology_config: config::TopologyConfig,
 
@@ -86,21 +84,6 @@ pub struct Assembly<'pktbuf> {
     pub certx: Option<KmCertExchange>,
 }
 
-pub struct PhFlags {
-    /// If set TRUE this allows any messages on ZPI 0.  VERY INSECURE!!
-    pub allow_insecure_zpi_zero: bool,
-    pub disable_key_management: bool,
-}
-
-impl Default for PhFlags {
-    /// Reasonable (and secure) defaults
-    fn default() -> Self {
-        Self {
-            allow_insecure_zpi_zero: false,
-            disable_key_management: false,
-        }
-    }
-}
 
 impl Assembly<'_> {
     pub fn is_node(&self) -> bool {
@@ -142,16 +125,14 @@ impl Assembly<'_> {
         let peer_id = self.add_peer(LinkType::NodeToAdapter, adapter_addr)?;
         self.peer_ids.lock().unwrap().push(peer_id);
 
-        if !self.flags.disable_key_management {
-            km_multiplexor::add_node_link(
-                &self,
-                peer_id,
-                ZPIPair::new(ZPI_ENCRYPTED_HEADER_FLAG | 3, 4),
-                self.self_noise_keypair.clone().unwrap(),
-                self.certx.clone().unwrap(),
-            )
-            .unwrap();
-        }
+        km_multiplexor::add_node_link(
+            &self,
+            peer_id,
+            ZPIPair::new(ZPI_ENCRYPTED_HEADER_FLAG | 3, 4),
+            self.self_noise_keypair.clone().unwrap(),
+            self.certx.clone().unwrap(),
+        )
+        .unwrap();
 
         info!(
             "{}: Successfully accepted tether from {}.  Assigned ID {}",
@@ -174,17 +155,15 @@ impl Assembly<'_> {
         let peer_id = self.add_peer(LinkType::AdapterToNode, node_addr)?;
         self.peer_ids.lock().unwrap().push(peer_id);
 
-        if !self.flags.disable_key_management {
-            km_multiplexor::add_adapter_link(
-                &self,
-                peer_id,
-                ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 5, 6),
-                self.self_noise_keypair.clone().unwrap(),
-                self.peer_noise_keypair.clone().unwrap().public,
-                self.certx.clone().unwrap(),
-            )
-            .unwrap();
-        }
+        km_multiplexor::add_adapter_link(
+            &self,
+            peer_id,
+            ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 5, 6),
+            self.self_noise_keypair.clone().unwrap(),
+            self.peer_noise_keypair.clone().unwrap().public,
+            self.certx.clone().unwrap(),
+        )
+        .unwrap();
 
         info!(
             "{}: Successfully initiated tether to {}.  Assigned ID {}",
@@ -215,7 +194,6 @@ pub mod test {
     #[derive(Default)]
     pub struct TestAssemblyBuilder<'a> {
         pub ph_mode: Option<PhMode>,
-        pub flags: Option<PhFlags>,
         pub topology_config: Option<TopologyConfig>,
         pub system_name: Option<String>,
         pub buffer_stack: Option<BufferStack<'a, { config::PACKET_BUFFER_SIZE }>>,
@@ -250,7 +228,6 @@ pub mod test {
     }
 
     pub fn create_assembly(builder: TestAssemblyBuilder) -> Assembly {
-        let flags = builder.flags.unwrap_or_default();
         let ph_mode = builder.ph_mode.unwrap_or(PhMode::Adapter);
         let topology_config = builder.topology_config.unwrap_or_default();
         let system_name = builder.system_name.unwrap_or("test".into());
@@ -301,7 +278,6 @@ pub mod test {
         });
 
         Assembly {
-            flags,
             ph_mode,
             topology_config,
             system_name,

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -84,7 +84,6 @@ pub struct Assembly<'pktbuf> {
     pub certx: Option<KmCertExchange>,
 }
 
-
 impl Assembly<'_> {
     pub fn is_node(&self) -> bool {
         self.ph_mode == PhMode::Node

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -552,16 +552,14 @@ pub fn substrate_ingress<'pktbuf>(
     // In ZPI zero only KM messages are allowed (well, and APR ARP which we don't support yet)
     // Can be overridden (FOR TESTING ONLY) in the flags.
     if !secure && base_hdr.packet_type != zdp::ZdpPacketType::KeyManagement {
-        if !asm.flags.allow_insecure_zpi_zero {
-            warn!(
-                "{}: ingress: link {}: ZPI 0 only allows key management messages, not {:?}",
-                asm.system_name,
-                pkt.metadata().ingress_link_id,
-                base_hdr.packet_type
-            );
-            drop_and_count(asm, pkt, CounterType::OtherError);
-            return;
-        }
+        warn!(
+            "{}: ingress: link {}: ZPI 0 only allows key management messages, not {:?}",
+            asm.system_name,
+            pkt.metadata().ingress_link_id,
+            base_hdr.packet_type
+        );
+        drop_and_count(asm, pkt, CounterType::OtherError);
+        return;
     }
 
     // enqueue non-transit packets with the management processor

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -159,16 +159,14 @@ fn main() -> ExitCode {
     let certx;
 
     let private_key =
-        km_cert_exchange::load_private_key(&Path::new(&config.private_key_file.unwrap()))
-            .unwrap();
+        km_cert_exchange::load_private_key(&Path::new(&config.private_key_file.unwrap())).unwrap();
     if ph_mode == PhMode::Node {
         peer_noise_keypair = None;
         self_noise_keypair = Some(NoiseKeypair::new(private_key));
     } else {
-        let public_key = km_cert_exchange::load_public_key(&Path::new(
-            &config.node_public_key_file.unwrap(),
-        ))
-        .unwrap();
+        let public_key =
+            km_cert_exchange::load_public_key(&Path::new(&config.node_public_key_file.unwrap()))
+                .unwrap();
         peer_noise_keypair = Some(NoiseKeypair {
             public: public_key,
             private: [0u8; 32], // unknown
@@ -336,7 +334,6 @@ fn main() -> ExitCode {
     js.spawn_local(rpc_worker::launch(asm, control_socket));
     js.spawn_local(km_multiplexor::launch_signal_worker(&*asm, km_sig_outq));
     js.spawn_local(km_multiplexor::launch_message_worker(&*asm, km_outq));
-
 
     //
     // start data path workers

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -59,7 +59,7 @@ mod zprtun;
 #[cfg(test)]
 mod km_testdata;
 
-use assembly::{Assembly, PhFlags, PhMode};
+use assembly::{Assembly, PhMode};
 use buffer_stack::BufferStack;
 use capture_worker::CaptureWorker;
 use flow_control::FlowControl;
@@ -100,12 +100,6 @@ struct Config {
     tun_if: Option<String>,
 
     #[arg(long)]
-    disable_km: bool,
-
-    #[arg(long)]
-    allow_insecure_zpi_zero: bool,
-
-    #[arg(long)]
     debug: bool,
 }
 
@@ -126,20 +120,16 @@ fn main() -> ExitCode {
     //
     // validate configuration
     //
-
-    if !config.disable_km {
-        if config.ca_file.is_none() {
-            panic!("Authority certificate file must be specified when key management is enabled");
-        }
-        if config.certificate_file.is_none() {
-            panic!("Certificate file must be specified when key management is enabled");
-        }
-        if config.private_key_file.is_none() {
-            panic!("Private key file must be specified when key management is enabled");
-        }
+    if config.ca_file.is_none() {
+        panic!("Authority certificate file must be specified when key management is enabled");
     }
-
-    if ph_mode == PhMode::Adapter && !config.disable_km && config.node_public_key_file.is_none() {
+    if config.certificate_file.is_none() {
+        panic!("Certificate file must be specified when key management is enabled");
+    }
+    if config.private_key_file.is_none() {
+        panic!("Private key file must be specified when key management is enabled");
+    }
+    if ph_mode == PhMode::Adapter && config.node_public_key_file.is_none() {
         panic!("Node public key file must be specified when starting an adapter");
     }
 
@@ -168,37 +158,31 @@ fn main() -> ExitCode {
     let peer_noise_keypair;
     let certx;
 
-    if !config.disable_km {
-        let private_key =
-            km_cert_exchange::load_private_key(&Path::new(&config.private_key_file.unwrap()))
-                .unwrap();
-        if ph_mode == PhMode::Node {
-            peer_noise_keypair = None;
-            self_noise_keypair = Some(NoiseKeypair::new(private_key));
-        } else {
-            let public_key = km_cert_exchange::load_public_key(&Path::new(
-                &config.node_public_key_file.unwrap(),
-            ))
+    let private_key =
+        km_cert_exchange::load_private_key(&Path::new(&config.private_key_file.unwrap()))
             .unwrap();
-            peer_noise_keypair = Some(NoiseKeypair {
-                public: public_key,
-                private: [0u8; 32], // unknown
-            });
-            self_noise_keypair = Some(NoiseKeypair::new(private_key));
-        }
-
-        certx = Some(
-            KmCertExchange::new_from_paths(
-                &Path::new(&config.certificate_file.as_ref().unwrap()),
-                &Path::new(&config.ca_file.as_ref().unwrap()),
-            )
-            .unwrap(),
-        );
-    } else {
+    if ph_mode == PhMode::Node {
         peer_noise_keypair = None;
-        self_noise_keypair = None;
-        certx = None;
+        self_noise_keypair = Some(NoiseKeypair::new(private_key));
+    } else {
+        let public_key = km_cert_exchange::load_public_key(&Path::new(
+            &config.node_public_key_file.unwrap(),
+        ))
+        .unwrap();
+        peer_noise_keypair = Some(NoiseKeypair {
+            public: public_key,
+            private: [0u8; 32], // unknown
+        });
+        self_noise_keypair = Some(NoiseKeypair::new(private_key));
     }
+
+    certx = Some(
+        KmCertExchange::new_from_paths(
+            &Path::new(&config.certificate_file.as_ref().unwrap()),
+            &Path::new(&config.ca_file.as_ref().unwrap()),
+        )
+        .unwrap(),
+    );
 
     //
     // instantiate bounded resources (queues and buffers)
@@ -295,21 +279,7 @@ fn main() -> ExitCode {
     //
     // create system assembly
     //
-
-    let flags = PhFlags {
-        allow_insecure_zpi_zero: config.disable_km || config.allow_insecure_zpi_zero,
-        disable_key_management: config.disable_km,
-        ..Default::default()
-    };
-
-    if flags.allow_insecure_zpi_zero {
-        warn!(
-            "Insecure ZPI ZERO is enabled.  This is insecure and should only be used for testing."
-        );
-    }
-
     let asm = Box::leak(Box::new(Assembly {
-        flags,
         ph_mode,
         topology_config,
         system_name: config.name,
@@ -364,10 +334,9 @@ fn main() -> ExitCode {
     js.spawn_local(mgmt_dispatch_worker::launch(asm, md_outq));
     js.spawn_local(adapter_manager_worker::launch(&*asm, am_outq));
     js.spawn_local(rpc_worker::launch(asm, control_socket));
-    if !config.disable_km {
-        js.spawn_local(km_multiplexor::launch_signal_worker(&*asm, km_sig_outq));
-        js.spawn_local(km_multiplexor::launch_message_worker(&*asm, km_outq));
-    }
+    js.spawn_local(km_multiplexor::launch_signal_worker(&*asm, km_sig_outq));
+    js.spawn_local(km_multiplexor::launch_message_worker(&*asm, km_outq));
+
 
     //
     // start data path workers
@@ -416,26 +385,23 @@ fn main() -> ExitCode {
     local_set.block_on(&runtime, async {
         if ph_mode == PhMode::Adapter {
             let Some(dsid) = dsid else { panic!("we are an adapter but have no tether configured"); };
-
-            if !config.disable_km {
-                info!(
-                    "{}: waiting on security assocaition establishment on link {}",
-                    asm.system_name, dsid
-                );
-                while !asm.peer_table.is_security_assocaition_established(dsid) {
-                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                }
-                info!(
-                    "{}: security assocaition established successfully on link {}",
-                    asm.system_name, dsid
-                );
-
-                // HACK - In our tests we need to send from adapter through the node to the adapter.
-                // We do not know when the other adapter has setup its association. So lets give
-                // it a little time here.
-                info!("{}: waiting for the other adapter to (hopfully) establish its security association...", asm.system_name);
-                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+            info!(
+                "{}: waiting on security assocaition establishment on link {}",
+                asm.system_name, dsid
+            );
+            while !asm.peer_table.is_security_assocaition_established(dsid) {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
             }
+            info!(
+                "{}: security assocaition established successfully on link {}",
+                asm.system_name, dsid
+            );
+
+            // HACK - In our tests we need to send from adapter through the node to the adapter.
+            // We do not know when the other adapter has setup its association. So lets give
+            // it a little time here.
+            info!("{}: waiting for the other adapter to (hopfully) establish its security association...", asm.system_name);
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         }
     });
 


### PR DESCRIPTION
Remove old "disable-km" and "allow insecure zpi zero" flags.  This is in prep for more arg cleanup.