### PR TITLE
update hashbrown to avoid vulnerability CWE-502

### DIFF
--- a/visaservice/admin/Cargo.lock
+++ b/visaservice/admin/Cargo.lock
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"


### PR DESCRIPTION
Addresses https://github.com/advisories/GHSA-wwq9-3cpr-mm53