### PR TITLE
libnode: eliminate internal Mutex from VSConn

### DIFF
--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -63,7 +63,7 @@ pub struct Assembly {
     pub agent_input: AgentInput,
     pub substrate_egress: SubstrateEgress,
 
-    pub vsconn: Option<libnode::vsconn::VSConn>, // present only on nodes
+    pub vsconn: Option<libnode::vsconn::VSConnHandle>, // present only on nodes
 
     // Used to intercept packets that are unencrypted but still have ZDP headers
     pub capture_queue: Capture,
@@ -318,7 +318,7 @@ pub mod test {
         pub buffer_stack: Option<BufferStack<{ config::PACKET_BUFFER_SIZE }>>,
         pub agent_input: Option<AgentInput>,
         pub substrate_egress: Option<SubstrateEgress>,
-        pub vsconn: Option<Option<libnode::vsconn::VSConn>>,
+        pub vsconn: Option<Option<libnode::vsconn::VSConnHandle>>,
         pub capture_queue: Option<Capture>,
         pub capture_worker: Option<CaptureWorker>,
         pub flow_control: Option<FlowControl>,

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -266,7 +266,7 @@ fn main() -> ExitCode {
     // instantiate (but don't launch yet) Visa Service connection manager if we're a node
     //
 
-    let vsconn;
+    let mut vsconn;
     let vs_outq;
 
     if ph_mode == PhMode::Node {
@@ -306,7 +306,7 @@ fn main() -> ExitCode {
         buffer_stack: BufferStack::new(buf_storage),
         agent_input: AgentInput::new(tun_devs.clone()),
         substrate_egress: SubstrateEgress::new(substrate_sockets.clone()),
-        vsconn,
+        vsconn: vsconn.as_ref().map(|c| c.handle()),
         capture_queue: Capture::new(cap_inq),
         capture_worker: CaptureWorker::new(),
         flow_control: FlowControl::new(),
@@ -450,12 +450,10 @@ fn main() -> ExitCode {
         // although it is an async method, it calls blocking functions (namely Thrift functions)...
         // once we switch to async Thrift we can simplify this
         let rt_handle = runtime.handle().clone();
-        let vsconn_asm = asm.clone();
         js.spawn_blocking(move || loop {
             let res = rt_handle.block_on(
-                vsconn_asm
-                    .vsconn
-                    .clone()
+                vsconn
+                    .as_mut()
                     .unwrap()
                     .run(tokio_util::sync::CancellationToken::new()),
             );

--- a/libnode/src/errors.rs
+++ b/libnode/src/errors.rs
@@ -15,8 +15,6 @@ pub enum VSError {
     EnqueueError,
     #[error("Disconnect")]
     Disconnect,
-    #[error("AlreadyRunning")]
-    AlreadyRunning,
 }
 
 #[derive(Debug, Error)]

--- a/libnode/src/errors.rs
+++ b/libnode/src/errors.rs
@@ -15,6 +15,8 @@ pub enum VSError {
     EnqueueError,
     #[error("Disconnect")]
     Disconnect,
+    #[error("AlreadyRunning")]
+    AlreadyRunning,
 }
 
 #[derive(Debug, Error)]

--- a/libnode/src/vscli.rs
+++ b/libnode/src/vscli.rs
@@ -36,7 +36,7 @@ pub struct VSClient {
 pub trait VSClientI: Send {
     fn authenticate(
         &mut self,
-        agent: vsapi::Agent,
+        agent: &vsapi::Agent,
         cert_pem_data: &str,
         vss_service_addr: SocketAddr,
     ) -> Result<String, VSClientError>;
@@ -102,7 +102,7 @@ impl VSClientI for VSClient {
     ///
     fn authenticate(
         &mut self,
-        agent: vsapi::Agent,
+        agent: &vsapi::Agent,
         cert_pem_data: &str,
         vss_service_addr: SocketAddr,
     ) -> Result<String, VSClientError> {
@@ -127,7 +127,7 @@ impl VSClientI for VSClient {
             node_cert: Some(cert_pem_data.into()),
             hmac: Some(hmac),
             vss_service: Some(vss_service_addr.to_string()),
-            node_agent: Some(agent),
+            node_agent: Some(agent.clone()),
         };
 
         debug!(target: VS_RPC, "sending AUTHENTICATE to {}", self.service);

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -9,7 +9,6 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
-use std::sync::Mutex;
 use std::time::SystemTime;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{self, Duration};
@@ -62,15 +61,11 @@ pub struct VSConn {
     service_addr: String, // visa service address, format "HOST:PORT"
     node_cert_pem_data: String,
     cmd_tx: mpsc::Sender<VSCommand>,
+    cmd_rx: mpsc::Receiver<VSCommand>,
     output_tx: mpsc::Sender<VSOutput>,
+    client_fac: vscli::VSClientFactory,
     vss_service_addr: SocketAddr, // visa support service listen address
     agent: vsapi::Agent,
-    state: Mutex<State>,
-}
-
-struct State {
-    cmd_rx: Option<mpsc::Receiver<VSCommand>>, // removed by the run loop while running
-    client_fac: vscli::VSClientFactory,
 }
 
 /// Helper function to create a basic node agent. Probably only useful for early versions
@@ -150,22 +145,19 @@ impl VSConn {
             service_addr: service_addr.to_string(),
             node_cert_pem_data: cert_pem_data,
             cmd_tx,
+            cmd_rx,
             output_tx,
+            client_fac: vscli::default_vsclient_factory,
             vss_service_addr,
             agent: node_agent,
-            state: Mutex::new(State {
-                cmd_rx: Some(cmd_rx),
-                client_fac: vscli::default_vsclient_factory,
-            }),
         };
 
         Ok(vs_conn)
     }
 
     #[cfg(test)]
-    fn set_client_factory(&self, fac: vscli::VSClientFactory) {
-        let mut state = self.state.lock().unwrap();
-        state.client_fac = fac;
+    fn set_client_factory(&mut self, fac: vscli::VSClientFactory) {
+        self.client_fac = fac;
     }
 
     /// Registers with visa service and obtains an API key.
@@ -188,36 +180,11 @@ impl VSConn {
     ///
     /// This little run loop is fairly basic: all requests of the visa service run one at a time and
     /// in order.
-    pub async fn run(&self, ctok: CancellationToken) -> Result<(), VSError> {
-        info!(target: VS_RPC, "run starts");
+    pub async fn run(&mut self, ctok: CancellationToken) -> Result<(), VSError> {
+        info!(target: VS_RPC, "VSConn::run starts");
 
-        let fac: vscli::VSClientFactory;
-        let mut cmd_rx: mpsc::Receiver<VSCommand>;
-        {
-            let mut state = self.state.lock().unwrap(); // TAKES LOCK (drops when state goes out of scope)
-            match state.cmd_rx.take() {
-                Some(rx) => cmd_rx = rx,
-                None => return Err(VSError::AlreadyRunning),
-            }
-            fac = state.client_fac.clone();
-        }
-
-        let res = self.run_inner(ctok, fac, &mut cmd_rx).await;
-
-        let mut state = self.state.lock().unwrap();
-        state.cmd_rx = Some(cmd_rx);
-
-        res
-    }
-
-    async fn run_inner(
-        &self,
-        ctok: CancellationToken,
-        fac: vscli::VSClientFactory,
-        cmd_rx: &mut mpsc::Receiver<VSCommand>,
-    ) -> Result<(), VSError> {
         // All use of the client is in our little loop. So we honor its non-multithreaded aspect.
-        let mut client = match (fac)(&self.service_addr) {
+        let mut client = match (self.client_fac)(&self.service_addr) {
             Ok(c) => c,
             Err(e) => return Err(e.into()),
         };
@@ -260,7 +227,7 @@ impl VSConn {
                 }
 
                 // Handle one of the "async" requests.
-                Some(cmd) = cmd_rx.recv() => {
+                Some(cmd) = self.cmd_rx.recv() => {
                     match cmd {
                         // send errors simply mean requestor ignored reply; ignore them
                         VSCommand::RequestVisa(req, resp_chan) => { let _ = resp_chan.send(Self::handle_request_visa(&mut client, req)); },
@@ -309,6 +276,20 @@ impl VSConn {
         }
     }
 
+    /// Creates a handle which can be used to issue commands to this connection.
+    pub fn handle(&self) -> VSConnHandle {
+        VSConnHandle {
+            cmd_tx: self.cmd_tx.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct VSConnHandle {
+    cmd_tx: mpsc::Sender<VSCommand>,
+}
+
+impl VSConnHandle {
     /// Attempt to enqueue an async command to the runloop.
     /// Returns an error if the command could not be enqueued.
     async fn send_command(&self, cmd: VSCommand) -> Result<(), VSClientError> {
@@ -365,7 +346,7 @@ mod test {
     use rand::Rng;
     use std::env;
     use std::fs;
-    use std::sync::Arc;
+    use std::sync::Mutex;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     const CERT_DATA: &str = r#"-----BEGIN CERTIFICATE-----
@@ -604,7 +585,7 @@ s5JVZ48=
         claims.insert(String::from("foo"), String::from("fee"));
         let agnt = new_node_agent(node_addr, "n0", &claims);
 
-        let conn = VSConn::new(
+        let mut conn = VSConn::new(
             agnt,
             tx,
             "127.0.0.1:0",
@@ -647,25 +628,23 @@ s5JVZ48=
         claims.insert(String::from("foo"), String::from("fee"));
         let agnt = new_node_agent(node_addr, "n0", &claims);
 
-        let conn = Arc::new(
-            VSConn::new(
-                agnt,
-                tx,
-                "127.0.0.1:0",
-                certfile.get_path(),
-                node_addr,
-                None,
-            )
-            .unwrap(),
-        );
+        let mut conn = VSConn::new(
+            agnt,
+            tx,
+            "127.0.0.1:0",
+            certfile.get_path(),
+            node_addr,
+            None,
+        )
+        .unwrap();
 
         conn.set_client_factory(testvscli_factory);
 
         let ctoken = CancellationToken::new();
         let vs_tok = ctoken.clone();
-        let sp_conn = conn.clone();
+        let conn_handle = conn.handle();
         tokio::spawn(async move {
-            let _ = sp_conn.run(vs_tok).await;
+            let _ = conn.run(vs_tok).await;
         });
 
         // Should get a ping message
@@ -686,7 +665,7 @@ s5JVZ48=
             l3_type: zpr::L3Type::Ipv4,
             packet: vec![1, 2, 3, 4],
         };
-        let resp = conn.request_visa(req);
+        let resp = conn_handle.request_visa(req);
 
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
@@ -710,7 +689,7 @@ s5JVZ48=
                 packet: vec![1, 2, 3, 4],
             };
             set_next_error(VSClientError::NoAPIKey);
-            let resp = conn.request_visa(req);
+            let resp = conn_handle.request_visa(req);
             match timeout(Duration::from_millis(100), resp).await {
                 Ok(resp) => {
                     assert!(matches!(resp.unwrap_err(), VSClientError::NoAPIKey));
@@ -738,25 +717,23 @@ s5JVZ48=
         claims.insert(String::from("foo"), String::from("fee"));
         let agnt = new_node_agent(node_addr, "n0", &claims);
 
-        let conn = Arc::new(
-            VSConn::new(
-                agnt,
-                tx,
-                "127.0.0.1:0",
-                certfile.get_path(),
-                node_addr,
-                None,
-            )
-            .unwrap(),
-        );
+        let mut conn = VSConn::new(
+            agnt,
+            tx,
+            "127.0.0.1:0",
+            certfile.get_path(),
+            node_addr,
+            None,
+        )
+        .unwrap();
 
         conn.set_client_factory(testvscli_factory);
 
         let ctoken = CancellationToken::new();
         let vs_tok = ctoken.clone();
-        let sp_conn = conn.clone();
+        let conn_handle = conn.handle();
         tokio::spawn(async move {
-            let _ = sp_conn.run(vs_tok).await;
+            let _ = conn.run(vs_tok).await;
         });
 
         // Should get a ping message
@@ -783,7 +760,7 @@ s5JVZ48=
             challenge: Some(vec![1, 2, 3, 4]),
             challenge_responses: Some(vec![vec![5, 6, 7, 8]]),
         };
-        let resp = conn.authorize_connect(req);
+        let resp = conn_handle.authorize_connect(req);
 
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {
@@ -810,7 +787,7 @@ s5JVZ48=
                 challenge_responses: None,
             };
             set_next_error(VSClientError::NoAPIKey);
-            let resp = conn.authorize_connect(req);
+            let resp = conn_handle.authorize_connect(req);
             match timeout(Duration::from_millis(100), resp).await {
                 Ok(resp) => {
                     assert!(matches!(resp.unwrap_err(), VSClientError::NoAPIKey));
@@ -838,25 +815,23 @@ s5JVZ48=
         claims.insert(String::from("foo"), String::from("fee"));
         let agnt = new_node_agent(node_addr, "n0", &claims);
 
-        let conn = Arc::new(
-            VSConn::new(
-                agnt,
-                tx,
-                "127.0.0.1:0",
-                certfile.get_path(),
-                node_addr,
-                None,
-            )
-            .unwrap(),
-        );
+        let mut conn = VSConn::new(
+            agnt,
+            tx,
+            "127.0.0.1:0",
+            certfile.get_path(),
+            node_addr,
+            None,
+        )
+        .unwrap();
 
         conn.set_client_factory(testvscli_factory);
 
         let ctoken = CancellationToken::new();
         let vs_tok = ctoken.clone();
-        let sp_conn = conn.clone();
+        let conn_handle = conn.handle();
         tokio::spawn(async move {
-            let _ = sp_conn.run(vs_tok).await;
+            let _ = conn.run(vs_tok).await;
         });
 
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -876,7 +851,7 @@ s5JVZ48=
 
         assert_eq!(get_counter(CounterT::AgentDisconnect), 0);
 
-        let resp = conn.agent_disconnect(node_addr);
+        let resp = conn_handle.agent_disconnect(node_addr);
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -892,7 +867,7 @@ s5JVZ48=
 
         // Run disconnect again check that we get the error:
         set_next_error(VSClientError::NoAPIKey);
-        let resp = conn.agent_disconnect(node_addr);
+        let resp = conn_handle.agent_disconnect(node_addr);
 
         match timeout(Duration::from_millis(100), resp).await {
             Ok(resp) => {

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -9,7 +9,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::SystemTime;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{self, Duration};
@@ -58,12 +58,7 @@ pub enum VSOutput {
     PingSuccess(u64, u64), // (CONFIG_ID, POLICY_VERSION)
 }
 
-#[derive(Clone)]
 pub struct VSConn {
-    shared: Arc<Shared>,
-}
-
-struct Shared {
     service_addr: String, // visa service address, format "HOST:PORT"
     node_cert_pem_data: String,
     cmd_tx: mpsc::Sender<VSCommand>,
@@ -151,7 +146,7 @@ impl VSConn {
 
         let (cmd_tx, cmd_rx) = mpsc::channel(16);
 
-        let shared = Arc::new(Shared {
+        let vs_conn = VSConn {
             service_addr: service_addr.to_string(),
             node_cert_pem_data: cert_pem_data,
             cmd_tx,
@@ -162,14 +157,14 @@ impl VSConn {
                 cmd_rx: Some(cmd_rx),
                 client_fac: vscli::default_vsclient_factory,
             }),
-        });
+        };
 
-        Ok(VSConn { shared })
+        Ok(vs_conn)
     }
 
     #[cfg(test)]
     fn set_client_factory(&self, fac: vscli::VSClientFactory) {
-        let mut state = self.shared.state.lock().unwrap();
+        let mut state = self.state.lock().unwrap();
         state.client_fac = fac;
     }
 
@@ -178,14 +173,12 @@ impl VSConn {
     fn initialize(&self, client: &mut Box<dyn VSClientI>) -> Result<(), VSError> {
         debug!(target: VS_RPC, "VSConn::initialize starts");
 
-        let agnt = &self.shared.agent;
-        let pem_data = &self.shared.node_cert_pem_data;
-        let vss_svc_addr = self.shared.vss_service_addr;
-
-        let _apikey = match client.authenticate(agnt, pem_data, vss_svc_addr) {
-            Ok(k) => k,
-            Err(e) => return Err(e.into()),
-        };
+        let _apikey =
+            match client.authenticate(&self.agent, &self.node_cert_pem_data, self.vss_service_addr)
+            {
+                Ok(k) => k,
+                Err(e) => return Err(e.into()),
+            };
 
         Ok(())
     }
@@ -201,7 +194,7 @@ impl VSConn {
         let fac: vscli::VSClientFactory;
         let mut cmd_rx: mpsc::Receiver<VSCommand>;
         {
-            let mut state = self.shared.state.lock().unwrap(); // TAKES LOCK (drops when state goes out of scope)
+            let mut state = self.state.lock().unwrap(); // TAKES LOCK (drops when state goes out of scope)
             match state.cmd_rx.take() {
                 Some(rx) => cmd_rx = rx,
                 None => return Err(VSError::AlreadyRunning),
@@ -211,7 +204,7 @@ impl VSConn {
 
         let res = self.run_inner(ctok, fac, &mut cmd_rx).await;
 
-        let mut state = self.shared.state.lock().unwrap();
+        let mut state = self.state.lock().unwrap();
         state.cmd_rx = Some(cmd_rx);
 
         res
@@ -223,10 +216,8 @@ impl VSConn {
         fac: vscli::VSClientFactory,
         cmd_rx: &mut mpsc::Receiver<VSCommand>,
     ) -> Result<(), VSError> {
-        let service_addr = &self.shared.service_addr;
-
         // All use of the client is in our little loop. So we honor its non-multithreaded aspect.
-        let mut client = match (fac)(&service_addr) {
+        let mut client = match (fac)(&self.service_addr) {
             Ok(c) => c,
             Err(e) => return Err(e.into()),
         };
@@ -242,7 +233,7 @@ impl VSConn {
                     match client.ping_vs() {
                         Ok(ping_resp) => {
                             ping_errors = 0;
-                            match self.shared.output_tx.send(VSOutput::PingSuccess(ping_resp.configuration.unwrap() as u64, ping_resp.policy_version.unwrap() as u64)).await {
+                            match self.output_tx.send(VSOutput::PingSuccess(ping_resp.configuration.unwrap() as u64, ping_resp.policy_version.unwrap() as u64)).await {
                                 Ok(_) => {}
                                 Err(e) => {
                                     error!(target: VS_RPC, "failed to send ping success message: {e}");
@@ -327,7 +318,7 @@ impl VSConn {
     /// Attempt to enqueue an async command to the runloop.
     /// Returns an error if the command could not be enqueued.
     async fn send_command(&self, cmd: VSCommand) -> Result<(), VSClientError> {
-        if let Err(e) = self.shared.cmd_tx.send(cmd).await {
+        if let Err(e) = self.cmd_tx.send(cmd).await {
             error!(target: VS_RPC, "VSConn::send_command failed to queue: {e}");
             return Err(VSClientError::ConnClosed);
         }
@@ -380,6 +371,7 @@ mod test {
     use rand::Rng;
     use std::env;
     use std::fs;
+    use std::sync::Arc;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     const CERT_DATA: &str = r#"-----BEGIN CERTIFICATE-----
@@ -661,15 +653,17 @@ s5JVZ48=
         claims.insert(String::from("foo"), String::from("fee"));
         let agnt = new_node_agent(node_addr, "n0", &claims);
 
-        let conn = VSConn::new(
-            agnt,
-            tx,
-            "127.0.0.1:0",
-            certfile.get_path(),
-            node_addr,
-            None,
-        )
-        .unwrap();
+        let conn = Arc::new(
+            VSConn::new(
+                agnt,
+                tx,
+                "127.0.0.1:0",
+                certfile.get_path(),
+                node_addr,
+                None,
+            )
+            .unwrap(),
+        );
 
         conn.set_client_factory(testvscli_factory);
 
@@ -750,15 +744,17 @@ s5JVZ48=
         claims.insert(String::from("foo"), String::from("fee"));
         let agnt = new_node_agent(node_addr, "n0", &claims);
 
-        let conn = VSConn::new(
-            agnt,
-            tx,
-            "127.0.0.1:0",
-            certfile.get_path(),
-            node_addr,
-            None,
-        )
-        .unwrap();
+        let conn = Arc::new(
+            VSConn::new(
+                agnt,
+                tx,
+                "127.0.0.1:0",
+                certfile.get_path(),
+                node_addr,
+                None,
+            )
+            .unwrap(),
+        );
 
         conn.set_client_factory(testvscli_factory);
 
@@ -848,15 +844,17 @@ s5JVZ48=
         claims.insert(String::from("foo"), String::from("fee"));
         let agnt = new_node_agent(node_addr, "n0", &claims);
 
-        let conn = VSConn::new(
-            agnt,
-            tx,
-            "127.0.0.1:0",
-            certfile.get_path(),
-            node_addr,
-            None,
-        )
-        .unwrap();
+        let conn = Arc::new(
+            VSConn::new(
+                agnt,
+                tx,
+                "127.0.0.1:0",
+                certfile.get_path(),
+                node_addr,
+                None,
+            )
+            .unwrap(),
+        );
 
         conn.set_client_factory(testvscli_factory);
 

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -178,7 +178,7 @@ impl VSConn {
     fn initialize(&self, client: &mut Box<dyn VSClientI>) -> Result<(), VSError> {
         debug!(target: VS_RPC, "VSConn::initialize starts");
 
-        let agnt = self.shared.agent.clone(); // FIXME: just take reference
+        let agnt = &self.shared.agent;
         let pem_data = &self.shared.node_cert_pem_data;
         let vss_svc_addr = self.shared.vss_service_addr;
 
@@ -510,7 +510,7 @@ s5JVZ48=
     impl VSClientI for TestVSCli {
         fn authenticate(
             &mut self,
-            _agent: vsapi::Agent,
+            _agent: &vsapi::Agent,
             _cert_pem_data: &str,
             _vss_service_addr: SocketAddr,
         ) -> Result<String, VSClientError> {

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -70,7 +70,8 @@ struct Shared {
 struct State {
     service_addr: String, // visa service address, format "HOST:PORT"
     node_cert_pem_data: String,
-    cmd_tx: Option<mpsc::Sender<VSCommand>>,
+    cmd_tx: mpsc::Sender<VSCommand>,
+    cmd_rx: Option<mpsc::Receiver<VSCommand>>, // removed by the run loop while running
     output_tx: mpsc::Sender<VSOutput>,
     client_fac: vscli::VSClientFactory,
     vss_service_addr: SocketAddr, // visa support service listen address
@@ -148,12 +149,15 @@ impl VSConn {
         let vss_service_addr =
             vss_service_addr.unwrap_or_else(|| SocketAddr::new(node_zpr_addr, DEFAULT_VSS_PORT));
 
+        let (cmd_tx, cmd_rx) = mpsc::channel(16);
+
         let shared = Arc::new(Shared {
             state: Mutex::new(State {
                 service_addr: service_addr.to_string(),
                 node_cert_pem_data: cert_pem_data,
-                cmd_tx: None,
-                output_tx: output_tx,
+                cmd_tx,
+                cmd_rx: Some(cmd_rx),
+                output_tx,
                 client_fac: vscli::default_vsclient_factory,
                 vss_service_addr,
                 agent: node_agent,
@@ -200,18 +204,39 @@ impl VSConn {
     pub async fn run(&self, ctok: CancellationToken) -> Result<(), VSError> {
         info!(target: VS_RPC, "run starts");
 
-        let (tx, mut rx) = mpsc::channel(16);
         let fac: vscli::VSClientFactory;
         let service_addr: String;
         let output_tx: mpsc::Sender<VSOutput>;
+        let mut cmd_rx: mpsc::Receiver<VSCommand>;
         {
             let mut state = self.shared.state.lock().unwrap(); // TAKES LOCK (drops when state goes out of scope)
-            state.cmd_tx = Some(tx.clone());
+            match state.cmd_rx.take() {
+                Some(rx) => cmd_rx = rx,
+                None => return Err(VSError::AlreadyRunning),
+            }
             output_tx = state.output_tx.clone();
             fac = state.client_fac.clone();
             service_addr = state.service_addr.clone();
         }
 
+        let res = self
+            .run_inner(ctok, fac, service_addr, output_tx, &mut cmd_rx)
+            .await;
+
+        let mut state = self.shared.state.lock().unwrap();
+        state.cmd_rx = Some(cmd_rx);
+
+        res
+    }
+
+    async fn run_inner(
+        &self,
+        ctok: CancellationToken,
+        fac: vscli::VSClientFactory,
+        service_addr: String,
+        output_tx: mpsc::Sender<VSOutput>,
+        cmd_rx: &mut mpsc::Receiver<VSCommand>,
+    ) -> Result<(), VSError> {
         // All use of the client is in our little loop. So we honor its non-multithreaded aspect.
         let mut client = match (fac)(&service_addr) {
             Ok(c) => c,
@@ -256,7 +281,7 @@ impl VSConn {
                 }
 
                 // Handle one of the "async" requests.
-                Some(cmd) = rx.recv() => {
+                Some(cmd) = cmd_rx.recv() => {
                     match cmd {
                         // send errors simply mean requestor ignored reply; ignore them
                         VSCommand::RequestVisa(req, resp_chan) => { let _ = resp_chan.send(self.handle_request_visa(&mut client, req)); },
@@ -318,12 +343,7 @@ impl VSConn {
         let tx_chan: mpsc::Sender<VSCommand>;
         {
             let state = self.shared.state.lock().unwrap(); // TAKES LOCK (drops when state goes out of scope)
-            if let Some(tx) = &state.cmd_tx {
-                tx_chan = tx.clone();
-            } else {
-                error!(target: VS_RPC, "VSConn::send_command called but no command channel available");
-                return Err(VSClientError::ConnClosed);
-            }
+            tx_chan = state.cmd_tx.clone();
         }
 
         if let Err(e) = tx_chan.send(cmd).await {

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -64,18 +64,18 @@ pub struct VSConn {
 }
 
 struct Shared {
+    service_addr: String, // visa service address, format "HOST:PORT"
+    node_cert_pem_data: String,
+    cmd_tx: mpsc::Sender<VSCommand>,
+    output_tx: mpsc::Sender<VSOutput>,
+    vss_service_addr: SocketAddr, // visa support service listen address
+    agent: vsapi::Agent,
     state: Mutex<State>,
 }
 
 struct State {
-    service_addr: String, // visa service address, format "HOST:PORT"
-    node_cert_pem_data: String,
-    cmd_tx: mpsc::Sender<VSCommand>,
     cmd_rx: Option<mpsc::Receiver<VSCommand>>, // removed by the run loop while running
-    output_tx: mpsc::Sender<VSOutput>,
     client_fac: vscli::VSClientFactory,
-    vss_service_addr: SocketAddr, // visa support service listen address
-    agent: vsapi::Agent,
 }
 
 /// Helper function to create a basic node agent. Probably only useful for early versions
@@ -152,15 +152,15 @@ impl VSConn {
         let (cmd_tx, cmd_rx) = mpsc::channel(16);
 
         let shared = Arc::new(Shared {
+            service_addr: service_addr.to_string(),
+            node_cert_pem_data: cert_pem_data,
+            cmd_tx,
+            output_tx,
+            vss_service_addr,
+            agent: node_agent,
             state: Mutex::new(State {
-                service_addr: service_addr.to_string(),
-                node_cert_pem_data: cert_pem_data,
-                cmd_tx,
                 cmd_rx: Some(cmd_rx),
-                output_tx,
                 client_fac: vscli::default_vsclient_factory,
-                vss_service_addr,
-                agent: node_agent,
             }),
         });
 
@@ -178,17 +178,11 @@ impl VSConn {
     fn initialize(&self, client: &mut Box<dyn VSClientI>) -> Result<(), VSError> {
         debug!(target: VS_RPC, "VSConn::initialize starts");
 
-        let pem_data: String;
-        let vss_svc_addr;
-        let agnt: vsapi::Agent;
-        {
-            let state = self.shared.state.lock().unwrap();
-            pem_data = state.node_cert_pem_data.clone();
-            vss_svc_addr = state.vss_service_addr;
-            agnt = state.agent.clone();
-        }
+        let agnt = self.shared.agent.clone(); // FIXME: just take reference
+        let pem_data = &self.shared.node_cert_pem_data;
+        let vss_svc_addr = self.shared.vss_service_addr;
 
-        let _apikey = match client.authenticate(agnt, &pem_data, vss_svc_addr) {
+        let _apikey = match client.authenticate(agnt, pem_data, vss_svc_addr) {
             Ok(k) => k,
             Err(e) => return Err(e.into()),
         };
@@ -205,8 +199,6 @@ impl VSConn {
         info!(target: VS_RPC, "run starts");
 
         let fac: vscli::VSClientFactory;
-        let service_addr: String;
-        let output_tx: mpsc::Sender<VSOutput>;
         let mut cmd_rx: mpsc::Receiver<VSCommand>;
         {
             let mut state = self.shared.state.lock().unwrap(); // TAKES LOCK (drops when state goes out of scope)
@@ -214,14 +206,10 @@ impl VSConn {
                 Some(rx) => cmd_rx = rx,
                 None => return Err(VSError::AlreadyRunning),
             }
-            output_tx = state.output_tx.clone();
             fac = state.client_fac.clone();
-            service_addr = state.service_addr.clone();
         }
 
-        let res = self
-            .run_inner(ctok, fac, service_addr, output_tx, &mut cmd_rx)
-            .await;
+        let res = self.run_inner(ctok, fac, &mut cmd_rx).await;
 
         let mut state = self.shared.state.lock().unwrap();
         state.cmd_rx = Some(cmd_rx);
@@ -233,10 +221,10 @@ impl VSConn {
         &self,
         ctok: CancellationToken,
         fac: vscli::VSClientFactory,
-        service_addr: String,
-        output_tx: mpsc::Sender<VSOutput>,
         cmd_rx: &mut mpsc::Receiver<VSCommand>,
     ) -> Result<(), VSError> {
+        let service_addr = &self.shared.service_addr;
+
         // All use of the client is in our little loop. So we honor its non-multithreaded aspect.
         let mut client = match (fac)(&service_addr) {
             Ok(c) => c,
@@ -254,7 +242,7 @@ impl VSConn {
                     match client.ping_vs() {
                         Ok(ping_resp) => {
                             ping_errors = 0;
-                            match output_tx.send(VSOutput::PingSuccess(ping_resp.configuration.unwrap() as u64, ping_resp.policy_version.unwrap() as u64)).await {
+                            match self.shared.output_tx.send(VSOutput::PingSuccess(ping_resp.configuration.unwrap() as u64, ping_resp.policy_version.unwrap() as u64)).await {
                                 Ok(_) => {}
                                 Err(e) => {
                                     error!(target: VS_RPC, "failed to send ping success message: {e}");
@@ -339,14 +327,7 @@ impl VSConn {
     /// Attempt to enqueue an async command to the runloop.
     /// Returns an error if the command could not be enqueued.
     async fn send_command(&self, cmd: VSCommand) -> Result<(), VSClientError> {
-        // Extract the tx channel from the state, but must do so without keeping lock across the await later.
-        let tx_chan: mpsc::Sender<VSCommand>;
-        {
-            let state = self.shared.state.lock().unwrap(); // TAKES LOCK (drops when state goes out of scope)
-            tx_chan = state.cmd_tx.clone();
-        }
-
-        if let Err(e) = tx_chan.send(cmd).await {
+        if let Err(e) = self.shared.cmd_tx.send(cmd).await {
             error!(target: VS_RPC, "VSConn::send_command failed to queue: {e}");
             return Err(VSClientError::ConnClosed);
         }

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -263,9 +263,9 @@ impl VSConn {
                 Some(cmd) = cmd_rx.recv() => {
                     match cmd {
                         // send errors simply mean requestor ignored reply; ignore them
-                        VSCommand::RequestVisa(req, resp_chan) => { let _ = resp_chan.send(self.handle_request_visa(&mut client, req)); },
-                        VSCommand::AuthorizeConnect(cr, resp_chan) => { let _ = resp_chan.send(self.handle_authorize_connect(&mut client, cr)); },
-                        VSCommand::AgentDisconnect(ipa, resp_chan) => { let _ = resp_chan.send(self.handle_agent_disconnect(&mut client, ipa)); },
+                        VSCommand::RequestVisa(req, resp_chan) => { let _ = resp_chan.send(Self::handle_request_visa(&mut client, req)); },
+                        VSCommand::AuthorizeConnect(cr, resp_chan) => { let _ = resp_chan.send(Self::handle_authorize_connect(&mut client, cr)); },
+                        VSCommand::AgentDisconnect(ipa, resp_chan) => { let _ = resp_chan.send(Self::handle_agent_disconnect(&mut client, ipa)); },
                     }
                 }
             }
@@ -274,7 +274,6 @@ impl VSConn {
     }
 
     fn handle_request_visa(
-        &self,
         client: &mut Box<dyn VSClientI>,
         req: VisaRequest,
     ) -> VisaRequestResponse {
@@ -288,7 +287,6 @@ impl VSConn {
     }
 
     fn handle_authorize_connect(
-        &self,
         client: &mut Box<dyn VSClientI>,
         cr: vsapi::ConnectRequest,
     ) -> AuthorizeConnectResponse {
@@ -301,11 +299,7 @@ impl VSConn {
         }
     }
 
-    fn handle_agent_disconnect(
-        &self,
-        client: &mut Box<dyn VSClientI>,
-        ipa: IpAddr,
-    ) -> DisconnectStatus {
+    fn handle_agent_disconnect(client: &mut Box<dyn VSClientI>, ipa: IpAddr) -> DisconnectStatus {
         match client.agent_disconnect(ipa) {
             Ok(_) => Ok(()),
             Err(e) => {


### PR DESCRIPTION
This is a handful of changes which ultimately restructure the `VSConn` struct and its API such that it no longer needs the internal Mutex or Arc.  Instead, the burden of managing exclusive and shared access is placed on the caller, and enforced using borrow-checking.  This is achieved by separating the various "API" methods of `VSConn` from the `run()` method.  The former are attached to a new `VSConnHandle` type, which is both cloneable, and to which only shared access is needed; the latter remains on the `VSConn` type, which is no longer cloneable, and which needs mutable access.