### PR TITLE
add timeout to libnode vss thrift connect

### DIFF
--- a/adapter/ph/Makefile
+++ b/adapter/ph/Makefile
@@ -6,6 +6,10 @@ all: build
 build:
 	cargo build --verbose
 
+.PHONY: release
+release:
+	cargo build -r
+
 .PHONY: test
 test:
 	cargo test --verbose

--- a/libnode/src/errors.rs
+++ b/libnode/src/errors.rs
@@ -1,4 +1,4 @@
-use std::error;
+use std::{error, net::AddrParseError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -27,10 +27,20 @@ pub enum VSClientError {
     NoAPIKey,
     #[error("Unsupported traffic type")]
     UnsupportedTrafficType,
+    #[error("Address error: {0}")]
+    AddressError(String),
+    #[error("IOError: {0}")]
+    IOError(#[from] std::io::Error),
 }
 
 impl From<thrift::Error> for VSClientError {
     fn from(e: thrift::Error) -> Self {
         VSClientError::RpcError(Box::new(e))
+    }
+}
+
+impl From<AddrParseError> for VSClientError {
+    fn from(e: AddrParseError) -> Self {
+        VSClientError::AddressError(format!("AddrParseError: {}", e))
     }
 }

--- a/libnode/src/vscli.rs
+++ b/libnode/src/vscli.rs
@@ -1,5 +1,5 @@
-use std::net::{IpAddr, SocketAddr};
-use std::time::SystemTime;
+use std::net::{IpAddr, SocketAddr, TcpStream};
+use std::time::{SystemTime, Duration};
 use thrift::protocol::{TBinaryInputProtocol, TBinaryOutputProtocol};
 use thrift::transport::{ReadHalf, WriteHalf};
 use thrift::transport::{TFramedReadTransport, TFramedWriteTransport};
@@ -11,6 +11,9 @@ use crate::m2;
 use crate::vsapi;
 use vsapi::{TVisaServiceSyncClient, VisaServiceSyncClient};
 use zpr;
+
+/// Timeout for connecting to the visa service.
+const VS_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 
 // ugh!!
 type VSClientT = VisaServiceSyncClient<
@@ -55,15 +58,16 @@ pub trait VSClientI: Send {
 impl VSClient {
     // Not public; use the factory.
     fn new(service: &str) -> Result<VSClient, VSClientError> {
-        // create thrift client:
-        let mut c = TTcpChannel::new();
-        c.open(service.to_string())?;
+        let saddr = service.parse::<SocketAddr>()?;
+        let stream = TcpStream::connect_timeout(&saddr, VS_CONNECT_TIMEOUT)?;
+        let c = TTcpChannel::with_stream(stream);
 
         let (i_chan, o_chan) = c.split()?;
 
         let i_prot = TBinaryInputProtocol::new(TFramedReadTransport::new(i_chan), true);
         let o_prot = TBinaryOutputProtocol::new(TFramedWriteTransport::new(o_chan), true);
 
+        debug!("XXX VSClient.new creating VisaServiceSyncClient");
         let tcli = vsapi::VisaServiceSyncClient::new(i_prot, o_prot);
 
         Ok(VSClient {

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -14,7 +14,7 @@ use std::time::SystemTime;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{self, Duration};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, debug};
 
 use crate::errors::{VSClientError, VSError};
 use crate::vsapi;
@@ -197,7 +197,7 @@ impl VSConn {
     /// This little run loop is fairly basic: all requests of the visa service run one at a time and
     /// in order.
     pub async fn run(&self, ctok: CancellationToken) -> Result<(), VSError> {
-        info!("VSConn::run starts");
+        info!("run starts");
 
         let (tx, mut rx) = mpsc::channel(16);
         let fac: vscli::VSClientFactory;
@@ -216,7 +216,9 @@ impl VSConn {
             Ok(c) => c,
             Err(e) => return Err(e.into()),
         };
+        debug!("client created successfully");
         self.initialize(&mut client)?;
+        debug!("initialize completed successfully");
 
         let mut interval = time::interval(PING_INTERVAL);
         let mut ping_errors = 0;


### PR DESCRIPTION
Add 3 sec timeout to VSS connect routine.  Was way to slow to timeout.

Still see MICV errors when running node in debug. Not sure which stream they are on.