### PR TITLE
Libnode request simplifications

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -907,11 +907,12 @@ dependencies = [
 
 [[package]]
 name = "libnode"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "openssl",
  "rand",
+ "thiserror",
  "thrift",
  "tokio",
  "tokio-util",

--- a/libnode/Cargo.lock
+++ b/libnode/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "bytes",
  "openssl",
  "rand",
+ "thiserror",
  "thrift",
  "tokio",
  "tokio-util",
@@ -395,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -532,13 +533,33 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/libnode/Cargo.lock
+++ b/libnode/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libnode"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "openssl",

--- a/libnode/Cargo.toml
+++ b/libnode/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 bytes = "1.7.2"
 openssl = "0.10.66"
 rand = "0.8.5"
+thiserror = "1.0.65"
 thrift = "0.17.0"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-util = { version = "0.7.12", features = ["rt"] }

--- a/libnode/Cargo.toml
+++ b/libnode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libnode"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/libnode/src/errors.rs
+++ b/libnode/src/errors.rs
@@ -1,60 +1,27 @@
-use std::fmt;
-use std::fmt::Formatter;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum VSError {
-    ClientError(VSClientError),
-    IOError(std::io::Error),
+    #[error("ClientError: {0}")]
+    ClientError(#[from] VSClientError),
+    #[error("IOError: {0}")]
+    IOError(#[from] std::io::Error),
+    #[error("CertificateError: {0}")]
     CertificateError(String),
+    #[error("KeyError: {0}")]
     KeyError(String),
+    #[error("EnqueueError")]
     EnqueueError,
+    #[error("Disconnect")]
     Disconnect,
 }
 
-impl From<VSClientError> for VSError {
-    fn from(e: VSClientError) -> Self {
-        VSError::ClientError(e)
-    }
-}
-
-impl From<std::io::Error> for VSError {
-    fn from(e: std::io::Error) -> Self {
-        VSError::IOError(e)
-    }
-}
-
-impl fmt::Display for VSError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            VSError::ClientError(e) => write!(f, "ClientError: {}", e),
-            VSError::IOError(e) => write!(f, "IOError: {}", e),
-            VSError::CertificateError(s) => write!(f, "CertificateError: {}", s),
-            VSError::KeyError(s) => write!(f, "KeyError: {}", s),
-            VSError::EnqueueError => write!(f, "EnqueueError"),
-            VSError::Disconnect => write!(f, "Disconnect"),
-        }
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum VSClientError {
-    Thrift(thrift::Error),
+    #[error("Thrift error: {0}")]
+    Thrift(#[from] thrift::Error),
+    #[error("No API key")]
     NoAPIKey,
+    #[error("Unsupported traffic type")]
     UnsupportedTrafficType,
-}
-
-impl fmt::Display for VSClientError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            VSClientError::Thrift(e) => write!(f, "Thrift error: {}", e),
-            VSClientError::NoAPIKey => write!(f, "No API key"),
-            VSClientError::UnsupportedTrafficType => write!(f, "Unsupported traffic type"),
-        }
-    }
-}
-
-impl From<thrift::Error> for VSClientError {
-    fn from(e: thrift::Error) -> Self {
-        VSClientError::Thrift(e)
-    }
 }

