### PR TITLE
agent_addr now a global config & required for nodes

### DIFF
--- a/examples/milestone2/adapter-client/adapter-client-conf.toml
+++ b/examples/milestone2/adapter-client/adapter-client-conf.toml
@@ -5,6 +5,7 @@ name = "client"
 ca_file = "ca-cert.pem"
 certificate_file = "adapter-client-cert.pem"
 private_key_file = "adapter-client-key.pem"
+agent_addr = "fd5a:5052:1::3133:7"
 
 # Currently tokio TUN on linux will not set an IPv6 address on a TUN interface.
 # So the running of the node needs to first create and then pass in the TUN
@@ -13,7 +14,6 @@ tun_if = "MISSING_TUN"
 
 [adapter]
 node_addr = "172.16.1.1:5000"
-agent_addr = "fd5a:5052:1::3133:7"
 node_public_key_file = "node-pubkey.pem"
 
 

--- a/examples/milestone2/adapter-service/adapter-service-conf.toml
+++ b/examples/milestone2/adapter-service/adapter-service-conf.toml
@@ -5,6 +5,7 @@ name = "service"
 ca_file = "ca-cert.pem"
 certificate_file = "adapter-service-cert.pem"
 private_key_file = "adapter-service-key.pem"
+agent_addr = "fd5a:5052:1::8080"
 
 # Currently tokio TUN on linux will not set an IPv6 address on a TUN interface.
 # So the running of the node needs to first create and then pass in the TUN
@@ -14,7 +15,6 @@ tun_if = "MISSING_TUN"
 
 [adapter]
 node_addr = "172.16.1.1:5000"
-agent_addr = "fd5a:5052:1::8080"
 node_public_key_file = "node-pubkey.pem"
 
 

--- a/examples/milestone2/adapter-vs/adapter-vs-conf.toml
+++ b/examples/milestone2/adapter-vs/adapter-vs-conf.toml
@@ -5,6 +5,7 @@ name = "vservice"
 ca_file = "ca-cert.pem"
 certificate_file = "adapter-vs-cert.pem"
 private_key_file = "adapter-vs-key.pem"
+agent_addr = "fd5a:5052::1" # visa service well known addr
 
 # Currently tokio TUN on linux will not set an IPv6 address on a TUN interface.
 # So the running of the node needs to first create and then pass in the TUN
@@ -14,7 +15,6 @@ tun_if = "MISSING_TUN"
 
 [adapter]
 node_addr = "172.16.1.1:5000"
-agent_addr = "fd5a:5052::1" # visa service well known addr
 node_public_key_file = "node-pubkey.pem"
 
 

--- a/examples/milestone2/node/node-conf.toml
+++ b/examples/milestone2/node/node-conf.toml
@@ -6,6 +6,7 @@ ca_file = "ca-cert.pem"
 certificate_file = "node-cert.pem"
 private_key_file = "node-key.pem"
 self_addr = "172.16.1.1:5000"
+agent_addr = "fd5a:5052:90de::1"
 
 # Currently tokio TUN on linux will not set an IPv6 address on a TUN interface.
 # So the running of the node needs to first create and then pass in the TUN
@@ -17,5 +18,4 @@ tun_if = "MISSING_TUN"
 #
 #          "zpr.addr" = "fd5a:5052:90de::1"
 #
-#       Also, how does node set its internal adapter address?
 


### PR DESCRIPTION
Once @cpacejo #554 goes through this patch makes the config files for milestone2 compatible with the new main_args.