### PR TITLE
bring the m2 configs and readme into alignment

### DIFF
--- a/examples/milestone2/README.md
+++ b/examples/milestone2/README.md
@@ -33,7 +33,7 @@ to the node with a register-address message). Some of these addresses must align
 with policy.
 
 Notes:
-- The ZPR address space is `fd5a:5052::/48`
+- The ZPR address space is `fd5a:5052::/32`
 - The visa service (and its adapter) always get address `fd5a:5052::1`.
 - The network `fd5a:5052:90de::/48` is reserved for nodes.
 - Below we are using `fd5a:5052:1::/48` for all the non-visaservice adapters.

--- a/examples/milestone2/adapter-client/adapter-client-conf.toml
+++ b/examples/milestone2/adapter-client/adapter-client-conf.toml
@@ -6,6 +6,7 @@ ca_file = "ca-cert.pem"
 certificate_file = "adapter-client-cert.pem"
 private_key_file = "adapter-client-key.pem"
 agent_addr = "fd5a:5052:1::3133:7"
+self_addr = "0.0.0.0:5000"
 
 # use `sudo mktun.sh` to set this up
 tun_if = "tun9"

--- a/examples/milestone2/adapter-client/mktun.sh
+++ b/examples/milestone2/adapter-client/mktun.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 ip tuntap add name tun9 mode tun multi_queue
-ip addr add fd5a:5052:1::3133:7/16 dev tun9
+ip link set tun9 mtu 1400
+ip addr add fd5a:5052:1::3133:7/32 dev tun9
 ip link set tun9 up

--- a/examples/milestone2/adapter-service/adapter-service-conf.toml
+++ b/examples/milestone2/adapter-service/adapter-service-conf.toml
@@ -6,6 +6,7 @@ ca_file = "ca-cert.pem"
 certificate_file = "adapter-service-cert.pem"
 private_key_file = "adapter-service-key.pem"
 agent_addr = "fd5a:5052:1::8080"
+self_addr = "0.0.0.0:5000"
 
 # use `sudo ./mktun.sh` to set this up
 tun_if = "tun9"

--- a/examples/milestone2/adapter-service/mktun.sh
+++ b/examples/milestone2/adapter-service/mktun.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ip tuntap add name tun9 mode tun multi_queue
-ip addr add fd5a:5052:1::8080/16 dev tun9
+ip link set tun9 mtu 1400
+ip addr add fd5a:5052:1::8080/32 dev tun9
 ip link set tun9 up
 

--- a/examples/milestone2/adapter-vs/adapter-vs-conf.toml
+++ b/examples/milestone2/adapter-vs/adapter-vs-conf.toml
@@ -6,6 +6,7 @@ ca_file = "ca-cert.pem"
 certificate_file = "adapter-vs-cert.pem"
 private_key_file = "adapter-vs-key.pem"
 agent_addr = "fd5a:5052::1" # visa service well known addr
+self_addr = "0.0.0.0:5000"
 
 # use `sudo ./mktun.sh` to set this up
 tun_if = "tun9"

--- a/examples/milestone2/adapter-vs/mktun.sh
+++ b/examples/milestone2/adapter-vs/mktun.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 ip tuntap add name tun9 mode tun multi_queue
+ip link set tun9 mtu 1400
 ip addr add fd5a:5052::1/32 dev tun9
 ip link set tun9 up

--- a/examples/milestone2/node/mktun.sh
+++ b/examples/milestone2/node/mktun.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ip tuntap add name tun9 mode tun multi_queue
+ip link set tun9 mtu 1400
 ip addr add fd5a:5052:90de::1/32 dev tun9
 ip link set tun9 up
 


### PR DESCRIPTION
Should be final tweak the the m2 example files.  This just brings them into alignment with what was running for demo.