### PR TITLE
centralize system name log decoration

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -49,10 +49,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: BufferPacket) {
             .peer_table
             .is_security_assocaition_established(dock_link_id)
     {
-        warn!(
-            "{}: Link {} has no security association, aborting bind request operation",
-            asm.system_name, dock_link_id
-        );
+        warn!("Link {dock_link_id} has no security association, aborting bind request operation");
         fastpath::drop_and_count(asm, pkt, CounterType::DroppedNoSA);
         return;
     }
@@ -66,10 +63,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: BufferPacket) {
     // compress only IP addresses for now
     let compression_mode: zpr::CompressionMode = 0;
 
-    info!(
-        "{}: link {}: Issuing bind request for {} (is now set PENDING)",
-        asm.system_name, dock_link_id, five_tuple
-    );
+    info!("link {dock_link_id}: Issuing bind request for {five_tuple} (is now set PENDING)");
 
     let bind_result = match asm.ph_mode {
         PhMode::Adapter => {
@@ -99,10 +93,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: BufferPacket) {
     match bind_result {
         Ok(tether_id) => {
             // Bind succeeded; add to ALT.
-            info!(
-                "{}: Bind of {} succeeded: {}",
-                asm.system_name, five_tuple, tether_id
-            );
+            info!("Bind of {five_tuple} succeeded: {tether_id}");
 
             let AltEntry::Pending(initial_packet) = asm
                 .alt
@@ -135,10 +126,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: BufferPacket) {
 
         Err(err) => {
             // Bind failed; remove pending entry from ALT.
-            error!(
-                "{}: Bind of {} failed: {}",
-                asm.system_name, five_tuple, err
-            );
+            error!("Bind of {five_tuple} failed: {err}");
             asm.alt.remove(&five_tuple);
         }
     }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -55,7 +55,6 @@ pub struct Assembly {
     pub topology_config: config::TopologyConfig,
 
     // Shared resources.  These may be accessed by any part of the system.
-    pub system_name: String, // For debugging use
     pub agent_address: Option<IpAddr>,
 
     pub buffer_stack: BufferStack<{ config::PACKET_BUFFER_SIZE }>,
@@ -156,10 +155,7 @@ impl Assembly {
         link_type: LinkType,
     ) -> Result<NonZero<LinkId>, PeerInsertError> {
         assert!(link_type != LinkType::NodeToNode);
-        debug!(
-            "{}: Starting tether with {}",
-            self.system_name, adapter_addr
-        );
+        debug!("Starting tether with {adapter_addr}");
         let peer_id = self.add_peer(link_type, adapter_addr)?;
         self.peer_ids.lock().unwrap().push(peer_id.get());
 
@@ -172,10 +168,7 @@ impl Assembly {
             .link_state_machine
             .process_event(self, LinkEvent::Configure)
         {
-            error!(
-                "{}: Link {} failed to configure with error {}.  Resetting",
-                self.system_name, peer_id, e
-            );
+            error!("Link {peer_id} failed to configure with error {e}.  Resetting");
             let _ = peer
                 .link_state_machine
                 .process_event(self, LinkEvent::Reset);
@@ -184,18 +177,12 @@ impl Assembly {
                 .link_state_machine
                 .process_event(self, LinkEvent::Start)
             {
-                error!(
-                    "{}: Link {} failed to start with error {}.  Resetting",
-                    self.system_name, peer_id, e
-                );
+                error!("Link {peer_id} failed to start with error {e}.  Resetting");
                 let _ = peer
                     .link_state_machine
                     .process_event(self, LinkEvent::Reset);
             } else {
-                info!(
-                    "{}: Successfully started tether with {}.  Assigned ID {}",
-                    self.system_name, adapter_addr, peer_id
-                );
+                info!("Successfully started tether with {adapter_addr}.  Assigned ID {peer_id}");
             }
         }
 
@@ -307,7 +294,6 @@ pub mod test {
     pub struct TestAssemblyBuilder {
         pub ph_mode: Option<PhMode>,
         pub topology_config: Option<TopologyConfig>,
-        pub system_name: Option<String>,
         pub agent_address: Option<Option<IpAddr>>,
         pub buffer_stack: Option<BufferStack<{ config::PACKET_BUFFER_SIZE }>>,
         pub agent_input: Option<AgentInput>,
@@ -344,7 +330,6 @@ pub mod test {
     pub fn create_assembly(builder: TestAssemblyBuilder) -> Assembly {
         let ph_mode = builder.ph_mode.unwrap_or(PhMode::Adapter);
         let topology_config = builder.topology_config.unwrap_or_default();
-        let system_name = builder.system_name.unwrap_or("test".into());
         let agent_address = builder
             .agent_address
             .unwrap_or(Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
@@ -396,7 +381,6 @@ pub mod test {
         Assembly {
             ph_mode,
             topology_config,
-            system_name,
             agent_address,
             buffer_stack,
             agent_input,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -30,7 +30,7 @@ use zpr_ext::zerocopy::*;
 /// Drop a packet and count the drop with the given reason.
 pub fn drop_and_count(asm: &Assembly, pkt: BufferPacket, reason: impl Into<CounterType>) {
     let reason = reason.into();
-    debug!("{}: dropping packet because {}", asm.system_name, reason);
+    debug!("dropping packet because {reason}");
     asm.buffer_stack.put_buffer(pkt.destroy());
     asm.counters[reason.into()].increment();
 }
@@ -310,10 +310,7 @@ fn substrate_egress_common(
     //       See https://github.com/org-zpr/zpr-core/issues/444
     let transport_sa;
     if zdp_hdr.packet_type == zdp::ZdpPacketType::KeyManagement {
-        debug!(
-            "{}: link {}: KM message detected, using ZPI=0 ignoring security association",
-            asm.system_name, link_id
-        );
+        debug!("link {link_id}: KM message detected, using ZPI=0 ignoring security association");
         transport_sa = None;
     } else {
         transport_sa = peer_state.get_established_transport_association();
@@ -438,10 +435,7 @@ pub fn substrate_ingress(
     pkt.metadata_mut().ingress_link_id = asm.peer_table.lookup_peer(peer_sa).unwrap_or_zero();
 
     if pkt.metadata().ingress_link_id == 0 {
-        warn!(
-            "{}: got packet from {peer_sa} which isn't in the peer table; peer table contains:",
-            asm.system_name
-        );
+        warn!("got packet from {peer_sa} which isn't in the peer table; peer table contains:");
         let ids = asm.peer_ids.lock().unwrap().clone();
         for id in ids {
             if let Some(peer) = asm.peer_table.get(id) {
@@ -485,8 +479,7 @@ pub fn substrate_ingress(
                 } else {
                     // We have an SA and ZPI does not match.
                     warn!(
-                        "{}: ingress: link {}: unexpected ZPI value {} (expected {:?})",
-                        asm.system_name,
+                        "ingress: link {}: unexpected ZPI value {} (expected {:?})",
                         pkt.metadata().ingress_link_id,
                         zpi_hdr.zpi,
                         transport_sa.recv_zpis
@@ -497,19 +490,14 @@ pub fn substrate_ingress(
             }
             None => {
                 // Either no security association on link, or it is not yet established.
-                warn!(
-                    "{}: INSECURE, no SA on link {}",
-                    asm.system_name,
-                    pkt.metadata().ingress_link_id
-                );
+                warn!("INSECURE, no SA on link {}", pkt.metadata().ingress_link_id);
                 secure = false;
             }
         },
         None => {
             // No link in peer table
             warn!(
-                "{}: INSECURE, no link in peer table for {}",
-                asm.system_name,
+                "INSECURE, no link in peer table for {}",
                 pkt.metadata().ingress_link_id
             );
             secure = false;
@@ -520,8 +508,7 @@ pub fn substrate_ingress(
         // Not under a security assocation, which means only ZPI 0 is allowed.
         if zpi_hdr.zpi != zpr::ZPI_0 && pkt.metadata().ingress_link_id != zpr::LINK_ID_UNKNOWN {
             warn!(
-                "{}: ingress: {}: ZPI {} not allowed on unestablished SA",
-                asm.system_name,
+                "ingress: {}: ZPI {} not allowed on unestablished SA",
                 pkt.metadata().ingress_link_id,
                 zpi_hdr.zpi
             );
@@ -529,8 +516,7 @@ pub fn substrate_ingress(
             return;
         }
         warn!(
-            "{}: INSECURE, decrypting null packet from {}",
-            asm.system_name,
+            "INSECURE, decrypting null packet from {}",
             pkt.metadata().ingress_link_id
         );
         match decrypt_null(&mut pkt) {
@@ -574,8 +560,7 @@ pub fn substrate_ingress(
     // Can be overridden (FOR TESTING ONLY) in the flags.
     if !secure && base_hdr.packet_type != zdp::ZdpPacketType::KeyManagement {
         warn!(
-            "{}: ingress: link {}: ZPI 0 only allows key management messages, not {:?}",
-            asm.system_name,
+            "ingress: link {}: ZPI 0 only allows key management messages, not {:?}",
             pkt.metadata().ingress_link_id,
             base_hdr.packet_type
         );
@@ -762,10 +747,7 @@ pub fn agent_output_post_classify(asm: &Assembly, mut pkt: BufferPacket, allow_b
             }
 
             // issue bind request
-            info!(
-                "{}: issuing bind request for {}",
-                asm.system_name, five_tuple
-            );
+            info!("issuing bind request for {five_tuple}");
             match asm.adapter_manager.try_request_tether_id(pkt) {
                 Ok(()) => (),
                 Err(TryEnqueueError::Full(pkt)) => {

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -86,7 +86,7 @@ pub async fn launch_signal_worker(
     loop {
         tokio::select! {
             _ = sp_ctok.cancelled() => {
-                debug!("{}: KM Multiplexor shutting down", asm.system_name);
+                debug!("KM Multiplexor shutting down");
                 break;
             }
 
@@ -97,43 +97,43 @@ pub async fn launch_signal_worker(
                         if let Some(km) = asm.peer_table.clone_km_manager(*link_id) {
                             match km.restart() {
                                 Ok(_) => {
-                                    debug!("{}: km_multiplexor: restarted key manager on link {} (error_count = {})", asm.system_name, link_id, stat.error_count);
+                                    debug!("km_multiplexor: restarted key manager on link {link_id} (error_count = {})", stat.error_count);
                                     stat.restart_t = now;
                                 }
                                 Err(e) => {
-                                    error!("{}: km_multiplexor: failed to restart KM on link {}: {:?}", asm.system_name, link_id, e);
+                                    error!("km_multiplexor: failed to restart KM on link {link_id}: {e:?}");
                                     stat.error_count += 1;
                                 }
                             }
                         } else {
-                            error!("{}: km_multiplexor: unable to restart key manager on link {}: not found in peer table", asm.system_name, link_id);
+                            error!("km_multiplexor: unable to restart key manager on link {link_id}: not found in peer table");
                         }
                     }
                 }
             }
 
             Some(linkmsg) = sig_queue.recv() => {
-                debug!("{}: km_multiplexor: link: {}, signal {:?}", asm.system_name, linkmsg.link_id, linkmsg.msg);
+                debug!("km_multiplexor: link: {}, signal {:?}", linkmsg.link_id, linkmsg.msg);
                 match linkmsg.msg {
                     KmSignal::SaIdChange { old, new } => {
-                        debug!("{}: km_multiplexor: SA ID change on link {}: {} -> {}", asm.system_name, linkmsg.link_id, old, new);
+                        debug!("km_multiplexor: SA ID change on link {}: {} -> {}", linkmsg.link_id, old, new);
                         if old == 0 {
                             let _ = status.remove(&linkmsg.link_id);
                         }
                     }
                     KmSignal::SaEstablished(sa) => {
-                        debug!("{}: km_multiplexor: link {}: SA established (SEND_ZPIS: {}, RECV_ZPIS: {}",
-                            asm.system_name, linkmsg.link_id, sa.send_zpis, sa.recv_zpis);
+                        debug!("km_multiplexor: link {}: SA established (SEND_ZPIS: {}, RECV_ZPIS: {}",
+                            linkmsg.link_id, sa.send_zpis, sa.recv_zpis);
 
                         match asm.peer_table.set_security_association(linkmsg.link_id, sa) {
                             Ok(_) => (),
                             Err(e) => {
-                                error!("{}: km_multiplexor: failed to set SA established: {:?}", asm.system_name, e);
+                                error!("km_multiplexor: failed to set SA established: {e:?}");
                             }
                         }
                         match asm.process_link_state_event(linkmsg.link_id, LinkEvent::KeyingDone) {
                             Err(e) => {
-                                error!("{}: Link state error: {:?}", asm.system_name, e);
+                                error!("Link state error: {e:?}");
                             }
                             Ok(_) => (),
                         }
@@ -162,11 +162,11 @@ pub async fn launch_signal_worker(
                         };
                         stat.error_count += 1;
                         stat.last_error_t = time::Instant::now();
-                        warn!("{}: km_multiplexor: Error signal on link {}", asm.system_name, linkmsg.link_id);
+                        warn!("km_multiplexor: Error signal on link {}", linkmsg.link_id);
                     }
                     KmSignal::Termination => {
                         let _ = status.remove(&linkmsg.link_id);
-                        debug!("{}: km_multiplexor: termination signal on link {}", asm.system_name, linkmsg.link_id);
+                        debug!("km_multiplexor: termination signal on link {}", linkmsg.link_id);
                     }
                 }
             }
@@ -252,10 +252,7 @@ pub async fn drop_link(asm: &Assembly, link_id: zpr::LinkId) {
         match kmh.join_handle.await {
             Ok(_) => (),
             Err(e) => {
-                error!(
-                    "{}: KeyManager statemachine shutdown join failed on link {}: {:?}",
-                    asm.system_name, link_id, e
-                );
+                error!("KeyManager statemachine shutdown join failed on link {link_id}: {e:?}");
             }
         }
     }
@@ -280,7 +277,6 @@ fn add_noise_link(
     let spawn_ctok = child_ctok.clone();
     let spawn_km_tx = asm.km_state.km_tx.clone();
     let spawn_sig_tx = asm.km_state.km_sig_tx.clone();
-    let system_name = asm.system_name.clone();
 
     let (km_tx, km_rx) = mpsc::channel(asm.topology_config.km_link_queue_size);
 
@@ -291,10 +287,7 @@ fn add_noise_link(
         {
             Ok(_) => (),
             Err(e) => {
-                error!(
-                    "{}: KeyManager failed on link {}: {:?}",
-                    system_name, link_id, e
-                );
+                error!("KeyManager failed on link {link_id}: {e:?}");
             }
         }
     });

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -241,7 +241,7 @@ impl LinkStateWrapper {
     /// Configure an uninitialized link/tether
     /// Transitions from Initial -> Inactive
     /// Does not generate any packets
-    fn configure(&self, asm: &Assembly) -> Result<(), LinkStateError> {
+    fn configure(&self, _asm: &Assembly) -> Result<(), LinkStateError> {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         if locked_fsm.state != LinkState::Initial {
             return Err(LinkStateError::UnexpectedTransition(
@@ -256,8 +256,8 @@ impl LinkStateWrapper {
         locked_fsm.state = LinkState::Inactive;
 
         debug!(
-            "{}: Configured link {}.  State: {:?}, status: {:?}",
-            asm.system_name, self.id, locked_fsm.state, locked_fsm.status
+            "Configured link {}.  State: {:?}, status: {:?}",
+            self.id, locked_fsm.state, locked_fsm.status
         );
         Ok(())
     }
@@ -277,10 +277,7 @@ impl LinkStateWrapper {
 
         locked_fsm.state = LinkState::Keying;
 
-        debug!(
-            "{}: Link {} started.  Keying in progress",
-            asm.system_name, self.id
-        );
+        debug!("Link {} started.  Keying in progress", self.id);
 
         match self.link_type {
             LinkType::AdapterToNode => {
@@ -342,34 +339,20 @@ impl LinkStateWrapper {
         };
 
         if let Some(ref peer_cert) = sa.peer_cert {
-            info!(
-                "{}: Link {} has name {:?}",
-                asm.system_name,
-                self.id,
-                peer_cert.subject_name()
-            );
+            info!("Link {} has name {:?}", self.id, peer_cert.subject_name());
 
             // assign special-peer name if this peer is special
             for name in
                 special_peers::special_peer_names_from_x509_subject_name(peer_cert.subject_name())
             {
                 match asm.peer_table.assign_special_name(name, self.id) {
-                    Ok(()) => info!(
-                        "{}: Link {} assigned special name {:?}",
-                        asm.system_name, self.id, name
-                    ),
-                    Err(_) => warn!(
-                        "{}: Unable to assign link {} special name {:?}",
-                        asm.system_name, self.id, name
-                    ),
+                    Ok(()) => info!("Link {} assigned special name {:?}", self.id, name),
+                    Err(_) => warn!("Unable to assign link {} special name {:?}", self.id, name),
                 }
             }
         }
 
-        debug!(
-            "{}: Link {} finished keying.  Starting hello",
-            asm.system_name, self.id
-        );
+        debug!("Link {} finished keying.  Starting hello", self.id);
 
         locked_fsm.state = LinkState::Helloing;
         drop(locked_fsm);
@@ -401,22 +384,19 @@ impl LinkStateWrapper {
     /// Update link state based on received hello request
     /// Transitions from Helloing to Registering Agent Address
     /// Does not generate any packets
-    fn process_hello_request(&self, asm: &Assembly) -> Result<(), LinkStateError> {
+    fn process_hello_request(&self, _asm: &Assembly) -> Result<(), LinkStateError> {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         match (self.link_type, locked_fsm.state) {
             (LinkType::NodeToNode, LinkState::Helloing) => {
                 locked_fsm.state = LinkState::Active;
-                debug!(
-                    "{}: Link {} finished helloing.  Becoming active",
-                    asm.system_name, self.id
-                );
+                debug!("Link {} finished helloing.  Becoming active", self.id);
                 Ok(())
             }
             (LinkType::NodeToAdapter, LinkState::Helloing) => {
                 locked_fsm.state = LinkState::RegisterAA;
                 debug!(
-                    "{}: Link {} finished helloing.  Waiting on register agent address",
-                    asm.system_name, self.id
+                    "Link {} finished helloing.  Waiting on register agent address",
+                    self.id
                 );
                 Ok(())
             }
@@ -442,8 +422,8 @@ impl LinkStateWrapper {
             (LinkType::AdapterToNode, LinkState::Helloing) => {
                 locked_fsm.state = LinkState::RegisterAA;
                 debug!(
-                    "{}: Link {} finished helloing.  Sending register agent address",
-                    asm.system_name, self.id
+                    "Link {} finished helloing.  Sending register agent address",
+                    self.id
                 );
                 let link_id = self.id;
                 let task_asm = asm.clone();
@@ -463,10 +443,7 @@ impl LinkStateWrapper {
             }
             (LinkType::NodeToNode, LinkState::Helloing) => {
                 locked_fsm.state = LinkState::Active;
-                debug!(
-                    "{}: Link {} finished helloing.  Becoming active",
-                    asm.system_name, self.id
-                );
+                debug!("Link {} finished helloing.  Becoming active", self.id);
                 Ok(())
             }
             (LinkType::NodeToAdapter, _) => {
@@ -495,8 +472,8 @@ impl LinkStateWrapper {
             (LinkType::NodeToAdapter, LinkState::RegisterAA) => {
                 locked_fsm.agent_addresses.push(addr);
                 debug!(
-                    "{}: Link {} received agent address ({addr}).  Authorizing with visa service",
-                    asm.system_name, self.id
+                    "Link {} received agent address ({addr}).  Authorizing with visa service",
+                    self.id
                 );
 
                 let Some(peer_state) = asm.peer_table.get(self.id) else {
@@ -526,13 +503,13 @@ impl LinkStateWrapper {
                     cn = String::new();
                 }
 
-                info!("{}: Link {} CN is {cn}", asm.system_name, self.id);
+                info!("Link {} CN is {cn}", self.id);
 
                 if cn == zpr::VISA_SERVICE_CN {
                     locked_fsm.state = LinkState::Active;
                     debug!(
-                        "{}: Link {} (Visa Service) received agent address.  Becoming active, no authorization required",
-                        asm.system_name, self.id
+                        "Link {} (Visa Service) received agent address.  Becoming active, no authorization required",
+                        self.id
                     );
                     drop(locked_fsm);
                     self.run_active(asm)
@@ -571,7 +548,7 @@ impl LinkStateWrapper {
                                 status: Some(libnode::vsapi::StatusCode::SUCCESS),
                                 ..
                             }) => {
-                                info!("{}: link {link_id} authorized", task_asm.system_name);
+                                info!("link {link_id} authorized");
 
                                 if task_asm
                                     .process_link_state_event(
@@ -588,8 +565,7 @@ impl LinkStateWrapper {
 
                             Ok(cr) => {
                                 warn!(
-                                    "{}: link {link_id} authorization rejected: {}",
-                                    task_asm.system_name,
+                                    "link {link_id} authorization rejected: {}",
                                     cr.reason.unwrap_or("(no reason given)".to_owned())
                                 );
 
@@ -604,10 +580,7 @@ impl LinkStateWrapper {
                             }
 
                             Err(err) => {
-                                warn!(
-                                    "{}: link {link_id} authorization failed: {err}",
-                                    task_asm.system_name
-                                );
+                                warn!("link {link_id} authorization failed: {err}");
 
                                 if task_asm
                                     .process_link_state_event(link_id, LinkEvent::Reset)
@@ -635,10 +608,7 @@ impl LinkStateWrapper {
         match (self.link_type, locked_fsm.state) {
             (LinkType::NodeToAdapter, LinkState::RegisterAA) => {
                 locked_fsm.state = LinkState::Active;
-                debug!(
-                    "{}: Link {} authorized.  Becoming active",
-                    asm.system_name, self.id
-                );
+                debug!("Link {} authorized.  Becoming active", self.id);
                 drop(locked_fsm);
                 self.run_active(asm)
             }
@@ -661,8 +631,8 @@ impl LinkStateWrapper {
                 locked_fsm.state = LinkState::Active;
                 asm.tun_ctl.set_carrier(true).unwrap();
                 debug!(
-                    "{}: Link {} finished registering agent address.  Becoming active",
-                    asm.system_name, self.id
+                    "Link {} finished registering agent address.  Becoming active",
+                    self.id
                 );
                 drop(locked_fsm);
                 self.run_active(asm)
@@ -686,7 +656,7 @@ impl LinkStateWrapper {
     /// Transitions from Closed to Inactive
     #[allow(dead_code)]
     pub fn complete_close(&self, asm: &Assembly) -> Result<(), LinkStateError> {
-        info!("{}: Shutting down link {}", asm.system_name, self.id);
+        info!("Shutting down link {}", self.id);
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         locked_fsm.state = LinkState::Inactive;
         if asm.ph_mode != PhMode::Node {
@@ -699,7 +669,7 @@ impl LinkStateWrapper {
     /// Reset the link, shutting it down and wiping its configuration
     /// Transitions to Initial from any state
     pub fn reset(&self, asm: &Assembly) {
-        info!("{}: Resetting link {}", asm.system_name, self.id);
+        info!("Resetting link {}", self.id);
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         locked_fsm.state = LinkState::Initial;
         locked_fsm.silent = false;
@@ -710,11 +680,8 @@ impl LinkStateWrapper {
         // TODO: Bring down KM
     }
 
-    pub fn run_active(&self, asm: &Assembly) -> Result<(), LinkStateError> {
-        debug!(
-            "{}: Link {} entering active state",
-            asm.system_name, self.id
-        );
+    pub fn run_active(&self, _asm: &Assembly) -> Result<(), LinkStateError> {
+        debug!("Link {} entering active state", self.id);
         // TODO send echoes
         Ok(())
     }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -103,7 +103,7 @@ fn main() -> ExitCode {
 
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
-    info!("{} starting with PID {}", config.name, process::id());
+    info!("starting with PID {}", process::id());
 
     //
     // read key material
@@ -299,7 +299,6 @@ fn main() -> ExitCode {
     let asm = Arc::new(Assembly {
         ph_mode,
         topology_config,
-        system_name: config.name,
         agent_address: config.agent_addr,
         buffer_stack: BufferStack::new(buf_storage),
         agent_input: AgentInput::new(tun_devs.clone()),
@@ -389,8 +388,7 @@ fn main() -> ExitCode {
             warn!("self_addr port is 0 which means dock listening port will be randomly assigned");
         }
         info!(
-            "node {} dock listening on {}",
-            asm.system_name,
+            "dock listening on {}",
             substrate_sockets[0].local_addr().unwrap()
         );
     }
@@ -424,17 +422,11 @@ fn main() -> ExitCode {
     if ph_mode == PhMode::Adapter {
         local_set.block_on(&runtime, async {
             let dsid = zpr::DOCK_LINK_ID;
-            debug!(
-                "{}: waiting on security assocaition establishment on link {}",
-                asm.system_name, dsid
-            );
+            debug!("waiting on security assocaition establishment on link {dsid}");
             while !asm.peer_table.is_security_assocaition_established(dsid) {
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
             }
-            debug!(
-                "{}: security assocaition established successfully on link {}",
-                asm.system_name, dsid
-            );
+            debug!("security assocaition established successfully on link {dsid}");
         });
     }
 
@@ -467,10 +459,7 @@ fn main() -> ExitCode {
                     .run(tokio_util::sync::CancellationToken::new()),
             );
 
-            error!(
-                "{}: visa service connection manager terminated: {res:?}",
-                vsconn_asm.system_name
-            );
+            error!("visa service connection manager terminated: {res:?}");
 
             std::thread::sleep(std::time::Duration::from_secs(1));
         });
@@ -489,7 +478,7 @@ fn main() -> ExitCode {
         }
     });
 
-    info!("{}: exiting", asm.system_name);
+    info!("exiting");
 
     ExitCode::SUCCESS
 }

--- a/adapter/ph/src/mgmt/dock.rs
+++ b/adapter/ph/src/mgmt/dock.rs
@@ -31,8 +31,7 @@ pub async fn bind_agent_address(
         if let Some(id) = asm.peer_table.lookup_special_peer(spname) {
             egress_link_id = id;
         } else {
-            error!("{}: visa request error: special peer routing applies, but special peer ({spname:?}) not connected",
-                asm.system_name);
+            error!("visa request error: special peer routing applies, but special peer ({spname:?}) not connected");
             return Err(BindAgentAddressError::PolicyError);
         }
     } else {
@@ -65,22 +64,19 @@ pub async fn bind_agent_address(
                 }
 
                 Ok(resp) => {
-                    info!("{}: visa request rejected: {resp:?}", asm.system_name);
+                    info!("visa request rejected: {resp:?}");
                     return Err(BindAgentAddressError::PolicyError);
                 }
 
                 Err(err) => {
-                    error!("{}: visa request error: {err}", asm.system_name);
+                    error!("visa request error: {err}");
                     return Err(BindAgentAddressError::PolicyError);
                 }
             }
         }
     }
 
-    debug!(
-        "{}: now routing {} from {} to {}",
-        asm.system_name, five_tuple, ingress_link_id, egress_link_id
-    );
+    debug!("now routing {five_tuple} from {ingress_link_id} to {egress_link_id}");
 
     let route_result = asm
         .add_route(
@@ -92,7 +88,7 @@ pub async fn bind_agent_address(
         )
         .await;
 
-    debug!("{}: route result {:?}", asm.system_name, route_result);
+    debug!("route result {route_result:?}");
 
     // TODO: reverse ingress TID needs to be sent to next-hop;
     // this is blocked on switching to new-style bind requests

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -64,8 +64,7 @@ pub async fn handle_report(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> Handle
 pub async fn handle_discard(asm: &Arc<Assembly>, pkt: BufferPacket) -> HandleMgmtResult {
     // TODO print to debug log, when implemented
     info!(
-        "{}: Discard message received from {}",
-        asm.system_name,
+        "Discard message received from {}",
         pkt.metadata().ingress_link_id
     );
     asm.buffer_stack.put_buffer(pkt.destroy());
@@ -80,10 +79,7 @@ pub async fn handle_hello_request(
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
-    debug!(
-        "{}: Received Hello Request for link {}",
-        asm.system_name, ingress_link_id
-    );
+    debug!("Received Hello Request for link {ingress_link_id}");
 
     if asm
         .process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloRequest)
@@ -119,10 +115,7 @@ pub async fn handle_hello_response(
         return Err((HandleMgmtError::BadStructure, pkt));
     };
     let status = hdr.status;
-    debug!(
-        "{}: Received Hello Response for link {}, status: {}",
-        asm.system_name, ingress_link_id, status
-    );
+    debug!("Received Hello Response for link {ingress_link_id}, status: {status}");
 
     if asm
         .process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloResponse)
@@ -168,10 +161,7 @@ pub async fn handle_register_agent_address_request(
         }
     }
 
-    debug!(
-        "{}: Received Register Agent Address Request for link {} with address {}",
-        asm.system_name, ingress_link_id, agent_address
-    );
+    debug!("Received Register Agent Address Request for link {ingress_link_id} with address {agent_address}");
 
     if asm
         .process_link_state_event(
@@ -205,10 +195,7 @@ pub async fn handle_register_agent_address_response(
     pkt: BufferPacket,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
-    debug!(
-        "{}: Received Register Agent Address Response for link {}",
-        asm.system_name, ingress_link_id
-    );
+    debug!("Received Register Agent Address Response for link {ingress_link_id}");
 
     if asm
         .process_link_state_event(ingress_link_id, LinkEvent::ReceivedRegisterResponse)
@@ -305,10 +292,7 @@ pub async fn handle_bind_agent_address_request(
 
     let Some(ingress_link_id) = NonZero::new(pkt.metadata().ingress_link_id) else {
         // who sent this??
-        error!(
-            "{}: coding error: stray packet from unknown source; dropping",
-            asm.system_name
-        );
+        error!("coding error: stray packet from unknown source; dropping");
         return Ok(());
     };
 

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -62,13 +62,13 @@ pub async fn send_hello_request(asm: &Assembly, link_id: zpr::LinkId) -> Result<
                 return Err(());
             };
             let status = hdr.status;
-            debug!("Received HelloResponse, status: {}", status);
+            debug!("Received HelloResponse, status: {status}");
             asm.buffer_stack.put_buffer(hello_res.destroy());
             Ok(())
         }
 
         Err(err) => {
-            warn!("{} error with HelloRequest", err);
+            warn!("{err} error with HelloRequest");
             Err(())
         }
     }
@@ -80,7 +80,7 @@ pub async fn send_register_agent_address_request(
     link_id: zpr::LinkId,
 ) -> Result<(), ()> {
     let Some(agent_addr) = asm.agent_address else {
-        warn!("{}: No agent address", asm.system_name);
+        warn!("No agent address");
         return Err(());
     };
 

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -48,8 +48,7 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> HandleMgmt
     };
 
     debug!(
-        "{}: handling mgmt message from {} type {:?} seq_num {}",
-        asm.system_name,
+        "handling mgmt message from {} type {:?} seq_num {}",
         pkt.metadata().ingress_link_id,
         base_hdr.packet_type,
         base_hdr.sequence_number

--- a/adapter/ph/src/signal_worker.rs
+++ b/adapter/ph/src/signal_worker.rs
@@ -5,8 +5,8 @@ use crate::counters::*;
 use std::sync::Arc;
 use tokio::signal::unix::{signal, SignalKind};
 
-fn emit_counts(system_name: &String, counters: &Counters) {
-    println!("\n*** {} Counters ***", system_name);
+fn emit_counts(counters: &Counters) {
+    println!("\n*** Counters ***");
     for (key, ref value) in counters {
         println!("{}: {}", key, value.get_count());
     }
@@ -18,9 +18,9 @@ pub async fn launch(asm: Arc<Assembly>) {
 
     loop {
         tokio::select! {
-            _ = usr1_stream.recv() => emit_counts(&asm.system_name, &asm.counters),
+            _ = usr1_stream.recv() => emit_counts(&asm.counters),
             _ = term_stream.recv() => {
-                emit_counts(&asm.system_name, &asm.counters);
+                emit_counts(&asm.counters);
                 std::process::exit(128 + SignalKind::terminate().as_raw_value())
             }
         }

--- a/adapter/ph/src/vs_worker.rs
+++ b/adapter/ph/src/vs_worker.rs
@@ -4,11 +4,8 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::*;
 
-pub async fn launch(asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSOutput>) {
+pub async fn launch(_asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSOutput>) {
     while let Some(msg) = queue.recv().await {
-        debug!(
-            "{}: received VS message {msg:?}; ignoring! (unimplemented)",
-            asm.system_name
-        );
+        debug!("received VS message {msg:?}; ignoring! (unimplemented)");
     }
 }

--- a/adapter/ph/src/vss_worker.rs
+++ b/adapter/ph/src/vss_worker.rs
@@ -4,11 +4,8 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::*;
 
-pub async fn launch(asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSSMsg>) {
+pub async fn launch(_asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSSMsg>) {
     while let Some(msg) = queue.recv().await {
-        info!(
-            "{}: received VSS message {msg:?}; ignoring! (unimplemented)",
-            asm.system_name
-        );
+        info!("received VSS message {msg:?}; ignoring! (unimplemented)");
     }
 }

--- a/integration-test/capture-test.sh
+++ b/integration-test/capture-test.sh
@@ -89,7 +89,7 @@ emit_vs_config ca vs.zpr > vs-config.yaml
 sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$VS_BIN" \
     -c vs-config.yaml \
     -p "$PREGEN/v6-1node-2agent-ping.bin" \
-    --listen_addr ["$VS_ZPR_ADDR6"]:5002 &
+    --listen_addr ["$VS_ZPR_ADDR6"]:5002 2>&1 | tee vs.log | prefix_log vs &
 
 sleep 2
 
@@ -105,7 +105,7 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --certificate-file node.crt \
   --private-key-file node.key \
   --tun-if tun0 \
-  --agent-addr "$NODE_ZPR_ADDR6" 2>&1 |tee node.log &
+  --agent-addr "$NODE_ZPR_ADDR6" 2>&1 | tee node.log | prefix_log zpr-node &
 
 sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
@@ -118,7 +118,7 @@ sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_VS":12345 \
   --node-public-key-file node.pubkey \
-  --agent-addr "$VS_ZPR_ADDR6" 2>&1 |tee vs.log &
+  --agent-addr "$VS_ZPR_ADDR6" 2>&1 | tee adapter-vs.log | prefix_log zpr-vs &
 
 sleep 2
 
@@ -133,7 +133,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_A":12345 \
   --agent-addr "$A_ZPR_ADDR6" \
-  --node-public-key-file node.pubkey 2>&1 |tee adapter1.log &
+  --node-public-key-file node.pubkey 2>&1 | tee adapter1.log | prefix_log zpr-a &
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
@@ -146,7 +146,7 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_B":12345 \
   --agent-addr "$B_ZPR_ADDR6" \
-  --node-public-key-file node.pubkey 2>&1 |tee adapter2.log &
+  --node-public-key-file node.pubkey 2>&1 | tee adapter2.log | prefix_log zpr-b &
 
 sleep 1 # FIXME: I think we need this b/c DTLS doesn't deal with dropped initial packet well
 set_program "$ADAPTER1_SOCK" "$TMPDIR/cap_test1.pcap" 'link[0] == 1'

--- a/integration-test/common_funcs.sh
+++ b/integration-test/common_funcs.sh
@@ -9,6 +9,12 @@ ZPR_PKI_BIN=$(realpath "$(dirname $0)/../tools/zpr-pki")
 # Functions used in multiple integration tests
 #
 
+function prefix_log() {
+  SYSNAME=$1
+  printf -v PREFIX '%10s' "[$SYSNAME]"
+  sed "s/^/$PREFIX /"
+}
+
 function wait_for() {
   RETRIES=$1
   shift

--- a/integration-test/one-node-v6-test.sh
+++ b/integration-test/one-node-v6-test.sh
@@ -77,7 +77,7 @@ echo "Launching Visa Service"
 sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$VS_BIN" \
     -c vs-config.yaml \
     -p "$PREGEN/v6-1node-2agent-ping.bin" \
-    --listen_addr "[$VS_ZPR_ADDR6]":5002 2>&1 | tee vs.log &
+    --listen_addr "[$VS_ZPR_ADDR6]":5002 2>&1 | tee vs.log | prefix_log vs &
 
 sleep 2
 
@@ -98,7 +98,7 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
      --certificate-file node.crt \
      --private-key-file node.key \
      --tun-if tun0 \
-     --agent-addr "$NODE_ZPR_ADDR6" 2>&1 |tee node.log &
+     --agent-addr "$NODE_ZPR_ADDR6" 2>&1 | tee node.log | prefix_log zpr-node &
 
 sleep 2  # TODO: remove?
 
@@ -115,7 +115,7 @@ sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_VS":12345 \
   --node-public-key-file node.pubkey \
-  --agent-addr "$VS_ZPR_ADDR6" 2>&1 |tee adapter-vs.log &
+  --agent-addr "$VS_ZPR_ADDR6" 2>&1 | tee adapter-vs.log | prefix_log zpr-vs &
 
 sleep 5
 
@@ -130,7 +130,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_A":12345 \
   --node-public-key-file node.pubkey \
-  --agent-addr "$A_ZPR_ADDR6" 2>&1 |tee adapter1.log &
+  --agent-addr "$A_ZPR_ADDR6" 2>&1 | tee adapter1.log | prefix_log zpr-a &
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
@@ -143,7 +143,7 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_B":12345 \
   --node-public-key-file node.pubkey \
-  --agent-addr "$B_ZPR_ADDR6" 2>&1 |tee adapter2.log &
+  --agent-addr "$B_ZPR_ADDR6" 2>&1 | tee adapter2.log | prefix_log zpr-b &
 
 #
 # Wait for connectivity


### PR DESCRIPTION
We now prefix all log messages with the system name _in the integration tests_.  No longer is it the responsibility of each log statement.

Only changes to Rust code are removing `system_name` arguments from log calls (and in some cases, moving other arguments into the format string).  Also removed `system_name` from the `Assembly` as it's no longer used.

Aside – the only use of config.name at this point is for the node agent, which I believe is incorrect (we should use the node's CN).  I'll address that in another PR.