### PR TITLE
boxed packet buffers

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -3,7 +3,7 @@ use crate::assembly::{Assembly, PhMode};
 use crate::counters::CounterType;
 use crate::fastpath;
 use crate::mgmt::requests;
-use crate::packet::Packet;
+use crate::packet::BufferPacket;
 use crate::queues::AdapterManagerMessage;
 use std::future::Future;
 use tokio::sync::mpsc;
@@ -12,7 +12,7 @@ use zpr;
 
 async fn worker<'pktbuf>(
     asm: &Assembly<'pktbuf>,
-    queue: &mut mpsc::Receiver<AdapterManagerMessage<'pktbuf>>,
+    queue: &mut mpsc::Receiver<AdapterManagerMessage>,
 ) {
     while let Some(msg) = queue.recv().await {
         match msg {
@@ -28,13 +28,13 @@ async fn worker<'pktbuf>(
 
 pub fn launch<'pktbuf>(
     asm: impl std::ops::Deref<Target = Assembly<'pktbuf>> + Send + Sync + 'pktbuf,
-    mut queue: mpsc::Receiver<AdapterManagerMessage<'pktbuf>>,
+    mut queue: mpsc::Receiver<AdapterManagerMessage>,
 ) -> impl Future<Output = ()> + 'pktbuf {
     async move { worker(&*asm, &mut queue).await }
 }
 
 // RFC 6.5 § 6.3.11
-async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: Packet<'pktbuf>) {
+async fn do_request_tether_id<'pktbuf>(asm: &Assembly<'pktbuf>, pkt: BufferPacket) {
     // TODO: node version... that just allocates a tether ID directly from the internal dock, no messages exchanged
     if matches!(asm.ph_mode, PhMode::Node) {
         fastpath::drop_and_count(asm, pkt, CounterType::DroppedNop);

--- a/adapter/ph/src/adapter_tables.rs
+++ b/adapter/ph/src/adapter_tables.rs
@@ -5,7 +5,7 @@
 #![allow(dead_code)]
 
 use crate::defs::FiveTuple;
-use crate::packet::Packet;
+use crate::packet::BufferPacket;
 use crate::rcu::{RcuBox, RcuCslabEntryGuard};
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::mapref::one::Ref as DashMapRef;
@@ -21,26 +21,26 @@ pub struct AltPep {
     pub tether_id: StreamId,
 }
 
-pub enum AltEntry<'pktbuf> {
+pub enum AltEntry {
     Active(AltPep),
-    Pending(Packet<'pktbuf>),
+    Pending(BufferPacket),
 }
 
-pub struct AgentLookupTable<'pktbuf> {
-    table: DashMap<FiveTuple, AltEntry<'pktbuf>>,
+pub struct AgentLookupTable {
+    table: DashMap<FiveTuple, AltEntry>,
 }
 
-pub struct AltEntryGuard<'a, 'pktbuf>(DashMapRef<'a, FiveTuple, AltEntry<'pktbuf>>);
+pub struct AltEntryGuard<'a>(DashMapRef<'a, FiveTuple, AltEntry>);
 
-impl<'pktbuf> std::ops::Deref for AltEntryGuard<'_, 'pktbuf> {
-    type Target = AltEntry<'pktbuf>;
+impl std::ops::Deref for AltEntryGuard<'_> {
+    type Target = AltEntry;
 
     fn deref(&self) -> &Self::Target {
         self.0.deref()
     }
 }
 
-impl<'pktbuf> AgentLookupTable<'pktbuf> {
+impl AgentLookupTable {
     pub fn new() -> Self {
         Self {
             table: DashMap::new(),
@@ -51,17 +51,17 @@ impl<'pktbuf> AgentLookupTable<'pktbuf> {
     pub fn inspect<T>(
         &self,
         five_tuple: &FiveTuple,
-        inspector: impl FnOnce(&AltEntry<'pktbuf>) -> T,
+        inspector: impl FnOnce(&AltEntry) -> T,
     ) -> Option<T> {
         self.table.get(five_tuple).map(|entry| inspector(&*entry))
     }
 
-    pub fn get(&self, five_tuple: &FiveTuple) -> Option<AltEntryGuard<'_, 'pktbuf>> {
+    pub fn get(&self, five_tuple: &FiveTuple) -> Option<AltEntryGuard<'_>> {
         self.table.get(five_tuple).map(AltEntryGuard)
     }
 
     // FIXME: ideally we want `try_insert()` but dashmap doesn't support that…
-    pub fn insert(&self, five_tuple: FiveTuple, entry: AltEntry<'pktbuf>) {
+    pub fn insert(&self, five_tuple: FiveTuple, entry: AltEntry) {
         self.table.insert(five_tuple, entry);
     }
 
@@ -73,7 +73,7 @@ impl<'pktbuf> AgentLookupTable<'pktbuf> {
     pub fn alter<T>(
         &self,
         five_tuple: &FiveTuple,
-        alterer: impl FnOnce(&mut AltEntry<'pktbuf>) -> T,
+        alterer: impl FnOnce(&mut AltEntry) -> T,
     ) -> Result<T, ()> {
         match self.table.get_mut(five_tuple) {
             Some(mut ref_) => Ok(alterer(ref_.value_mut())),

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -52,13 +52,13 @@ pub struct Assembly<'pktbuf> {
     pub system_name: String, // For debugging use
     pub agent_address: Option<IpAddr>,
 
-    pub buffer_stack: BufferStack<'pktbuf, { config::PACKET_BUFFER_SIZE }>,
+    pub buffer_stack: BufferStack<{ config::PACKET_BUFFER_SIZE }>,
 
     pub agent_input: AgentInput<'pktbuf>,
     pub substrate_egress: SubstrateEgress<'pktbuf>,
 
     // Used to intercept packets that are unencrypted but still have ZDP headers
-    pub capture_queue: Capture<'pktbuf>,
+    pub capture_queue: Capture,
     pub capture_worker: CaptureWorker,
     pub flow_control: FlowControl,
 
@@ -66,16 +66,16 @@ pub struct Assembly<'pktbuf> {
 
     pub tun_ctl: Box<dyn TunCtl + 'pktbuf>,
 
-    pub peer_table: peer_table::PeerTable<'pktbuf>,
+    pub peer_table: peer_table::PeerTable,
     pub peer_ids: std::sync::Mutex<Vec<zpr::LinkId>>, // HACK until peer_table is enumerable
 
     // Adapter tables
     // NOTE: only adapter_manager_worker should modify these tables!
-    pub alt: adapter_tables::AgentLookupTable<'pktbuf>,
+    pub alt: adapter_tables::AgentLookupTable,
     pub dlt: adapter_tables::DockLookupTable,
 
-    pub mgmt_dispatch: MgmtDispatch<'pktbuf>,
-    pub adapter_manager: AdapterManager<'pktbuf>,
+    pub mgmt_dispatch: MgmtDispatch,
+    pub adapter_manager: AdapterManager,
     pub km_state: KmState,
 
     pub self_noise_keypair: Option<NoiseKeypair>,
@@ -207,20 +207,20 @@ pub mod test {
         pub topology_config: Option<TopologyConfig>,
         pub system_name: Option<String>,
         pub agent_address: Option<Option<IpAddr>>,
-        pub buffer_stack: Option<BufferStack<'a, { config::PACKET_BUFFER_SIZE }>>,
+        pub buffer_stack: Option<BufferStack<{ config::PACKET_BUFFER_SIZE }>>,
         pub agent_input: Option<AgentInput<'a>>,
         pub substrate_egress: Option<SubstrateEgress<'a>>,
-        pub capture_queue: Option<Capture<'a>>,
+        pub capture_queue: Option<Capture>,
         pub capture_worker: Option<CaptureWorker>,
         pub flow_control: Option<FlowControl>,
         pub counters: Option<EnumMap<CounterType, Counter>>,
         pub tun_ctl: Option<Box<dyn TunCtl + 'a>>,
-        pub peer_table: Option<peer_table::PeerTable<'a>>,
+        pub peer_table: Option<peer_table::PeerTable>,
         pub peer_ids: Option<Vec<zpr::LinkId>>,
-        pub alt: Option<adapter_tables::AgentLookupTable<'a>>,
+        pub alt: Option<adapter_tables::AgentLookupTable>,
         pub dlt: Option<adapter_tables::DockLookupTable>,
-        pub mgmt_dispatch: Option<MgmtDispatch<'a>>,
-        pub adapter_manager: Option<AdapterManager<'a>>,
+        pub mgmt_dispatch: Option<MgmtDispatch>,
+        pub adapter_manager: Option<AdapterManager>,
         pub km_state: Option<KmState>,
     }
 
@@ -246,8 +246,8 @@ pub mod test {
             .agent_address
             .unwrap_or(Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
         let buffer_stack = builder.buffer_stack.unwrap_or_else(|| {
-            let buf_storage = vec![[0u8; config::PACKET_BUFFER_SIZE]; 0];
-            BufferStack::new(buf_storage.leak::<'static>())
+            let buf_storage = vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]); 0];
+            BufferStack::new(buf_storage)
         });
         let agent_input = builder.agent_input.unwrap_or_else(|| {
             let v: Vec<&ZprTun> = Vec::new();

--- a/adapter/ph/src/buffer_stack.rs
+++ b/adapter/ph/src/buffer_stack.rs
@@ -1,3 +1,4 @@
+use std::ops::{Deref, DerefMut};
 use std::sync::Mutex;
 use tokio::sync::Notify;
 use zpr_ext::std::mem::{drop_guard, DropGuard};
@@ -19,21 +20,37 @@ macro_rules! test_barrier_wait {
     };
 }
 
-// This is used by the ingress stage to allocate buffers for incoming
-// packets.  Buffers are reused in a LIFO manner to promote cache reuse.
-
-pub struct BufferStack<'buf, const BUFSIZ: usize> {
-    buffers: Mutex<Vec<&'buf mut [u8; BUFSIZ]>>,
+/// This is used by the ingress stage to allocate buffers for incoming
+/// packets.  Buffers are reused in a LIFO manner to promote cache reuse.
+pub struct BufferStack<const BUFSIZ: usize> {
+    buffers: Mutex<Vec<Box<[u8; BUFSIZ]>>>,
     notify: Notify,
 }
 
+/// Owning reference to a buffer allocated from the stack.
+pub struct Buffer<const BUFSIZ: usize>(Box<[u8; BUFSIZ]>);
+
+impl<const BUFSIZ: usize> Deref for Buffer<BUFSIZ> {
+    type Target = [u8; BUFSIZ];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<const BUFSIZ: usize> DerefMut for Buffer<BUFSIZ> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.deref_mut()
+    }
+}
+
 #[allow(dead_code)]
-impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
+impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
     pub const BUFFER_SIZE: usize = BUFSIZ;
 
     pub fn new<I>(bufs: I) -> Self
     where
-        I: IntoIterator<Item = &'buf mut [u8; BUFSIZ]>,
+        I: IntoIterator<Item = Box<[u8; BUFSIZ]>>,
     {
         Self {
             buffers: Mutex::new(bufs.into_iter().collect()),
@@ -42,7 +59,7 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
     }
 
     /// Blocks until a single buffer can be returned.
-    pub async fn get_buffer(&self) -> &'buf mut [u8; BUFSIZ] {
+    pub async fn get_buffer(&self) -> Buffer<BUFSIZ> {
         loop {
             test_barrier_wait!();
 
@@ -50,7 +67,7 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
                 let mut bufs = self.buffers.lock().unwrap();
 
                 match bufs.pop() {
-                    Some(buf) => break buf,
+                    Some(buf) => break Buffer(buf),
                     None => (),
                 }
 
@@ -72,19 +89,19 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
     /// Same as `get_buffer()`, but returns the buffer in a `DropGuard`
     /// which will automatically return the buffer to the pool if it goes
     /// out of scope.
-    pub async fn get_buffer_guarded(&'buf self) -> impl DropGuard<&'buf mut [u8; BUFSIZ]> {
+    pub async fn get_buffer_guarded(&self) -> impl DropGuard<Buffer<BUFSIZ>> + '_ {
         drop_guard(self.get_buffer().await, |buf| self.put_buffer(buf))
     }
 
     /// Attempts to acquire a single buffer.  Does not block.
-    pub fn try_get_buffer(&self) -> Option<&'buf mut [u8; BUFSIZ]> {
-        self.buffers.lock().unwrap().pop()
+    pub fn try_get_buffer(&self) -> Option<Buffer<BUFSIZ>> {
+        self.buffers.lock().unwrap().pop().map(|b| Buffer(b))
     }
 
     /// Blocks until at least 1 buffer can be returned.
     /// Returns up to n buffers.
     /// Exception: if n is 0, returns immediately with no buffers.
-    pub async fn get_buffers(&self, n: usize, bufs_out: &mut Vec<&'buf mut [u8; BUFSIZ]>) -> usize {
+    pub async fn get_buffers(&self, n: usize, bufs_out: &mut Vec<Buffer<BUFSIZ>>) -> usize {
         if n == 0 {
             return 0;
         }
@@ -99,7 +116,7 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
 
                 for _ in 0..to_get {
                     // note: intentional reversing!  keep bufs on top of stack hot
-                    bufs_out.push(bufs.pop().unwrap());
+                    bufs_out.push(Buffer(bufs.pop().unwrap()));
                 }
 
                 if to_get > 0 {
@@ -123,7 +140,7 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
 
     /// Does not block.  May return 0 if no buffers could be returned.
     /// Returns up to n buffers.
-    pub fn try_get_buffers(&self, n: usize, bufs_out: &mut Vec<&'buf mut [u8; BUFSIZ]>) -> usize {
+    pub fn try_get_buffers(&self, n: usize, bufs_out: &mut Vec<Buffer<BUFSIZ>>) -> usize {
         if n == 0 {
             return 0;
         }
@@ -134,17 +151,17 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
 
         for _ in 0..to_get {
             // note: intentional reversing!  keep bufs on top of stack hot
-            bufs_out.push(bufs.pop().unwrap());
+            bufs_out.push(Buffer(bufs.pop().unwrap()));
         }
 
         to_get
     }
 
     /// Returns a single buffer.  Does not block.
-    pub fn put_buffer(&self, buf: &'buf mut [u8; BUFSIZ]) {
+    pub fn put_buffer(&self, buf: Buffer<BUFSIZ>) {
         let mut bufs = self.buffers.lock().unwrap();
         let was_empty = bufs.is_empty();
-        bufs.push(buf);
+        bufs.push(buf.0);
         drop(bufs);
         if was_empty {
             self.notify.notify_waiters();
@@ -154,15 +171,17 @@ impl<'buf, const BUFSIZ: usize> BufferStack<'buf, BUFSIZ> {
     /// Returns all buffers in the given collection.  Does not block.
     pub fn put_buffers<I>(&self, bufs_in: I)
     where
-        I: IntoIterator<Item = &'buf mut [u8; BUFSIZ]>,
+        I: IntoIterator<Item = Buffer<BUFSIZ>>,
     {
         let mut it = bufs_in.into_iter();
         match it.next() {
             Some(first_buf) => {
                 let mut bufs = self.buffers.lock().unwrap();
                 let was_empty = bufs.is_empty();
-                bufs.push(first_buf);
-                bufs.extend(it);
+                bufs.push(first_buf.0);
+                for buf in it {
+                    bufs.push(buf.0);
+                }
                 drop(bufs);
                 if was_empty {
                     self.notify.notify_waiters();
@@ -180,7 +199,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_buffer_notify_race() {
-        let buf = Box::leak(Box::new([0u8; 1]));
+        let buf = Box::new([0u8; 1]);
         let bs = Box::leak(Box::new(BufferStack::<1>::new([])));
         let barrier = Box::leak(Box::new(tokio::sync::Barrier::new(2)));
         let gb_task = tokio::task::spawn(BARRIER.scope(barrier, bs.get_buffer()));
@@ -189,7 +208,7 @@ mod tests {
         barrier.wait().await;
 
         // add a buffer
-        bs.put_buffer(buf);
+        bs.put_buffer(Buffer(buf));
 
         // allow gb_task to register for notifications
         barrier.wait().await;
@@ -207,7 +226,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_buffers_notify_race() {
-        let buf = Box::leak(Box::new([0u8; 1]));
+        let buf = Box::new([0u8; 1]);
         let bs = Box::leak(Box::new(BufferStack::<1>::new([])));
         let barrier = Box::leak(Box::new(tokio::sync::Barrier::new(2)));
         let gb_task = tokio::task::spawn(BARRIER.scope(barrier, async {
@@ -219,7 +238,7 @@ mod tests {
         barrier.wait().await;
 
         // add a buffer
-        bs.put_buffer(buf);
+        bs.put_buffer(Buffer(buf));
 
         // allow gb_task to register for notifications
         barrier.wait().await;

--- a/adapter/ph/src/capture_worker.rs
+++ b/adapter/ph/src/capture_worker.rs
@@ -62,7 +62,7 @@ pub struct Config {
 async fn worker<'pktbuf>(
     config: &Config,
     asm: &Assembly<'pktbuf>,
-    queue: &mut mpsc::Receiver<CapPacket<'pktbuf>>,
+    queue: &mut mpsc::Receiver<CapPacket>,
 ) {
     let mut messages = Vec::new();
 
@@ -98,7 +98,7 @@ async fn worker<'pktbuf>(
 pub fn launch<'pktbuf, AsmRef: 'pktbuf>(
     config: &Config,
     asm: AsmRef,
-    mut queue: mpsc::Receiver<CapPacket<'pktbuf>>,
+    mut queue: mpsc::Receiver<CapPacket>,
 ) -> impl Future<Output = ()> + Send + 'pktbuf
 where
     AsmRef: std::ops::Deref<Target = Assembly<'pktbuf>> + Send + Sync,
@@ -107,9 +107,9 @@ where
     async move { worker(&cfg, &*asm, &mut queue).await }
 }
 
-async fn savefile_write_batch<'a, 'b: 'a>(
+async fn savefile_write_batch<'a>(
     savefile: &'a mut PcapWriter<File>,
-    cap_packs: impl IntoIterator<Item = &'a CapPacket<'b>>,
+    cap_packs: impl IntoIterator<Item = &'a CapPacket>,
     force_flush: bool,
 ) -> io::Result<()> {
     for cap_pack in cap_packs.into_iter() {
@@ -126,10 +126,7 @@ async fn savefile_write_batch<'a, 'b: 'a>(
     Ok(())
 }
 
-async fn savefile_write(
-    savefile: &mut PcapWriter<File>,
-    cap_pack: &CapPacket<'_>,
-) -> io::Result<()> {
+async fn savefile_write(savefile: &mut PcapWriter<File>, cap_pack: &CapPacket) -> io::Result<()> {
     let packet = PcapPacket {
         timestamp: cap_pack.timestamp,
         orig_len: cap_pack.orig_len,

--- a/adapter/ph/src/classifier.rs
+++ b/adapter/ph/src/classifier.rs
@@ -76,7 +76,9 @@ pub fn get_ip_version(body: &[u8]) -> u8 {
     (body[0] & IP_VERSION_MASK) >> 4
 }
 
-pub fn classify(packet: &mut packet::Packet) -> Result<ClassifierResult, &'static str> {
+pub fn classify<PktBuf: packet::PacketBuffer>(
+    packet: &mut packet::Packet<PktBuf>,
+) -> Result<ClassifierResult, &'static str> {
     let (metadata, body) = packet.metadata_mut_and_body_mut();
     classify_zdp(metadata, body)
 }

--- a/adapter/ph/src/compress.rs
+++ b/adapter/ph/src/compress.rs
@@ -3,7 +3,7 @@
 use crate::classifier;
 use crate::defs::FiveTuple;
 use crate::net_defs;
-use crate::packet::Packet;
+use crate::packet::{Packet, PacketBuffer};
 use bytes::Buf;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use zerocopy::*;
@@ -21,7 +21,7 @@ struct CompressedIPv6Header {
     pub hop_limit: u8,
 }
 
-fn compress_addrs_v4(pkt: &mut Packet) {
+fn compress_addrs_v4(pkt: &mut Packet<impl PacketBuffer>) {
     let hdr = classifier::IPv4Header::ref_from_prefix(pkt.body())
         .unwrap()
         .0;
@@ -55,7 +55,12 @@ fn compress_addrs_v4(pkt: &mut Packet) {
     pkt.push_header(&[hl_zdpflags, dscp]);
 }
 
-fn expand_addrs_v4(pkt: &mut Packet, proto: u8, src_address: Ipv4Addr, dst_address: Ipv4Addr) {
+fn expand_addrs_v4(
+    pkt: &mut Packet<impl PacketBuffer>,
+    proto: u8,
+    src_address: Ipv4Addr,
+    dst_address: Ipv4Addr,
+) {
     let hl_zdpflags_tos = pkt.get_array::<2>();
     let hl_zdpflags = hl_zdpflags_tos[0];
     let tos = hl_zdpflags_tos[1];
@@ -98,7 +103,7 @@ fn expand_addrs_v4(pkt: &mut Packet, proto: u8, src_address: Ipv4Addr, dst_addre
         .header_checksum = csum;
 }
 
-fn compress_addrs_v6(pkt: &mut Packet) {
+fn compress_addrs_v6(pkt: &mut Packet<impl PacketBuffer>) {
     let hdr = classifier::IPv6Header::ref_from_prefix(pkt.body())
         .unwrap()
         .0;
@@ -117,7 +122,7 @@ fn compress_addrs_v6(pkt: &mut Packet) {
 }
 
 fn expand_addrs_v6(
-    pkt: &mut Packet,
+    pkt: &mut Packet<impl PacketBuffer>,
     next_header: u8,
     src_address: Ipv6Addr,
     dst_address: Ipv6Addr,
@@ -152,7 +157,7 @@ pub fn compress(
     compression_mode: CompressionMode,
     l3_type: L3Type,
     _l4_protocol: net_defs::IpProtocol,
-    pkt: &mut Packet,
+    pkt: &mut Packet<impl PacketBuffer>,
 ) {
     match l3_type {
         L3Type::Ipv4 => compress_addrs_v4(pkt),
@@ -166,7 +171,11 @@ pub fn compress(
 }
 
 /// Expand a packet.  Fills payload length from body length, so trailers (e.g. A2A MAC) must not be present.
-pub fn expand(compression_mode: CompressionMode, five_tuple: &FiveTuple, pkt: &mut Packet) {
+pub fn expand(
+    compression_mode: CompressionMode,
+    five_tuple: &FiveTuple,
+    pkt: &mut Packet<impl PacketBuffer>,
+) {
     match five_tuple.l3_type {
         L3Type::Ipv4 => expand_addrs_v4(
             pkt,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -12,7 +12,7 @@ use crate::defs::Direction;
 use crate::km::Codec;
 use crate::km_noise::NOISE_PADLEN;
 use crate::net_defs;
-use crate::packet::Packet;
+use crate::packet::{BufferPacket, Packet, PacketBuffer};
 use crate::queues::TryEnqueueError;
 use crate::zdp;
 use crate::zdp_ll;
@@ -29,7 +29,7 @@ use zpr_ext::zerocopy::*;
 /// Drop a packet and count the drop with the given reason.
 pub fn drop_and_count<'pktbuf>(
     asm: &Assembly<'pktbuf>,
-    pkt: Packet<'pktbuf>,
+    pkt: BufferPacket,
     reason: impl Into<CounterType>,
 ) {
     let reason = reason.into();
@@ -43,7 +43,7 @@ pub fn encap_zpi<'pktbuf>(
     _asm: &Assembly<'pktbuf>,
     _link_id: zpr::LinkId,
     zpi: zpr::Zpi,
-    pkt: &mut Packet<'pktbuf>,
+    pkt: &mut Packet<impl PacketBuffer>,
 ) {
     pkt.alloc_zeroed_header::<zdp::ZdpZpiHeader>().zpi = zpi;
 }
@@ -52,15 +52,19 @@ pub fn encap_zpi<'pktbuf>(
 /// The packet must be a complete ZDP message.
 /// Despite the &mut borrow, the packet will return materially unchanged.
 /// (It will have a link-layer header temporarily added to it.)
-pub fn maybe_capture<'pktbuf>(asm: &Assembly<'pktbuf>, dir: Direction, pkt: &mut Packet<'pktbuf>) {
+pub fn maybe_capture<'pktbuf>(
+    asm: &Assembly<'pktbuf>,
+    dir: Direction,
+    pkt: &mut Packet<impl PacketBuffer>,
+) {
     maybe_capture_batch(asm, dir, [pkt])
 }
 
 /// Batch packet capture.
-pub fn maybe_capture_batch<'a, 'pktbuf: 'a>(
+pub fn maybe_capture_batch<'a, 'pktbuf: 'a, PktBuf: PacketBuffer + 'a>(
     asm: &'a Assembly<'pktbuf>,
     dir: Direction,
-    pkts: impl IntoIterator<Item = &'a mut Packet<'pktbuf>>,
+    pkts: impl IntoIterator<Item = &'a mut Packet<PktBuf>>,
 ) {
     if !asm.flow_control.program_exists() {
         return;
@@ -97,7 +101,7 @@ pub fn maybe_capture_batch<'a, 'pktbuf: 'a>(
             }) {
                 Some(buf) => {
                     let orig_len = pkt.body().len();
-                    let pkt_clone: Packet =
+                    let pkt_clone: BufferPacket =
                         pkt.clone_prefix_into(buf, std::cmp::min(caplen, orig_len));
                     // remove direction indicator from beginning of packet
                     pkt.advance(std::mem::size_of::<zdp_ll::ZdpLinkP2P>());
@@ -153,7 +157,7 @@ pub fn maybe_capture_batch<'a, 'pktbuf: 'a>(
 }
 
 /// Encrypt a ZDP packet according to its ZPI header (which is not encrypted).
-pub fn encrypt_null<'pktbuf>(pkt: &mut Packet<'pktbuf>) {
+pub fn encrypt_null(pkt: &mut Packet<impl PacketBuffer>) {
     // RFC 6.5 § 5.25.2
     pkt.put(
         net_defs::inet_checksum(&pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..]).as_slice(),
@@ -161,7 +165,7 @@ pub fn encrypt_null<'pktbuf>(pkt: &mut Packet<'pktbuf>) {
 }
 
 /// Slap an HMAC onto the end of the packet.
-pub fn encrypt_hmac<'pktbuf>(send_hmac_key: [u8; 32], pkt: &mut Packet<'pktbuf>) {
+pub fn encrypt_hmac(send_hmac_key: [u8; 32], pkt: &mut Packet<impl PacketBuffer>) {
     let mut link_mac = [0u8; zdp::ZDP_PACKET_MAC_SIZE];
     link_mac[..zdp::ZDP_PACKET_MAC_SIZE].copy_from_slice(
         &blake3::keyed_hash(&send_hmac_key, pkt.body()).as_bytes()[..zdp::ZDP_PACKET_MAC_SIZE],
@@ -172,7 +176,7 @@ pub fn encrypt_hmac<'pktbuf>(send_hmac_key: [u8; 32], pkt: &mut Packet<'pktbuf>)
 pub fn encrypt_full<'pktbuf>(
     _asm: &Assembly<'pktbuf>,
     codec: &dyn Codec,
-    pkt: &mut Packet<'pktbuf>,
+    pkt: &mut Packet<impl PacketBuffer>,
 ) -> Result<(), km::EncryptionError> {
     // TODO: Could do some length checks here on the packet body.  Is it too short? Too long? Etc.
 
@@ -214,7 +218,7 @@ impl From<DecryptError> for CounterType {
 }
 
 /// Decrypt a ZDP packet according to its ZPI header (which is not removed).
-pub fn decrypt_null<'pktbuf>(pkt: &mut Packet<'pktbuf>) -> Result<(), DecryptError> {
+pub fn decrypt_null(pkt: &mut Packet<impl PacketBuffer>) -> Result<(), DecryptError> {
     // RFC 6.5 § 5.25.2
     if !net_defs::validate_inet_checksum(&pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..]) {
         return Err(DecryptError::MicvFailure);
@@ -226,9 +230,9 @@ pub fn decrypt_null<'pktbuf>(pkt: &mut Packet<'pktbuf>) -> Result<(), DecryptErr
 }
 
 /// Check and remove the link-2-link HMAC on the (presumed) transit packet.
-pub fn decrypt_hmac<'pktbuf>(
+pub fn decrypt_hmac(
     recv_hmac_key: [u8; 32],
-    pkt: &mut Packet<'pktbuf>,
+    pkt: &mut Packet<impl PacketBuffer>,
 ) -> Result<(), DecryptError> {
     if pkt.body().len() < zdp::ZDP_PACKET_MAC_SIZE {
         return Err(DecryptError::BadStructure);
@@ -250,10 +254,10 @@ pub fn decrypt_hmac<'pktbuf>(
 
 /// Decrypt a ZDP packet according to its ZPI header (which is not removed).
 pub fn decrypt_full<'pktbuf>(
-    asm: &Assembly<'pktbuf>,
+    _asm: &Assembly<'pktbuf>,
     codec: &dyn Codec,
     padlen: usize,
-    pkt: &mut Packet<'pktbuf>,
+    pkt: &mut Packet<impl PacketBuffer>,
 ) -> Result<(), DecryptError> {
     if pkt.body().len() < 1 {
         return Err(DecryptError::BadStructure);
@@ -263,9 +267,9 @@ pub fn decrypt_full<'pktbuf>(
         return Err(DecryptError::BadStructure);
     }
 
-    let decr_buf = asm.buffer_stack.try_get_buffer().unwrap();
+    let mut decr_buf = [0u8; config::PACKET_BUFFER_SIZE];
 
-    match codec.decrypt_transport_stateless(&pkt.body()[1..encr_len + 1], decr_buf) {
+    match codec.decrypt_transport_stateless(&pkt.body()[1..encr_len + 1], &mut decr_buf) {
         Ok(len) => {
             // Copy the decrypted data back into the message -- do not overwrite ZPI.
             pkt.shrink_by(encr_len); // remove ciphertext body, leave ZPI
@@ -282,7 +286,7 @@ pub fn decrypt_full<'pktbuf>(
 fn substrate_egress_common<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     link_id: zpr::LinkId,
-    pkt: &mut Packet<'pktbuf>,
+    pkt: &mut BufferPacket,
 ) -> Result<Option<zpr::SubstrateAddr>, km::EncryptionError> {
     // TODO: should we add ZDP header here also??
 
@@ -362,7 +366,7 @@ fn substrate_egress_common<'pktbuf>(
 pub fn substrate_egress<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     link_id: zpr::LinkId,
-    mut pkt: Packet<'pktbuf>,
+    mut pkt: BufferPacket,
 ) {
     let dest_sa = match substrate_egress_common(asm, link_id, &mut pkt) {
         Ok(Some(dest_sa)) => dest_sa,
@@ -393,7 +397,7 @@ pub fn substrate_egress<'pktbuf>(
 pub async fn substrate_egress_blocking<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     link_id: zpr::LinkId,
-    mut pkt: Packet<'pktbuf>,
+    mut pkt: BufferPacket,
 ) {
     let dest_sa = match substrate_egress_common(asm, link_id, &mut pkt) {
         Ok(Some(dest_sa)) => dest_sa,
@@ -436,7 +440,7 @@ pub fn substrate_ingress<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     #[cfg_attr(not(debug_assertions), allow(unused_variables))] worker_index: usize,
     peer_sa: &zpr::SubstrateAddr,
-    mut pkt: Packet<'pktbuf>,
+    mut pkt: BufferPacket,
 ) {
     asm.counters[CounterType::InPacksRec].increment();
 
@@ -607,7 +611,7 @@ pub fn substrate_ingress<'pktbuf>(
 pub fn agent_input<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     tether_id: zpr::StreamId, // TODO: should we keep this in metadata? or per-flow header?
-    mut pkt: Packet<'pktbuf>,
+    mut pkt: BufferPacket,
 ) {
     // extract A2A MAC
     let Ok(a2a_hdr) = zdp::ZdpA2aHeader::read_from_buf(&mut pkt) else {
@@ -656,7 +660,7 @@ pub fn agent_input<'pktbuf>(
 
 /// Process uncompressed packet from the agent.
 /// The packet will be compressed, or trigger a Bind request.
-pub fn agent_output<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) {
+pub fn agent_output<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: BufferPacket) {
     pkt.metadata_mut().ingress_link_id = zpr::AGENT_LINK_ID;
 
     // determine five tuple
@@ -694,7 +698,7 @@ pub fn agent_output<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) 
 /// as to prevent the theoretical possibility of a packet loop).
 pub fn agent_output_post_classify<'pktbuf>(
     asm: &Assembly<'pktbuf>,
-    mut pkt: Packet<'pktbuf>,
+    mut pkt: BufferPacket,
     allow_bind_request: bool,
 ) {
     let five_tuple = *pkt.metadata().five_tuple(); // TODO: convince borrow checker we don't need to copy this out
@@ -756,7 +760,7 @@ pub fn agent_output_post_classify<'pktbuf>(
 }
 
 /// Forward compressed packet.
-pub fn forward<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: Packet<'pktbuf>) {
+pub fn forward<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: BufferPacket) {
     // TODO: node forwarding
 
     // adapter forwarding

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -9,7 +9,7 @@
 //! parsing key management ZDP messages.
 
 use crate::config;
-use crate::packet::Packet;
+use crate::packet::{Packet, PacketBuffer};
 use crate::zdp::{ZdpBaseHeader, ZdpPacketType, ZdpZpiHeader};
 use bytes::{BufMut, Bytes};
 use openssl::x509::X509;
@@ -770,7 +770,10 @@ impl Default for KmTransportSA {
 /// Helper function which is ZDP aware.  Does some error checking and leaves the ZPI
 /// in place.
 #[allow(dead_code)]
-pub fn encrypt_transport_zdp(message: &mut Packet, codec: Arc<dyn Codec>) -> KmResult<()> {
+pub fn encrypt_transport_zdp(
+    message: &mut Packet<impl PacketBuffer>,
+    codec: Arc<dyn Codec>,
+) -> KmResult<()> {
     if message.body().len()
         < std::mem::size_of::<ZdpZpiHeader>() + std::mem::size_of::<ZdpBaseHeader>()
     {
@@ -804,7 +807,10 @@ pub fn encrypt_transport_zdp(message: &mut Packet, codec: Arc<dyn Codec>) -> KmR
 
 /// Helper function which is ZDP aware.  Does some error checking and leaves the ZPI in place.
 #[allow(dead_code)]
-pub fn decrypt_transport_zdp(message: &mut Packet, codec: Arc<dyn Codec>) -> KmResult<()> {
+pub fn decrypt_transport_zdp(
+    message: &mut Packet<impl PacketBuffer>,
+    codec: Arc<dyn Codec>,
+) -> KmResult<()> {
     if message.body().len() < 1 {
         return Err(KmError::ShortPacket);
     }

--- a/adapter/ph/src/km_demo.rs
+++ b/adapter/ph/src/km_demo.rs
@@ -7,7 +7,6 @@
 use bytes::BufMut;
 use zerocopy::FromBytes;
 
-use crate::config;
 use crate::packet::*;
 use crate::zdp::*;
 use zpr;
@@ -31,10 +30,10 @@ pub const ZDP_REPORT_DATA_OFFSET: usize =
 
 /// Creates a packet like: [ZdpZpiHeader][ZdpBaseHeader]|[ZdpReportHeader]|<report_data>
 /// ZPI set to zero.
-pub fn build_zdp_report_packet<'buf>(
-    pbuf: &'buf mut [u8; config::PACKET_BUFFER_SIZE],
+pub fn build_zdp_report_packet<PktBuf: PacketBuffer>(
+    pbuf: PktBuf,
     report_data: &[u8],
-) -> Packet<'buf> {
+) -> Packet<PktBuf> {
     let mut pkt = Packet::new(pbuf, HEADROOM);
 
     let mlen = report_data.len() as u16;
@@ -53,10 +52,10 @@ pub fn build_zdp_report_packet<'buf>(
 }
 
 /// Creates a packet like: [ZdpZpiHeader]|[ZdpBaseHeader]|[ZdpKeyManagementHeader]<km_payload>
-pub fn build_zdp_km_noise_packet<'buf>(
-    pbuf: &'buf mut [u8; config::PACKET_BUFFER_SIZE],
+pub fn build_zdp_km_noise_packet<PktBuf: PacketBuffer>(
+    pbuf: PktBuf,
     km_payload: &[u8],
-) -> Packet<'buf> {
+) -> Packet<PktBuf> {
     let mut pkt = Packet::new(pbuf, HEADROOM);
     pkt.put(&km_payload[..]);
 
@@ -73,7 +72,7 @@ pub fn build_zdp_km_noise_packet<'buf>(
 
 /// Parse a full ZDP packet as a ZDP Report Message, expecting the payload of that message
 /// to be a string which is returned.
-pub fn parse_zdp_report_pkt(pkt: &Packet) -> Result<String, String> {
+pub fn parse_zdp_report_pkt(pkt: &Packet<impl PacketBuffer>) -> Result<String, String> {
     let Ok((_zpi_hdr, _)) = ZdpZpiHeader::ref_from_prefix(&pkt.body()) else {
         return Err(String::from(
             "error parsing ZPI header from decrypted payload",

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -399,8 +399,8 @@ mod test {
         let (km_tx, mut km_rx) = mpsc::channel(4);
         let km_state = KmState::new(km_tx, km_sig_tx);
 
-        let buf_storage = vec![[0u8; config::PACKET_BUFFER_SIZE]; 8];
-        let buffer_stack = BufferStack::new(buf_storage.leak::<'static>());
+        let buf_storage = vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]); 8];
+        let buffer_stack = BufferStack::new(buf_storage);
 
         let mut builder = TestAssemblyBuilder::new();
         builder.km_state = Some(km_state);

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -273,7 +273,8 @@ fn main() -> ExitCode {
 
     let topology_config = config::TopologyConfig::default();
 
-    let buf_storage = vec![[0u8; config::PACKET_BUFFER_SIZE]; topology_config.buffer_count];
+    let buf_storage =
+        vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]); topology_config.buffer_count];
 
     let (cap_inq, cap_outq) = mpsc::channel(topology_config.capture_queue_size);
     let (md_inq, md_outq) = mpsc::channel(topology_config.mgmt_dispatch_queue_size);
@@ -367,7 +368,7 @@ fn main() -> ExitCode {
         topology_config,
         system_name: config.name,
         agent_address: config.agent_addr,
-        buffer_stack: BufferStack::new(buf_storage.leak::<'static>()),
+        buffer_stack: BufferStack::new(buf_storage),
         agent_input: AgentInput::new(tun_devs.iter()),
         substrate_egress: SubstrateEgress::new(substrate_sockets.iter()),
         capture_queue: Capture::new(cap_inq),

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -7,7 +7,7 @@ use crate::assembly::Assembly;
 use crate::config;
 use crate::counters::CounterType;
 use crate::fastpath;
-use crate::packet::Packet;
+use crate::packet::{BufferPacket, Packet};
 use crate::zdp;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -21,7 +21,7 @@ pub async fn send_non_flow_mgmt<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
-    packet: Packet<'pktbuf>,
+    packet: BufferPacket,
 ) {
     send_mgmt_helper(asm, link_id, packet_type, None, None, packet).await
 }
@@ -34,7 +34,7 @@ pub async fn send_per_flow_mgmt<'pktbuf>(
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
     stream_id: zpr::StreamId,
-    packet: Packet<'pktbuf>,
+    packet: BufferPacket,
 ) {
     send_mgmt_helper(asm, link_id, packet_type, Some(stream_id), None, packet).await
 }
@@ -44,7 +44,7 @@ pub async fn send_non_flow_mgmt_response<'pktbuf>(
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
     sequence_number: zpr::SeqNum,
-    packet: Packet<'pktbuf>,
+    packet: BufferPacket,
 ) {
     send_mgmt_helper(
         asm,
@@ -63,7 +63,7 @@ pub async fn send_per_flow_mgmt_response<'pktbuf>(
     packet_type: zdp::ZdpPacketType,
     stream_id: zpr::StreamId,
     sequence_number: zpr::SeqNum,
-    packet: Packet<'pktbuf>,
+    packet: BufferPacket,
 ) {
     send_mgmt_helper(
         asm,
@@ -82,7 +82,7 @@ async fn send_mgmt_helper<'pktbuf>(
     packet_type: zdp::ZdpPacketType,
     stream_id: Option<zpr::StreamId>,
     sequence_number: Option<zpr::SeqNum>,
-    mut packet: Packet<'pktbuf>,
+    mut packet: BufferPacket,
 ) {
     debug_assert_eq!(stream_id.is_some(), packet_type.is_per_flow());
 
@@ -112,8 +112,8 @@ pub async fn send_sync_non_flow_req<'pktbuf>(
     link_id: zpr::LinkId,
     zdp_request_type: zdp::ZdpPacketType,
     zdp_response_type: zdp::ZdpPacketType,
-    pkt_fn: impl Fn(&mut Packet<'_>) + Send + 'static,
-) -> Result<Packet<'pktbuf>, SyncReqError> {
+    pkt_fn: impl Fn(&mut BufferPacket) + Send + 'static,
+) -> Result<BufferPacket, SyncReqError> {
     send_sync_req_helper(
         asm,
         link_id,
@@ -136,8 +136,8 @@ pub async fn send_sync_per_flow_req<'pktbuf>(
     zdp_request_type: zdp::ZdpPacketType,
     zdp_response_type: zdp::ZdpPacketType,
     stream_id: zpr::StreamId,
-    pkt_fn: impl Fn(&mut Packet<'_>) + Send + 'static,
-) -> Result<(zpr::StreamId, Packet<'pktbuf>), SyncReqError> {
+    pkt_fn: impl Fn(&mut BufferPacket /* FIXME: can relax to Packet<_> */) + Send + 'static,
+) -> Result<(zpr::StreamId, BufferPacket), SyncReqError> {
     match send_sync_req_helper(
         asm,
         link_id,
@@ -186,8 +186,8 @@ async fn send_sync_req_helper<'pktbuf>(
     zdp_request_type: zdp::ZdpPacketType,
     zdp_response_type: zdp::ZdpPacketType,
     stream_id: Option<zpr::StreamId>,
-    pkt_fn: impl Fn(&mut Packet<'_>) + 'static,
-) -> Result<Packet<'pktbuf>, SyncReqError> {
+    pkt_fn: impl Fn(&mut BufferPacket /* FIXME: relax to Packet */) + 'static,
+) -> Result<BufferPacket, SyncReqError> {
     // acquire a permit to send a manamgement message
     let Some(peer_state) = asm.peer_table.get(link_id) else {
         return Err(SyncReqError::LinkClosed);
@@ -233,10 +233,10 @@ async fn send_sync_req_helper<'pktbuf>(
 // TODO: rename/move this
 fn match_received<'pktbuf>(
     asm: &Assembly<'pktbuf>,
-    response: Option<(zdp::ZdpPacketType, Packet<'pktbuf>)>,
+    response: Option<(zdp::ZdpPacketType, BufferPacket)>,
     err_type: SyncReqError,
     zdp_response_type: zdp::ZdpPacketType,
-) -> Result<Packet<'pktbuf>, SyncReqError> {
+) -> Result<BufferPacket, SyncReqError> {
     match response {
         Some((pkt_type, pkt)) => {
             if pkt_type != zdp_response_type {

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -6,7 +6,7 @@ use crate::counters::CounterType;
 use crate::fastpath;
 use crate::km_multiplexor;
 use crate::link_state::LinkType;
-use crate::packet::Packet;
+use crate::packet::BufferPacket;
 use crate::queues;
 use crate::zdp;
 use bytes::Buf;
@@ -22,7 +22,7 @@ use zpr_ext::zerocopy::FromBytesExt;
 pub fn dispatch_mgmt_packet_with_addr<'pktbuf>(
     asm: &'static Assembly<'pktbuf>,
     peer_sa: zpr::SubstrateAddr,
-    mut pkt: Packet<'pktbuf>,
+    mut pkt: BufferPacket,
 ) {
     match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
         Ok(base_hdr) if base_hdr.0.packet_type == zdp::ZdpPacketType::KeyManagement => {
@@ -54,7 +54,7 @@ pub fn dispatch_mgmt_packet_with_addr<'pktbuf>(
 /// It merely dispatches the management packet to the correct queue.
 pub fn dispatch_mgmt_packet_with_link<'pktbuf>(
     asm: &'static Assembly<'pktbuf>,
-    mut pkt: Packet<'pktbuf>,
+    mut pkt: BufferPacket,
 ) {
     match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
         Ok((base_hdr, _)) if base_hdr.packet_type == zdp::ZdpPacketType::KeyManagement => {
@@ -89,10 +89,7 @@ pub fn dispatch_mgmt_packet_with_link<'pktbuf>(
     }
 }
 
-fn handle_response<'pktbuf>(
-    asm: &Assembly<'pktbuf>,
-    mut pkt: Packet<'pktbuf>,
-) -> HandleMgmtResult<'pktbuf> {
+fn handle_response<'pktbuf>(asm: &Assembly<'pktbuf>, mut pkt: BufferPacket) -> HandleMgmtResult {
     let Ok(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };
@@ -121,8 +118,8 @@ fn handle_response<'pktbuf>(
 // to parse starting from the KeyManagement header.
 fn handle_key_management<'pktbuf>(
     asm: &'static Assembly<'pktbuf>,
-    mut pkt: Packet<'pktbuf>,
-) -> HandleMgmtResult<'pktbuf> {
+    mut pkt: BufferPacket,
+) -> HandleMgmtResult {
     let Ok(km_hdr) = zdp::ZdpKeyManagementHeader::read_from_buf(&mut pkt) else {
         error!("KeyManagement packet arrived with unparseable header");
         return Err((HandleMgmtError::BadStructure, pkt));

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -8,7 +8,7 @@ use crate::defs::*;
 use crate::dock_tables;
 use crate::link_state::LinkEvent;
 use crate::net_defs::IpAddress;
-use crate::packet::Packet;
+use crate::packet::{BufferPacket, Packet};
 use crate::zdp;
 use bytes::{Buf, BufMut};
 use tracing::info;
@@ -37,13 +37,13 @@ impl From<HandleMgmtError> for counters::CounterType {
     }
 }
 
-pub type HandleMgmtResult<'pktbuf> = Result<(), (HandleMgmtError, Packet<'pktbuf>)>;
+pub type HandleMgmtResult = Result<(), (HandleMgmtError, BufferPacket)>;
 
 /// handle a Report message (RFC 6.5 § 6.3.13)
 pub async fn handle_report<'pktbuf>(
     asm: &Assembly<'pktbuf>,
-    mut pkt: Packet<'pktbuf>,
-) -> HandleMgmtResult<'pktbuf> {
+    mut pkt: BufferPacket,
+) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpReportHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };
@@ -65,8 +65,8 @@ pub async fn handle_report<'pktbuf>(
 /// handle a Discard message (RFC 6.5 § 6.3.1)
 pub async fn handle_discard<'pktbuf>(
     asm: &Assembly<'pktbuf>,
-    pkt: Packet<'pktbuf>,
-) -> HandleMgmtResult<'pktbuf> {
+    pkt: BufferPacket,
+) -> HandleMgmtResult {
     // TODO print to debug log, when implemented
     info!(
         "{}: Discard message received from {}",
@@ -81,8 +81,8 @@ pub async fn handle_discard<'pktbuf>(
 pub async fn handle_hello_request<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     seq_num: zpr::SeqNum,
-    pkt: Packet<'pktbuf>,
-) -> HandleMgmtResult<'pktbuf> {
+    pkt: BufferPacket,
+) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
     info!(
@@ -116,8 +116,8 @@ pub async fn handle_hello_request<'pktbuf>(
 pub async fn handle_hello_response<'pktbuf>(
     asm: &'static Assembly<'pktbuf>,
     _seq_num: zpr::SeqNum,
-    mut pkt: Packet<'pktbuf>,
-) -> HandleMgmtResult<'pktbuf> {
+    mut pkt: BufferPacket,
+) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
     let Ok(hdr) = zdp::ZdpHelloResponseHeader::read_from_buf(&mut pkt) else {
@@ -144,8 +144,8 @@ pub async fn handle_hello_response<'pktbuf>(
 pub async fn handle_register_agent_address_request<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     seq_num: zpr::SeqNum,
-    mut pkt: Packet<'pktbuf>,
-) -> HandleMgmtResult<'pktbuf> {
+    mut pkt: BufferPacket,
+) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
     let Ok(hdr) = zdp::ZdpRegisterAgentAddressRequestHeader::read_from_buf(&mut pkt) else {
@@ -207,8 +207,8 @@ pub async fn handle_register_agent_address_request<'pktbuf>(
 pub async fn handle_register_agent_address_response<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     _seq_num: zpr::SeqNum,
-    pkt: Packet<'pktbuf>,
-) -> HandleMgmtResult<'pktbuf> {
+    pkt: BufferPacket,
+) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
     info!(
         "{}: Received Register Agent Address Response for link {}",
@@ -228,8 +228,8 @@ pub async fn handle_register_agent_address_response<'pktbuf>(
 pub async fn handle_bind_agent_address_request<'pktbuf>(
     asm: &Assembly<'pktbuf>,
     seq_num: zpr::SeqNum,
-    mut pkt: Packet<'pktbuf>,
-) -> HandleMgmtResult<'pktbuf> {
+    mut pkt: BufferPacket,
+) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpBindAgentAddressRequestHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };

--- a/adapter/ph/src/mgmt_dispatch_worker.rs
+++ b/adapter/ph/src/mgmt_dispatch_worker.rs
@@ -6,10 +6,7 @@ use crate::queues::MgmtDispatchMessage;
 use std::future::Future;
 use tokio::sync::mpsc;
 
-async fn worker(
-    asm: &'static Assembly<'_>,
-    queue: &mut mpsc::Receiver<MgmtDispatchMessage<'static>>,
-) {
+async fn worker(asm: &'static Assembly<'_>, queue: &mut mpsc::Receiver<MgmtDispatchMessage>) {
     while let Some(msg) = queue.recv().await {
         match msg {
             MgmtDispatchMessage::WithLink(pkt) => {
@@ -24,7 +21,7 @@ async fn worker(
 
 pub fn launch(
     asm: &'static Assembly,
-    mut queue: mpsc::Receiver<MgmtDispatchMessage<'static>>,
+    mut queue: mpsc::Receiver<MgmtDispatchMessage>,
 ) -> impl Future<Output = ()> + 'static {
     async move { worker(&*asm, &mut queue).await }
 }

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -2,7 +2,7 @@ use crate::assembly::Assembly;
 use crate::counters::CounterType;
 use crate::fastpath;
 use crate::mgmt::handlers::{self, HandleMgmtError, HandleMgmtResult};
-use crate::packet::Packet;
+use crate::packet::BufferPacket;
 use crate::queues::MgmtProcessorMessage;
 use crate::zdp::*;
 use std::future::Future;
@@ -16,10 +16,10 @@ pub struct Config {
     pub link_id: zpr::LinkId,
 }
 
-async fn worker<'pktbuf>(
+async fn worker(
     config: &Config,
     asm: &'static Assembly<'_>,
-    queue: &mut mpsc::Receiver<MgmtProcessorMessage<'static>>,
+    queue: &mut mpsc::Receiver<MgmtProcessorMessage>,
 ) {
     while let Some(msg) = queue.recv().await {
         match msg {
@@ -45,16 +45,13 @@ async fn worker<'pktbuf>(
 pub fn launch(
     config: &Config,
     asm: &'static Assembly,
-    mut queue: mpsc::Receiver<MgmtProcessorMessage<'static>>,
+    mut queue: mpsc::Receiver<MgmtProcessorMessage>,
 ) -> impl Future<Output = ()> + 'static {
     let cfg = *config;
     async move { worker(&cfg, &*asm, &mut queue).await }
 }
 
-async fn handle_packet<'pktbuf>(
-    asm: &'static Assembly<'pktbuf>,
-    mut pkt: Packet<'pktbuf>,
-) -> HandleMgmtResult<'pktbuf> {
+async fn handle_packet(asm: &'static Assembly<'static>, mut pkt: BufferPacket) -> HandleMgmtResult {
     let Ok(base_hdr) = ZdpBaseHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -67,13 +67,13 @@ use zpr_ext::std::mem::DropGuard;
 ///
 ///     // We need a backing byte buffer for the packet.  This would tupically be allocated
 ///     // from a buffer pool.
-///     let mut pkt_buf = [0u8; config::PACKET_BUFFER_SIZE];
+///     let pkt_buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
 ///
 ///     // Create the packet. Since we are reading this packet with
 ///     // full (ZDP) headers already on it and we don't plan on pushing
 ///     // anything on to the front, we don't need any headroom so
 ///     // we set it to 0.
-///     let mut pkt = packet::Packet::new(&mut pkt_buf, 0);
+///     let mut pkt = packet::Packet::new(pkt_buf, 0);
 ///
 ///     // Write (copy) the received data into the packet.
 ///     pkt.put(&sock_buf[..read_len]);
@@ -146,9 +146,29 @@ use zpr_ext::std::mem::DropGuard;
 /// }
 /// ```
 
-pub struct Packet<'buf> {
-    buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE],
+/// A generic packet type, backed by any sort of buffer.
+///
+/// Use this type in functions which operate only on the contents of a packet,
+/// and do not interact with the buffer stack in any way.
+pub struct Packet<PktBuf> {
+    buf: PktBuf,
 }
+
+/// Blanket trait capturing all the traits needed to act as a packet backing buffer.
+pub trait PacketBuffer:
+    std::ops::DerefMut<Target = [u8; config::PACKET_BUFFER_SIZE]> + Send
+{
+}
+impl<PktBuf: std::ops::DerefMut<Target = [u8; config::PACKET_BUFFER_SIZE]> + Send> PacketBuffer
+    for PktBuf
+{
+}
+
+/// A `Packet` backed specifically by a `Buffer` from the buffer stack.
+///
+/// Use this type in any code which moves a packet through the packet processing
+/// pipeline (ultimately starting from, or ending with, the buffer stack).
+pub type BufferPacket = Packet<crate::buffer_stack::Buffer<{ config::PACKET_BUFFER_SIZE }>>;
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout)]
 #[repr(C)]
@@ -242,17 +262,17 @@ pub const PACKET_BUFFER_MAX_BODY_SIZE: usize =
     config::PACKET_BUFFER_SIZE - PACKET_BUFFER_MIN_BODY_OFFSET;
 
 #[allow(dead_code)]
-impl<'buf> Packet<'buf> {
+impl<PktBuf: PacketBuffer> Packet<PktBuf> {
     /// Initialize a buffer as a packet buffer, returning an exclusive handle to it.
     /// `headroom` indicates room to keep free at packet start for possible extension.
-    pub fn new(buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE], headroom: usize) -> Self {
+    pub fn new(buf: PktBuf, headroom: usize) -> Self {
         Self::new_with_existing_data(buf, PACKET_BUFFER_MIN_BODY_OFFSET + headroom, 0)
     }
 
     /// Same as `new()`, but accepts a `DropGuard`-protected buffer, and produces
     /// a `DropGuard`-protected packet buffer, so manually calling `destroy()`
     /// is unnecessary.
-    pub fn new_guarded<B: DropGuard<&'buf mut [u8; config::PACKET_BUFFER_SIZE]> + Send>(
+    pub fn new_guarded<B: DropGuard<PktBuf> + Send>(
         buf: B,
         headroom: usize,
     ) -> impl DropGuard<Self> + Send {
@@ -261,21 +281,17 @@ impl<'buf> Packet<'buf> {
 
     /// Consumes a packet handle, returning the underlying buffer.
     #[must_use]
-    pub fn destroy(self) -> &'buf mut [u8; config::PACKET_BUFFER_SIZE] {
+    pub fn destroy(self) -> PktBuf {
         self.buf
     }
 
     /// Initialize a buffer with existing packet data as a packet buffer.
     /// `offset` is offset of data within buffer.
     /// It must be at least equal to `PACKET_BUFFER_MIN_BODY_OFFSET`.
-    pub fn new_with_existing_data(
-        buf: &'buf mut [u8; config::PACKET_BUFFER_SIZE],
-        offset: usize,
-        len: usize,
-    ) -> Self {
+    pub fn new_with_existing_data(buf: PktBuf, offset: usize, len: usize) -> Self {
         assert!(offset >= PACKET_BUFFER_MIN_BODY_OFFSET);
-        assert!(len <= size_of_val(buf));
-        assert!(offset <= size_of_val(buf) - len);
+        assert!(len <= size_of_val(&*buf));
+        assert!(offset <= size_of_val(&*buf) - len);
         let mut pkt = Packet { buf };
         let md = pkt.metadata_mut();
         md.offset = offset;
@@ -286,42 +302,39 @@ impl<'buf> Packet<'buf> {
     }
 
     /// Copy this packet's metadata, data and layout into a new buffer, returning a handle for it.
-    pub fn clone_into<'other>(
-        &self,
-        buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
-    ) -> Packet<'other> {
+    pub fn clone_into<OtherPktBuf: PacketBuffer>(&self, buf: OtherPktBuf) -> Packet<OtherPktBuf> {
         self.clone_prefix_into_with_headroom(buf, self.headroom_available(), self.body().len())
     }
 
     /// Like `clone_into()`, but only copy a prefix of the packet's data.
-    pub fn clone_prefix_into<'other>(
+    pub fn clone_prefix_into<OtherPktBuf: PacketBuffer>(
         &self,
-        buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
+        buf: OtherPktBuf,
         len: usize,
-    ) -> Packet<'other> {
+    ) -> Packet<OtherPktBuf> {
         self.clone_prefix_into_with_headroom(buf, self.headroom_available(), len)
     }
 
     /// Copy this packet's metadata and data into a new buffer, returning a handle for it.
     /// The packet body will be positioned to leave the specified amount of headroom in the new buffer.
-    pub fn clone_into_with_headroom<'other>(
+    pub fn clone_into_with_headroom<OtherPktBuf: PacketBuffer>(
         &self,
-        buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
+        buf: OtherPktBuf,
         headroom: usize,
-    ) -> Packet<'other> {
+    ) -> Packet<OtherPktBuf> {
         self.clone_prefix_into_with_headroom(buf, headroom, self.body().len())
     }
 
     /// Like `clone_into_with_headroom()`, but only copy a prefix of the packet's data.
-    pub fn clone_prefix_into_with_headroom<'other>(
+    pub fn clone_prefix_into_with_headroom<OtherPktBuf: PacketBuffer>(
         &self,
-        buf: &'other mut [u8; config::PACKET_BUFFER_SIZE],
+        mut buf: OtherPktBuf,
         headroom: usize,
         len: usize,
-    ) -> Packet<'other> {
+    ) -> Packet<OtherPktBuf> {
         let body = self.body();
         assert!(len <= body.len());
-        assert!(headroom <= size_of_val(buf) - len - PACKET_BUFFER_MIN_BODY_OFFSET);
+        assert!(headroom <= size_of_val(&*buf) - len - PACKET_BUFFER_MIN_BODY_OFFSET);
         buf[..size_of::<PacketMetadata>()]
             .copy_from_slice(&self.buf[..size_of::<PacketMetadata>()]);
         let offset = PACKET_BUFFER_MIN_BODY_OFFSET + headroom;
@@ -454,7 +467,7 @@ impl<'buf> Packet<'buf> {
     }
 }
 
-impl<'buf> buf::Buf for Packet<'buf> {
+impl<PktBuf: PacketBuffer> buf::Buf for Packet<PktBuf> {
     //! Reading from a `Packet` using the `Buf` interface consumes data
     //! from the front of the packet.
 
@@ -479,14 +492,14 @@ impl<'buf> buf::Buf for Packet<'buf> {
     }
 }
 
-unsafe impl<'buf> buf::BufMut for Packet<'buf> {
+unsafe impl<PktBuf: PacketBuffer> buf::BufMut for Packet<PktBuf> {
     //! Writing to a `Packet` using the `BufMut` interface appends data
     //! into the tailroom and the end of the packet.
 
     /// This indicates how much tailroom is remaining.
     fn remaining_mut(&self) -> usize {
         let md = self.metadata();
-        size_of_val(self.buf) - (md.offset + md.len)
+        size_of_val(&*self.buf) - (md.offset + md.len)
     }
 
     /// Provides a reference to a portion of the remaining tailroom.
@@ -504,7 +517,7 @@ unsafe impl<'buf> buf::BufMut for Packet<'buf> {
     }
 }
 
-impl std::fmt::Debug for Packet<'_> {
+impl<PktBuf: PacketBuffer> std::fmt::Debug for Packet<PktBuf> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         writeln!(f, "\n=== Begin dumping packet info ===")?;
         self.metadata().fmt(f)?;

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -25,12 +25,12 @@ const PEER_TABLE_SIZE: usize = 1024;
 // break adapters/docking sessions out into a separate table.
 // this matches the RFC model of separate docks and forwarders.
 // for now, everyone has a DFT.......
-pub struct PeerState<'pktbuf> {
+pub struct PeerState {
     pub substrate_addr: SubstrateAddr,
     pub link_state_machine: LinkStateWrapper,
-    pub sync_req_state: sync_req::SyncReqState<'pktbuf>,
+    pub sync_req_state: sync_req::SyncReqState,
     pub dft: DockForwardingTable,
-    pub mgmt_processor: queues::MgmtProcessor<'pktbuf>,
+    pub mgmt_processor: queues::MgmtProcessor,
     pub mgmt_processor_worker: task::JoinHandle<()>,
     km_state: PeerKmState,
 }
@@ -63,13 +63,13 @@ impl PeerKmState {
 const MGMT_PROCESSOR_QUEUE_SIZE: usize = 16;
 
 // FIXME: can we eliminate the reliance on `'static` herein?
-impl PeerState<'static> {
+impl PeerState {
     pub fn new<Worker>(
         link_id: LinkId,
         link_type: LinkType,
         substrate_addr: SubstrateAddr,
         launch_mgmt_processor_worker: impl FnOnce(
-            mpsc::Receiver<queues::MgmtProcessorMessage<'static>>,
+            mpsc::Receiver<queues::MgmtProcessorMessage>,
         ) -> Worker,
     ) -> Self
     where
@@ -90,9 +90,7 @@ impl PeerState<'static> {
             km_state: PeerKmState::new(),
         }
     }
-}
 
-impl PeerState<'_> {
     /// Return a reference to the transport SA if there is an SA on the link, and if it is established.
     pub fn get_established_transport_association(
         &self,
@@ -101,13 +99,13 @@ impl PeerState<'_> {
     }
 }
 
-pub struct PeerTable<'pktbuf> {
-    peer_slab: Mutex<RcuCslab<PeerState<'pktbuf>>>,
-    peer_slab_reader: RcuBox<RcuCslabReader<PeerState<'pktbuf>>>,
+pub struct PeerTable {
+    peer_slab: Mutex<RcuCslab<PeerState>>,
+    peer_slab_reader: RcuBox<RcuCslabReader<PeerState>>,
     sa_to_link: DashMap<SubstrateAddr, LinkId>,
 }
 
-pub type PeerTableEntryGuard<'a, 'pktbuf> = RcuCslabEntryGuard<'a, PeerState<'pktbuf>>;
+pub type PeerTableEntryGuard<'a> = RcuCslabEntryGuard<'a, PeerState>;
 
 #[derive(Debug)]
 pub enum PeerInsertError {
@@ -119,7 +117,7 @@ pub enum SecurityAssocaitionStateError {
     NoAssociationForLink,
 }
 
-impl<'pktbuf> PeerTable<'pktbuf> {
+impl PeerTable {
     pub fn new() -> Self {
         let peer_slab = RcuCslab::with_fixed_capacity(PEER_TABLE_SIZE);
         let peer_slab_reader = RcuBox::new(peer_slab.reader());
@@ -131,11 +129,11 @@ impl<'pktbuf> PeerTable<'pktbuf> {
         }
     }
 
-    pub fn insert(&self, peer_state: PeerState<'pktbuf>) -> Result<LinkId, PeerInsertError> {
+    pub fn insert(&self, peer_state: PeerState) -> Result<LinkId, PeerInsertError> {
         Ok(self.vacant_entry()?.insert(peer_state))
     }
 
-    pub fn vacant_entry(&self) -> Result<VacantPeerTableEntry<'_, 'pktbuf>, PeerInsertError> {
+    pub fn vacant_entry(&self) -> Result<VacantPeerTableEntry<'_>, PeerInsertError> {
         let peer_slab_guard = self.peer_slab.lock().unwrap();
 
         if matches!(peer_slab_guard.vacant_key(), Err(_)) {
@@ -178,13 +176,13 @@ impl<'pktbuf> PeerTable<'pktbuf> {
     pub fn inspect<T>(
         &self,
         link_id: LinkId,
-        inspector: impl FnOnce(&PeerState<'pktbuf>) -> T,
+        inspector: impl FnOnce(&PeerState) -> T,
     ) -> Option<T> {
         self.peer_slab_reader
             .inspect(|r| r.get((link_id as usize).wrapping_sub(1)).map(inspector))
     }
 
-    pub fn get(&self, link_id: LinkId) -> Option<PeerTableEntryGuard<'_, 'pktbuf>> {
+    pub fn get(&self, link_id: LinkId) -> Option<PeerTableEntryGuard<'_>> {
         self.peer_slab_reader
             .get_guarded((link_id as usize).wrapping_sub(1))
     }
@@ -275,17 +273,17 @@ impl<'pktbuf> PeerTable<'pktbuf> {
     }
 }
 
-pub struct VacantPeerTableEntry<'a, 'pktbuf> {
-    peer_slab_guard: MutexGuard<'a, RcuCslab<PeerState<'pktbuf>>>,
+pub struct VacantPeerTableEntry<'a> {
+    peer_slab_guard: MutexGuard<'a, RcuCslab<PeerState>>,
     sa_to_link_ref: &'a DashMap<SubstrateAddr, LinkId>,
 }
 
-impl<'pktbuf> VacantPeerTableEntry<'_, 'pktbuf> {
+impl VacantPeerTableEntry<'_> {
     pub fn key(&self) -> LinkId {
         (self.peer_slab_guard.vacant_key().unwrap() + 1) as LinkId
     }
 
-    pub fn insert(mut self, peer_state: PeerState<'pktbuf>) -> LinkId {
+    pub fn insert(mut self, peer_state: PeerState) -> LinkId {
         let sa = peer_state.substrate_addr;
 
         let link_id = (self.peer_slab_guard.insert(peer_state).unwrap() + 1) as LinkId;

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -1,7 +1,7 @@
 //! Queues (i.e., frontend interface) for each stage of the system.
 
 use crate::net_defs;
-use crate::packet::Packet;
+use crate::packet::{BufferPacket, Packet, PacketBuffer};
 use crate::sys::ZprTun;
 use crate::test_packet::*;
 use std::io::ErrorKind;
@@ -20,27 +20,27 @@ pub enum TryEnqueueError<T> {
     Full(T),
 }
 
-pub enum MgmtProcessorMessage<'pktbuf> {
-    Packet(Packet<'pktbuf>),
+pub enum MgmtProcessorMessage {
+    Packet(BufferPacket),
     TestPacket(TestPacket),
 }
 
 /// MgmtProcessor processes all inbound management requests.
 /// Unlike other queues, this doesn't live directly in the assembly,
 /// but rather in the peer table, as there is one of these per peer.
-pub struct MgmtProcessor<'pktbuf> {
-    sender: mpsc::Sender<MgmtProcessorMessage<'pktbuf>>,
+pub struct MgmtProcessor {
+    sender: mpsc::Sender<MgmtProcessorMessage>,
 }
 
-impl<'pktbuf> MgmtProcessor<'pktbuf> {
-    pub fn new(sender: mpsc::Sender<MgmtProcessorMessage<'pktbuf>>) -> Self {
+impl MgmtProcessor {
+    pub fn new(sender: mpsc::Sender<MgmtProcessorMessage>) -> Self {
         Self { sender }
     }
 
     pub fn try_enqueue_packet(
         &self,
-        packet: Packet<'pktbuf>,
-    ) -> Result<(), TryEnqueueError<Packet<'pktbuf>>> {
+        packet: BufferPacket,
+    ) -> Result<(), TryEnqueueError<BufferPacket>> {
         match self.sender.try_send(MgmtProcessorMessage::Packet(packet)) {
             Ok(()) => Ok(()),
 
@@ -88,7 +88,7 @@ impl<'a> AgentInput<'a> {
         }
     }
 
-    pub fn try_enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>(
+    pub fn try_enqueue_packet<P: DropGuard<BufferPacket>>(
         &self,
         mut packet: P,
     ) -> Result<(), TryEnqueueError<P>> {
@@ -129,7 +129,7 @@ impl<'a> SubstrateEgress<'a> {
         }
     }
 
-    pub async fn enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>(
+    pub async fn enqueue_packet<P: DropGuard<BufferPacket>>(
         &self,
         packet: P,
         dest_sa: zpr::SubstrateAddr,
@@ -155,7 +155,7 @@ impl<'a> SubstrateEgress<'a> {
     }
 
     // TODO: batch enqueue
-    pub fn try_enqueue_packet<'pktbuf, P: DropGuard<Packet<'pktbuf>>>(
+    pub fn try_enqueue_packet<P: DropGuard<BufferPacket>>(
         &self,
         packet: P,
         dest_sa: zpr::SubstrateAddr,
@@ -184,7 +184,7 @@ impl<'a> SubstrateEgress<'a> {
 
     fn select_socket_and_set_flowinfo(
         &self,
-        packet: &Packet<'_>,
+        packet: &Packet<impl PacketBuffer>,
         mut dest_sa: zpr::SubstrateAddr,
     ) -> (&'a UdpSocket, std::net::SocketAddr) {
         match &mut dest_sa {
@@ -205,18 +205,18 @@ impl<'a> SubstrateEgress<'a> {
 }
 
 /// Capture will intercept packets in the PH and dump them into a file for debugging purposes
-pub struct CapPacket<'pktbuf> {
-    pub packet: Packet<'pktbuf>,
+pub struct CapPacket {
+    pub packet: BufferPacket,
     pub timestamp: SystemTime,
     pub orig_len: usize,
 }
 
-pub struct Capture<'pktbuf> {
-    sender: mpsc::Sender<CapPacket<'pktbuf>>,
+pub struct Capture {
+    sender: mpsc::Sender<CapPacket>,
 }
 
-impl<'pktbuf> Capture<'pktbuf> {
-    pub fn new(sender: mpsc::Sender<CapPacket<'pktbuf>>) -> Self {
+impl Capture {
+    pub fn new(sender: mpsc::Sender<CapPacket>) -> Self {
         Self { sender }
     }
 
@@ -224,7 +224,7 @@ impl<'pktbuf> Capture<'pktbuf> {
     #[allow(dead_code)]
     pub async fn enqueue_packet(
         &self,
-        packet: Packet<'pktbuf>,
+        packet: BufferPacket,
         timestamp: SystemTime,
         orig_len: usize,
     ) {
@@ -239,10 +239,10 @@ impl<'pktbuf> Capture<'pktbuf> {
     /// Does not block
     pub fn try_enqueue_packet(
         &self,
-        packet: Packet<'pktbuf>,
+        packet: BufferPacket,
         timestamp: SystemTime,
         orig_len: usize,
-    ) -> Result<(), TryEnqueueError<Packet<'pktbuf>>> {
+    ) -> Result<(), TryEnqueueError<BufferPacket>> {
         let cap_pack: CapPacket = CapPacket {
             packet,
             timestamp,
@@ -256,24 +256,24 @@ impl<'pktbuf> Capture<'pktbuf> {
     }
 }
 
-pub enum MgmtDispatchMessage<'pktbuf> {
-    WithLink(Packet<'pktbuf>), // Link ID stored in packet metadata
-    WithAddr(zpr::SubstrateAddr, Packet<'pktbuf>),
+pub enum MgmtDispatchMessage {
+    WithLink(BufferPacket), // Link ID stored in packet metadata
+    WithAddr(zpr::SubstrateAddr, BufferPacket),
 }
 
-pub struct MgmtDispatch<'pktbuf> {
-    sender: mpsc::Sender<MgmtDispatchMessage<'pktbuf>>,
+pub struct MgmtDispatch {
+    sender: mpsc::Sender<MgmtDispatchMessage>,
 }
 
-impl<'pktbuf> MgmtDispatch<'pktbuf> {
-    pub fn new(sender: mpsc::Sender<MgmtDispatchMessage<'pktbuf>>) -> Self {
+impl MgmtDispatch {
+    pub fn new(sender: mpsc::Sender<MgmtDispatchMessage>) -> Self {
         Self { sender }
     }
 
     pub fn try_dispatch_mgmt_packet_with_link(
         &self,
-        packet: Packet<'pktbuf>,
-    ) -> Result<(), TryEnqueueError<Packet<'pktbuf>>> {
+        packet: BufferPacket,
+    ) -> Result<(), TryEnqueueError<BufferPacket>> {
         debug_assert_ne!(packet.metadata().ingress_link_id, 0);
         match self.sender.try_send(MgmtDispatchMessage::WithLink(packet)) {
             Ok(()) => Ok(()),
@@ -292,8 +292,8 @@ impl<'pktbuf> MgmtDispatch<'pktbuf> {
     pub fn try_dispatch_mgmt_packet_with_addr(
         &self,
         peer_sa: &zpr::SubstrateAddr,
-        packet: Packet<'pktbuf>,
-    ) -> Result<(), TryEnqueueError<Packet<'pktbuf>>> {
+        packet: BufferPacket,
+    ) -> Result<(), TryEnqueueError<BufferPacket>> {
         debug_assert_eq!(packet.metadata().ingress_link_id, 0);
         match self
             .sender
@@ -313,16 +313,16 @@ impl<'pktbuf> MgmtDispatch<'pktbuf> {
     }
 }
 
-pub enum AdapterManagerMessage<'pktbuf> {
-    RequestTetherId(Packet<'pktbuf>),
+pub enum AdapterManagerMessage {
+    RequestTetherId(BufferPacket),
 }
 
-pub struct AdapterManager<'pktbuf> {
-    sender: mpsc::Sender<AdapterManagerMessage<'pktbuf>>,
+pub struct AdapterManager {
+    sender: mpsc::Sender<AdapterManagerMessage>,
 }
 
-impl<'pktbuf> AdapterManager<'pktbuf> {
-    pub fn new(sender: mpsc::Sender<AdapterManagerMessage<'pktbuf>>) -> Self {
+impl AdapterManager {
+    pub fn new(sender: mpsc::Sender<AdapterManagerMessage>) -> Self {
         Self { sender }
     }
 
@@ -339,8 +339,8 @@ impl<'pktbuf> AdapterManager<'pktbuf> {
     /// The specified packet must have already been classified.
     pub fn try_request_tether_id(
         &self,
-        packet: Packet<'pktbuf>,
-    ) -> Result<(), TryEnqueueError<Packet<'pktbuf>>> {
+        packet: BufferPacket,
+    ) -> Result<(), TryEnqueueError<BufferPacket>> {
         match self
             .sender
             .try_send(AdapterManagerMessage::RequestTetherId(packet))

--- a/adapter/ph/src/sync_req.rs
+++ b/adapter/ph/src/sync_req.rs
@@ -1,4 +1,4 @@
-use crate::packet::Packet;
+use crate::packet::BufferPacket;
 use crate::zdp;
 use std::future::Future;
 use std::sync::Mutex as StdMutex;
@@ -7,20 +7,20 @@ use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
 use tracing::debug;
 use zpr;
 
-pub struct SyncReqState<'pktbuf> {
-    listener_state: StdMutex<ListenerState<'pktbuf>>,
+pub struct SyncReqState {
+    listener_state: StdMutex<ListenerState>,
     window_state: TokioMutex<WindowState>,
 }
 
-struct ListenerState<'pktbuf> {
-    response_listener: Option<(zpr::SeqNum, oneshot::Sender<Response<'pktbuf>>)>,
+struct ListenerState {
+    response_listener: Option<(zpr::SeqNum, oneshot::Sender<Response>)>,
 }
 
 struct WindowState {
     next_seq_num: zpr::SeqNum,
 }
 
-pub type Response<'pktbuf> = (zdp::ZdpPacketType, Packet<'pktbuf>);
+pub type Response = (zdp::ZdpPacketType, BufferPacket);
 
 pub struct Permit<'a> {
     /// use our lock on the window state as a semaphore
@@ -39,20 +39,20 @@ impl Permit<'_> {
 
 pub struct ResponseError();
 
-pub struct ResponseFuture<'pktbuf> {
-    receiver: oneshot::Receiver<Response<'pktbuf>>,
+pub struct ResponseFuture {
+    receiver: oneshot::Receiver<Response>,
 }
 
-impl<'pktbuf> ResponseFuture<'pktbuf> {
-    pub fn hangup(&mut self) -> Option<Response<'pktbuf>> {
+impl ResponseFuture {
+    pub fn hangup(&mut self) -> Option<Response> {
         self.receiver.close();
         // catch any message which raced the close
         self.receiver.try_recv().ok()
     }
 }
 
-impl<'pktbuf> Future for ResponseFuture<'pktbuf> {
-    type Output = Result<Response<'pktbuf>, ResponseError>;
+impl Future for ResponseFuture {
+    type Output = Result<Response, ResponseError>;
 
     fn poll(
         mut self: std::pin::Pin<&mut Self>,
@@ -64,7 +64,7 @@ impl<'pktbuf> Future for ResponseFuture<'pktbuf> {
     }
 }
 
-impl<'pktbuf> SyncReqState<'pktbuf> {
+impl SyncReqState {
     pub fn new() -> Self {
         Self {
             listener_state: StdMutex::new(ListenerState {
@@ -95,7 +95,7 @@ impl<'pktbuf> SyncReqState<'pktbuf> {
         )
     }
 
-    pub fn install_response_listener(&self, permit: &Permit) -> ResponseFuture<'pktbuf> {
+    pub fn install_response_listener(&self, permit: &Permit) -> ResponseFuture {
         assert!(self.is_associated_permit(permit));
         let (sender, receiver) = oneshot::channel();
         self.listener_state.lock().unwrap().response_listener = Some((permit.seq_num(), sender));
@@ -110,8 +110,8 @@ impl<'pktbuf> SyncReqState<'pktbuf> {
     pub fn forward_response(
         &self,
         seq_num: zpr::SeqNum,
-        response: Response<'pktbuf>,
-    ) -> Result<(), Packet<'pktbuf>> {
+        response: Response,
+    ) -> Result<(), BufferPacket> {
         let listener = &mut self.listener_state.lock().unwrap().response_listener;
         match listener {
             Some((expected_seq_num, _)) => {


### PR DESCRIPTION
In preparation for removing `'pktbuf` from `Assembly`, this commit makes `buffer_stack` own the buffers it manages.  It owns them as `Box`es, so there is no performance hit (i.e. no reference counting).  The difference though is that this prevents us from allocating a single contiguous slab of memory and divvying it up in order to avoid malloc header overhead.  However it's possible we can leverage the [`yoke`](https://docs.rs/yoke/latest/yoke/) crate to give us this capability in the future.

`Packet`s now become parameterized over the backing buffer type, rather than the lifetime of the buffer reference.  Backing buffers must meet various requirements which are captured by the `PacketBuffer` trait.

Since almost all of our code relies on `Packets` being sourced from the buffer stack and being of a specified size, rather than write `Packet<Buffer<{ config::PACKET_BUFFER_SIZE }>>` everywhere, I've also introduced the `BufferPacket` alias, which is used through most of the packet processing path.

Therefore most of the changes here are either:
* replacing `Packet<'pktbuf>` with `Packet<impl PacketBuffer>` in buffer-agnostic code
* replacing `Packet<'pktbuf>` with `BufferPacket` in code which is part of the packet pipeline
* deleting `<'pktbuf>` arguments in many places

The only real changes are in `buffer_stack` and the top of `packet`.