### PR TITLE
"Special" peers

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -484,6 +484,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +557,27 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "enumset"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a4b049558765cef5f0c1a273c3fc57084d768b44d2f98127aef4cceb17293"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c3b24c345d8c314966bdc1832f6c2635bfcce8e7cf363bd115987bba2ee242"
+dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -576,6 +631,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -778,6 +839,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -1084,6 +1151,7 @@ dependencies = [
  "curve25519-dalek",
  "dashmap",
  "enum-map",
+ "enumset",
  "hdrhistogram",
  "libc",
  "nix",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -16,6 +16,7 @@ cslab = { path = "../../cslab" }
 curve25519-dalek = "4.1.3"
 dashmap = { version = "6.0.1" }
 enum-map = { version = "2.7.3" }
+enumset = "1.1.5"
 hdrhistogram = { version = "7.5.4" }
 libc = { version = "0.2.155" }
 nix = { version = "0.29.0", features = ["ioctl", "net"] }

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -8,6 +8,8 @@ use crate::sync_req;
 use bytes::Bytes;
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::DashMap;
+use enum_map::{Enum, EnumMap};
+use enumset::{EnumSet, EnumSetType};
 use std::future::Future;
 use std::sync::atomic::{self, Ordering};
 use std::sync::Mutex;
@@ -20,8 +22,16 @@ use zpr::{LinkId, SubstrateAddr};
 
 const PEER_TABLE_SIZE: usize = 1024;
 
+/// Some peers are "special", e.g. the visa service adapter attached to the initial node.
+/// These names let us identify them.
+#[derive(Debug, Enum, EnumSetType)]
+pub enum SpecialPeerName {
+    VisaServiceAdapter,
+}
+
 pub struct PeerState {
     pub substrate_addr: SubstrateAddr,
+    pub special_names: EnumSet<SpecialPeerName>,
     pub link_state_machine: LinkStateWrapper,
     pub sync_req_state: sync_req::SyncReqState,
     pub pft: PeerForwardingTable,
@@ -76,6 +86,7 @@ impl PeerState {
 
         Self {
             substrate_addr,
+            special_names: EnumSet::<SpecialPeerName>::empty(),
             link_state_machine: LinkStateWrapper::new(link_id, link_type),
             pft: PeerForwardingTable::new(),
             sync_req_state: sync_req::SyncReqState::new(),
@@ -83,6 +94,10 @@ impl PeerState {
             mgmt_processor_worker,
             km_state: PeerKmState::new(),
         }
+    }
+
+    pub fn add_special_name(&mut self, name: SpecialPeerName) {
+        self.special_names |= name;
     }
 
     /// Return a reference to the transport SA if there is an SA on the link, and if it is established.
@@ -93,10 +108,14 @@ impl PeerState {
     }
 }
 
+type AtomicLinkId = atomic::AtomicU32;
+const _: () = assert!(std::mem::size_of::<AtomicLinkId>() == std::mem::size_of::<LinkId>());
+
 pub struct PeerTable {
     peer_slab: Mutex<RcuCslab<PeerState>>,
     peer_slab_reader: RcuBox<RcuCslabReader<PeerState>>,
     sa_to_link: DashMap<SubstrateAddr, LinkId>,
+    special_peers: EnumMap<SpecialPeerName, AtomicLinkId>,
 }
 
 pub type PeerTableEntryGuard<'a> = RcuCslabEntryGuard<'a, PeerState>;
@@ -115,11 +134,11 @@ impl PeerTable {
     pub fn new() -> Self {
         let peer_slab = RcuCslab::with_fixed_capacity(PEER_TABLE_SIZE);
         let peer_slab_reader = RcuBox::new(peer_slab.reader());
-        let sa_to_link = DashMap::with_capacity(PEER_TABLE_SIZE);
         Self {
             peer_slab: Mutex::new(peer_slab),
             peer_slab_reader,
-            sa_to_link,
+            sa_to_link: DashMap::with_capacity(PEER_TABLE_SIZE),
+            special_peers: EnumMap::default(),
         }
     }
 
@@ -137,6 +156,7 @@ impl PeerTable {
         Ok(VacantPeerTableEntry {
             peer_slab_guard,
             sa_to_link_ref: &self.sa_to_link,
+            special_peers_ref: &self.special_peers,
         })
     }
 
@@ -146,6 +166,9 @@ impl PeerTable {
             return;
         };
         self.sa_to_link.remove(&peer_state.substrate_addr);
+        for name in peer_state.special_names {
+            self.special_peers[name].store(0, Ordering::Relaxed); // note; no useful ordering possible here
+        }
         let new_reader = peer_slab.remove((link_id as usize).wrapping_sub(1));
         std::mem::drop(peer_slab);
         self.peer_slab_reader.write(new_reader);
@@ -172,6 +195,19 @@ impl PeerTable {
         atomic::fence(Ordering::Acquire);
 
         id
+    }
+
+    pub fn lookup_special_peer(&self, name: SpecialPeerName) -> Option<LinkId> {
+        // synchronizes with the Release in VacantPeerTableEntry::insert();
+        // ensures anyone who reads from the slab following this sees the peer
+        // (assuming of course it hasn't been removed!)
+        let id = self.special_peers[name].load(Ordering::Acquire);
+
+        if id == 0 {
+            None
+        } else {
+            Some(id)
+        }
     }
 
     pub fn inspect<T>(
@@ -277,6 +313,7 @@ impl PeerTable {
 pub struct VacantPeerTableEntry<'a> {
     peer_slab_guard: MutexGuard<'a, RcuCslab<PeerState>>,
     sa_to_link_ref: &'a DashMap<SubstrateAddr, LinkId>,
+    special_peers_ref: &'a EnumMap<SpecialPeerName, AtomicLinkId>,
 }
 
 impl VacantPeerTableEntry<'_> {
@@ -303,6 +340,16 @@ impl VacantPeerTableEntry<'_> {
                 "duplicate peer substrate address: {link_id} and {other} share {}",
                 peer_state_ref.substrate_addr
             );
+        }
+
+        for name in peer_state_ref.special_names {
+            let other = self.special_peers_ref[name].swap(link_id, Ordering::Relaxed);
+            if other != 0 {
+                panic!(
+                    "duplicate special peer name: {link_id} and {other} share {:?}",
+                    name
+                );
+            }
         }
 
         link_id

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -8,7 +8,7 @@ use crate::sync_req;
 use bytes::Bytes;
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::DashMap;
-use enum_map::{Enum, EnumMap};
+use enum_map::{enum_map, Enum, EnumMap};
 use enumset::{EnumSet, EnumSetType};
 use std::future::Future;
 use std::sync::atomic::{self, Ordering};
@@ -18,7 +18,7 @@ use tokio::sync::mpsc;
 use tokio::task;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use zpr::{LinkId, SubstrateAddr};
+use zpr::{LinkId, SubstrateAddr, LINK_ID_UNKNOWN};
 
 const PEER_TABLE_SIZE: usize = 1024;
 
@@ -138,7 +138,7 @@ impl PeerTable {
             peer_slab: Mutex::new(peer_slab),
             peer_slab_reader,
             sa_to_link: DashMap::with_capacity(PEER_TABLE_SIZE),
-            special_peers: EnumMap::default(),
+            special_peers: enum_map! { _ => LINK_ID_UNKNOWN.into() },
         }
     }
 
@@ -167,7 +167,7 @@ impl PeerTable {
         };
         self.sa_to_link.remove(&peer_state.substrate_addr);
         for name in peer_state.special_names {
-            self.special_peers[name].store(0, Ordering::Relaxed); // note; no useful ordering possible here
+            self.special_peers[name].store(LINK_ID_UNKNOWN, Ordering::Relaxed); // note; no useful ordering possible here
         }
         let new_reader = peer_slab.remove((link_id as usize).wrapping_sub(1));
         std::mem::drop(peer_slab);
@@ -203,7 +203,7 @@ impl PeerTable {
         // (assuming of course it hasn't been removed!)
         let id = self.special_peers[name].load(Ordering::Acquire);
 
-        if id == 0 {
+        if id == LINK_ID_UNKNOWN {
             None
         } else {
             Some(id)
@@ -344,7 +344,7 @@ impl VacantPeerTableEntry<'_> {
 
         for name in peer_state_ref.special_names {
             let other = self.special_peers_ref[name].swap(link_id, Ordering::Relaxed);
-            if other != 0 {
+            if other != LINK_ID_UNKNOWN {
                 panic!(
                     "duplicate special peer name: {link_id} and {other} share {:?}",
                     name

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -9,6 +9,7 @@ use bytes::Bytes;
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::DashMap;
 use std::future::Future;
+use std::sync::atomic::{self, Ordering};
 use std::sync::Mutex;
 use std::sync::MutexGuard;
 use tokio::sync::mpsc;
@@ -163,7 +164,14 @@ impl PeerTable {
     }
 
     pub fn lookup_peer(&self, substrate_addr: &SubstrateAddr) -> Option<LinkId> {
-        self.sa_to_link.get(substrate_addr).map(|id| *id)
+        let id = self.sa_to_link.get(substrate_addr).map(|id| *id);
+
+        // synchronizes with the Release in VacantPeerTableEntry::insert();
+        // ensures anyone who reads from the slab following this sees the peer
+        // (assuming of course it hasn't been removed!)
+        atomic::fence(Ordering::Acquire);
+
+        id
     }
 
     pub fn inspect<T>(
@@ -277,12 +285,24 @@ impl VacantPeerTableEntry<'_> {
     }
 
     pub fn insert(mut self, peer_state: PeerState) -> LinkId {
-        let sa = peer_state.substrate_addr;
+        let id = self.peer_slab_guard.insert(peer_state).unwrap();
+        let peer_state_ref = self.peer_slab_guard.get(id).unwrap();
 
-        let link_id = (self.peer_slab_guard.insert(peer_state).unwrap() + 1) as LinkId;
+        let link_id = (id + 1) as LinkId;
 
-        if let Some(_) = self.sa_to_link_ref.insert(sa, link_id) {
-            panic!("duplicate peer substrate address");
+        // synchronizes with the Acquire in PeerTable::lookup_*();
+        // ensures the peer slab entry is visible to anyone who first reads from one of the
+        // below "reverse" tables with Acquire ordering
+        atomic::fence(Ordering::Release);
+
+        if let Some(other) = self
+            .sa_to_link_ref
+            .insert(peer_state_ref.substrate_addr, link_id)
+        {
+            panic!(
+                "duplicate peer substrate address: {link_id} and {other} share {}",
+                peer_state_ref.substrate_addr
+            );
         }
 
         link_id


### PR DESCRIPTION
Add a notion of "special" peers to the peer table.  The only type of "special" peer right now is the visa service adapter.  There can be at most one of any "special" peer of each type registered.

Also while doing this I noticed that it was possible, both for special peer lookup and substrate lookup, for the lookup to succeed, but a subsequent `get()` of the returned link ID to fail, if memory ordering doesn't behave.  (Since the writes into these "reverse" lookup tables might become visible before writes into the main peer table.)  So also, I added some release/acquire fences to ensure that (so long as the peer is not removed) performing a reverse lookup immediately after an insert will always ensure that the inserted peer is visible.