--- a/libnode/src/errors.rs
+++ b/libnode/src/errors.rs
@@ -1,3 +1,4 @@
+use std::error;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -18,10 +19,16 @@ pub enum VSError {
 
 #[derive(Debug, Error)]
 pub enum VSClientError {
-    #[error("Thrift error: {0}")]
-    Thrift(#[from] thrift::Error),
+    #[error("RPC error: {0}")]
+    RpcError(#[source] Box<dyn error::Error + Sync + Send>),
     #[error("No API key")]
     NoAPIKey,
     #[error("Unsupported traffic type")]
     UnsupportedTrafficType,
+}
+
+impl From<thrift::Error> for VSClientError {
+    fn from(e: thrift::Error) -> Self {
+        VSClientError::RpcError(Box::new(e))
+    }
 }

--- a/libnode/src/errors.rs
+++ b/libnode/src/errors.rs
@@ -21,6 +21,8 @@ pub enum VSError {
 pub enum VSClientError {
     #[error("RPC error: {0}")]
     RpcError(#[source] Box<dyn error::Error + Sync + Send>),
+    #[error("Conn closed")]
+    ConnClosed,
     #[error("No API key")]
     NoAPIKey,
     #[error("Unsupported traffic type")]

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -33,9 +33,9 @@ pub struct VisaRequest {
     pub packet: Vec<u8>,
 }
 
-pub type VisaRequestResponse = Result<vsapi::VisaResponse, VSClientError>;
-pub type AuthorizeConnectResponse = Result<vsapi::ConnectResponse, VSClientError>;
-pub type DisconnectStatus = Result<(), VSClientError>;
+type VisaRequestResponse = Result<vsapi::VisaResponse, VSClientError>;
+type AuthorizeConnectResponse = Result<vsapi::ConnectResponse, VSClientError>;
+type DisconnectStatus = Result<(), VSClientError>;
 
 // The async "commands" that can be sent into the running visa service client.
 #[derive(Debug)]
@@ -310,7 +310,7 @@ impl VSConn {
 
     /// Attempt to enqueue an async command to the runloop.
     /// Returns an error if the command could not be enqueued.
-    async fn send_command(&self, cmd: VSCommand) -> Result<(), VSError> {
+    async fn send_command(&self, cmd: VSCommand) -> Result<(), VSClientError> {
         // Extract the tx channel from the state, but must do so without keeping lock across the await later.
         let tx_chan: mpsc::Sender<VSCommand>;
         {
@@ -319,13 +319,13 @@ impl VSConn {
                 tx_chan = tx.clone();
             } else {
                 error!("VSConn::send_command called but no command channel available");
-                return Err(VSError::EnqueueError);
+                return Err(VSClientError::ConnClosed);
             }
         }
 
         if let Err(e) = tx_chan.send(cmd).await {
             error!("VSConn::send_command failed to queue: {}", e);
-            return Err(VSError::EnqueueError);
+            return Err(VSClientError::ConnClosed);
         }
         Ok(())
     }
@@ -334,36 +334,32 @@ impl VSConn {
     ///
     /// ## Errors
     /// - [VSError::EnqueueError] if the request could not be enqueued.
-    pub async fn request_visa(&self, req: VisaRequest) -> Result<VisaRequestResponse, VSError> {
+    pub async fn request_visa(&self, req: VisaRequest) -> VisaRequestResponse {
         let (tx, rx) = oneshot::channel();
         self.send_command(VSCommand::RequestVisa(req, tx)).await?;
-        rx.await.map_err(|_| VSError::Disconnect)
+        rx.await.map_err(|_| VSClientError::ConnClosed)?
     }
 
     /// Perform an async authorize_connect.
     ///
     /// ## Errors
     /// - [VSError::EnqueueError] if the request could not be enqueued.
-    pub async fn authorize_connect(
-        &self,
-        req: vsapi::ConnectRequest,
-    ) -> Result<AuthorizeConnectResponse, VSError> {
+    pub async fn authorize_connect(&self, req: vsapi::ConnectRequest) -> AuthorizeConnectResponse {
         let (tx, rx) = oneshot::channel();
         self.send_command(VSCommand::AuthorizeConnect(req, tx))
             .await?;
-        rx.await.map_err(|_| VSError::Disconnect)
+        rx.await.map_err(|_| VSClientError::ConnClosed)?
     }
 
-    /// Async message to visa service noting that an agent has disconnected. The response is
-    /// a [DisconnectStatus].
+    /// Async message to visa service noting that an agent has disconnected.
     ///
     /// ## Errors
     /// - [VSError::EnqueueError] if the request could not be enqueued.
-    pub async fn agent_disconnect(&self, zpr_addr: IpAddr) -> Result<DisconnectStatus, VSError> {
+    pub async fn agent_disconnect(&self, zpr_addr: IpAddr) -> DisconnectStatus {
         let (tx, rx) = oneshot::channel();
         self.send_command(VSCommand::AgentDisconnect(zpr_addr, tx))
             .await?;
-        rx.await.map_err(|_| VSError::Disconnect)
+        rx.await.map_err(|_| VSClientError::ConnClosed)?
     }
 }
 
@@ -702,8 +698,7 @@ s5JVZ48=
 
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
-                let vrr = resp.unwrap();
-                let vr = vrr.unwrap();
+                let vr = resp.unwrap();
                 assert_eq!(vr.status, Some(vsapi::StatusCode::FAIL));
                 assert!(vr.reason.is_some());
                 let reason = vr.reason.unwrap();
@@ -726,8 +721,7 @@ s5JVZ48=
             let resp = conn.request_visa(req);
             match timeout(Duration::from_millis(100), resp).await {
                 Ok(resp) => {
-                    let vrr = resp.unwrap();
-                    assert!(matches!(vrr.unwrap_err(), VSClientError::NoAPIKey));
+                    assert!(matches!(resp.unwrap_err(), VSClientError::NoAPIKey));
                 }
                 _ => {
                     panic!("expected visa-response message, but got nothing (timeout)");
@@ -799,8 +793,7 @@ s5JVZ48=
 
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
-                let cr = resp.unwrap();
-                let cresp = cr.unwrap();
+                let cresp = resp.unwrap();
                 assert!(cresp.agent.is_some());
                 let agnt = cresp.agent.unwrap();
                 let attrs = agnt.attrs.unwrap();
@@ -826,8 +819,7 @@ s5JVZ48=
             let resp = conn.authorize_connect(req);
             match timeout(Duration::from_millis(100), resp).await {
                 Ok(resp) => {
-                    let cr = resp.unwrap();
-                    assert!(matches!(cr.unwrap_err(), VSClientError::NoAPIKey));
+                    assert!(matches!(resp.unwrap_err(), VSClientError::NoAPIKey));
                 }
                 _ => {
                     panic!("expected connect-response message, but got nothing (timeout)");
@@ -894,8 +886,7 @@ s5JVZ48=
 
         match timeout(Duration::from_millis(10), resp).await {
             Ok(resp) => {
-                let dr = resp.unwrap();
-                assert!(dr.is_ok());
+                assert!(resp.is_ok());
             }
             _ => {
                 panic!("expected agent-disconnect-response message, but got nothing (timeout)");
@@ -909,8 +900,7 @@ s5JVZ48=
 
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
-                let dr = resp.unwrap();
-                assert!(matches!(dr.unwrap_err(), VSClientError::NoAPIKey));
+                assert!(matches!(resp.unwrap_err(), VSClientError::NoAPIKey));
             }
             _ => {
                 panic!("expected agent-disconnect-response message, but got nothing (timeout)");

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -11,7 +11,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
-use tokio::sync::mpsc::{self, Sender};
+use tokio::sync::{mpsc, oneshot};
 use tokio::time::{self, Duration};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
@@ -68,9 +68,12 @@ pub struct DisconnectStatus {
 #[derive(Debug)]
 #[allow(dead_code)]
 enum VSCommand {
-    RequestVisa(VisaRequest),
-    AuthorizeConnect(vsapi::ConnectRequest),
-    AgentDisconnect(IpAddr), // takes a ZPR address assigned to the agent
+    RequestVisa(VisaRequest, oneshot::Sender<VisaRequestResponse>),
+    AuthorizeConnect(
+        vsapi::ConnectRequest,
+        oneshot::Sender<AuthorizeConnectResponse>,
+    ),
+    AgentDisconnect(IpAddr, oneshot::Sender<DisconnectStatus>), // takes a ZPR address assigned to the agent
 }
 
 // This will change a bit too. This is for output messages from the visa service. These are asynchronous
@@ -79,9 +82,6 @@ enum VSCommand {
 #[derive(Debug)]
 pub enum VSOutput {
     PingSuccess(u64, u64), // (CONFIG_ID, POLICY_VERSION)
-    VisaResponse(VisaRequestResponse),
-    ConnectResponse(AuthorizeConnectResponse),
-    AgentDisconnect(DisconnectStatus),
 }
 
 #[derive(Clone)]
@@ -158,7 +158,7 @@ impl VSConn {
     //
     pub fn new(
         node_agent: vsapi::Agent,
-        output_tx: Sender<VSOutput>,
+        output_tx: mpsc::Sender<VSOutput>,
         service_addr: &str,
         node_cert_file: &Path,
         node_zpr_addr: IpAddr,
@@ -229,7 +229,7 @@ impl VSConn {
         let (tx, mut rx) = mpsc::channel(16);
         let fac: vscli::VSClientFactory;
         let service_addr: String;
-        let output_tx: Sender<VSOutput>;
+        let output_tx: mpsc::Sender<VSOutput>;
         {
             let mut state = self.shared.state.lock().unwrap(); // TAKES LOCK (drops when state goes out of scope)
             state.cmd_tx = Some(tx.clone());
@@ -281,17 +281,11 @@ impl VSConn {
 
                 // Handle one of the "async" requests.
                 Some(cmd) = rx.recv() => {
-                    let resp = match cmd {
-                        VSCommand::RequestVisa(req) => self.handle_request_visa(&mut client, req),
-                        VSCommand::AuthorizeConnect(cr) => self.handle_authorize_connect(&mut client, cr),
-                        VSCommand::AgentDisconnect(ipa) => self.handle_agent_disconnect(&mut client, ipa),
-                    };
-                    match output_tx.send(resp).await {
-                        Ok(_) => {}
-                        Err(e) => {
-                            error!("failed to enqueue a response: {}", e);
-                            return Err(VSError::EnqueueError);
-                        }
+                    match cmd {
+                        // send errors simply mean requestor ignored reply; ignore them
+                        VSCommand::RequestVisa(req, resp_chan) => { let _ = resp_chan.send(self.handle_request_visa(&mut client, req)); },
+                        VSCommand::AuthorizeConnect(cr, resp_chan) => { let _ = resp_chan.send(self.handle_authorize_connect(&mut client, cr)); },
+                        VSCommand::AgentDisconnect(ipa, resp_chan) => { let _ = resp_chan.send(self.handle_agent_disconnect(&mut client, ipa)); },
                     }
                 }
             }
@@ -299,8 +293,12 @@ impl VSConn {
         Ok(())
     }
 
-    fn handle_request_visa(&self, client: &mut Box<dyn VSClientI>, req: VisaRequest) -> VSOutput {
-        let resp = match client.request_visa(req.source_tether_addr, req.l3_type, req.packet) {
+    fn handle_request_visa(
+        &self,
+        client: &mut Box<dyn VSClientI>,
+        req: VisaRequest,
+    ) -> VisaRequestResponse {
+        match client.request_visa(req.source_tether_addr, req.l3_type, req.packet) {
             Ok(vr) => VisaRequestResponse {
                 request_id: req.request_id,
                 api_error: None,
@@ -314,20 +312,19 @@ impl VSConn {
                     response: None,
                 }
             }
-        };
-        VSOutput::VisaResponse(resp)
+        }
     }
 
     fn handle_authorize_connect(
         &self,
         client: &mut Box<dyn VSClientI>,
         cr: vsapi::ConnectRequest,
-    ) -> VSOutput {
+    ) -> AuthorizeConnectResponse {
         let id = match cr.connection_id {
             Some(i) => i,
             None => 0,
         };
-        let resp = match client.authorize_connect(cr) {
+        match client.authorize_connect(cr) {
             Ok(acr) => AuthorizeConnectResponse {
                 connection_id: id,
                 api_error: None,
@@ -341,12 +338,15 @@ impl VSConn {
                     response: None,
                 }
             }
-        };
-        VSOutput::ConnectResponse(resp)
+        }
     }
 
-    fn handle_agent_disconnect(&self, client: &mut Box<dyn VSClientI>, ipa: IpAddr) -> VSOutput {
-        let resp = match client.agent_disconnect(ipa) {
+    fn handle_agent_disconnect(
+        &self,
+        client: &mut Box<dyn VSClientI>,
+        ipa: IpAddr,
+    ) -> DisconnectStatus {
+        match client.agent_disconnect(ipa) {
             Ok(_) => DisconnectStatus {
                 zpr_addr: ipa,
                 api_error: None,
@@ -358,15 +358,14 @@ impl VSConn {
                     api_error: Some(e),
                 }
             }
-        };
-        VSOutput::AgentDisconnect(resp)
+        }
     }
 
     /// Attempt to enqueue an async command to the runloop.
     /// Returns an error if the command could not be enqueued.
     async fn send_command(&self, cmd: VSCommand) -> Result<(), VSError> {
         // Extract the tx channel from the state, but must do so without keeping lock across the await later.
-        let tx_chan: Sender<VSCommand>;
+        let tx_chan: mpsc::Sender<VSCommand>;
         {
             let state = self.shared.state.lock().unwrap(); // TAKES LOCK (drops when state goes out of scope)
             if let Some(tx) = &state.cmd_tx {
@@ -384,35 +383,40 @@ impl VSConn {
         Ok(())
     }
 
-    /// Perform an async visa request. The response will come back over the channel set in the
-    /// [VSConn::new] function and will have a request_id matching the request.
+    /// Perform an async visa request. The response will have a request_id matching the request.
     ///
     /// ## Errors
     /// - [VSError::EnqueueError] if the request could not be enqueued.
-    #[allow(dead_code)]
-    pub async fn request_visa(&self, req: VisaRequest) -> Result<(), VSError> {
-        self.send_command(VSCommand::RequestVisa(req)).await
+    pub async fn request_visa(&self, req: VisaRequest) -> Result<VisaRequestResponse, VSError> {
+        let (tx, rx) = oneshot::channel();
+        self.send_command(VSCommand::RequestVisa(req, tx)).await?;
+        rx.await.map_err(|_| VSError::Disconnect)
     }
 
-    /// Perform an async authorize_connect. The response will come back over the channel set in the
-    /// [VSConn::new] function and will have a connection_id matching the request.
+    /// Perform an async authorize_connect. The response will have a connection_id matching the request.
     ///
     /// ## Errors
     /// - [VSError::EnqueueError] if the request could not be enqueued.
-    #[allow(dead_code)]
-    pub async fn authorize_connect(&self, req: vsapi::ConnectRequest) -> Result<(), VSError> {
-        self.send_command(VSCommand::AuthorizeConnect(req)).await
+    pub async fn authorize_connect(
+        &self,
+        req: vsapi::ConnectRequest,
+    ) -> Result<AuthorizeConnectResponse, VSError> {
+        let (tx, rx) = oneshot::channel();
+        self.send_command(VSCommand::AuthorizeConnect(req, tx))
+            .await?;
+        rx.await.map_err(|_| VSError::Disconnect)
     }
 
-    /// Async message to visa service noting that an agent has disconnected. A [VSOutput::AgentDisconnect]
-    /// message will be generated when this runs.
+    /// Async message to visa service noting that an agent has disconnected. The response is
+    /// a [DisconnectStatus].
     ///
     /// ## Errors
     /// - [VSError::EnqueueError] if the request could not be enqueued.
-    #[allow(dead_code)]
-    pub async fn agent_disconnect(&self, zpr_addr: IpAddr) -> Result<(), VSError> {
-        self.send_command(VSCommand::AgentDisconnect(zpr_addr))
-            .await
+    pub async fn agent_disconnect(&self, zpr_addr: IpAddr) -> Result<DisconnectStatus, VSError> {
+        let (tx, rx) = oneshot::channel();
+        self.send_command(VSCommand::AgentDisconnect(zpr_addr, tx))
+            .await?;
+        rx.await.map_err(|_| VSError::Disconnect)
     }
 }
 
@@ -748,27 +752,20 @@ s5JVZ48=
             l3_type: zpr::L3Type::Ipv4,
             packet: vec![1, 2, 3, 4],
         };
-        conn.request_visa(req).await.unwrap();
+        let resp = conn.request_visa(req);
 
-        match timeout(Duration::from_millis(100), rx.recv()).await {
+        match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
-                let output = resp.unwrap();
-                match output {
-                    VSOutput::VisaResponse(vrr) => {
-                        assert_eq!(vrr.request_id, 123);
-                        assert!(vrr.api_error.is_none());
-                        assert!(vrr.response.is_some());
-                        let vr = vrr.response.unwrap();
-                        assert_eq!(vr.status, Some(vsapi::StatusCode::FAIL));
-                        assert!(vr.reason.is_some());
-                        let reason = vr.reason.unwrap();
-                        assert!(reason.contains(&node_addr.to_string()));
-                        assert!(reason.contains(format!("type: {}", zpr::L3Type::Ipv4).as_str()));
-                    }
-                    _ => {
-                        panic!("expected visa-response message, not {:?}", output);
-                    }
-                }
+                let vrr = resp.unwrap();
+                assert_eq!(vrr.request_id, 123);
+                assert!(vrr.api_error.is_none());
+                assert!(vrr.response.is_some());
+                let vr = vrr.response.unwrap();
+                assert_eq!(vr.status, Some(vsapi::StatusCode::FAIL));
+                assert!(vr.reason.is_some());
+                let reason = vr.reason.unwrap();
+                assert!(reason.contains(&node_addr.to_string()));
+                assert!(reason.contains(format!("type: {}", zpr::L3Type::Ipv4).as_str()));
             }
             _ => {
                 panic!("expected visa-response message, but got nothing (timeout)");
@@ -784,20 +781,13 @@ s5JVZ48=
                 packet: vec![1, 2, 3, 4],
             };
             set_next_error(VSClientError::NoAPIKey);
-            conn.request_visa(req).await.unwrap();
-            match timeout(Duration::from_millis(100), rx.recv()).await {
+            let resp = conn.request_visa(req);
+            match timeout(Duration::from_millis(100), resp).await {
                 Ok(resp) => {
-                    let output = resp.unwrap();
-                    match output {
-                        VSOutput::VisaResponse(vrr) => {
-                            assert_eq!(vrr.request_id, 123);
-                            assert!(vrr.api_error.is_some());
-                            assert!(matches!(vrr.api_error.unwrap(), VSClientError::NoAPIKey));
-                        }
-                        _ => {
-                            panic!("expected visa-response message, not {:?}", output);
-                        }
-                    }
+                    let vrr = resp.unwrap();
+                    assert_eq!(vrr.request_id, 123);
+                    assert!(vrr.api_error.is_some());
+                    assert!(matches!(vrr.api_error.unwrap(), VSClientError::NoAPIKey));
                 }
                 _ => {
                     panic!("expected visa-response message, but got nothing (timeout)");
@@ -865,27 +855,20 @@ s5JVZ48=
             challenge: Some(vec![1, 2, 3, 4]),
             challenge_responses: Some(vec![vec![5, 6, 7, 8]]),
         };
-        conn.authorize_connect(req).await.unwrap();
+        let resp = conn.authorize_connect(req);
 
-        match timeout(Duration::from_millis(100), rx.recv()).await {
+        match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
-                let output = resp.unwrap();
-                match output {
-                    VSOutput::ConnectResponse(cr) => {
-                        assert_eq!(cr.connection_id, 456);
-                        assert!(cr.api_error.is_none());
-                        assert!(cr.response.is_some());
-                        let cresp = cr.response.unwrap();
-                        assert!(cresp.agent.is_some());
-                        let agnt = cresp.agent.unwrap();
-                        let attrs = agnt.attrs.unwrap();
-                        for (k, v) in attrs {
-                            assert_eq!(v, *(claims.get(&k).unwrap()));
-                        }
-                    }
-                    _ => {
-                        panic!("expected connect-response message, not {:?}", output);
-                    }
+                let cr = resp.unwrap();
+                assert_eq!(cr.connection_id, 456);
+                assert!(cr.api_error.is_none());
+                assert!(cr.response.is_some());
+                let cresp = cr.response.unwrap();
+                assert!(cresp.agent.is_some());
+                let agnt = cresp.agent.unwrap();
+                let attrs = agnt.attrs.unwrap();
+                for (k, v) in attrs {
+                    assert_eq!(v, *(claims.get(&k).unwrap()));
                 }
             }
             _ => {
@@ -903,20 +886,13 @@ s5JVZ48=
                 challenge_responses: None,
             };
             set_next_error(VSClientError::NoAPIKey);
-            conn.authorize_connect(req).await.unwrap();
-            match timeout(Duration::from_millis(100), rx.recv()).await {
+            let resp = conn.authorize_connect(req);
+            match timeout(Duration::from_millis(100), resp).await {
                 Ok(resp) => {
-                    let output = resp.unwrap();
-                    match output {
-                        VSOutput::ConnectResponse(cr) => {
-                            assert_eq!(cr.connection_id, 456);
-                            assert!(cr.api_error.is_some());
-                            assert!(matches!(cr.api_error.unwrap(), VSClientError::NoAPIKey));
-                        }
-                        _ => {
-                            panic!("expected connect-response message, not {:?}", output);
-                        }
-                    }
+                    let cr = resp.unwrap();
+                    assert_eq!(cr.connection_id, 456);
+                    assert!(cr.api_error.is_some());
+                    assert!(matches!(cr.api_error.unwrap(), VSClientError::NoAPIKey));
                 }
                 _ => {
                     panic!("expected connect-response message, but got nothing (timeout)");
@@ -977,22 +953,15 @@ s5JVZ48=
 
         assert_eq!(get_counter(CounterT::AgentDisconnect), 0);
 
-        conn.agent_disconnect(node_addr).await.unwrap();
+        let resp = conn.agent_disconnect(node_addr);
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        match timeout(Duration::from_millis(10), rx.recv()).await {
+        match timeout(Duration::from_millis(10), resp).await {
             Ok(resp) => {
-                let output = resp.unwrap();
-                match output {
-                    VSOutput::AgentDisconnect(dr) => {
-                        assert_eq!(dr.zpr_addr, node_addr);
-                        assert!(dr.api_error.is_none());
-                    }
-                    _ => {
-                        panic!("expected agent-disconnect message, not {:?}", output);
-                    }
-                }
+                let dr = resp.unwrap();
+                assert_eq!(dr.zpr_addr, node_addr);
+                assert!(dr.api_error.is_none());
             }
             _ => {
                 panic!("expected agent-disconnect-response message, but got nothing (timeout)");
@@ -1002,21 +971,14 @@ s5JVZ48=
 
         // Run disconnect again check that we get the error:
         set_next_error(VSClientError::NoAPIKey);
-        conn.agent_disconnect(node_addr).await.unwrap();
+        let resp = conn.agent_disconnect(node_addr);
 
-        match timeout(Duration::from_millis(100), rx.recv()).await {
+        match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
-                let output = resp.unwrap();
-                match output {
-                    VSOutput::AgentDisconnect(dr) => {
-                        assert_eq!(dr.zpr_addr, node_addr);
-                        assert!(dr.api_error.is_some());
-                        assert!(matches!(dr.api_error.unwrap(), VSClientError::NoAPIKey));
-                    }
-                    _ => {
-                        panic!("expected agent-disconnect message, not {:?}", output);
-                    }
-                }
+                let dr = resp.unwrap();
+                assert_eq!(dr.zpr_addr, node_addr);
+                assert!(dr.api_error.is_some());
+                assert!(matches!(dr.api_error.unwrap(), VSClientError::NoAPIKey));
             }
             _ => {
                 panic!("expected agent-disconnect-response message, but got nothing (timeout)");

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -28,7 +28,6 @@ const MAX_PING_ERRORS: u32 = 5;
 
 #[derive(Debug)]
 pub struct VisaRequest {
-    pub request_id: u32,
     pub source_tether_addr: IpAddr,
     pub l3_type: zpr::L3Type,
     pub packet: Vec<u8>,
@@ -36,9 +35,6 @@ pub struct VisaRequest {
 
 #[derive(Debug)]
 pub struct VisaRequestResponse {
-    /// Copied from `VisaRequest`
-    pub request_id: u32,
-
     /// If an API error orccess error occurred, this will be set.
     pub api_error: Option<VSClientError>,
 
@@ -48,9 +44,6 @@ pub struct VisaRequestResponse {
 
 #[derive(Debug)]
 pub struct AuthorizeConnectResponse {
-    /// Copied from the thrift ConnectRequest
-    pub connection_id: i32,
-
     /// If an API error orccess error occurred, this will be set.
     pub api_error: Option<VSClientError>,
 
@@ -60,7 +53,6 @@ pub struct AuthorizeConnectResponse {
 
 #[derive(Debug)]
 pub struct DisconnectStatus {
-    pub zpr_addr: IpAddr,
     pub api_error: Option<VSClientError>,
 }
 
@@ -300,14 +292,12 @@ impl VSConn {
     ) -> VisaRequestResponse {
         match client.request_visa(req.source_tether_addr, req.l3_type, req.packet) {
             Ok(vr) => VisaRequestResponse {
-                request_id: req.request_id,
                 api_error: None,
                 response: Some(vr),
             },
             Err(e) => {
                 error!("failed to request visa: {}", e);
                 VisaRequestResponse {
-                    request_id: req.request_id,
                     api_error: Some(e),
                     response: None,
                 }
@@ -320,20 +310,14 @@ impl VSConn {
         client: &mut Box<dyn VSClientI>,
         cr: vsapi::ConnectRequest,
     ) -> AuthorizeConnectResponse {
-        let id = match cr.connection_id {
-            Some(i) => i,
-            None => 0,
-        };
         match client.authorize_connect(cr) {
             Ok(acr) => AuthorizeConnectResponse {
-                connection_id: id,
                 api_error: None,
                 response: Some(acr),
             },
             Err(e) => {
                 error!("failed to authorize connect: {}", e);
                 AuthorizeConnectResponse {
-                    connection_id: id,
                     api_error: Some(e),
                     response: None,
                 }
@@ -347,16 +331,10 @@ impl VSConn {
         ipa: IpAddr,
     ) -> DisconnectStatus {
         match client.agent_disconnect(ipa) {
-            Ok(_) => DisconnectStatus {
-                zpr_addr: ipa,
-                api_error: None,
-            },
+            Ok(_) => DisconnectStatus { api_error: None },
             Err(e) => {
-                error!("ailed to call agent disconnect: {}", e);
-                DisconnectStatus {
-                    zpr_addr: ipa,
-                    api_error: Some(e),
-                }
+                error!("failed to call agent disconnect: {}", e);
+                DisconnectStatus { api_error: Some(e) }
             }
         }
     }
@@ -383,7 +361,7 @@ impl VSConn {
         Ok(())
     }
 
-    /// Perform an async visa request. The response will have a request_id matching the request.
+    /// Perform an async visa request.
     ///
     /// ## Errors
     /// - [VSError::EnqueueError] if the request could not be enqueued.
@@ -393,7 +371,7 @@ impl VSConn {
         rx.await.map_err(|_| VSError::Disconnect)
     }
 
-    /// Perform an async authorize_connect. The response will have a connection_id matching the request.
+    /// Perform an async authorize_connect.
     ///
     /// ## Errors
     /// - [VSError::EnqueueError] if the request could not be enqueued.
@@ -747,7 +725,6 @@ s5JVZ48=
         }
 
         let req = VisaRequest {
-            request_id: 123,
             source_tether_addr: node_addr,
             l3_type: zpr::L3Type::Ipv4,
             packet: vec![1, 2, 3, 4],
@@ -757,7 +734,6 @@ s5JVZ48=
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
                 let vrr = resp.unwrap();
-                assert_eq!(vrr.request_id, 123);
                 assert!(vrr.api_error.is_none());
                 assert!(vrr.response.is_some());
                 let vr = vrr.response.unwrap();
@@ -775,7 +751,6 @@ s5JVZ48=
         {
             // Run again check that we get the error:
             let req = VisaRequest {
-                request_id: 123,
                 source_tether_addr: node_addr,
                 l3_type: zpr::L3Type::Ipv4,
                 packet: vec![1, 2, 3, 4],
@@ -785,7 +760,6 @@ s5JVZ48=
             match timeout(Duration::from_millis(100), resp).await {
                 Ok(resp) => {
                     let vrr = resp.unwrap();
-                    assert_eq!(vrr.request_id, 123);
                     assert!(vrr.api_error.is_some());
                     assert!(matches!(vrr.api_error.unwrap(), VSClientError::NoAPIKey));
                 }
@@ -860,7 +834,6 @@ s5JVZ48=
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
                 let cr = resp.unwrap();
-                assert_eq!(cr.connection_id, 456);
                 assert!(cr.api_error.is_none());
                 assert!(cr.response.is_some());
                 let cresp = cr.response.unwrap();
@@ -890,7 +863,6 @@ s5JVZ48=
             match timeout(Duration::from_millis(100), resp).await {
                 Ok(resp) => {
                     let cr = resp.unwrap();
-                    assert_eq!(cr.connection_id, 456);
                     assert!(cr.api_error.is_some());
                     assert!(matches!(cr.api_error.unwrap(), VSClientError::NoAPIKey));
                 }
@@ -960,7 +932,6 @@ s5JVZ48=
         match timeout(Duration::from_millis(10), resp).await {
             Ok(resp) => {
                 let dr = resp.unwrap();
-                assert_eq!(dr.zpr_addr, node_addr);
                 assert!(dr.api_error.is_none());
             }
             _ => {
@@ -976,7 +947,6 @@ s5JVZ48=
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
                 let dr = resp.unwrap();
-                assert_eq!(dr.zpr_addr, node_addr);
                 assert!(dr.api_error.is_some());
                 assert!(matches!(dr.api_error.unwrap(), VSClientError::NoAPIKey));
             }

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -33,28 +33,9 @@ pub struct VisaRequest {
     pub packet: Vec<u8>,
 }
 
-#[derive(Debug)]
-pub struct VisaRequestResponse {
-    /// If an API error orccess error occurred, this will be set.
-    pub api_error: Option<VSClientError>,
-
-    /// Response from visa service -- Even if this is some, it may not be a successful request.
-    pub response: Option<vsapi::VisaResponse>,
-}
-
-#[derive(Debug)]
-pub struct AuthorizeConnectResponse {
-    /// If an API error orccess error occurred, this will be set.
-    pub api_error: Option<VSClientError>,
-
-    /// If we got a response from the visa service, it will be here.
-    pub response: Option<vsapi::ConnectResponse>,
-}
-
-#[derive(Debug)]
-pub struct DisconnectStatus {
-    pub api_error: Option<VSClientError>,
-}
+pub type VisaRequestResponse = Result<vsapi::VisaResponse, VSClientError>;
+pub type AuthorizeConnectResponse = Result<vsapi::ConnectResponse, VSClientError>;
+pub type DisconnectStatus = Result<(), VSClientError>;
 
 // The async "commands" that can be sent into the running visa service client.
 #[derive(Debug)]
@@ -291,16 +272,10 @@ impl VSConn {
         req: VisaRequest,
     ) -> VisaRequestResponse {
         match client.request_visa(req.source_tether_addr, req.l3_type, req.packet) {
-            Ok(vr) => VisaRequestResponse {
-                api_error: None,
-                response: Some(vr),
-            },
+            Ok(vr) => Ok(vr),
             Err(e) => {
                 error!("failed to request visa: {}", e);
-                VisaRequestResponse {
-                    api_error: Some(e),
-                    response: None,
-                }
+                Err(e)
             }
         }
     }
@@ -311,16 +286,10 @@ impl VSConn {
         cr: vsapi::ConnectRequest,
     ) -> AuthorizeConnectResponse {
         match client.authorize_connect(cr) {
-            Ok(acr) => AuthorizeConnectResponse {
-                api_error: None,
-                response: Some(acr),
-            },
+            Ok(acr) => Ok(acr),
             Err(e) => {
                 error!("failed to authorize connect: {}", e);
-                AuthorizeConnectResponse {
-                    api_error: Some(e),
-                    response: None,
-                }
+                Err(e)
             }
         }
     }
@@ -331,10 +300,10 @@ impl VSConn {
         ipa: IpAddr,
     ) -> DisconnectStatus {
         match client.agent_disconnect(ipa) {
-            Ok(_) => DisconnectStatus { api_error: None },
+            Ok(_) => Ok(()),
             Err(e) => {
                 error!("failed to call agent disconnect: {}", e);
-                DisconnectStatus { api_error: Some(e) }
+                Err(e)
             }
         }
     }
@@ -734,9 +703,7 @@ s5JVZ48=
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
                 let vrr = resp.unwrap();
-                assert!(vrr.api_error.is_none());
-                assert!(vrr.response.is_some());
-                let vr = vrr.response.unwrap();
+                let vr = vrr.unwrap();
                 assert_eq!(vr.status, Some(vsapi::StatusCode::FAIL));
                 assert!(vr.reason.is_some());
                 let reason = vr.reason.unwrap();
@@ -760,8 +727,7 @@ s5JVZ48=
             match timeout(Duration::from_millis(100), resp).await {
                 Ok(resp) => {
                     let vrr = resp.unwrap();
-                    assert!(vrr.api_error.is_some());
-                    assert!(matches!(vrr.api_error.unwrap(), VSClientError::NoAPIKey));
+                    assert!(matches!(vrr.unwrap_err(), VSClientError::NoAPIKey));
                 }
                 _ => {
                     panic!("expected visa-response message, but got nothing (timeout)");
@@ -834,9 +800,7 @@ s5JVZ48=
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
                 let cr = resp.unwrap();
-                assert!(cr.api_error.is_none());
-                assert!(cr.response.is_some());
-                let cresp = cr.response.unwrap();
+                let cresp = cr.unwrap();
                 assert!(cresp.agent.is_some());
                 let agnt = cresp.agent.unwrap();
                 let attrs = agnt.attrs.unwrap();
@@ -863,8 +827,7 @@ s5JVZ48=
             match timeout(Duration::from_millis(100), resp).await {
                 Ok(resp) => {
                     let cr = resp.unwrap();
-                    assert!(cr.api_error.is_some());
-                    assert!(matches!(cr.api_error.unwrap(), VSClientError::NoAPIKey));
+                    assert!(matches!(cr.unwrap_err(), VSClientError::NoAPIKey));
                 }
                 _ => {
                     panic!("expected connect-response message, but got nothing (timeout)");
@@ -932,7 +895,7 @@ s5JVZ48=
         match timeout(Duration::from_millis(10), resp).await {
             Ok(resp) => {
                 let dr = resp.unwrap();
-                assert!(dr.api_error.is_none());
+                assert!(dr.is_ok());
             }
             _ => {
                 panic!("expected agent-disconnect-response message, but got nothing (timeout)");
@@ -947,8 +910,7 @@ s5JVZ48=
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
                 let dr = resp.unwrap();
-                assert!(dr.api_error.is_some());
-                assert!(matches!(dr.api_error.unwrap(), VSClientError::NoAPIKey));
+                assert!(matches!(dr.unwrap_err(), VSClientError::NoAPIKey));
             }
             _ => {
                 panic!("expected agent-disconnect-response message, but got nothing (timeout)");

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -97,7 +97,7 @@ struct State {
     service_addr: String, // visa service address, format "HOST:PORT"
     node_cert_pem_data: String,
     cmd_tx: Option<mpsc::Sender<VSCommand>>,
-    output_tx: Option<mpsc::Sender<VSOutput>>,
+    output_tx: mpsc::Sender<VSOutput>,
     client_fac: vscli::VSClientFactory,
     vss_service_addr: SocketAddr, // visa support service listen address
     agent: vsapi::Agent,
@@ -179,7 +179,7 @@ impl VSConn {
                 service_addr: service_addr.to_string(),
                 node_cert_pem_data: cert_pem_data,
                 cmd_tx: None,
-                output_tx: Some(output_tx),
+                output_tx: output_tx,
                 client_fac: vscli::default_vsclient_factory,
                 vss_service_addr,
                 agent: node_agent,
@@ -233,7 +233,7 @@ impl VSConn {
         {
             let mut state = self.shared.state.lock().unwrap(); // TAKES LOCK (drops when state goes out of scope)
             state.cmd_tx = Some(tx.clone());
-            output_tx = state.output_tx.clone().unwrap();
+            output_tx = state.output_tx.clone();
             fac = state.client_fac.clone();
             service_addr = state.service_addr.clone();
         }

--- a/visaservice/cli/Cargo.lock
+++ b/visaservice/cli/Cargo.lock
@@ -332,11 +332,12 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libnode"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "openssl",
  "rand",
+ "thiserror",
  "thrift",
  "tokio",
  "tokio-util",
@@ -553,9 +554,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -734,13 +735,33 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]


### PR DESCRIPTION
Backlog of some changes I've had kicking around my repo for a while.  The main changes here are to make the request methods return the responses, so we no longer need the request ID mechanism.  I also simplified the return types so they just follow the pattern `Result<ActualResponse, VSClientError>`.  (All in service of simplifying integration into the PH…)