### PR TITLE
unify process_event and process_static_event

### DIFF
--- a/adapter/cd/Cargo.lock
+++ b/adapter/cd/Cargo.lock
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "ph"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2152,6 +2152,5 @@ dependencies = [
  "libc",
  "nix",
  "tokio",
- "tokio-tun",
  "zerocopy 0.8.3",
 ]

--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "ph"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aarc",
  "arrayref",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ph"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -88,20 +88,8 @@ impl Assembly {
         self.ph_mode == PhMode::Node
     }
 
-    // TODO: REMOVE ME
-    pub fn process_link_state_event_static(
-        self: &Arc<Self>,
-        id: LinkId,
-        event: LinkEvent,
-    ) -> Result<(), LinkStateError> {
-        let Some(peer) = self.peer_table.get(id) else {
-            return Err(LinkStateError::NotFound(id));
-        };
-        peer.link_state_machine.process_static_event(self, event)
-    }
-
     pub fn process_link_state_event(
-        &self,
+        self: &Arc<Self>,
         id: LinkId,
         event: LinkEvent,
     ) -> Result<(), LinkStateError> {
@@ -158,7 +146,7 @@ impl Assembly {
             );
             let _ = peer
                 .link_state_machine
-                .process_static_event(self, LinkEvent::Reset);
+                .process_event(self, LinkEvent::Reset);
         } else {
             if let Err(e) = peer
                 .link_state_machine
@@ -170,7 +158,7 @@ impl Assembly {
                 );
                 let _ = peer
                     .link_state_machine
-                    .process_static_event(self, LinkEvent::Reset);
+                    .process_event(self, LinkEvent::Reset);
             } else {
                 info!(
                     "{}: Successfully started tether with {}.  Assigned ID {}",

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -131,7 +131,7 @@ pub async fn launch_signal_worker(
                                 error!("{}: km_multiplexor: failed to set SA established: {:?}", asm.system_name, e);
                             }
                         }
-                        match asm.process_link_state_event_static(linkmsg.link_id, LinkEvent::KeyingDone) {
+                        match asm.process_link_state_event(linkmsg.link_id, LinkEvent::KeyingDone) {
                             Err(e) => {
                                 error!("{}: Link state error: {:?}", asm.system_name, e);
                             }

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -210,11 +210,17 @@ impl LinkStateWrapper {
         self.locked_fsm.lock().unwrap().status
     }
 
-    pub fn process_event(&self, asm: &Assembly, event: LinkEvent) -> Result<(), LinkStateError> {
+    pub fn process_event(
+        &self,
+        asm: &Arc<Assembly>,
+        event: LinkEvent,
+    ) -> Result<(), LinkStateError> {
         match event {
             LinkEvent::Configure => self.configure(asm),
             LinkEvent::Start => self.start(asm),
+            LinkEvent::KeyingDone => self.keying_done(asm),
             LinkEvent::ReceivedHelloRequest => self.process_hello_request(asm),
+            LinkEvent::ReceivedHelloResponse => self.process_hello_response(asm),
             LinkEvent::ReceivedRegisterRequest(addr) => {
                 self.process_register_agent_address_request(asm, addr)
             }
@@ -227,22 +233,8 @@ impl LinkStateWrapper {
             LinkEvent::ReceivedTerminationIndication => {
                 Err(LinkStateError::OperationNotSupportedYet)
             }
-            _ => panic!("Called wrong function for event {:?}", event),
-        }
-    }
-
-    // FIXME: This is a temporary hack until we get rid of the static stuff
-    pub fn process_static_event(
-        &self,
-        asm: &Arc<Assembly>,
-        event: LinkEvent,
-    ) -> Result<(), LinkStateError> {
-        match event {
-            LinkEvent::KeyingDone => self.keying_done(asm),
-            LinkEvent::ReceivedHelloResponse => self.process_hello_response(asm),
             LinkEvent::Close => Ok(self.initiate_close()),
             LinkEvent::Reset => Ok(self.reset(asm)),
-            _ => panic!("Called wrong function for event {:?}", event),
         }
     }
 
@@ -293,7 +285,7 @@ impl LinkStateWrapper {
         match self.link_type {
             LinkType::AdapterToNode => {
                 km_multiplexor::add_adapter_link(
-                    &asm,
+                    asm,
                     self.id,
                     ZPIPair::new(zpr::ZPI_ENCRYPTED_HEADER_FLAG | 5, 6),
                     asm.self_noise_keypair.clone().unwrap(),
@@ -310,7 +302,7 @@ impl LinkStateWrapper {
             }
             LinkType::NodeToAdapter => {
                 km_multiplexor::add_node_link(
-                    &asm,
+                    asm,
                     self.id,
                     ZPIPair::new(ZPI_ENCRYPTED_HEADER_FLAG | 3, 4),
                     asm.self_noise_keypair.clone().unwrap(),
@@ -354,7 +346,7 @@ impl LinkStateWrapper {
                 mgmt::requests::send_hello_request(&task_asm, link_id).await?;
 
                 if task_asm
-                    .process_link_state_event_static(link_id, LinkEvent::ReceivedHelloResponse)
+                    .process_link_state_event(link_id, LinkEvent::ReceivedHelloResponse)
                     .is_err()
                 {
                     Err(())

--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "ph"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -2187,6 +2187,5 @@ dependencies = [
  "libc",
  "nix",
  "tokio",
- "tokio-tun",
  "zerocopy 0.8.3",
 ]


### PR DESCRIPTION
Final PR of the 'pktbuf removal series.  Unifies the two `process_event` functions.  Also bump the major version of PH to reflect all the interface changes of this patch series.  Cleaned up a couple minor nits from the series too.