### PR TITLE
ICMPv4 support

### DIFF
--- a/visaservice/core/pkg/policy/matcher.go
+++ b/visaservice/core/pkg/policy/matcher.go
@@ -493,13 +493,23 @@ POLICYLOOP:
 func (m *Matcher) policiesForScope(td *snip.Traffic, srcAgent, dstAgent *AgentInfo) []*polio.MatchedPolicy {
 	var pset []*polio.MatchedPolicy
 
+	// HACK - The prototype compiler will allow for ICMPv4 and ICMPv6, but it always writes
+	//        the scope protocol as ICMPv6 since the prototype ZPL does not differentiate.
+	//        Therefore the matcher index always uses ICMP6.  If we are getting IPv4 traffic and
+	//        the protocol is ICMP4 we pretend it is ICMP6.
+	tdProtoNum := td.Proto.Num()
+	if td.SrcAddr.Is4() && td.Proto == snip.ProtocolICMP4 {
+		tdProtoNum = snip.ProtocolICMP6.Num()
+	}
+
 	// In all cases, either the source or destination must have a service to offer. Possibly they both do.
 	m.log.Debug("[MX] matcher - running policiesForScope")
 	for _, svcID := range dstAgent.AgentProvides {
 		m.log.Debug("[MX] found dest agent provides", "provides", svcID)
 		if protIdx, match := m.trafficIdx[svcID]; match {
 			m.log.Debug("[MX]  -- found service in match table", "protocolCount", len(protIdx))
-			if portIdx, match := protIdx[td.Proto.Num()]; match {
+			m.log.Debug("[MX]  -- XXX ", "wanted_proto_num", tdProtoNum, "protIdx", protIdx)
+			if portIdx, match := protIdx[tdProtoNum]; match {
 				m.log.Debug("[MX]  -- found protocol in match table", "portCount", len(portIdx))
 				if set, merr := m.matchy(td, true, portIdx, dstAgent); len(set) > 0 { // FORWARD !
 					m.log.Debugf("[MX]  -- -- matched %d policies on FWD", len(set))
@@ -519,7 +529,7 @@ func (m *Matcher) policiesForScope(td *snip.Traffic, srcAgent, dstAgent *AgentIn
 	for _, svcID := range srcAgent.AgentProvides {
 		m.log.Debug("[MX]  checking source agent provides", "provides", svcID)
 		if protIdx, match := m.trafficIdx[svcID]; match {
-			if portIdx, match := protIdx[td.Proto.Num()]; match {
+			if portIdx, match := protIdx[tdProtoNum]; match {
 				if set, merr := m.matchy(td, false, portIdx, dstAgent); len(set) > 0 { // REVERSE !
 					m.log.Debugf("[MX]  -- -- matched %d policies on REV", len(set))
 					pset = append(pset, set...)
@@ -546,7 +556,7 @@ func (m *Matcher) matchy(td *snip.Traffic, isFWD bool, portIdx map[uint32][]int,
 			qPortVal = uint32(td.SrcPort)
 		}
 
-	case snip.ProtocolICMP6:
+	case snip.ProtocolICMP6, snip.ProtocolICMP4:
 		// This is not quite right for ICMP. PING, for example, expects one typecode as a request
 		// and the other as a response.  This index will match either typecode in either direction.  So more
 		// detailed checking is required for ICMP.
@@ -563,7 +573,7 @@ func (m *Matcher) matchy(td *snip.Traffic, isFWD bool, portIdx map[uint32][]int,
 	for _, px := range policies {
 		cpol := m.policy.Policies[px]
 		switch td.Proto {
-		case snip.ProtocolICMP6:
+		case snip.ProtocolICMP6, snip.ProtocolICMP4:
 			// Eg policy says REQ-REP to 128, 129
 			// so,
 			//     128 must match client to service
@@ -605,7 +615,7 @@ func (m *Matcher) icmpSpecialHandling(cpol *polio.CPolicy, qPortVal uint32, isFW
 	// must only match on a request, and a reverse must match on a response.
 	keep := false
 	for _, sc := range cpol.Scope {
-		if sc.Protocol == snip.ProtocolICMP6.Num() {
+		if (sc.Protocol == snip.ProtocolICMP6.Num()) || (sc.Protocol == snip.ProtocolICMP4.Num()) {
 			icmpScope := sc.GetIcmp()
 			if len(icmpScope.Codes) == 1 {
 				if icmpScope.Codes[0] == qPortVal {

--- a/visaservice/core/pkg/policy/matcher_test.go
+++ b/visaservice/core/pkg/policy/matcher_test.go
@@ -86,6 +86,76 @@ zpr:
                     -----END CERTIFICATE-----
 `
 
+// IPv4 version
+const mtpreambleIP4 = `
+zpl_format: 2
+main:
+  policy_version: 1
+  policy_date: "2020-10-22T12:23:00Z"
+
+services:
+  http:
+    tcp: 80
+  ping:
+    icmp:
+      type: request-response
+      type_codes: 8, 0
+`
+
+// IPv4 version
+const networkIP4 = `
+zpr:
+  globals:
+    max_connections: 100
+    max_connections_per_dock: 10
+    max_connections_per_agent: 3
+  visaservice:
+    provider:
+      - [intern.foo, fox]
+    admin_attrs:
+      - [intern.foo, fee]
+  nodes:
+    n0:
+      key: "cffa793530e6d63e560e8b314b5035db34aaae324f63cb76b204d3e4c00d5a1a"
+      provider:
+        - [intern.cn, eq, nodus]
+      address: "10.0.0.88"
+      interfaces:
+        i0:
+          netaddr: "n0.spacelaser.net:5000"
+  addresses:
+    node_net: "10.0.0.0/24"
+    zpr_net: "10.1.0.0/24"
+  datasources:
+    intern:
+      api: validation/1
+      authority:
+        encoding: pem
+        cert_data: |
+                    -----BEGIN CERTIFICATE-----
+                    MIIDlDCCAnwCCQC8eSseeO7eyzANBgkqhkiG9w0BAQsFADCBizELMAkGA1UEBhMC
+                    VVMxCzAJBgNVBAgMAktZMRMwEQYDVQQHDApMb3Vpc3ZpbGxlMQswCQYDVQQKDAJB
+                    STEQMA4GA1UECwwHc3VyZW5ldDEdMBsGA1UEAwwUYXV0aDAuc3BhY2VsYXNlci5u
+                    ZXQxHDAaBgkqhkiG9w0BCQEWDW1hdGhpYXNAYWkuY28wHhcNMTkwMzE5MTUxNTE3
+                    WhcNMjAwMzE4MTUxNTE3WjCBizELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAktZMRMw
+                    EQYDVQQHDApMb3Vpc3ZpbGxlMQswCQYDVQQKDAJBSTEQMA4GA1UECwwHc3VyZW5l
+                    dDEdMBsGA1UEAwwUYXV0aDAuc3BhY2VsYXNlci5uZXQxHDAaBgkqhkiG9w0BCQEW
+                    DW1hdGhpYXNAYWkuY28wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDh
+                    FIpG5LpTIrhaM2vsccVRJjLbOTZvXf2kBlNDX+HeK59KLUoS/TSV7AR4Yj56uOO6
+                    6iUl17r6ukxlPhqyH0+26DfKCuAsAO72nFSLEAgEqoJBxhuKZB25Qr7ZSnVu6S4J
+                    sOCmW4z87jZmAZ6kSRw+ReVrqzDj67mihHCasOfYsGnZAp+1/5nqBvW+7CQlxJt4
+                    im4IKDb21kIRtn4EjYzf/ecysD3Hqcb8qY6Cq7AWibajhZWmkQVkWfOc0hfixUck
+                    2Szjm+uzZb1ZwCCZFIXEnUvQ5lOiswOkuy2+t/mEiWvhLtRrXms/dhKUtqtyhtGO
+                    dkPuT2zDmOtB92gb2ttxAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAMGvqGBGTVUd
+                    6tpyhcm6J9o1P7pnOjc4HlDpOebqPMnwkuWmOOODshbFD/biDDNtpPt9DikAiSqZ
+                    iVZ/RC6r42dVH0G4tiiQJDPLsLJ0pj/cdJnmmYXwUUqE4IXxsqbKMkhToZlp9Yw1
+                    N+wBxdue8Nix5LhI7YYfut1JlMqtho6hxX712uMlZqUJUFsPUPErxKQIcuwuDJmP
+                    RQiwkwIEZOEvrIQjkFUy+wOxsJI9cqtpVE1hSSc1dwAL0tjLqO5LtQhBMFORXUuK
+                    R+E8nfJH0YhY9AIiRjJM6Gujxa9lMofSlHK0LtS7jaDnbFVsKa4fK8iIAlqGDSnc
+                    roROWU/mSb0=
+                    -----END CERTIFICATE-----
+`
+
 // MatchTrafficAgents helper to call matcher.MatchTraffic
 func MatchTrafficAgents(m *policy.Matcher, td *snip.Traffic, src, dst *agent.Agent) ([]*polio.MatchedPolicy, error) {
 	mtSrc, mtDst := &policy.AgentInfo{src.GetAuthedClaims(), src.GetProvides()}, &policy.AgentInfo{dst.GetAuthedClaims(), dst.GetProvides()}
@@ -1046,4 +1116,62 @@ func TestWithNilPolicy(t *testing.T) {
 	m, err := policy.NewMatcher(nil, 1, logr.NewTestLogger())
 	require.Nil(t, err)
 	require.NotNil(t, m)
+}
+
+func TestICMP4EchoRequest(t *testing.T) {
+	pyml := mtpreambleIP4 + networkIP4 + `
+communications:
+  systems:
+    testnet:
+      desc: testnet
+      components:
+        webserver:
+          desc: webserver
+          services: [http, ping]
+          provider:
+            - [zpr.addr, eq, 10.1.0.8]
+          address: "10.1.0.8"
+          policies:
+            - desc: access
+              conditions:
+                - desc: all access
+                  attrs:
+                    - [intern.foo, eq, fee]
+`
+
+	fs, err := fs.NewMemoryFileStore()
+	require.Nil(t, err)
+	fs.AddFile("root.yaml", []byte(pyml))
+	opts := compiler.CompileOpts{
+		Revision: "t04",
+		Verbose:  true,
+	}
+	p, err := compiler.Compile("root.yaml", fs, &opts)
+	require.Nil(t, err)
+
+	m, err := policy.NewMatcher(p, 1, logr.NewTestLogger())
+	require.Nil(t, err)
+
+	client := agent.NewAgentFromUnsubstantiatedClaims(nil)
+	client.SetAuthenticated(mkClaims("intern.foo", "fee", time.Hour), time.Time{}, []string{"intern"}, []string{"token"}, 1)
+
+	server := agent.NewAgentFromUnsubstantiatedClaims(nil)
+	server.SetAuthenticated(mkClaims("zpr.addr", "10.1.0.8", time.Hour), time.Time{}, nil, nil, 1)
+	server.SetProvides([]string{"/zpr/testnet/webserver"})
+
+	td := &snip.Traffic{
+		Proto:    snip.ProtocolICMP4,
+		SrcAddr:  netip.MustParseAddr("10.1.0.20"),
+		DstAddr:  netip.MustParseAddr("10.1.0.8"),
+		ICMPType: 0x8,
+		ICMPCode: 0,
+	}
+
+	matches, err := MatchTrafficAgents(m, td, client, server)
+	require.Nil(t, err)
+	require.Len(t, matches, 1)
+	match := matches[0]
+	require.True(t, match.FWD)
+	require.Equal(t, "access", match.CPol.Id)
+	require.Equal(t, "/zpr/testnet/webserver", match.CPol.ServiceId)
 }

--- a/visaservice/mods/zpl/compiler/compiler_test.go
+++ b/visaservice/mods/zpl/compiler/compiler_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-  VisaServiceAddress = "fd5a:5052::1"
+	VisaServiceAddress = "fd5a:5052::1"
 )
 
 const ca0cert = `
@@ -1897,7 +1897,7 @@ func TestAllowRestrictsServicesInComponents(t *testing.T) {
             cert_data: $import[ca0-cert.pem]
       visaservice:
         provider:
-          - [ca0.fox, eq, foh]          
+          - [ca0.fox, eq, foh]
         admin_attrs:
           - [ca0.foo, eq, fee]
 
@@ -2674,7 +2674,7 @@ func TestNestedDatasource(t *testing.T) {
       visaservice:
         provider:
           - [ca0.fox, eq, foh]
-        admin_attrs:        
+        admin_attrs:
           - [ca0.foo, eq, fee]
 
     communications:
@@ -3644,4 +3644,66 @@ func TestWillNotPermitNonDefaultAPISpecForInternalDS(t *testing.T) {
 	}
 	_, err := compiler.Compile("/pol.yaml", fst, opts)
 	require.ErrorContains(t, err, "validation/1")
+}
+
+func TestCompilesICMPv4(t *testing.T) {
+	pyaml := `
+    zpl_format: 2
+    main:
+      name: foo
+    services:
+      http:
+        tcp: 80
+      ping:
+        icmp:
+          type: request-response
+          type_codes: 8, 0
+    zpr:
+      nodes:
+        n0:
+          key: "13024a188fddbc76db8ee98eeef91ad81a80846e99f6f9b988184a2173950052"
+          provider:
+            - [ca0.x509.cn, eq, n0.internal]
+          address: "10.0.0.7"
+          interfaces:
+            n0i0:
+              netaddr: "n0.spacelaser.net:5000"
+          services:
+            - ping
+          policies:
+            - desc: allow ping
+              conditions:
+                - desc: match on authority
+                  attrs:
+                    - [zpr.authority, eq, ca0]
+      datasources:
+        ca0:
+          api: validation/1
+          authority:
+            encoding: pem
+            cert_data: $import[ca0-cert.pem]
+      visaservice:
+        provider:
+          - [ca0.fox, eq, foh]
+        admin_attrs:
+          - [ca0.foo, eq, fee]
+
+    communications:
+      systems:
+        mathiasland:
+          desc: mathiasland system
+          components:
+`
+
+	fst, _ := fs.NewMemoryFileStore()
+	fst.AddFile("/pol.yaml", []byte(pyaml))
+	fst.AddFile("/ca0-cert.pem", []byte(ca0cert))
+
+	opts := &compiler.CompileOpts{
+		Revision: "t01",
+		Verbose:  true,
+	}
+	p, err := compiler.Compile("/pol.yaml", fst, opts)
+	require.Nil(t, err)
+	require.NotNil(t, p)
 }

--- a/visaservice/mods/zpl/compiler/connect.go
+++ b/visaservice/mods/zpl/compiler/connect.go
@@ -444,8 +444,8 @@ func (c *Compilation) getAttrExprSetForComponent(sID string, comp *doc.Component
 			epidSet = true // EPID is set already
 			if attrExpr.Op.String() == doc.AttrExprOpEq {
 				// Preprocessor should catch this.
-				if ipa, err := netip.ParseAddr(attrExpr.Value.String()); err != nil || !ipa.Is6() {
-					return nil, doc.ZplScalarErrorf(attrExpr.Value, "service %v with invalid zpr.addr, expect IPv6 found: %v", sID, attrExpr.Value)
+				if ipa, err := netip.ParseAddr(attrExpr.Value.String()); err != nil {
+					return nil, doc.ZplScalarErrorf(attrExpr.Value, "service %v with invalid zpr.addr: %v (%v)", sID, attrExpr.Value, err)
 				} else {
 					// Warn if the zpr.addr is different from the svcEPID.
 					if !(svcEPID == ipa) {
@@ -555,21 +555,21 @@ func explodeScope(s []*doc.Scoping, ploded map[uint8][]uint16) error {
 		var ports []uint16
 		if scope.TCP.Value() != nil {
 			proto = defs.ProtocolTCP
-			ports, err = explodePorts(scope.TCP.String())
+			ports, err = explodePorts(scope.TCP.String(), doc.RangeTcpUdp)
 			if err != nil {
 				return doc.ZplScalarErrorf(scope.TCP, "%w", err)
 			}
 		}
 		if scope.UDP.Value() != nil {
 			proto = defs.ProtocolUDP
-			ports, err = explodePorts(scope.UDP.String())
+			ports, err = explodePorts(scope.UDP.String(), doc.RangeTcpUdp)
 			if err != nil {
 				return doc.ZplScalarErrorf(scope.UDP, "%w", err)
 			}
 		}
 		if scope.ICMP != nil {
 			proto = defs.ProtocolICMP6
-			ports, err = explodePorts(scope.ICMP.TypeCodes.String()) // Not sure about this
+			ports, err = explodePorts(scope.ICMP.TypeCodes.String(), doc.RangeICMP) // Not sure about this
 		}
 
 		if proto > 0 {
@@ -596,7 +596,7 @@ func explodeScope(s []*doc.Scoping, ploded map[uint8][]uint16) error {
 }
 
 // explodePorts given a ports string, returns the list of (unique) ports described.
-func explodePorts(portstr string) ([]uint16, error) {
+func explodePorts(portstr string, pr doc.PortRange) ([]uint16, error) {
 	uniqports := make(map[uint16]bool)
 	for _, ps := range strings.Split(portstr, ",") {
 		if strings.Index(ps, "-") > 0 {
@@ -604,11 +604,11 @@ func explodePorts(portstr string) ([]uint16, error) {
 			if len(abs) != 2 {
 				return nil, fmt.Errorf("expected port range 'N-M' not: '%v'", ps)
 			}
-			low, err := portFromString(abs[0])
+			low, err := portFromString(abs[0], pr)
 			if err != nil {
 				return nil, fmt.Errorf("invalid port range: '%v': %v", ps, err)
 			}
-			high, err := portFromString(abs[1])
+			high, err := portFromString(abs[1], pr)
 			if err != nil {
 				return nil, fmt.Errorf("invalid port range: '%v': %v", ps, err)
 			}
@@ -619,7 +619,7 @@ func explodePorts(portstr string) ([]uint16, error) {
 				uniqports[i] = true
 			}
 		} else {
-			p, err := portFromString(ps)
+			p, err := portFromString(ps, pr)
 			if err != nil {
 				return nil, err
 			}
@@ -633,13 +633,13 @@ func explodePorts(portstr string) ([]uint16, error) {
 	return ports, nil
 }
 
-func portFromString(s string) (uint16, error) {
+func portFromString(s string, pr doc.PortRange) (uint16, error) {
 	p, err := strconv.Atoi(strings.TrimSpace(s))
 	if err != nil {
-		return 0, fmt.Errorf("invalid port value '%v': %v", s, err)
+		return 0, fmt.Errorf("invalid port-spec value '%v': %v", s, err)
 	}
-	if p <= 0 || p > 65535 {
-		return 0, fmt.Errorf("invalid port value: '%v': %v", p, err)
+	if p <= pr.Min || p > pr.Max {
+		return 0, fmt.Errorf("invalid port-spec value: '%v': %v", p, err)
 	}
 	return uint16(p), nil
 }

--- a/visaservice/mods/zpl/compiler/match.go
+++ b/visaservice/mods/zpl/compiler/match.go
@@ -26,13 +26,13 @@ func assertScopesDistinct(news, exist []*doc.Scoping) error {
 			continue
 		}
 		for _, xscope := range exist {
-			if xscope.TCP.Value() != nil && portsOverlap(xscope.TCP, nscope.TCP) {
+			if xscope.TCP.Value() != nil && portsOverlap(xscope.TCP, nscope.TCP, doc.RangeTcpUdp) {
 				return doc.ZplScalarErrorf(nscope.TCP, "service on same host with overlapping scope: %v", nscope.String())
 			}
-			if xscope.UDP.Value() != nil && portsOverlap(xscope.UDP, nscope.UDP) {
+			if xscope.UDP.Value() != nil && portsOverlap(xscope.UDP, nscope.UDP, doc.RangeTcpUdp) {
 				return doc.ZplScalarErrorf(nscope.UDP, "service on same host with overlapping scope: %v", nscope.String())
 			}
-			if xscope.ICMP != nil && nscope.ICMP != nil && portsOverlap(xscope.ICMP.TypeCodes, nscope.ICMP.TypeCodes) {
+			if xscope.ICMP != nil && nscope.ICMP != nil && portsOverlap(xscope.ICMP.TypeCodes, nscope.ICMP.TypeCodes, doc.RangeICMP) {
 				return doc.ZplScalarErrorf(nscope.ICMP.TypeCodes, "service on same host with overlapping scope: %v", nscope.String())
 			}
 		}
@@ -40,9 +40,9 @@ func assertScopesDistinct(news, exist []*doc.Scoping) error {
 	return nil
 }
 
-func portsOverlap(a, b doc.ZplString) bool {
-	aports, _ := explodePorts(a.String())
-	bports, _ := explodePorts(b.String())
+func portsOverlap(a, b doc.ZplString, pr doc.PortRange) bool {
+	aports, _ := explodePorts(a.String(), pr)
+	bports, _ := explodePorts(b.String(), pr)
 	for _, portNum := range bports {
 		for _, apn := range aports {
 			if portNum == apn {
@@ -199,7 +199,7 @@ func docScopeToPolicyScope(ds []*doc.Scoping) ([]*polio.Scope, error) {
 	var scopes []*polio.Scope
 	for _, s := range ds {
 		if s.ICMP != nil {
-			specs, err := portTypeToPortSpec(s.ICMP.TypeCodes.String())
+			specs, err := portTypeToPortSpec(s.ICMP.TypeCodes.String(), doc.RangeICMP)
 			if err != nil {
 				return nil, doc.ZplScalarErrorf(s.ICMP.TypeCodes, "%w", err)
 			}
@@ -230,7 +230,7 @@ func docScopeToPolicyScope(ds []*doc.Scoping) ([]*polio.Scope, error) {
 			scopes = append(scopes, scope)
 		}
 		if s.TCP.Value() != nil {
-			specs, err := portTypeToPortSpec(s.TCP.String())
+			specs, err := portTypeToPortSpec(s.TCP.String(), doc.RangeTcpUdp)
 			if err != nil {
 				return nil, doc.ZplScalarErrorf(s.TCP, "%w", err)
 			}
@@ -245,7 +245,7 @@ func docScopeToPolicyScope(ds []*doc.Scoping) ([]*polio.Scope, error) {
 			scopes = append(scopes, scope)
 		}
 		if s.UDP.Value() != nil {
-			specs, err := portTypeToPortSpec(s.UDP.String())
+			specs, err := portTypeToPortSpec(s.UDP.String(), doc.RangeTcpUdp)
 			if err != nil {
 				return nil, doc.ZplScalarErrorf(s.UDP, "%w", err)
 			}
@@ -423,7 +423,7 @@ func (c *Compilation) splitGroup(consval string) (stripped string, group string,
 	return
 }
 
-func portTypeToPortSpec(pt string) ([]*polio.PortSpec, error) {
+func portTypeToPortSpec(pt string, pr doc.PortRange) ([]*polio.PortSpec, error) {
 	var specs []*polio.PortSpec
 	for _, ps := range strings.Split(pt, ",") {
 		if strings.Index(ps, "-") > 0 {
@@ -431,11 +431,11 @@ func portTypeToPortSpec(pt string) ([]*polio.PortSpec, error) {
 			if len(abs) != 2 {
 				return nil, fmt.Errorf("expected port range 'N-M' not: '%v'", ps)
 			}
-			low, err := portFromString(abs[0])
+			low, err := portFromString(abs[0], pr)
 			if err != nil {
 				return nil, fmt.Errorf("invalid port range: '%v': %v", ps, err)
 			}
-			high, err := portFromString(abs[1])
+			high, err := portFromString(abs[1], pr)
 			if err != nil {
 				return nil, fmt.Errorf("invalid port range: '%v': %v", ps, err)
 			}
@@ -450,7 +450,7 @@ func portTypeToPortSpec(pt string) ([]*polio.PortSpec, error) {
 				Parg: &polio.PortSpec_Pr{pr},
 			})
 		} else {
-			p, err := portFromString(ps)
+			p, err := portFromString(ps, pr)
 			if err != nil {
 				return nil, err
 			}

--- a/visaservice/mods/zpl/doc/typeassert.go
+++ b/visaservice/mods/zpl/doc/typeassert.go
@@ -28,9 +28,17 @@ var (
 )
 
 var (
-	ErrPortNumOutOfRange = errors.New("port number out of range")
-	ErrInvalidPortRange  = errors.New("invalid port range")
+	ErrPortSpecNumOutOfRange = errors.New("port-spec value out of range")
+	ErrInvalidPortRange      = errors.New("invalid port-spec range")
 )
+
+type PortRange struct {
+	Min int // exclusive
+	Max int // inclusive
+}
+
+var RangeTcpUdp = PortRange{0, 65535}
+var RangeICMP = PortRange{-1, 255}
 
 func AssertValidID(id string) error {
 	if !IDTypeRegex.MatchString(id) {
@@ -143,7 +151,15 @@ func AssertValidHostRef(h string) error {
 
 // AssertValidPortType checks for the ZPL port type which is:
 // a port number, a range of port numbers N-M, or a comma separated list of either.
-func AssertValidPortType(p string) error {
+func AssertValidTcpUdpPortType(p string) error {
+	return assertValidPortSpecType(p, RangeTcpUdp)
+}
+
+func AssertValidIcmpType(p string) error {
+	return assertValidPortSpecType(p, RangeICMP)
+}
+
+func assertValidPortSpecType(p string, r PortRange) error {
 	if p == "" {
 		return fmt.Errorf("port spec cannot be empty")
 	}
@@ -160,8 +176,8 @@ func AssertValidPortType(p string) error {
 				return err
 			}
 			for _, pn := range []int{low, high} {
-				if pn <= 0 || pn > 65535 {
-					return ErrPortNumOutOfRange
+				if pn <= r.Min || pn > r.Max {
+					return ErrPortSpecNumOutOfRange
 				}
 			}
 			if high < low {
@@ -173,8 +189,8 @@ func AssertValidPortType(p string) error {
 			if pn, err := strconv.Atoi(atom); err != nil {
 				return err
 			} else {
-				if pn <= 0 || pn > 65535 {
-					return ErrPortNumOutOfRange
+				if pn <= r.Min || pn > r.Max {
+					return ErrPortSpecNumOutOfRange
 				}
 			}
 			continue

--- a/visaservice/mods/zpl/doc/typeassert_test.go
+++ b/visaservice/mods/zpl/doc/typeassert_test.go
@@ -113,7 +113,7 @@ func TestValidNetAddr(t *testing.T) {
 }
 
 func TestValidPortType(t *testing.T) {
-	testPasses(t, doc.AssertValidPortType, []string{
+	testPasses(t, doc.AssertValidTcpUdpPortType, []string{
 		"123",
 		"1",
 		"1,2,3",
@@ -122,10 +122,35 @@ func TestValidPortType(t *testing.T) {
 		"1-1",
 		"1-10, 11, 12, 20, 100-200, 65534",
 	})
-	testFails(t, doc.AssertValidPortType, []string{
+	testFails(t, doc.AssertValidTcpUdpPortType, []string{
 		"5-1",
 		"-1",
 		"0",
+		"ha ho",
+		"1, 2, 3, a, b, c",
+		"1--10",
+		"1,,,,4",
+		"1,",
+		",1",
+	})
+}
+
+func TestValidIcmpType(t *testing.T) {
+	testPasses(t, doc.AssertValidIcmpType, []string{
+		"0",
+		"123",
+		"255",
+		"1",
+		"0,1,2,3",
+		"1,  2,     3",
+		"10-20",
+		"1-1",
+		"1-10, 11, 12, 20, 100-200",
+	})
+	testFails(t, doc.AssertValidIcmpType, []string{
+		"256",
+		"-1",
+		"5-1",
 		"ha ho",
 		"1, 2, 3, a, b, c",
 		"1--10",

--- a/visaservice/mods/zpl/pp/assertions.go
+++ b/visaservice/mods/zpl/pp/assertions.go
@@ -816,27 +816,28 @@ func extractSubmatchText(input string, re *regexp.Regexp, submatches []int, subm
 // expression struct on success, nil and an error on failure.
 //
 // Grammar:
-//     expr := posexpr | negexpr
-//     posexpr := svcexpr? "allowed" ("with" conspred)? ("for" <countpred>)? ("if" condpred)?
-//     negexpr := svcexpr ? "not' "allowed" ("with" conspred)? ("if" condpred)?
-//     svcexpr := "any"? svcspec ("and" svcspec)*
-//     svcspec := "(" svcid ")" | "tcp" ports? | "udp" ports? | "icmp" types?)
-//     conspred := (bwpred | durpred) ("and" (bwpred | durpred))*
-//     condpred := attrkey attrop attrval ("and" attrkey attrop attrval)*
-//     countpred := "count" "(" countitem ")" relop countval ("and" "count" "(" countitem ")" relop countval)*
-//     countitem := "users"
-//     bwpred := "max(bandwidth)" relop bwval
-//     durpred := "max(duration)" relop durval
-//     relop := "=" | "==" | "!=" | "<" | "<=" | ">" | ">="
-//     attrop := "=" | "==" | "!=" | "eq" | "ne" | "has" | "excludes"
-//     svcid := [a ZPL service ID]
-//     ports := [a ZPL PORTS_TYPE value]
-//     types := [a ZPL PORTS_TYPE value with <= 2 numbers]
-//     bwval := [a ZPL BANDWIDTH_TYPE value]
-//     durval := [a ZPL DURATION_TYPE value]
-//     countval := [a nonnegative integer]
-//     attrkey := [a string of the form datasource.attrname]
-//     attrval := [a string]
+//
+//	expr := posexpr | negexpr
+//	posexpr := svcexpr? "allowed" ("with" conspred)? ("for" <countpred>)? ("if" condpred)?
+//	negexpr := svcexpr ? "not' "allowed" ("with" conspred)? ("if" condpred)?
+//	svcexpr := "any"? svcspec ("and" svcspec)*
+//	svcspec := "(" svcid ")" | "tcp" ports? | "udp" ports? | "icmp" types?)
+//	conspred := (bwpred | durpred) ("and" (bwpred | durpred))*
+//	condpred := attrkey attrop attrval ("and" attrkey attrop attrval)*
+//	countpred := "count" "(" countitem ")" relop countval ("and" "count" "(" countitem ")" relop countval)*
+//	countitem := "users"
+//	bwpred := "max(bandwidth)" relop bwval
+//	durpred := "max(duration)" relop durval
+//	relop := "=" | "==" | "!=" | "<" | "<=" | ">" | ">="
+//	attrop := "=" | "==" | "!=" | "eq" | "ne" | "has" | "excludes"
+//	svcid := [a ZPL service ID]
+//	ports := [a ZPL PORTS_TYPE value]
+//	types := [a ZPL PORTS_TYPE value with <= 2 numbers]
+//	bwval := [a ZPL BANDWIDTH_TYPE value]
+//	durval := [a ZPL DURATION_TYPE value]
+//	countval := [a nonnegative integer]
+//	attrkey := [a string of the form datasource.attrname]
+//	attrval := [a string]
 //
 // Although "=[=]" and "!=" operators are allowed in attribute predicates for
 // convenience, they are translated to "eq" and "ne" in the returned structure.
@@ -920,7 +921,7 @@ func parseServiceExpression(svcExpr string) ([]serviceSpec, error) {
 				switch proto {
 				case "tcp", "udp":
 					if params != "" {
-						if err := doc.AssertValidPortType(params); err != nil {
+						if err := doc.AssertValidTcpUdpPortType(params); err != nil {
 							return nil, fmt.Errorf("invalid %s parameter string %q: %w", proto, params, err)
 						}
 					}

--- a/visaservice/mods/zpl/pp/preprocessor.go
+++ b/visaservice/mods/zpl/pp/preprocessor.go
@@ -2232,13 +2232,13 @@ func parseScoping(scopePath []yt.Node, fussy ErrMode) (*doc.Scoping, error) {
 		case "tcp":
 			if scoping.TCP, err = doc.NewZplString(childPath); err != nil {
 				return nil, err
-			} else if err = doc.AssertValidPortType(scoping.TCP.String()); err != nil {
+			} else if err = doc.AssertValidTcpUdpPortType(scoping.TCP.String()); err != nil {
 				return nil, doc.ZplScalarErrorf(scoping.TCP, "invalid TCP port specification: %w", err)
 			}
 		case "udp":
 			if scoping.UDP, err = doc.NewZplString(childPath); err != nil {
 				return nil, err
-			} else if err = doc.AssertValidPortType(scoping.UDP.String()); err != nil {
+			} else if err = doc.AssertValidTcpUdpPortType(scoping.UDP.String()); err != nil {
 				return nil, doc.ZplScalarErrorf(scoping.UDP, "invalid UDP port specification: %w", err)
 			}
 		case "icmp":
@@ -2261,7 +2261,7 @@ func parseScoping(scopePath []yt.Node, fussy ErrMode) (*doc.Scoping, error) {
 				case "type_codes":
 					if scoping.ICMP.TypeCodes, err = doc.NewZplString(icmpValPath); err != nil {
 						return nil, err
-					} else if err := doc.AssertValidPortType(scoping.ICMP.TypeCodes.String()); err != nil {
+					} else if err := doc.AssertValidIcmpType(scoping.ICMP.TypeCodes.String()); err != nil {
 						return nil, doc.ZplScalarErrorf(scoping.ICMP.TypeCodes, "invalid ICMP type codes: %w", err)
 					}
 				default:


### PR DESCRIPTION
Only slightly hacky support for ICMPv4.  I already patched the prototype compiler.  This patches the copy of the compiler that is included in ref-impl (so that the tests run), and importantly, patches the visa service lookup system so that it can properly detect ICMP4.

Still not totally sure that VS works great with IPv4 in general.