### PR TITLE
correctly handle self-addr port 0

### DIFF
--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -1,5 +1,8 @@
 //! Static system configuration.
 
+use std::net::{IpAddr, SocketAddr};
+use std::path::PathBuf;
+
 /// Size of a packet buffer.
 pub const PACKET_BUFFER_SIZE: usize = 4096 * 3;
 
@@ -22,6 +25,46 @@ const DEFAULT_WORKER_CONCURRENCY: usize = 4;
 
 #[cfg(target_os = "macos")]
 const DEFAULT_WORKER_CONCURRENCY: usize = 1;
+
+/// This config struct is loaded up from the command line args and used by the
+/// ph system to configure itself.  Do not create this directly, use [argparse].
+#[derive(Debug)]
+pub struct Config {
+    /// Name (for logging, etc) of the node or adapter instance.
+    pub name: String,
+
+    /// Path to the unix domain socket for the control interface.
+    pub control_path: PathBuf,
+
+    /// Source address for our UDP substrate socket. For an adapter this should (always?) be `0.0.0.0:0`.
+    /// For a node this is the nodes dock listening address.
+    pub self_addr: SocketAddr,
+
+    /// Path to a PEM file containing the Certificate Authority certificate.
+    pub ca_file: PathBuf,
+
+    /// Path to a PEM file containing the signed certificate listing the noise public key.
+    pub certificate_file: PathBuf,
+
+    /// Path to a PEM file containing the noise private key.
+    pub private_key_file: PathBuf,
+
+    /// Optionally specify the name of the TUN interface to use. In most cases this
+    /// should be left as None so that the kernal can pick a free one.
+    pub tun_if: Option<String>,
+
+    /// Enable debug logging.
+    pub debug: bool,
+
+    /// Required for adapter - the node dock address on substrate.
+    pub node_addr: Option<SocketAddr>,
+
+    /// Required for adapter - the adapters ZPR agent address.
+    pub agent_addr: Option<IpAddr>,
+
+    /// Required for adapter - the path to the PEM file containing the nodes noise public key (not a certificate).
+    pub node_public_key_file: Option<PathBuf>,
+}
 
 /// Configuration of data path & control plane topology.
 pub struct TopologyConfig {

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -78,7 +78,7 @@ fn main() -> ExitCode {
     //
     // parse configuration from command line
     //
-    let (ph_mode, config) = match main_args::argparse(None) {
+    let (ph_mode, mut config) = match main_args::argparse(None) {
         Ok((ph_mode, config)) => (ph_mode, config),
         Err(e) => {
             eprintln!("failed to parse command line arguments: {:?}", e);
@@ -238,6 +238,11 @@ fn main() -> ExitCode {
         socket
             .bind(&socket2::SockAddr::from(config.self_addr))
             .expect("unable to bind to self_addr");
+        if config.self_addr.port() == 0 {
+            let port = socket.local_addr().unwrap().as_socket().unwrap().port();
+            config.self_addr.set_port(port);
+            info!("assigned substrate UDP port {port}");
+        }
         substrate_sockets.push(Arc::new(UdpSocket::from_std(socket.into()).unwrap()));
     }
 

--- a/adapter/ph/src/main_args.rs
+++ b/adapter/ph/src/main_args.rs
@@ -4,52 +4,13 @@
 //! and any config file, returning a PH configuration.
 
 use crate::assembly::PhMode;
+use crate::config::Config;
 use clap::{Args, Parser, Subcommand};
 use serde::Deserialize;
 use std::io::Read;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{self, Path, PathBuf};
 use std::{env, fs};
-
-/// This config struct is loaded up from the command line args and used by the
-/// ph system to configure itself.  Do not create this directly, use [argparse].
-#[derive(Debug)]
-pub struct Config {
-    /// Name (for logging, etc) of the node or adapter instance.
-    pub name: String,
-
-    /// Path to the unix domain socket for the control interface.
-    pub control_path: PathBuf,
-
-    /// Source address for our UDP substrate socket. For an adapter this should (always?) be `0.0.0.0:0`.
-    /// For a node this is the nodes dock listening address.
-    pub self_addr: SocketAddr,
-
-    /// Path to a PEM file containing the Certificate Authority certificate.
-    pub ca_file: PathBuf,
-
-    /// Path to a PEM file containing the signed certificate listing the noise public key.
-    pub certificate_file: PathBuf,
-
-    /// Path to a PEM file containing the noise private key.
-    pub private_key_file: PathBuf,
-
-    /// Optionally specify the name of the TUN interface to use. In most cases this
-    /// should be left as None so that the kernal can pick a free one.
-    pub tun_if: Option<String>,
-
-    /// Enable debug logging.
-    pub debug: bool,
-
-    /// Required for adapter - the node dock address on substrate.
-    pub node_addr: Option<SocketAddr>,
-
-    /// Required for adapter - the adapters ZPR agent address.
-    pub agent_addr: Option<IpAddr>,
-
-    /// Required for adapter - the path to the PEM file containing the nodes noise public key (not a certificate).
-    pub node_public_key_file: Option<PathBuf>,
-}
 
 /// Errors you may encounter when trying to parse command line or configuration
 /// file.

--- a/adapter/ph/test/basic-test.sh
+++ b/adapter/ph/test/basic-test.sh
@@ -101,7 +101,7 @@ sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --name "zpr-vs" \
   --control-path "$VS_SOCK" \
-  --self-addr "$VS_SUBSTRATE_ADDR":12345 \
+  --self-addr "$VS_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
   --certificate-file vs.zpr.crt \
   --private-key-file vs.zpr.key \
@@ -116,7 +116,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --name "zpr-a" \
   --control-path "$ADAPTER1_SOCK" \
-  --self-addr "$A_SUBSTRATE_ADDR":12345 \
+  --self-addr "$A_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
   --certificate-file adapter1.crt \
   --private-key-file adapter1.key \
@@ -131,7 +131,7 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --name "zpr-b" \
   --control-path "$ADAPTER2_SOCK" \
-  --self-addr "$B_SUBSTRATE_ADDR":12345 \
+  --self-addr "$B_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
   --certificate-file adapter2.crt \
   --private-key-file adapter2.key \

--- a/adapter/ph/test/capture-test.sh
+++ b/adapter/ph/test/capture-test.sh
@@ -104,7 +104,7 @@ sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --name "zpr-vs" \
   --control-path "$VS_SOCK" \
-  --self-addr "$VS_SUBSTRATE_ADDR":12345 \
+  --self-addr "$VS_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
   --certificate-file vs.zpr.crt \
   --private-key-file vs.zpr.key \
@@ -119,7 +119,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --name "zpr-a" \
   --control-path "$ADAPTER1_SOCK" \
-  --self-addr "$A_SUBSTRATE_ADDR":12345 \
+  --self-addr "$A_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
   --certificate-file adapter1.crt \
   --private-key-file adapter1.key \
@@ -132,7 +132,7 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --name "zpr-b" \
   --control-path "$ADAPTER2_SOCK" \
-  --self-addr "$B_SUBSTRATE_ADDR":12345 \
+  --self-addr "$B_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
   --certificate-file adapter2.crt \
   --private-key-file adapter2.key \


### PR DESCRIPTION
Issue was, each substrate socket would get assigned a different random port.  And then our egress steering code would more or less randomly choose one.

Solution is, if the port # is 0, allow the OS to choose it for the _first_ socket, then use that as the port for all the _subsequent_ sockets.

Also moves the generic config struct into the config module.