### PR TITLE
Log categories

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -2,6 +2,7 @@ use crate::adapter_tables::{AltEntry, AltPep};
 use crate::assembly::{Assembly, PhMode};
 use crate::counters::CounterType;
 use crate::fastpath;
+use crate::logging::targets::FLOW_MGMT;
 use crate::mgmt;
 use crate::packet::BufferPacket;
 use crate::queues::AdapterManagerMessage;
@@ -49,7 +50,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: BufferPacket) {
             .peer_table
             .is_security_assocaition_established(dock_link_id)
     {
-        warn!("Link {dock_link_id} has no security association, aborting bind request operation");
+        warn!(target: FLOW_MGMT, "Link {dock_link_id} has no security association, aborting bind request operation");
         fastpath::drop_and_count(asm, pkt, CounterType::DroppedNoSA);
         return;
     }
@@ -63,7 +64,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: BufferPacket) {
     // compress only IP addresses for now
     let compression_mode: zpr::CompressionMode = 0;
 
-    info!("link {dock_link_id}: Issuing bind request for {five_tuple} (is now set PENDING)");
+    info!(target: FLOW_MGMT, "link {dock_link_id}: Issuing bind request for {five_tuple} (is now set PENDING)");
 
     let bind_result = match asm.ph_mode {
         PhMode::Adapter => {
@@ -93,7 +94,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: BufferPacket) {
     match bind_result {
         Ok(tether_id) => {
             // Bind succeeded; add to ALT.
-            info!("Bind of {five_tuple} succeeded: {tether_id}");
+            info!(target: FLOW_MGMT, "Bind of {five_tuple} succeeded: {tether_id}");
 
             let AltEntry::Pending(initial_packet) = asm
                 .alt
@@ -126,7 +127,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: BufferPacket) {
 
         Err(err) => {
             // Bind failed; remove pending entry from ALT.
-            error!("Bind of {five_tuple} failed: {err}");
+            error!(target: FLOW_MGMT, "Bind of {five_tuple} failed: {err}");
             asm.alt.remove(&five_tuple);
         }
     }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -10,6 +10,7 @@ use crate::km_cert_exchange::KmCertExchange;
 use crate::km_multiplexor::KmState;
 use crate::km_noise;
 use crate::link_state::{LinkEvent, LinkStateError, LinkType};
+use crate::logging::targets::PEER_MGMT;
 use crate::mgmt;
 use crate::mgmt_processor_worker;
 use crate::peer_table;
@@ -155,7 +156,7 @@ impl Assembly {
         link_type: LinkType,
     ) -> Result<NonZero<LinkId>, PeerInsertError> {
         assert!(link_type != LinkType::NodeToNode);
-        debug!("Starting tether with {adapter_addr}");
+        debug!(target: PEER_MGMT, "Starting tether with {adapter_addr}");
         let peer_id = self.add_peer(link_type, adapter_addr)?;
         self.peer_ids.lock().unwrap().push(peer_id.get());
 
@@ -168,7 +169,7 @@ impl Assembly {
             .link_state_machine
             .process_event(self, LinkEvent::Configure)
         {
-            error!("Link {peer_id} failed to configure with error {e}.  Resetting");
+            error!(target: PEER_MGMT, "Link {peer_id} failed to configure with error {e}.  Resetting");
             let _ = peer
                 .link_state_machine
                 .process_event(self, LinkEvent::Reset);
@@ -177,12 +178,12 @@ impl Assembly {
                 .link_state_machine
                 .process_event(self, LinkEvent::Start)
             {
-                error!("Link {peer_id} failed to start with error {e}.  Resetting");
+                error!(target: PEER_MGMT, "Link {peer_id} failed to start with error {e}.  Resetting");
                 let _ = peer
                     .link_state_machine
                     .process_event(self, LinkEvent::Reset);
             } else {
-                info!("Successfully started tether with {adapter_addr}.  Assigned ID {peer_id}");
+                info!(target: PEER_MGMT, "Successfully started tether with {adapter_addr}.  Assigned ID {peer_id}");
             }
         }
 

--- a/adapter/ph/src/capture_worker.rs
+++ b/adapter/ph/src/capture_worker.rs
@@ -1,4 +1,5 @@
 use crate::assembly::Assembly;
+use crate::logging::targets::CAPTURE;
 use crate::pcap_writer::*;
 use crate::queues::CapPacket;
 use std::io;
@@ -74,10 +75,12 @@ pub async fn launch(config: Config, asm: Arc<Assembly>, mut queue: mpsc::Receive
                     Ok(()) => (),
 
                     Err(err) => {
-                        error!("Error writing to capture file, ending capture: {}", err);
+                        error!(target: CAPTURE, "Error writing to capture file, ending capture: {}", err);
                         match state.savefile.take().unwrap().close().await {
                             Ok(_file) => (),
-                            Err(err) => error!("Error closing capture file: {}", err),
+                            Err(err) => {
+                                error!(target: CAPTURE, "Error closing capture file: {}", err)
+                            }
                         }
                     }
                 }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -11,6 +11,7 @@ use crate::counters::CounterType;
 use crate::defs::Direction;
 use crate::km::Codec;
 use crate::km_noise::NOISE_PADLEN;
+use crate::logging::targets::DATAPATH;
 use crate::net_defs;
 use crate::packet::{BufferPacket, Packet, PacketBuffer};
 use crate::queues::TryEnqueueError;
@@ -30,7 +31,7 @@ use zpr_ext::zerocopy::*;
 /// Drop a packet and count the drop with the given reason.
 pub fn drop_and_count(asm: &Assembly, pkt: BufferPacket, reason: impl Into<CounterType>) {
     let reason = reason.into();
-    debug!("dropping packet because {reason}");
+    debug!(target: DATAPATH, "dropping packet because {reason}");
     asm.buffer_stack.put_buffer(pkt.destroy());
     asm.counters[reason.into()].increment();
 }
@@ -271,7 +272,7 @@ pub fn decrypt_full(
             pkt.put(&decr_buf[0..len]); // copy over cleartext body
         }
         Err(e) => {
-            error!("decryption failed: {}", e);
+            error!(target: DATAPATH, "decryption failed: {}", e);
             return Err(DecryptError::DecryptionFailure);
         }
     }
@@ -288,7 +289,7 @@ fn substrate_egress_common(
     let zdp_hdr = match zdp::ZdpBaseHeader::ref_from_prefix(&pkt.body()) {
         Ok((zdp_hdr, _)) => zdp_hdr,
         Err(_) => {
-            error!("egress: link {}: failed to parse the ZDP header", link_id);
+            error!(target: DATAPATH, "egress: link {}: failed to parse the ZDP header", link_id);
             return Err(km::EncryptionError::ParseError);
         }
     };
@@ -310,7 +311,7 @@ fn substrate_egress_common(
     //       See https://github.com/org-zpr/zpr-core/issues/444
     let transport_sa;
     if zdp_hdr.packet_type == zdp::ZdpPacketType::KeyManagement {
-        debug!("link {link_id}: KM message detected, using ZPI=0 ignoring security association");
+        debug!(target: DATAPATH, "link {link_id}: KM message detected, using ZPI=0 ignoring security association");
         transport_sa = None;
     } else {
         transport_sa = peer_state.get_established_transport_association();
@@ -363,7 +364,7 @@ pub fn substrate_egress(asm: &Assembly, link_id: zpr::LinkId, mut pkt: BufferPac
             return;
         }
         Err(err) => {
-            error!("egress: link {}: encryption error: {}", link_id, err);
+            error!(target: DATAPATH, "egress: link {}: encryption error: {}", link_id, err);
             drop_and_count(asm, pkt, CounterType::EncryptionFailure);
             return;
         }
@@ -394,7 +395,7 @@ pub async fn substrate_egress_blocking(
             return;
         }
         Err(err) => {
-            error!("egress: link {}: encryption error: {}", link_id, err);
+            error!(target: DATAPATH, "egress: link {}: encryption error: {}", link_id, err);
             drop_and_count(asm, pkt, CounterType::EncryptionFailure);
             return;
         }
@@ -434,17 +435,6 @@ pub fn substrate_ingress(
 
     pkt.metadata_mut().ingress_link_id = asm.peer_table.lookup_peer(peer_sa).unwrap_or_zero();
 
-    if pkt.metadata().ingress_link_id == 0 {
-        warn!("got packet from {peer_sa} which isn't in the peer table; peer table contains:");
-        let ids = asm.peer_ids.lock().unwrap().clone();
-        for id in ids {
-            if let Some(peer) = asm.peer_table.get(id) {
-                warn!("{id}: {}", peer.substrate_addr);
-            }
-        }
-        warn!("[end of peer table]");
-    }
-
     // Read, but do not remove the ZPI header
     let Ok((zpi_hdr, _)) = zdp::ZdpZpiHeader::read_from_prefix(&pkt.body()) else {
         drop_and_count(asm, pkt, CounterType::BadStructure);
@@ -479,6 +469,7 @@ pub fn substrate_ingress(
                 } else {
                     // We have an SA and ZPI does not match.
                     warn!(
+                        target: DATAPATH,
                         "ingress: link {}: unexpected ZPI value {} (expected {:?})",
                         pkt.metadata().ingress_link_id,
                         zpi_hdr.zpi,
@@ -490,13 +481,14 @@ pub fn substrate_ingress(
             }
             None => {
                 // Either no security association on link, or it is not yet established.
-                warn!("INSECURE, no SA on link {}", pkt.metadata().ingress_link_id);
+                warn!(target: DATAPATH, "INSECURE, no SA on link {}", pkt.metadata().ingress_link_id);
                 secure = false;
             }
         },
         None => {
             // No link in peer table
             warn!(
+                target: DATAPATH,
                 "INSECURE, no link in peer table for {}",
                 pkt.metadata().ingress_link_id
             );
@@ -508,6 +500,7 @@ pub fn substrate_ingress(
         // Not under a security assocation, which means only ZPI 0 is allowed.
         if zpi_hdr.zpi != zpr::ZPI_0 && pkt.metadata().ingress_link_id != zpr::LINK_ID_UNKNOWN {
             warn!(
+                target: DATAPATH,
                 "ingress: {}: ZPI {} not allowed on unestablished SA",
                 pkt.metadata().ingress_link_id,
                 zpi_hdr.zpi
@@ -516,6 +509,7 @@ pub fn substrate_ingress(
             return;
         }
         warn!(
+            target: DATAPATH,
             "INSECURE, decrypting null packet from {}",
             pkt.metadata().ingress_link_id
         );
@@ -560,6 +554,7 @@ pub fn substrate_ingress(
     // Can be overridden (FOR TESTING ONLY) in the flags.
     if !secure && base_hdr.packet_type != zdp::ZdpPacketType::KeyManagement {
         warn!(
+            target: DATAPATH,
             "ingress: link {}: ZPI 0 only allows key management messages, not {:?}",
             pkt.metadata().ingress_link_id,
             base_hdr.packet_type
@@ -747,7 +742,7 @@ pub fn agent_output_post_classify(asm: &Assembly, mut pkt: BufferPacket, allow_b
             }
 
             // issue bind request
-            info!("issuing bind request for {five_tuple}");
+            info!(target: DATAPATH, "issuing bind request for {five_tuple}");
             match asm.adapter_manager.try_request_tether_id(pkt) {
                 Ok(()) => (),
                 Err(TryEnqueueError::Full(pkt)) => {

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -18,6 +18,7 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use thiserror::Error;
 use tokio::sync::mpsc;
 use tokio::time;
 use tokio_util::sync::CancellationToken;
@@ -25,133 +26,68 @@ use tracing::*;
 use zerocopy::FromBytes;
 use zpr;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 #[allow(dead_code)]
 pub enum KmError {
+    #[error("ConfigurationError")]
     ConfigurationError,
+    #[error("InvalidState")]
     InvalidState,
+    #[error("InvalidPacketType")]
     InvalidPacketType,
+    #[error("HandshakeError")]
     HandshakeError,
+    #[error("CertExchangeError")]
     CertExchangeError,
+    #[error("NoHeadroom")]
     NoHeadroom,
+    #[error("ShortPacket")]
     ShortPacket,
+    #[error("SaIdZero")]
     SaIdZero,
+    #[error("SaIdMismatch")]
     SaIdMismatch,
+    #[error("EnqueueFailued")]
     EnqueueFailed,
+    #[error("MachineError: {0}")]
     MachineError(String),
-    IoError(std::io::Error),
+    #[error("IoError: {0}")]
+    IoError(#[from] std::io::Error),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum EncryptionError {
     /// Unspecified error occurred in the encryption implementation.  The string arg is an error description.
+    #[error("InternalError: {0}")]
     InternalError(String),
 
     /// Message is too large for the encryption implementation to handle.
+    #[error("MessageTooLarge")]
     MessageTooLarge,
 
     /// Message is malformed in some way.
+    #[error("ParseError")]
     ParseError,
 }
 
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum DecryptionError {
     /// Unspecified error occurred in the decryption implementation.  The string arg is an error description.
+    #[error("InternalError: {0}")]
     InternalError(String),
 
     /// Message is too short to be decrypted.
+    #[error("MessageTooShort")]
     MessageTooShort,
 
     /// Message is malformed in some way.
+    #[error("ParseError")]
     ParseError,
 
     /// Unable to decrypt the message due to wrong key or some other cipher issue.
+    #[error("DecryptFailed")]
     DecryptFailed,
-}
-
-impl fmt::Display for DecryptionError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            DecryptionError::InternalError(ref s) => {
-                write!(f, "InternalError: {}", s)
-            }
-            DecryptionError::MessageTooShort => {
-                write!(f, "MessageTooShort")
-            }
-            DecryptionError::ParseError => {
-                write!(f, "ParseError")
-            }
-            DecryptionError::DecryptFailed => {
-                write!(f, "DecryptFailed")
-            }
-        }
-    }
-}
-
-impl fmt::Display for EncryptionError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            EncryptionError::InternalError(ref s) => {
-                write!(f, "InternalError: {}", s)
-            }
-            EncryptionError::MessageTooLarge => {
-                write!(f, "MessageTooLarge")
-            }
-            EncryptionError::ParseError => {
-                write!(f, "ParseError")
-            }
-        }
-    }
-}
-
-impl fmt::Display for KmError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            KmError::InvalidState => {
-                write!(f, "InvalidState")
-            }
-            KmError::HandshakeError => {
-                write!(f, "HandshakeError")
-            }
-            KmError::CertExchangeError => {
-                write!(f, "CertExchangeError")
-            }
-            KmError::ConfigurationError => {
-                write!(f, "ConfigurationError")
-            }
-            KmError::MachineError(ref s) => {
-                write!(f, "MachineError: {}", s)
-            }
-            KmError::IoError(ref e) => {
-                write!(f, "IoError: {}", e)
-            }
-            KmError::InvalidPacketType => {
-                write!(f, "InvalidPacketType")
-            }
-            KmError::NoHeadroom => {
-                write!(f, "NoHeadroom")
-            }
-            KmError::ShortPacket => {
-                write!(f, "ShortPacket")
-            }
-            KmError::SaIdZero => {
-                write!(f, "SaIdZero")
-            }
-            KmError::SaIdMismatch => {
-                write!(f, "SaIdMismatch")
-            }
-            KmError::EnqueueFailed => {
-                write!(f, "EnqueueFailed")
-            }
-        }
-    }
-}
-
-impl From<std::io::Error> for KmError {
-    fn from(e: std::io::Error) -> KmError {
-        KmError::IoError(e)
-    }
 }
 
 // Copying of off std::io::Result

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -9,6 +9,7 @@
 //! parsing key management ZDP messages.
 
 use crate::config;
+use crate::logging::targets::KEY_MGMT;
 use crate::packet::{Packet, PacketBuffer};
 use crate::zdp::{ZdpBaseHeader, ZdpPacketType, ZdpZpiHeader};
 use bytes::{BufMut, Bytes};
@@ -331,7 +332,7 @@ impl KeyManager {
         self.start_state_machine_internal(link_id, &km_signals_out, &km_buffers_out)
             .await
             .or_else(|e| {
-                error!("failed to start state machine: {}", e);
+                error!(target: KEY_MGMT, "failed to start state machine: {}", e);
                 Err(e)
             })?;
 
@@ -418,7 +419,7 @@ impl KeyManager {
         {
             Ok(_) => {}
             Err(_) => {
-                error!("failed to enqueue reset signal")
+                error!(target: KEY_MGMT, "failed to enqueue reset signal")
             }
         };
 
@@ -476,7 +477,7 @@ impl KeyManager {
                 match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
                     Ok(_) => {}
                     Err(_) => {
-                        error!("failed to enqueue outbound KM message");
+                        error!(target: KEY_MGMT, "failed to enqueue outbound KM message");
                         return Err(KmError::EnqueueFailed);
                     }
                 }
@@ -488,7 +489,7 @@ impl KeyManager {
                 {
                     Ok(_) => {}
                     Err(_) => {
-                        error!("failed to enqueue reset signal, aborting");
+                        error!(target: KEY_MGMT, "failed to enqueue reset signal, aborting");
                         return Err(KmError::EnqueueFailed);
                     }
                 }
@@ -503,7 +504,7 @@ impl KeyManager {
                 resp = match state.statemachine.tick() {
                     Ok(h) => h,
                     Err(e) => {
-                        warn!("error during tick processing: {}", e);
+                        warn!(target: KEY_MGMT, "error during tick processing: {}", e);
                         None
                     }
                 };
@@ -512,7 +513,7 @@ impl KeyManager {
                 match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
                     Ok(_) => {}
                     Err(_) => {
-                        error!("failed to enqueue oubound KM message");
+                        error!(target: KEY_MGMT, "failed to enqueue oubound KM message");
                         return Err(KmError::EnqueueFailed);
                     }
                 }
@@ -528,7 +529,7 @@ impl KeyManager {
         link_id: zpr::LinkId,
         km_signals_out: &mpsc::Sender<KmLinkMsg<KmSignal>>,
     ) -> KmResult<()> {
-        debug!("KM state transition {:?} -> {:?}", prev_state, next_state);
+        debug!(target: KEY_MGMT, "state transition {:?} -> {:?}", prev_state, next_state);
         if matches!(prev_state, KmSMState::Error) {
             // We transitioned out of error state -- clear error related settings.
             let mut state = self.shared.state.lock().unwrap();
@@ -552,7 +553,7 @@ impl KeyManager {
                     my_sa.sa_id = cur_id;
                     state.ts = my_sa.clone();
                 }
-                debug!("KM: New SA_ID: {}", cur_id);
+                debug!(target: KEY_MGMT, "New SA_ID: {}", cur_id);
                 match self
                     .send_signal(
                         &km_signals_out,
@@ -566,7 +567,7 @@ impl KeyManager {
                 {
                     Ok(_) => {}
                     Err(_) => {
-                        error!("failed to enqueue SaIdChange signal");
+                        error!(target: KEY_MGMT, "failed to enqueue SaIdChange signal");
                         return Err(KmError::EnqueueFailed);
                     }
                 }
@@ -576,7 +577,7 @@ impl KeyManager {
                 {
                     Ok(_) => {}
                     Err(_) => {
-                        error!("failed to enqueue SaIdEstablished signal");
+                        error!(target: KEY_MGMT, "failed to enqueue SaIdEstablished signal");
                         return Err(KmError::EnqueueFailed);
                     }
                 }
@@ -594,7 +595,7 @@ impl KeyManager {
                     {
                         Ok(_) => {}
                         Err(_) => {
-                            error!("failed to enqueue error signal, aborting");
+                            error!(target: KEY_MGMT, "failed to enqueue error signal, aborting");
                             return Err(KmError::EnqueueFailed);
                         }
                     }
@@ -623,7 +624,7 @@ impl KeyManager {
             resp = match state.statemachine.handle_message(&inmsg) {
                 Ok(h) => h,
                 Err(e) => {
-                    error!("failed to handle key manager message: {}", e);
+                    error!(target: KEY_MGMT, "failed to handle key manager message: {e}");
                     None
                 }
             };
@@ -632,7 +633,7 @@ impl KeyManager {
             match km_buffers_out.send(KmLinkMsg::new(link_id, r)).await {
                 Ok(_) => {}
                 Err(_) => {
-                    error!("failed to enqueue outbound KM message");
+                    error!(target: KEY_MGMT, "failed to enqueue outbound KM message");
                     return Err(KmError::EnqueueFailed);
                 }
             }

--- a/adapter/ph/src/km_cert_exchange.rs
+++ b/adapter/ph/src/km_cert_exchange.rs
@@ -19,7 +19,6 @@
 
 use openssl::pkey::PKey;
 use openssl::x509::X509;
-use std::fmt;
 use std::fs;
 use std::path::Path;
 use tracing::error;
@@ -43,22 +42,12 @@ pub enum CertExchangeError {
     KeyMismatchError,
 }
 
+#[derive(Debug)]
 pub enum ParseError {
     PEMCertNotFound,
     PEMFormatError,
     KeyError,
-    IOError(std::io::Error),
-}
-
-impl fmt::Debug for ParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ParseError::PEMCertNotFound => write!(f, "PEMCertNotFound"),
-            ParseError::PEMFormatError => write!(f, "PEMFormatError"),
-            ParseError::KeyError => write!(f, "KeyError"),
-            ParseError::IOError(e) => write!(f, "IO Error: {}", e),
-        }
-    }
+    IOError(#[allow(dead_code)] std::io::Error),
 }
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]

--- a/adapter/ph/src/km_cert_exchange.rs
+++ b/adapter/ph/src/km_cert_exchange.rs
@@ -26,6 +26,7 @@ use zerocopy::byteorder::network_endian::*;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::km_noise::NOISE_KEY_LEN;
+use crate::logging::targets::KEY_MGMT;
 
 const PEM_BEGIN_CERTIFICATE: &str = "-----BEGIN CERTIFICATE-----";
 const PEM_END_CERTIFICATE: &str = "-----END CERTIFICATE-----";
@@ -91,14 +92,14 @@ impl KmCertExchange {
         let cert = match X509::from_pem(cert_pem.as_bytes()) {
             Ok(c) => c,
             Err(e) => {
-                error!("error constructing cert from PEM data: {}", e);
+                error!(target: KEY_MGMT, "error constructing cert from PEM data: {e}");
                 return Err(ParseError::PEMFormatError);
             }
         };
         let authority_cert = match X509::from_pem(authority_cert_pem.as_bytes()) {
             Ok(c) => c,
             Err(e) => {
-                error!("error constructing cert from PEM data: {}", e);
+                error!(target: KEY_MGMT, "error constructing cert from PEM data: {e}");
                 return Err(ParseError::PEMFormatError);
             }
         };
@@ -165,7 +166,7 @@ impl KmCertExchange {
         let initiator_cert = match X509::from_der(&payload[cert_offset..]) {
             Ok(c) => c,
             Err(e) => {
-                error!("error constructing cert from DER data: {}", e);
+                error!(target: KEY_MGMT, "error constructing cert from DER data: {e}");
                 return Err(CertExchangeError::CertificateParseError);
             }
         };
@@ -176,7 +177,7 @@ impl KmCertExchange {
             match initiator_cert.verify(&authority_pkey) {
                 Ok(_) => (),
                 Err(e) => {
-                    error!("cert verification failed: {}", e);
+                    error!(target: KEY_MGMT, "cert verification failed: {e}");
                     return Err(CertExchangeError::CertificateVerificationError);
                 }
             }
@@ -186,7 +187,7 @@ impl KmCertExchange {
         let initiator_public_key = match initiator_cert.public_key() {
             Ok(p) => p,
             Err(e) => {
-                error!("error extracting public key from cert: {}", e);
+                error!(target: KEY_MGMT, "error extracting public key from cert: {e}");
                 return Err(CertExchangeError::CertificateFormatError);
             }
         };
@@ -198,7 +199,7 @@ impl KmCertExchange {
                 }
             }
             Err(e) => {
-                error!("unable to get raw public key: {}", e);
+                error!(target: KEY_MGMT, "unable to get raw public key: {e}");
                 return Err(CertExchangeError::KeyError);
             }
         }
@@ -248,7 +249,7 @@ pub fn load_cert(path: &Path) -> Result<X509, ParseError> {
     match X509::from_pem(cert_pem_data.as_bytes()) {
         Ok(cert) => Ok(cert),
         Err(e) => {
-            error!("error constructing cert from PEM data: {}", e);
+            error!(target: KEY_MGMT, "error constructing cert from PEM data: {e}");
             Err(ParseError::PEMFormatError)
         }
     }
@@ -264,7 +265,7 @@ pub fn load_private_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseError> 
     let pk = match PKey::private_key_from_pem(&contents.as_bytes()) {
         Ok(k) => k,
         Err(e) => {
-            error!("error reading key from PEM data: {}", e);
+            error!(target: KEY_MGMT, "error reading key from PEM data: {e}");
             return Err(ParseError::PEMFormatError);
         }
     };
@@ -276,7 +277,7 @@ pub fn load_private_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseError> 
             Ok(key)
         }
         Err(e) => {
-            error!("error extracting raw key: {}", e);
+            error!(target: KEY_MGMT, "error extracting raw key: {e}");
             Err(ParseError::KeyError)
         }
     }
@@ -291,7 +292,7 @@ pub fn load_public_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseError> {
     let pk = match PKey::public_key_from_pem(&contents.as_bytes()) {
         Ok(k) => k,
         Err(e) => {
-            error!("error reading key from PEM data: {}", e);
+            error!(target: KEY_MGMT, "error reading key from PEM data: {e}");
             return Err(ParseError::PEMFormatError);
         }
     };
@@ -300,9 +301,9 @@ pub fn load_public_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseError> {
         Ok(k) => {
             if k.len() != NOISE_KEY_LEN {
                 error!(
-                    "public key in cert is incorrect length (got {} bytes, expected {})",
+                    target: KEY_MGMT,
+                    "public key in cert is incorrect length (got {} bytes, expected {NOISE_KEY_LEN})",
                     k.len(),
-                    NOISE_KEY_LEN
                 );
                 return Err(ParseError::KeyError);
             }
@@ -310,7 +311,7 @@ pub fn load_public_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseError> {
             Ok(key)
         }
         Err(e) => {
-            error!("error extracting raw key: {}", e);
+            error!(target: KEY_MGMT, "error extracting raw key: {e}");
             Err(ParseError::KeyError)
         }
     }

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -3,6 +3,7 @@ use crate::km::*;
 use crate::km_cert_exchange::KmCertExchange;
 use crate::km_noise::{KmNoise, NoiseKeypair};
 use crate::link_state::LinkEvent;
+use crate::logging::targets::{KEY_MGMT, LINK_STATE};
 use crate::mgmt::requests;
 use crate::peer_table::KmHandle;
 use bytes::Bytes;
@@ -86,7 +87,7 @@ pub async fn launch_signal_worker(
     loop {
         tokio::select! {
             _ = sp_ctok.cancelled() => {
-                debug!("KM Multiplexor shutting down");
+                debug!(target: KEY_MGMT, "Multiplexor shutting down");
                 break;
             }
 
@@ -97,43 +98,43 @@ pub async fn launch_signal_worker(
                         if let Some(km) = asm.peer_table.clone_km_manager(*link_id) {
                             match km.restart() {
                                 Ok(_) => {
-                                    debug!("km_multiplexor: restarted key manager on link {link_id} (error_count = {})", stat.error_count);
+                                    debug!(target: KEY_MGMT, "multiplexor: restarted key manager on link {link_id} (error_count = {})", stat.error_count);
                                     stat.restart_t = now;
                                 }
                                 Err(e) => {
-                                    error!("km_multiplexor: failed to restart KM on link {link_id}: {e:?}");
+                                    error!(target: KEY_MGMT, "multiplexor: failed to restart KM on link {link_id}: {e:?}");
                                     stat.error_count += 1;
                                 }
                             }
                         } else {
-                            error!("km_multiplexor: unable to restart key manager on link {link_id}: not found in peer table");
+                            error!(target: KEY_MGMT, "multiplexor: unable to restart key manager on link {link_id}: not found in peer table");
                         }
                     }
                 }
             }
 
             Some(linkmsg) = sig_queue.recv() => {
-                debug!("km_multiplexor: link: {}, signal {:?}", linkmsg.link_id, linkmsg.msg);
+                debug!(target: KEY_MGMT, "multiplexor: link: {}, signal {:?}", linkmsg.link_id, linkmsg.msg);
                 match linkmsg.msg {
                     KmSignal::SaIdChange { old, new } => {
-                        debug!("km_multiplexor: SA ID change on link {}: {} -> {}", linkmsg.link_id, old, new);
+                        debug!(target: KEY_MGMT, "multiplexor: SA ID change on link {}: {} -> {}", linkmsg.link_id, old, new);
                         if old == 0 {
                             let _ = status.remove(&linkmsg.link_id);
                         }
                     }
                     KmSignal::SaEstablished(sa) => {
-                        debug!("km_multiplexor: link {}: SA established (SEND_ZPIS: {}, RECV_ZPIS: {}",
+                        debug!(target: KEY_MGMT, "multiplexor: link {}: SA established (SEND_ZPIS: {}, RECV_ZPIS: {}",
                             linkmsg.link_id, sa.send_zpis, sa.recv_zpis);
 
                         match asm.peer_table.set_security_association(linkmsg.link_id, sa) {
                             Ok(_) => (),
                             Err(e) => {
-                                error!("km_multiplexor: failed to set SA established: {e:?}");
+                                error!(target: KEY_MGMT, "multiplexor: failed to set SA established: {e:?}");
                             }
                         }
                         match asm.process_link_state_event(linkmsg.link_id, LinkEvent::KeyingDone) {
                             Err(e) => {
-                                error!("Link state error: {e:?}");
+                                error!(target: LINK_STATE, "error: {e:?}");
                             }
                             Ok(_) => (),
                         }
@@ -162,11 +163,11 @@ pub async fn launch_signal_worker(
                         };
                         stat.error_count += 1;
                         stat.last_error_t = time::Instant::now();
-                        warn!("km_multiplexor: Error signal on link {}", linkmsg.link_id);
+                        warn!(target: KEY_MGMT, "multiplexor: Error signal on link {}", linkmsg.link_id);
                     }
                     KmSignal::Termination => {
                         let _ = status.remove(&linkmsg.link_id);
-                        debug!("km_multiplexor: termination signal on link {}", linkmsg.link_id);
+                        debug!(target: KEY_MGMT, "multiplexor: termination signal on link {}", linkmsg.link_id);
                     }
                 }
             }
@@ -252,7 +253,7 @@ pub async fn drop_link(asm: &Assembly, link_id: zpr::LinkId) {
         match kmh.join_handle.await {
             Ok(_) => (),
             Err(e) => {
-                error!("KeyManager statemachine shutdown join failed on link {link_id}: {e:?}");
+                error!(target: KEY_MGMT, "statemachine shutdown join failed on link {link_id}: {e:?}");
             }
         }
     }
@@ -287,7 +288,7 @@ fn add_noise_link(
         {
             Ok(_) => (),
             Err(e) => {
-                error!("KeyManager failed on link {link_id}: {e:?}");
+                error!(target: KEY_MGMT, "failed on link {link_id}: {e:?}");
             }
         }
     });

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -34,6 +34,7 @@
 
 use crate::km::*;
 use crate::km_cert_exchange::KmCertExchange;
+use crate::logging::targets::KEY_MGMT;
 use base64::prelude::*;
 use bytes::{BufMut, Bytes, BytesMut};
 use curve25519_dalek::montgomery::MontgomeryPoint;
@@ -187,7 +188,7 @@ impl KmNoise {
         certx: KmCertExchange,
     ) -> Result<Self, KmError> {
         if initiate && peer_pub_key.is_none() {
-            error!("noise: peer public key required for initiator");
+            error!(target: KEY_MGMT, "noise: peer public key required for initiator");
             return Err(KmError::ConfigurationError);
         }
 
@@ -235,7 +236,7 @@ impl KmNoise {
         match self.certx.write_payload(&mut payload_buf) {
             Ok(_) => {}
             Err(e) => {
-                error!("noise: error writing certificate exchange payload: {:?}", e);
+                error!(target: KEY_MGMT, "noise: error writing certificate exchange payload: {e:?}");
                 return Err(KmError::CertExchangeError);
             }
         };
@@ -246,7 +247,7 @@ impl KmNoise {
                 Ok(buf.freeze())
             }
             Err(e) => {
-                error!("noise: error creating handshake message: {:?}", e);
+                error!(target: KEY_MGMT, "noise: error creating handshake message: {e:?}");
                 Err(KmError::HandshakeError)
             }
         }
@@ -254,12 +255,12 @@ impl KmNoise {
 
     fn parse_km_payload(&mut self, payload: &[u8], peer_public_key: &[u8]) -> KmResult<()> {
         if payload.len() < std::mem::size_of::<KeyMsg>() {
-            error!("noise: handshake payload is too short: {}", payload.len());
+            error!(target: KEY_MGMT, "noise: handshake payload is too short: {}", payload.len());
             return Err(KmError::HandshakeError);
         }
 
         let Ok((km, _)) = KeyMsg::ref_from_prefix(&payload) else {
-            error!("noise: error parsing KeyMsg handshake payload");
+            error!(target: KEY_MGMT, "noise: error parsing KeyMsg handshake payload");
             return Err(KmError::HandshakeError);
         };
 
@@ -277,8 +278,8 @@ impl KmNoise {
             Ok(c) => c,
             Err(e) => {
                 error!(
-                    "noise: error processing certificate exchange payload: {:?}",
-                    e
+                    target: KEY_MGMT,
+                    "noise: error processing certificate exchange payload: {e:?}",
                 );
                 return Err(KmError::CertExchangeError);
             }
@@ -339,7 +340,7 @@ impl Codec for NoiseCodec {
         // nonce is first 8 bytes of the message.
         let plen = payload.len();
         if plen < NOISE_NONCE_LEN {
-            error!("noise: message too short");
+            error!(target: KEY_MGMT, "noise: message too short");
             return Err(DecryptionError::MessageTooShort);
         }
         let nonce: u64 = u64::from_be_bytes(payload[0..NOISE_NONCE_LEN].try_into().unwrap()); // pretty sure this cannot fail
@@ -373,7 +374,7 @@ impl KeyManagerStateMachine for KmNoise {
         let np: snow::params::NoiseParams = match PATTERN.parse() {
             Ok(p) => p,
             Err(e) => {
-                error!("noise: error parsing pattern: {:?}", e);
+                error!(target: KEY_MGMT, "noise: error parsing pattern: {e:?}");
                 self.state = KmSMState::Error;
                 return Err(KmError::ConfigurationError);
             }
@@ -389,7 +390,7 @@ impl KeyManagerStateMachine for KmNoise {
             {
                 Ok(i) => i,
                 Err(e) => {
-                    error!("noise: error building initiator: {:?}", e);
+                    error!(target: KEY_MGMT, "noise: error building initiator: {e:?}");
                     self.state = KmSMState::Error;
                     return Err(KmError::MachineError(format!(
                         "failed to build initiator: {}",
@@ -414,7 +415,7 @@ impl KeyManagerStateMachine for KmNoise {
             {
                 Ok(r) => r,
                 Err(e) => {
-                    error!("noise: error building responder: {:?}", e);
+                    error!(target: KEY_MGMT, "noise: error building responder: {e:?}");
                     self.state = KmSMState::Error;
                     return Err(KmError::MachineError(format!(
                         "failed to build responder: {}",
@@ -434,6 +435,7 @@ impl KeyManagerStateMachine for KmNoise {
     fn handle_message(&mut self, message: &[u8]) -> Result<Option<Bytes>, KmError> {
         if self.state != KmSMState::Configuring {
             error!(
+                target: KEY_MGMT,
                 "noise: handle_message called but not in configuring state: in {:?}",
                 self.state
             );
@@ -449,7 +451,7 @@ impl KeyManagerStateMachine for KmNoise {
                 let peer_pubkey = match hs.get_remote_static() {
                     Some(p) => p,
                     None => {
-                        error!("noise: no remote public key - cannot do cert exchange");
+                        error!(target: KEY_MGMT, "noise: no remote public key - cannot do cert exchange");
                         self.state = KmSMState::Error;
                         self.hs_state = Some(hs);
                         return Err(KmError::CertExchangeError);
@@ -465,7 +467,7 @@ impl KeyManagerStateMachine for KmNoise {
                 }
             }
             Err(e) => {
-                error!("noise: error handling handhsake message: {:?}", e);
+                error!(target: KEY_MGMT, "noise: error handling handhsake message: {e:?}");
                 self.state = KmSMState::Error;
                 self.hs_state = Some(hs);
                 return Err(KmError::HandshakeError);
@@ -491,7 +493,7 @@ impl KeyManagerStateMachine for KmNoise {
             let send_zpis = match self.send_zpis {
                 Some(z) => z,
                 None => {
-                    error!("noise: handshake finished by no ZPIs received");
+                    error!(target: KEY_MGMT, "noise: handshake finished by no ZPIs received");
                     self.state = KmSMState::Error;
                     return Err(KmError::HandshakeError);
                 }
@@ -499,7 +501,7 @@ impl KeyManagerStateMachine for KmNoise {
             let send_key = match self.send_hmac_key {
                 Some(h) => h,
                 None => {
-                    error!("noise: handshake finished by no HMAC key received");
+                    error!(target: KEY_MGMT, "noise: handshake finished by no HMAC key received");
                     self.state = KmSMState::Error;
                     return Err(KmError::HandshakeError);
                 }
@@ -507,7 +509,7 @@ impl KeyManagerStateMachine for KmNoise {
             let peer_cert = match &self.peer_cert {
                 Some(c) => Some(c.clone()),
                 None => {
-                    warn!("noise: handshake finished but no peer cert received");
+                    warn!(target: KEY_MGMT, "noise: handshake finished but no peer cert received");
                     None
                 }
             };
@@ -524,7 +526,7 @@ impl KeyManagerStateMachine for KmNoise {
                     ));
                 }
                 Err(e) => {
-                    error!("noise: error switching to transport mode: {:?}", e);
+                    error!(target: KEY_MGMT, "noise: error switching to transport mode: {e:?}");
                     self.state = KmSMState::Error;
                     return Err(KmError::HandshakeError);
                 }
@@ -540,7 +542,7 @@ impl KeyManagerStateMachine for KmNoise {
             && self.hs_sent_t.is_some()
             && Instant::now().duration_since(self.hs_sent_t.unwrap()) > HANDSHAKE_TIMEOUT
         {
-            error!("noise: handhsake timeout");
+            error!(target: KEY_MGMT, "noise: handhsake timeout");
             self.hs_state = None;
             self.hs_sent_t = None;
             self.state = KmSMState::Error;

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1,6 +1,7 @@
 use crate::assembly::{Assembly, PhMode};
 use crate::km::ZPIPair;
 use crate::km_multiplexor;
+use crate::logging::targets::LINK_STATE;
 use crate::mgmt;
 use crate::net_defs::IpAddress;
 use crate::special_peers;
@@ -256,6 +257,7 @@ impl LinkStateWrapper {
         locked_fsm.state = LinkState::Inactive;
 
         debug!(
+            target: LINK_STATE,
             "Configured link {}.  State: {:?}, status: {:?}",
             self.id, locked_fsm.state, locked_fsm.status
         );
@@ -277,7 +279,7 @@ impl LinkStateWrapper {
 
         locked_fsm.state = LinkState::Keying;
 
-        debug!("Link {} started.  Keying in progress", self.id);
+        debug!(target: LINK_STATE, "Link {} started.  Keying in progress", self.id);
 
         match self.link_type {
             LinkType::AdapterToNode => {
@@ -293,7 +295,7 @@ impl LinkStateWrapper {
                 Ok(())
             }
             LinkType::NodeToNode => {
-                warn!("Error: Node to node not supported yet");
+                error!(target: LINK_STATE, "Error: Node to node not supported yet");
                 locked_fsm.state = LinkState::Error;
                 Err(LinkStateError::OperationNotSupportedYet)
             }
@@ -309,7 +311,7 @@ impl LinkStateWrapper {
                 Ok(())
             }
             LinkType::Internal => {
-                error!("Coding error: internal link state machine should not be controlled");
+                error!(target: LINK_STATE, "Coding error: internal link state machine should not be controlled");
                 Err(LinkStateError::InvalidOperation("coding error".into()))
             }
         }
@@ -339,20 +341,24 @@ impl LinkStateWrapper {
         };
 
         if let Some(ref peer_cert) = sa.peer_cert {
-            info!("Link {} has name {:?}", self.id, peer_cert.subject_name());
+            info!(target: LINK_STATE, "Link {} has name {:?}", self.id, peer_cert.subject_name());
 
             // assign special-peer name if this peer is special
             for name in
                 special_peers::special_peer_names_from_x509_subject_name(peer_cert.subject_name())
             {
                 match asm.peer_table.assign_special_name(name, self.id) {
-                    Ok(()) => info!("Link {} assigned special name {:?}", self.id, name),
-                    Err(_) => warn!("Unable to assign link {} special name {:?}", self.id, name),
+                    Ok(()) => {
+                        info!(target: LINK_STATE, "Link {} assigned special name {:?}", self.id, name)
+                    }
+                    Err(_) => {
+                        warn!(target: LINK_STATE, "Unable to assign link {} special name {:?}", self.id, name)
+                    }
                 }
             }
         }
 
-        debug!("Link {} finished keying.  Starting hello", self.id);
+        debug!(target: LINK_STATE, "Link {} finished keying.  Starting hello", self.id);
 
         locked_fsm.state = LinkState::Helloing;
         drop(locked_fsm);
@@ -389,12 +395,13 @@ impl LinkStateWrapper {
         match (self.link_type, locked_fsm.state) {
             (LinkType::NodeToNode, LinkState::Helloing) => {
                 locked_fsm.state = LinkState::Active;
-                debug!("Link {} finished helloing.  Becoming active", self.id);
+                debug!(target: LINK_STATE, "Link {} finished helloing.  Becoming active", self.id);
                 Ok(())
             }
             (LinkType::NodeToAdapter, LinkState::Helloing) => {
                 locked_fsm.state = LinkState::RegisterAA;
                 debug!(
+                    target: LINK_STATE,
                     "Link {} finished helloing.  Waiting on register agent address",
                     self.id
                 );
@@ -422,6 +429,7 @@ impl LinkStateWrapper {
             (LinkType::AdapterToNode, LinkState::Helloing) => {
                 locked_fsm.state = LinkState::RegisterAA;
                 debug!(
+                    target: LINK_STATE,
                     "Link {} finished helloing.  Sending register agent address",
                     self.id
                 );
@@ -450,7 +458,7 @@ impl LinkStateWrapper {
             }
             (LinkType::NodeToNode, LinkState::Helloing) => {
                 locked_fsm.state = LinkState::Active;
-                debug!("Link {} finished helloing.  Becoming active", self.id);
+                debug!(target: LINK_STATE, "Link {} finished helloing.  Becoming active", self.id);
                 Ok(())
             }
             (LinkType::NodeToAdapter, _) => {
@@ -479,6 +487,7 @@ impl LinkStateWrapper {
             (LinkType::NodeToAdapter, LinkState::RegisterAA) => {
                 locked_fsm.agent_addresses.push(addr);
                 debug!(
+                    target: LINK_STATE,
                     "Link {} received agent address ({addr}).  Authorizing with visa service",
                     self.id
                 );
@@ -510,11 +519,12 @@ impl LinkStateWrapper {
                     cn = String::new();
                 }
 
-                info!("Link {} CN is {cn}", self.id);
+                info!(target: LINK_STATE, "Link {} CN is {cn}", self.id);
 
                 if cn == zpr::VISA_SERVICE_CN {
                     locked_fsm.state = LinkState::Active;
                     debug!(
+                        target: LINK_STATE,
                         "Link {} (Visa Service) received agent address.  Becoming active, no authorization required",
                         self.id
                     );
@@ -554,7 +564,7 @@ impl LinkStateWrapper {
                                 status: Some(libnode::vsapi::StatusCode::SUCCESS),
                                 ..
                             }) => {
-                                info!("link {link_id} authorized");
+                                info!(target: LINK_STATE, "link {link_id} authorized");
 
                                 if task_asm
                                     .process_link_state_event(
@@ -571,6 +581,7 @@ impl LinkStateWrapper {
 
                             Ok(cr) => {
                                 warn!(
+                                    target: LINK_STATE,
                                     "link {link_id} authorization rejected: {}",
                                     cr.reason.unwrap_or("(no reason given)".to_owned())
                                 );
@@ -586,7 +597,7 @@ impl LinkStateWrapper {
                             }
 
                             Err(err) => {
-                                warn!("link {link_id} authorization failed: {err}");
+                                warn!(target: LINK_STATE, "link {link_id} authorization failed: {err}");
 
                                 if task_asm
                                     .process_link_state_event(link_id, LinkEvent::Reset)
@@ -614,7 +625,7 @@ impl LinkStateWrapper {
         match (self.link_type, locked_fsm.state) {
             (LinkType::NodeToAdapter, LinkState::RegisterAA) => {
                 locked_fsm.state = LinkState::Active;
-                debug!("Link {} authorized.  Becoming active", self.id);
+                debug!(target: LINK_STATE, "Link {} authorized.  Becoming active", self.id);
                 drop(locked_fsm);
                 self.run_active(asm)
             }
@@ -637,6 +648,7 @@ impl LinkStateWrapper {
                 locked_fsm.state = LinkState::Active;
                 asm.tun_ctl.set_carrier(true).unwrap();
                 debug!(
+                    target: LINK_STATE,
                     "Link {} finished registering agent address.  Becoming active",
                     self.id
                 );
@@ -662,7 +674,7 @@ impl LinkStateWrapper {
     /// Transitions from Closed to Inactive
     #[allow(dead_code)]
     pub fn complete_close(&self, asm: &Assembly) -> Result<(), LinkStateError> {
-        info!("Shutting down link {}", self.id);
+        info!(target: LINK_STATE, "Shutting down link {}", self.id);
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         locked_fsm.state = LinkState::Inactive;
         if asm.ph_mode != PhMode::Node {
@@ -675,7 +687,7 @@ impl LinkStateWrapper {
     /// Reset the link, shutting it down and wiping its configuration
     /// Transitions to Initial from any state
     pub fn reset(&self, asm: &Assembly) {
-        info!("Resetting link {}", self.id);
+        info!(target: LINK_STATE, "Resetting link {}", self.id);
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         locked_fsm.state = LinkState::Initial;
         locked_fsm.silent = false;
@@ -687,7 +699,7 @@ impl LinkStateWrapper {
     }
 
     pub fn run_active(&self, _asm: &Assembly) -> Result<(), LinkStateError> {
-        debug!("Link {} entering active state", self.id);
+        debug!(target: LINK_STATE, "Link {} entering active state", self.id);
         // TODO send echoes
         Ok(())
     }

--- a/adapter/ph/src/logging.rs
+++ b/adapter/ph/src/logging.rs
@@ -1,0 +1,32 @@
+//! Logging-related stuff.
+
+/// Target of a log message, for filtering.
+pub mod targets {
+    // Design note: my intent is for targets to indicate, to which
+    // subsystem/API they are reporting on "behalf of".  This is usually,
+    // but not always, the "subject" of the message.  An example where these
+    // differ is a callee in subsystem X who logs the result of an API call
+    // to subsystem Y.  Though the "subject" is an object managed by Y, the
+    // log target should be X, since the message is reporting on behalf of
+    // an action in X.  (But if Y itself logs the result, it should do so
+    // under target Y.) This helps provide a complete picture to someone
+    // debugging X why X is behaving in a certain way, without needing to
+    // also enable logging for Y (and all other APIs which X happens to use).
+
+    // More succinctly, the "golden rule" here is, if someone is trying to
+    // debug subsystem X, log target X should give them a complete
+    // understanding of why X is acting the way it is (even if the bug
+    // ultimately lies with a dependency of X).
+
+    pub const CAPTURE: &str = "capture";
+    pub const DATAPATH: &str = "datapath";
+    pub const FLOW_MGMT: &str = "flow_mgmt";
+    pub const KEY_MGMT: &str = "key_mgmt";
+    pub const LINK_STATE: &str = "link_state";
+    pub const PEER_MGMT: &str = "peer_mgmt";
+    pub const REPORTING: &str = "reporting";
+    pub const RPC: &str = "rpc";
+    pub const STARTUP: &str = "startup";
+    pub const VISA_MGMT: &str = "visa_mgmt";
+    pub const ZDP: &str = "zdp";
+}

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -35,6 +35,7 @@ mod km_cert_exchange;
 mod km_multiplexor;
 mod km_noise;
 mod link_state;
+mod logging;
 mod main_args;
 mod mgmt;
 mod mgmt_dispatch_worker;
@@ -69,6 +70,7 @@ use capture_worker::CaptureWorker;
 use flow_control::FlowControl;
 use km_multiplexor::KmState;
 use km_noise::NoiseKeypair;
+use logging::targets::STARTUP;
 use queues::*;
 use sys::ZprTun;
 use tun_ctl::TunCtl;
@@ -103,7 +105,7 @@ fn main() -> ExitCode {
 
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
-    info!("starting with PID {}", process::id());
+    info!(target: STARTUP, "starting with PID {}", process::id());
 
     //
     // read key material
@@ -118,8 +120,9 @@ fn main() -> ExitCode {
         Ok(key) => key,
         Err(e) => {
             error!(
-                "failed to load private key file: {:?}: {:?}",
-                &config.private_key_file, e
+                target: STARTUP,
+                "failed to load private key file: {:?}: {e:?}",
+                &config.private_key_file,
             );
             return ExitCode::FAILURE;
         }
@@ -133,7 +136,7 @@ fn main() -> ExitCode {
         )) {
             Ok(key) => key,
             Err(e) => {
-                error!("failed to load node public key file: {:?}", e);
+                error!(target: STARTUP, "failed to load node public key file: {e:?}");
                 return ExitCode::FAILURE;
             }
         };
@@ -147,7 +150,7 @@ fn main() -> ExitCode {
     certx = match KmCertExchange::new_from_paths(&config.certificate_file, &config.ca_file) {
         Ok(certx) => Some(certx),
         Err(e) => {
-            error!("failed to initialize key exchange: {:?}", e);
+            error!(target: STARTUP, "failed to initialize key exchange: {e:?}");
             return ExitCode::FAILURE;
         }
     };
@@ -194,7 +197,7 @@ fn main() -> ExitCode {
     let control_socket = Arc::new(
         UnixListener::bind(&config.control_path).expect("failed to bind to control socket"),
     );
-    info!("control socket bound to {:?}", config.control_path);
+    info!(target: STARTUP, "control socket bound to {:?}", config.control_path);
 
     //
     // open TUN devices
@@ -240,7 +243,7 @@ fn main() -> ExitCode {
         if config.self_addr.port() == 0 {
             let port = socket.local_addr().unwrap().as_socket().unwrap().port();
             config.self_addr.set_port(port);
-            info!("assigned substrate UDP port {port}");
+            info!(target: STARTUP, "assigned substrate UDP port {port}");
         }
         substrate_sockets.push(Arc::new(UdpSocket::from_std(socket.into()).unwrap()));
     }
@@ -256,7 +259,7 @@ fn main() -> ExitCode {
     ) {
         // It's OK if this fails; flows will still be pinned to a queue;
         // they'll just be pinned there with all other flows from the same link.
-        warn!("Unable to enable ingress packet steering: {err}");
+        warn!(target: STARTUP, "Unable to enable ingress packet steering: {err}");
     }
 
     //
@@ -385,9 +388,10 @@ fn main() -> ExitCode {
     if ph_mode == PhMode::Node {
         if config.self_addr.port() == 0 {
             // TODO: Should we force setting a port when configuring a node?
-            warn!("self_addr port is 0 which means dock listening port will be randomly assigned");
+            warn!(target: STARTUP, "self_addr port is 0 which means dock listening port will be randomly assigned");
         }
         info!(
+            target: STARTUP,
             "dock listening on {}",
             substrate_sockets[0].local_addr().unwrap()
         );
@@ -422,11 +426,11 @@ fn main() -> ExitCode {
     if ph_mode == PhMode::Adapter {
         local_set.block_on(&runtime, async {
             let dsid = zpr::DOCK_LINK_ID;
-            debug!("waiting on security assocaition establishment on link {dsid}");
+            debug!(target: STARTUP, "waiting on security assocaition establishment on link {dsid}");
             while !asm.peer_table.is_security_assocaition_established(dsid) {
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
             }
-            debug!("security assocaition established successfully on link {dsid}");
+            debug!(target: STARTUP, "security assocaition established successfully on link {dsid}");
         });
     }
 
@@ -456,7 +460,7 @@ fn main() -> ExitCode {
                     .run(tokio_util::sync::CancellationToken::new()),
             );
 
-            error!("visa service connection manager terminated: {res:?}");
+            error!(target: STARTUP, "visa service connection manager terminated: {res:?}");
 
             std::thread::sleep(std::time::Duration::from_secs(1));
         });
@@ -475,7 +479,7 @@ fn main() -> ExitCode {
         }
     });
 
-    info!("exiting");
+    info!(target: STARTUP, "exiting");
 
     ExitCode::SUCCESS
 }

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -6,6 +6,7 @@ use crate::counters::CounterType;
 use crate::fastpath;
 use crate::km_multiplexor;
 use crate::link_state::LinkType;
+use crate::logging::targets::{KEY_MGMT, ZDP};
 use crate::packet::BufferPacket;
 use crate::queues;
 use crate::zdp;
@@ -116,12 +117,13 @@ fn handle_response(asm: &Assembly, mut pkt: BufferPacket) -> HandleMgmtResult {
 // to parse starting from the KeyManagement header.
 fn handle_key_management(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> HandleMgmtResult {
     let Ok(km_hdr) = zdp::ZdpKeyManagementHeader::read_from_buf(&mut pkt) else {
-        error!("KeyManagement packet arrived with unparseable header");
+        error!(target: ZDP, "KeyManagement packet arrived with unparseable header");
         return Err((HandleMgmtError::BadStructure, pkt));
     };
 
     if !km_hdr.is_noise() {
         error!(
+            target: KEY_MGMT,
             "KeyManagement packet not using NOISE - type is {}",
             km_hdr.message_type
         );
@@ -133,7 +135,7 @@ fn handle_key_management(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> HandleMg
 
     let km_msg_len = usize::from(km_hdr.message_length);
     if pkt.remaining() < km_msg_len {
-        error!("KeyManagement packet arrived with truncated payload");
+        error!(target: KEY_MGMT, "KeyManagement packet arrived with truncated payload");
         return Err((HandleMgmtError::BadStructure, pkt));
     }
 
@@ -145,11 +147,11 @@ fn handle_key_management(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> HandleMg
         Ok(()) => (),
         Err(e) => {
             error!(
-                "key management handling failed on link {}: {:?}",
+                target: KEY_MGMT,
+                "key management handling failed on link {}: {e:?}",
                 pkt.metadata().ingress_link_id,
-                e
             );
-            return Err((HandleMgmtError::KeyManagementError(format!("{:?}", e)), pkt));
+            return Err((HandleMgmtError::KeyManagementError(format!("{e:?}")), pkt));
         }
     };
     asm.buffer_stack.put_buffer(pkt.destroy());

--- a/adapter/ph/src/mgmt/dock.rs
+++ b/adapter/ph/src/mgmt/dock.rs
@@ -1,5 +1,6 @@
 use crate::assembly::{AddRouteError, Assembly};
 use crate::defs::FiveTuple;
+use crate::logging::targets::FLOW_MGMT;
 use crate::special_peers;
 use libnode::{vsapi, vsconn};
 use std::num::NonZero;
@@ -31,7 +32,7 @@ pub async fn bind_agent_address(
         if let Some(id) = asm.peer_table.lookup_special_peer(spname) {
             egress_link_id = id;
         } else {
-            error!("visa request error: special peer routing applies, but special peer ({spname:?}) not connected");
+            error!(target: FLOW_MGMT, "visa request error: special peer routing applies, but special peer ({spname:?}) not connected");
             return Err(BindAgentAddressError::PolicyError);
         }
     } else {
@@ -57,6 +58,7 @@ pub async fn bind_agent_address(
                     ..
                 }) => {
                     info!(
+                        target: FLOW_MGMT,
                         "visa request succeeds, egress_link_id = {}",
                         proposed_egress_link_id
                     );
@@ -64,19 +66,19 @@ pub async fn bind_agent_address(
                 }
 
                 Ok(resp) => {
-                    info!("visa request rejected: {resp:?}");
+                    info!(target: FLOW_MGMT, "visa request rejected: {resp:?}");
                     return Err(BindAgentAddressError::PolicyError);
                 }
 
                 Err(err) => {
-                    error!("visa request error: {err}");
+                    error!(target: FLOW_MGMT, "visa request error: {err}");
                     return Err(BindAgentAddressError::PolicyError);
                 }
             }
         }
     }
 
-    debug!("now routing {five_tuple} from {ingress_link_id} to {egress_link_id}");
+    debug!(target: FLOW_MGMT, "now routing {five_tuple} from {ingress_link_id} to {egress_link_id}");
 
     let route_result = asm
         .add_route(
@@ -87,8 +89,6 @@ pub async fn bind_agent_address(
             packet_body,
         )
         .await;
-
-    debug!("route result {route_result:?}");
 
     // TODO: reverse ingress TID needs to be sent to next-hop;
     // this is blocked on switching to new-style bind requests

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -6,6 +6,7 @@ use crate::config;
 use crate::counters;
 use crate::defs::*;
 use crate::link_state::LinkEvent;
+use crate::logging::targets::{FLOW_MGMT, REPORTING, ZDP};
 use crate::net_defs::IpAddress;
 use crate::packet::{BufferPacket, Packet};
 use crate::zdp;
@@ -51,6 +52,7 @@ pub async fn handle_report(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> Handle
     pkt.advance(std::mem::size_of::<zdp::ZdpReportHeader>());
     if pkt.body().len() >= report_data_length {
         info!(
+            target: REPORTING,
             "{}: {}",
             pkt.metadata().ingress_link_id,
             std::str::from_utf8(&pkt.body()[..report_data_length]).unwrap()
@@ -64,6 +66,7 @@ pub async fn handle_report(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> Handle
 pub async fn handle_discard(asm: &Arc<Assembly>, pkt: BufferPacket) -> HandleMgmtResult {
     // TODO print to debug log, when implemented
     info!(
+        target: REPORTING,
         "Discard message received from {}",
         pkt.metadata().ingress_link_id
     );
@@ -79,7 +82,7 @@ pub async fn handle_hello_request(
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
-    debug!("Received Hello Request for link {ingress_link_id}");
+    debug!(target: ZDP, "Received Hello Request for link {ingress_link_id}");
 
     if asm
         .process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloRequest)
@@ -115,7 +118,7 @@ pub async fn handle_hello_response(
         return Err((HandleMgmtError::BadStructure, pkt));
     };
     let status = hdr.status;
-    debug!("Received Hello Response for link {ingress_link_id}, status: {status}");
+    debug!(target: ZDP, "Received Hello Response for link {ingress_link_id}, status: {status}");
 
     if asm
         .process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloResponse)
@@ -161,7 +164,7 @@ pub async fn handle_register_agent_address_request(
         }
     }
 
-    debug!("Received Register Agent Address Request for link {ingress_link_id} with address {agent_address}");
+    debug!(target: ZDP, "Received Register Agent Address Request for link {ingress_link_id} with address {agent_address}");
 
     if asm
         .process_link_state_event(
@@ -195,7 +198,7 @@ pub async fn handle_register_agent_address_response(
     pkt: BufferPacket,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
-    debug!("Received Register Agent Address Response for link {ingress_link_id}");
+    debug!(target: ZDP, "Received Register Agent Address Response for link {ingress_link_id}");
 
     if asm
         .process_link_state_event(ingress_link_id, LinkEvent::ReceivedRegisterResponse)
@@ -292,7 +295,7 @@ pub async fn handle_bind_agent_address_request(
 
     let Some(ingress_link_id) = NonZero::new(pkt.metadata().ingress_link_id) else {
         // who sent this??
-        error!("coding error: stray packet from unknown source; dropping");
+        error!(target: FLOW_MGMT, "coding error: stray packet from unknown source; dropping");
         return Ok(());
     };
 

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -7,6 +7,7 @@ use crate::config;
 use crate::counters::CounterType;
 use crate::defs::*;
 use crate::fastpath;
+use crate::logging::targets::ZDP;
 use crate::packet::{self, Packet};
 use crate::zdp;
 use bytes::{Buf, BufMut};
@@ -62,13 +63,13 @@ pub async fn send_hello_request(asm: &Assembly, link_id: zpr::LinkId) -> Result<
                 return Err(());
             };
             let status = hdr.status;
-            debug!("Received HelloResponse, status: {status}");
+            debug!(target: ZDP, "Received HelloResponse, status: {status}");
             asm.buffer_stack.put_buffer(hello_res.destroy());
             Ok(())
         }
 
         Err(err) => {
-            warn!("{err} error with HelloRequest");
+            warn!(target: ZDP, "{err} error with HelloRequest");
             Err(())
         }
     }
@@ -117,6 +118,7 @@ pub async fn send_register_agent_address_request(
                 return Err(());
             };
             debug!(
+                target: ZDP,
                 "Received RegisterAgentAddressResponse, status: {}",
                 hdr.status_code
             );
@@ -124,7 +126,7 @@ pub async fn send_register_agent_address_request(
         }
 
         Err(err) => {
-            warn!("{} error with RegisterAgentAddressRequest", err);
+            warn!(target: ZDP, "{err} error with RegisterAgentAddressRequest");
             return Err(());
         }
     }

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -1,6 +1,7 @@
 use crate::assembly::Assembly;
 use crate::counters::CounterType;
 use crate::fastpath;
+use crate::logging::targets::ZDP;
 use crate::mgmt::handlers::{self, HandleMgmtError, HandleMgmtResult};
 use crate::packet::BufferPacket;
 use crate::queues::MgmtProcessorMessage;
@@ -48,6 +49,7 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> HandleMgmt
     };
 
     debug!(
+        target: ZDP,
         "handling mgmt message from {} type {:?} seq_num {}",
         pkt.metadata().ingress_link_id,
         base_hdr.packet_type,

--- a/adapter/ph/src/rpc_worker.rs
+++ b/adapter/ph/src/rpc_worker.rs
@@ -7,6 +7,7 @@
 
 use crate::assembly::Assembly;
 use crate::config;
+use crate::logging::targets::RPC;
 use crate::test_packet::TestPacketMetrics;
 use cbpf_rs;
 use core::future::Future;
@@ -40,8 +41,8 @@ pub async fn launch(asm: Arc<Assembly>, socket: Arc<UnixListener>) {
             Some(ret) = set.join_next() =>
                 match ret {
                     Ok(Ok(())) => (),
-                    Ok(Err(err)) => error!("Handle Connection Failed: {err}"),
-                    Err(err) => error!("join_next panicked: {err}")
+                    Ok(Err(err)) => error!(target: RPC, "Handle Connection Failed: {err}"),
+                    Err(err) => error!(target: RPC, "join_next panicked: {err}")
                 },
             accepted = socket.accept() =>
                 match accepted {
@@ -49,7 +50,7 @@ pub async fn launch(asm: Arc<Assembly>, socket: Arc<UnixListener>) {
                         set.spawn(handle_connection(asm.clone(), stream));
                     },
                     Err(_e) => {
-                        error!("Connection failed");
+                        error!(target: RPC, "Connection failed");
                     }
             }
         }

--- a/adapter/ph/src/sync_req.rs
+++ b/adapter/ph/src/sync_req.rs
@@ -1,3 +1,4 @@
+use crate::logging::targets::ZDP;
 use crate::packet::BufferPacket;
 use crate::zdp;
 use std::future::Future;
@@ -116,7 +117,7 @@ impl SyncReqState {
         match listener {
             Some((expected_seq_num, _)) => {
                 if seq_num != *expected_seq_num {
-                    debug!("expected seq num {} got {}", expected_seq_num, seq_num);
+                    debug!(target: ZDP, "expected seq num {} got {}", expected_seq_num, seq_num);
                     return Err(response.1);
                 }
 

--- a/adapter/ph/src/vs_worker.rs
+++ b/adapter/ph/src/vs_worker.rs
@@ -1,4 +1,5 @@
 use crate::assembly::Assembly;
+use crate::logging::targets::VISA_MGMT;
 use libnode::vsconn::VSOutput;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -6,6 +7,6 @@ use tracing::*;
 
 pub async fn launch(_asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSOutput>) {
     while let Some(msg) = queue.recv().await {
-        debug!("received VS message {msg:?}; ignoring! (unimplemented)");
+        debug!(target: VISA_MGMT, "received VS message {msg:?}; ignoring! (unimplemented)");
     }
 }

--- a/adapter/ph/src/vss_worker.rs
+++ b/adapter/ph/src/vss_worker.rs
@@ -1,4 +1,5 @@
 use crate::assembly::Assembly;
+use crate::logging::targets::VISA_MGMT;
 use libnode::vss::VSSMsg;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -6,6 +7,6 @@ use tracing::*;
 
 pub async fn launch(_asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSSMsg>) {
     while let Some(msg) = queue.recv().await {
-        info!("received VSS message {msg:?}; ignoring! (unimplemented)");
+        info!(target: VISA_MGMT, "received VSS message {msg:?}; ignoring! (unimplemented)");
     }
 }

--- a/libnode/src/lib.rs
+++ b/libnode/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod errors;
+pub mod logging;
 pub mod m2;
 pub mod vsapi;
 mod vscli;

--- a/libnode/src/logging.rs
+++ b/libnode/src/logging.rs
@@ -1,0 +1,4 @@
+pub mod targets {
+    pub const VS_RPC: &str = "vs_rpc";
+    pub const VSS_RPC: &str = "vss_rpc";
+}

--- a/libnode/src/vscli.rs
+++ b/libnode/src/vscli.rs
@@ -7,6 +7,7 @@ use thrift::transport::{TIoChannel, TTcpChannel};
 use tracing::{debug, info};
 
 use crate::errors::VSClientError;
+use crate::logging::targets::VS_RPC;
 use crate::m2;
 use crate::vsapi;
 use vsapi::{TVisaServiceSyncClient, VisaServiceSyncClient};
@@ -67,7 +68,7 @@ impl VSClient {
         let i_prot = TBinaryInputProtocol::new(TFramedReadTransport::new(i_chan), true);
         let o_prot = TBinaryOutputProtocol::new(TFramedWriteTransport::new(o_chan), true);
 
-        debug!("XXX VSClient.new creating VisaServiceSyncClient");
+        debug!(target: VS_RPC, "XXX VSClient.new creating VisaServiceSyncClient");
         let tcli = vsapi::VisaServiceSyncClient::new(i_prot, o_prot);
 
         Ok(VSClient {
@@ -105,7 +106,7 @@ impl VSClientI for VSClient {
         cert_pem_data: &str,
         vss_service_addr: SocketAddr,
     ) -> Result<String, VSClientError> {
-        debug!("sending HELLO to {}", self.service);
+        debug!(target: VS_RPC, "sending HELLO to {}", self.service);
         let hello_response = self.cli.hello()?;
 
         let timestamp = SystemTime::now()
@@ -129,7 +130,7 @@ impl VSClientI for VSClient {
             node_agent: Some(agent),
         };
 
-        debug!("sending AUTHENTICATE to {}", self.service);
+        debug!(target: VS_RPC, "sending AUTHENTICATE to {}", self.service);
         let apikey = match self.cli.authenticate(authreq) {
             Ok(result) => result,
             Err(e) => return Err(e.into()),
@@ -144,7 +145,7 @@ impl VSClientI for VSClient {
             return Err(VSClientError::NoAPIKey);
         }
         let key = self.key.as_ref().unwrap();
-        debug!("sending DE-REGISTER to {}", self.service);
+        debug!(target: VS_RPC, "sending DE-REGISTER to {}", self.service);
         self.cli.de_register(key.clone())?;
         Ok(())
     }
@@ -155,7 +156,7 @@ impl VSClientI for VSClient {
             return Err(VSClientError::NoAPIKey);
         }
         let key = self.key.as_ref().unwrap();
-        debug!("sending PING to {}", self.service);
+        debug!(target: VS_RPC, "sending PING to {}", self.service);
         match self.cli.ping(key.clone()) {
             Ok(result) => Ok(result),
             Err(e) => Err(e.into()),
@@ -185,7 +186,7 @@ impl VSClientI for VSClient {
             _ => return Err(VSClientError::UnsupportedTrafficType),
         };
 
-        info!("sending VISA_REQUEST to {}", self.service); // raising from debug to info for M/2
+        info!(target: VS_RPC, "sending VISA_REQUEST to {}", self.service); // raising from debug to info for M/2
         match self.cli.request_visa(key.clone(), addr_bytes, l3t, packet) {
             Ok(result) => Ok(result),
             Err(e) => Err(e.into()),
@@ -201,7 +202,7 @@ impl VSClientI for VSClient {
             return Err(VSClientError::NoAPIKey);
         }
         let key = self.key.as_ref().unwrap();
-        debug!("sending AUTHORIZE_CONNECT to {}", self.service);
+        debug!(target: VS_RPC, "sending AUTHORIZE_CONNECT to {}", self.service);
         match self.cli.authorize_connect(key.clone(), req) {
             Ok(result) => Ok(result),
             Err(e) => Err(e.into()),
@@ -218,7 +219,7 @@ impl VSClientI for VSClient {
             IpAddr::V4(v4) => v4.octets().to_vec(),
             IpAddr::V6(v6) => v6.octets().to_vec(),
         };
-        debug!("sending AGENT_DISCONNECT to {}", self.service);
+        debug!(target: VS_RPC, "sending AGENT_DISCONNECT to {}", self.service);
         match self.cli.agent_disconnect(key.clone(), addr_bytes) {
             Ok(_) => Ok(()),
             Err(e) => Err(e.into()),

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -17,6 +17,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, debug};
 
 use crate::errors::{VSClientError, VSError};
+use crate::logging::targets::VS_RPC;
 use crate::vsapi;
 use crate::vscli::{self, VSClientI};
 use crate::vss::DEFAULT_VSS_PORT;
@@ -171,7 +172,7 @@ impl VSConn {
     /// Registers with visa service and obtains an API key.
     /// Blocking network call.
     fn initialize(&self, client: &mut Box<dyn VSClientI>) -> Result<(), VSError> {
-        debug!("VSConn::initialize starts");
+        debug!(target: VS_RPC, "VSConn::initialize starts");
 
         let pem_data: String;
         let vss_svc_addr;
@@ -197,7 +198,7 @@ impl VSConn {
     /// This little run loop is fairly basic: all requests of the visa service run one at a time and
     /// in order.
     pub async fn run(&self, ctok: CancellationToken) -> Result<(), VSError> {
-        info!("run starts");
+        info!(target: VS_RPC, "run starts");
 
         let (tx, mut rx) = mpsc::channel(16);
         let fac: vscli::VSClientFactory;
@@ -216,9 +217,9 @@ impl VSConn {
             Ok(c) => c,
             Err(e) => return Err(e.into()),
         };
-        debug!("client created successfully");
+        debug!(target: VS_RPC, "client created successfully");
         self.initialize(&mut client)?;
-        debug!("initialize completed successfully");
+        debug!(target: VS_RPC, "initialize completed successfully");
 
         let mut interval = time::interval(PING_INTERVAL);
         let mut ping_errors = 0;
@@ -231,25 +232,25 @@ impl VSConn {
                             match output_tx.send(VSOutput::PingSuccess(ping_resp.configuration.unwrap() as u64, ping_resp.policy_version.unwrap() as u64)).await {
                                 Ok(_) => {}
                                 Err(e) => {
-                                    error!("failed to send ping success message: {}", e);
+                                    error!(target: VS_RPC, "failed to send ping success message: {e}");
                                     return Err(VSError::EnqueueError);
                                 }
                             }
                         }
                         Err(e) => {
-                            error!("VSConn::run ping failed: {}", e);
+                            error!(target: VS_RPC, "VSConn::run ping failed: {e}");
                             ping_errors += 1;
                             if ping_errors > MAX_PING_ERRORS {
-                                error!("too many ping errors, assuming we are disconnected");
+                                error!(target: VS_RPC, "too many ping errors, assuming we are disconnected");
                                 return Err(VSError::Disconnect);
                             }
                         }
                     }
                 }
                 _ = ctok.cancelled() => {
-                    info!("VSConn::run cancelled");
+                    info!(target: VS_RPC, "VSConn::run cancelled");
                     if let Err(e) = client.de_register() {
-                        error!("failed to de-register: {}", e);
+                        error!(target: VS_RPC, "failed to de-register: {e}");
                     }
                     break;
                 }
@@ -276,7 +277,7 @@ impl VSConn {
         match client.request_visa(req.source_tether_addr, req.l3_type, req.packet) {
             Ok(vr) => Ok(vr),
             Err(e) => {
-                error!("failed to request visa: {}", e);
+                error!(target: VS_RPC, "failed to request visa: {e}");
                 Err(e)
             }
         }
@@ -290,7 +291,7 @@ impl VSConn {
         match client.authorize_connect(cr) {
             Ok(acr) => Ok(acr),
             Err(e) => {
-                error!("failed to authorize connect: {}", e);
+                error!(target: VS_RPC, "failed to authorize connect: {e}");
                 Err(e)
             }
         }
@@ -304,7 +305,7 @@ impl VSConn {
         match client.agent_disconnect(ipa) {
             Ok(_) => Ok(()),
             Err(e) => {
-                error!("failed to call agent disconnect: {}", e);
+                error!(target: VS_RPC, "failed to call agent disconnect: {e}");
                 Err(e)
             }
         }
@@ -320,13 +321,13 @@ impl VSConn {
             if let Some(tx) = &state.cmd_tx {
                 tx_chan = tx.clone();
             } else {
-                error!("VSConn::send_command called but no command channel available");
+                error!(target: VS_RPC, "VSConn::send_command called but no command channel available");
                 return Err(VSClientError::ConnClosed);
             }
         }
 
         if let Err(e) = tx_chan.send(cmd).await {
-            error!("VSConn::send_command failed to queue: {}", e);
+            error!(target: VS_RPC, "VSConn::send_command failed to queue: {e}");
             return Err(VSClientError::ConnClosed);
         }
         Ok(())

--- a/libnode/src/vss.rs
+++ b/libnode/src/vss.rs
@@ -13,9 +13,9 @@ use thrift::transport::{TFramedWriteTransportFactory, TWriteTransportFactory};
 use tokio::sync::mpsc::Sender;
 use tracing::{debug, error, info};
 
-use crate::vsapi;
+use crate::logging::targets::VSS_RPC;
 use crate::vsapi::{
-    PolicyInfo, VisaHop, VisaRevocation, VisaSupportSyncHandler, VisaSupportSyncProcessor,
+    self, PolicyInfo, VisaHop, VisaRevocation, VisaSupportSyncHandler, VisaSupportSyncProcessor,
 };
 
 /// Default port for the visa support service. Note that the visa support service
@@ -84,33 +84,33 @@ pub fn start_vss_server(tx_chan: Sender<VSSMsg>, listen_addr: SocketAddr) {
 
     // TODO: super annoying that thrift gives us no way to run non-blocking or
     //       even a way to stop the server.
-    info!("starting visa support service on {}", listen_addr);
+    info!(target: VSS_RPC, "starting visa support service on {listen_addr}");
     match vss_server.listen(listen_addr) {
-        Ok(_) => info!("VSS server completed OK"),
-        Err(e) => error!("VSS server failed with error: {}", e),
+        Ok(_) => info!(target: VSS_RPC, "VSS server completed OK"),
+        Err(e) => error!(target: VSS_RPC, "VSS server failed with error: {e}"),
     };
 }
 
 impl VisaSupportSyncHandler for VisaSupportHandlerImpl {
     /// Accept the visa service message and put in on the message channel.
     fn handle_network_policy_installed(&self, pi: vsapi::PolicyInfo) -> thrift::Result<()> {
-        debug!("handle_network_policy_installed: {:?}", pi);
+        debug!(target: VSS_RPC, "handle_network_policy_installed: {pi:?}");
         self.msg_chan_out
             .blocking_send(VSSMsg::PolicyInstall(pi))
             .or_else(|e| {
-                error!("failed to enque policy message to node: {}", e);
+                error!(target: VSS_RPC, "failed to enque policy message to node: {e}");
                 Err(thrift::Error::from("enqueue failed"))
             })
     }
 
     /// Accept the pushed visa(s) and put on to the message channel.
     fn handle_install_visas(&self, vh: Vec<vsapi::VisaHop>) -> thrift::Result<()> {
-        debug!("handle_install_visas, count={}", vh.len());
+        debug!(target: VSS_RPC, "handle_install_visas, count={}", vh.len());
         for v in vh {
             self.msg_chan_out
                 .blocking_send(VSSMsg::PushedVisa(v))
                 .or_else(|e| {
-                    error!("failed to enqueue visa message to node: {}", e);
+                    error!(target: VSS_RPC, "failed to enqueue visa message to node: {e}");
                     Err(thrift::Error::from("enqueue failed"))
                 })?;
         }
@@ -119,12 +119,12 @@ impl VisaSupportSyncHandler for VisaSupportHandlerImpl {
 
     /// Accept the visa revocation(s) and put on to the message channel.
     fn handle_revoke_visas(&self, vr: Vec<vsapi::VisaRevocation>) -> thrift::Result<()> {
-        debug!("handle_revoke_visas, count={}", vr.len());
+        debug!(target: VSS_RPC, "handle_revoke_visas, count={}", vr.len());
         for r in vr {
             self.msg_chan_out
                 .blocking_send(VSSMsg::PushedRevocation(r))
                 .or_else(|e| {
-                    error!("failed to enque visa revocation to node: {}", e);
+                    error!(target: VSS_RPC, "failed to enque visa revocation to node: {}", e);
                     Err(thrift::Error::from("enqueue failed"))
                 })?;
         }


### PR DESCRIPTION
Promulgate the use of `tracing`'s "target" specifiers for log messages.  I've defined a handful of categories (corresponding to "functional areas" or "cohesive things that might need debugging") and applied them to every logging statement.  This way, we can turn on/off logging for each area independently.

Support for actually filtering messages (e.g. via the command line and/or debug tool) will come in a separate PR.

Also, deleted one or two leftover chatty log messages from M2 debugging.

Also, automated Display/Debug impls for a couple KM errors.

No functional changes.