### PR TITLE
Add a rust cache to speed builds up

### DIFF
--- a/.github/workflows/rust-adapter.yml
+++ b/.github/workflows/rust-adapter.yml
@@ -25,6 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache-workspaces: |
+          adapter/ph
+          adapter/ph-debug
+          zpr-ext
+          cslab
+          cbpf-rs
 
     - name: Install Deps
       timeout-minutes: 2
@@ -62,6 +70,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache-workspaces: |
+          adapter/ph
+          adapter/ph-debug
+          zpr-ext
+          cslab
+          cbpf-rs
+
     - name: Build + test ph
       timeout-minutes: 5
       run: |
@@ -75,6 +92,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache-workspaces: |
+          adapter/ph
+          adapter/ph-debug
+          zpr-ext
+          cslab
+          cbpf-rs
     - name: Check format
       timeout-minutes: 5
       run: |
@@ -86,6 +111,14 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
     - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache-workspaces: |
+          adapter/ph
+          adapter/ph-debug
+          zpr-ext
+          cslab
+          cbpf-rs
     - name: Check warnings 
       timeout-minutes: 5
       run: |
@@ -98,6 +131,14 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
     - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache-workspaces: |
+          adapter/ph
+          adapter/ph-debug
+          zpr-ext
+          cslab
+          cbpf-rs
     - name: Check test warnings
       timeout-minutes: 5
       run: |
@@ -111,6 +152,14 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
     - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache-workspaces: |
+          adapter/ph
+          adapter/ph-debug
+          zpr-ext
+          cslab
+          cbpf-rs
     - name: Check test warnings
       timeout-minutes: 10
       run: |
@@ -125,8 +174,16 @@ jobs:
   capture-integration-test:
     needs: [ph-build, ph-debug-build]
     runs-on: ubuntu-latest
-    steps: 
+    steps:
     - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache-workspaces: |
+          adapter/ph
+          adapter/ph-debug
+          zpr-ext
+          cslab
+          cbpf-rs
     - name: Check test warnings
       timeout-minutes: 10
       run: |

--- a/.github/workflows/rust-adapter.yml
+++ b/.github/workflows/rust-adapter.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: Swatinem/rust-cache@v2
       with:
-        cache-workspaces: |
+        workspaces: |
           adapter/ph
           adapter/ph-debug
           zpr-ext
@@ -70,9 +70,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: Swatinem/rust-cache@v2
       with:
-        cache-workspaces: |
+        workspaces: |
           adapter/ph
           adapter/ph-debug
           zpr-ext
@@ -92,14 +92,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        cache-workspaces: |
-          adapter/ph
-          adapter/ph-debug
-          zpr-ext
-          cslab
-          cbpf-rs
     - name: Check format
       timeout-minutes: 5
       run: |
@@ -111,14 +103,6 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
     - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        cache-workspaces: |
-          adapter/ph
-          adapter/ph-debug
-          zpr-ext
-          cslab
-          cbpf-rs
     - name: Check warnings 
       timeout-minutes: 5
       run: |
@@ -131,14 +115,6 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
     - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        cache-workspaces: |
-          adapter/ph
-          adapter/ph-debug
-          zpr-ext
-          cslab
-          cbpf-rs
     - name: Check test warnings
       timeout-minutes: 5
       run: |
@@ -152,15 +128,16 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
     - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: Swatinem/rust-cache@v2
       with:
-        cache-workspaces: |
+        workspaces: |
           adapter/ph
           adapter/ph-debug
           zpr-ext
           cslab
           cbpf-rs
-    - name: Check test warnings
+
+    - name: Build
       timeout-minutes: 10
       run: |
         sudo apt update
@@ -169,6 +146,10 @@ jobs:
         make ph
         make visaservice
         cargo build --manifest-path adapter/ph-debug/Cargo.toml
+
+    - name: One Node v6 Test
+      timeout-minutes: 10
+      run: |
         ZPR_TEST_VERBOSE=1 integration-test/one-node-v6-test.sh
 
   capture-integration-test:
@@ -176,15 +157,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: Swatinem/rust-cache@v2
       with:
-        cache-workspaces: |
+        workspaces: |
           adapter/ph
           adapter/ph-debug
           zpr-ext
           cslab
           cbpf-rs
-    - name: Check test warnings
+
+    - name: Build
       timeout-minutes: 10
       run: |
         sudo apt update
@@ -193,4 +175,8 @@ jobs:
         make ph
         make visaservice
         cargo build --manifest-path adapter/ph-debug/Cargo.toml
+
+    - name: Capture Test
+      timeout-minutes: 10
+      run: |
         ZPR_TEST_VERBOSE=1 integration-test/capture-test.sh

--- a/integration-test/capture-test.sh
+++ b/integration-test/capture-test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/bash
 set -euo pipefail
-
 PH_BIN=$(realpath "$(dirname $0)/../adapter/ph/target/debug/ph")
 PH_DEBUG_BIN=$(realpath "$(dirname $0)/../adapter/ph-debug/target/debug/ph-debug")
 VS_BIN=$(realpath "$(dirname $0)/../visaservice/core/build/vservice")


### PR DESCRIPTION
Relates to https://github.com/org-zpr/zpr-core/issues/602

Baseline

```
ph-debug-build: 53s
ph-build: 2m 51s

basic int-test: 5m 19s
cap int-test: 4m 51s
```

With `Swatinem/rust-cache`, on a Retry build: 

```
ph-debug-build: 31s
ph-build: 1m 16s

basic int-test: 3m 36s
cap int-test: 3m 24s
```

I attempted to add artifact uploading and caching but we need a better plan for this. My recommendation would be to have each project build their artifacts and then release them, and we separate out the integration tests into its own github action file that might end up running only hourly. The local artifact generation seemed to save a tiny bit amount of time but really not much because the adapter rust action is asked to also build the go visa service and all the rust visa service components as well.