### PR TITLE
node: get node name from cert

### DIFF
--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -30,9 +30,6 @@ const DEFAULT_WORKER_CONCURRENCY: usize = 1;
 /// ph system to configure itself.  Do not create this directly, use [argparse].
 #[derive(Debug)]
 pub struct Config {
-    /// Name (for logging, etc) of the node or adapter instance.
-    pub name: String,
-
     /// Path to the unix domain socket for the control interface.
     pub control_path: PathBuf,
 

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -270,11 +270,21 @@ fn main() -> ExitCode {
     let vs_outq;
 
     if ph_mode == PhMode::Node {
-        let node_agent = libnode::vsconn::new_node_agent(
-            config.agent_addr[0],
-            &config.name,
-            &Default::default(),
-        );
+        let node_cert = km_cert_exchange::load_cert(&config.certificate_file)
+            .expect("unable to read certificate");
+
+        let node_name = node_cert
+            .subject_name()
+            .entries_by_nid(openssl::nid::Nid::COMMONNAME)
+            .next()
+            .expect("unable to locate CN in certificate subject name")
+            .data()
+            .as_utf8()
+            .expect("CN must be UTF-8 string");
+        info!(target: STARTUP, "node name is \"{node_name}\"");
+
+        let node_agent =
+            libnode::vsconn::new_node_agent(config.agent_addr[0], &node_name, &Default::default());
 
         let (vs_inq, vs_outq_inner) = mpsc::channel(topology_config.vs_queue_size);
         vs_outq = Some(vs_outq_inner);

--- a/adapter/ph/src/main_args.rs
+++ b/adapter/ph/src/main_args.rs
@@ -56,7 +56,7 @@ impl ArgError for str {
 ///    sudo ./ph adapter -c adapter_config.toml --node-addr 10.1.0.8:12345
 ///
 /// Eg, override the name of the node (which may or may not be also set in the config file):
-///    sudo ./ph node -c node_config.toml --name node0
+///    sudo ./ph node -c node_config.toml
 ///
 #[derive(Debug, Parser)]
 #[command(version, verbatim_doc_comment)]
@@ -67,10 +67,6 @@ struct Control {
 
 #[derive(Args, Debug)]
 pub struct CommonArgs {
-    /// Optional, identifying name for instance (defaults to "adapter" or "node" depending on mode)
-    #[arg(short = 'n', long)]
-    name: Option<String>,
-
     /// Unix domain socket path for the "control" interface
     #[arg(long, value_name = "DOMAIN_SOCKET_PATH")]
     control_path: Option<String>,
@@ -164,7 +160,6 @@ fn get_data_home() -> PathBuf {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            name: "".to_string(),
             control_path: get_data_home().join("control.sock"),
             self_addr: SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)), 0),
             ca_file: PathBuf::from(""),
@@ -199,7 +194,6 @@ impl Config {
         common: &CommonArgs,
     ) -> Result<Self, ArgsError> {
         let mut config = Config::default();
-        config.name = "adapter".to_string();
         // fold in anything from the config file:
         if let Some(config_file) = config_file {
             let base_dir = config_file.config_path.parent().unwrap();
@@ -215,7 +209,6 @@ impl Config {
         common: &CommonArgs,
     ) -> Result<Self, ArgsError> {
         let mut config = Config::default();
-        config.name = "node".to_string();
         // fold in anything from the config file:
         if let Some(config_file) = config_file {
             let base_dir = config_file.config_path.parent().unwrap();
@@ -228,10 +221,6 @@ impl Config {
     // Check that the required bits are present based on mode.
     // Also checks that the various files exist.
     fn check_valid(&self, mode: PhMode) -> Result<(), ArgsError> {
-        if self.name.is_empty() {
-            // return Err(MissingArgError("name"));
-            return Err("name".arg_missing());
-        }
         if self.control_path.to_str().unwrap().is_empty() {
             return Err("control_path".arg_missing());
         }
@@ -284,9 +273,6 @@ impl Config {
         config: &GlobalConfigSection,
         base_dir: &Path,
     ) -> Result<(), ArgsError> {
-        if let Some(name) = &config.name {
-            self.name = name.clone();
-        }
         if let Some(control_path) = &config.control_path {
             if control_path.is_relative() {
                 self.control_path = base_dir.join(control_path);
@@ -351,9 +337,6 @@ impl Config {
 
     // Overwrite our internal state with the values present in the CommonArgs (from command line)
     fn set_from_common(&mut self, common: &CommonArgs) -> Result<(), ArgsError> {
-        if let Some(name) = &common.name {
-            self.name = name.clone();
-        }
         if let Some(control_path) = &common.control_path {
             let cp = PathBuf::from(control_path);
             if cp.is_relative() {
@@ -443,7 +426,6 @@ struct NodeConfig {
 // Global section is shared by nodes and adapters.
 #[derive(Deserialize, Debug, Clone)]
 struct GlobalConfigSection {
-    name: Option<String>,
     control_path: Option<PathBuf>,
     self_addr: Option<SocketAddr>,
     ca_file: Option<PathBuf>,
@@ -628,7 +610,6 @@ mod test {
     fn test_main_args_load_config_adapter() {
         let tomltxt = r#"
         [global]
-        name = "adapter0"
         control_path = "/var/run/zpr/control.sock"
         self_addr = "192.168.0.1:12345"
         ca_file = "tests/ca.pem"
@@ -647,7 +628,6 @@ mod test {
 
         let config: AdapterConfig = load_config(tmpfile.get_path()).unwrap();
 
-        assert_eq!(config.global.name, Some("adapter0".to_string()));
         assert_eq!(
             config.global.control_path,
             Some(PathBuf::from("/var/run/zpr/control.sock"))
@@ -694,7 +674,6 @@ mod test {
     fn test_main_args_load_config_node() {
         let tomltxt = r#"
         [global]
-        name = "node0"
         control_path = "/var/run/zpr/control.sock"
         self_addr = "192.168.0.1:12345"
         ca_file = "tests/ca.pem"
@@ -708,7 +687,6 @@ mod test {
 
         let config: NodeConfig = load_config(tmpfile.get_path()).unwrap();
 
-        assert_eq!(config.global.name, Some("node0".to_string()));
         assert_eq!(
             config.global.control_path,
             Some(PathBuf::from("/var/run/zpr/control.sock"))
@@ -737,7 +715,6 @@ mod test {
     fn test_main_args_argparse_adapter_config() {
         let mut tomltxt = r#"
         [global]
-        name = "adapter0"
         control_path = "$CONTROLFILE"
         self_addr = "192.168.0.1:12345"
         ca_file = "$CAFILE"
@@ -768,20 +745,12 @@ mod test {
 
         let tmpfile = TempFile::new_toml(&tomltxt);
 
-        let args = vec![
-            "ph",
-            "adapter",
-            "-c",
-            tmpfile.get_path().to_str().unwrap(),
-            "-n",
-            "a0",
-        ];
+        let args = vec!["ph", "adapter", "-c", tmpfile.get_path().to_str().unwrap()];
 
         let (pmode, config) = argparse(Some(args)).unwrap();
 
         assert_eq!(pmode, PhMode::Adapter);
 
-        assert_eq!(config.name, "a0".to_string());
         assert_eq!(config.control_path, control_file.get_path());
         assert_eq!(
             config.self_addr,
@@ -814,7 +783,6 @@ mod test {
     fn test_main_args_adapter_config_requires_adapter_section() {
         let tomltxt = r#"
         [global]
-        name = "adapter0"
         control_path = "/var/run/zpr/control.sock"
         self_addr = "192.168.0.1:12345"
         ca_file = "tests/ca.pem"
@@ -826,14 +794,7 @@ mod test {
 
         let tmpfile = TempFile::new_toml(&tomltxt);
 
-        let args = vec![
-            "ph",
-            "adapter",
-            "-c",
-            tmpfile.get_path().to_str().unwrap(),
-            "-n",
-            "a0",
-        ];
+        let args = vec!["ph", "adapter", "-c", tmpfile.get_path().to_str().unwrap()];
         match argparse(Some(args)) {
             Err(ArgsError::ParseError(_)) => {}
             _ => panic!("Expected ParseError"),
@@ -846,7 +807,6 @@ mod test {
     fn test_main_args_adapter_config_blank_adapter() {
         let mut tomltxt = r#"
         [global]
-        name = "adapter0"
         control_path = "/tmp/control.sock"
         self_addr = "192.168.0.1:12345"
         ca_file = "$CAFILE"
@@ -956,7 +916,6 @@ mod test {
 
         assert_eq!(pmode, PhMode::Adapter);
 
-        assert_eq!(config.name, "adapter".to_string());
         assert_eq!(config.control_path, control_file.get_path());
         assert_eq!(
             config.self_addr,
@@ -1021,7 +980,6 @@ mod test {
 
         assert_eq!(pmode, PhMode::Adapter);
 
-        assert_eq!(config.name, "adapter".to_string());
         assert!(!config.control_path.to_string_lossy().is_empty());
         assert_eq!(
             config.self_addr,
@@ -1080,7 +1038,6 @@ mod test {
 
         assert_eq!(pmode, PhMode::Node);
 
-        assert_eq!(config.name, "node".to_string());
         assert!(!config.control_path.to_string_lossy().is_empty());
         assert_eq!(
             config.self_addr,
@@ -1122,7 +1079,6 @@ mod test {
 
         assert_eq!(pmode, PhMode::Node);
 
-        assert_eq!(config.name, "node".to_string());
         assert!(!config.control_path.to_string_lossy().is_empty());
         assert_eq!(
             config.self_addr,

--- a/integration-test/capture-test.sh
+++ b/integration-test/capture-test.sh
@@ -98,7 +98,6 @@ sleep 2
 #
 sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
   node \
-  --name "zpr-node" \
   --control-path "$NODE_SOCK" \
   --self-addr 0.0.0.0:12345 \
   --ca-file ca.crt \
@@ -109,7 +108,6 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
 
 sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
-  --name "zpr-vs" \
   --control-path "$VS_SOCK" \
   --self-addr "$VS_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
@@ -124,7 +122,6 @@ sleep 2
 
 sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
-  --name "zpr-a" \
   --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
@@ -137,7 +134,6 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
-  --name "zpr-b" \
   --control-path "$ADAPTER2_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \

--- a/integration-test/one-node-v6-test.sh
+++ b/integration-test/one-node-v6-test.sh
@@ -88,15 +88,14 @@ sleep 2
 echo "Launching Node"
 
 sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
-     node \
-     --name "n0" \
-     --control-path "$NODE_SOCK" \
-     --self-addr 0.0.0.0:12345 \
-     --ca-file ca.crt \
-     --certificate-file node.crt \
-     --private-key-file node.key \
-     --tun-if tun0 \
-     --agent-addr "$NODE_ZPR_ADDR6" 2>&1 | tee node.log | prefix_log zpr-node &
+  node \
+  --control-path "$NODE_SOCK" \
+  --self-addr 0.0.0.0:12345 \
+  --ca-file ca.crt \
+  --certificate-file node.crt \
+  --private-key-file node.key \
+  --tun-if tun0 \
+  --agent-addr "$NODE_ZPR_ADDR6" 2>&1 | tee node.log | prefix_log zpr-node &
 
 sleep 2  # TODO: remove?
 
@@ -104,7 +103,6 @@ echo "Launching Adapters"
 
 sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
-  --name "zpr-vs" \
   --control-path "$VS_SOCK" \
   --self-addr "$VS_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
@@ -119,7 +117,6 @@ sleep 5
 
 sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
-  --name "zpr-a" \
   --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
@@ -132,7 +129,6 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
-  --name "zpr-b" \
   --control-path "$ADAPTER2_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \


### PR DESCRIPTION
The only code left using the "name" command-line argument is the code that connects to the visa server, and this expects the name to match that found in the certificate subject.  So, let's simply derive the name from the certificate, and ditch the command-line argument.