### PR TITLE
use a bash selector that works on mac and linux at the same time

### DIFF
--- a/diagrams/README.md
+++ b/diagrams/README.md
@@ -10,7 +10,7 @@ Then, set up a shell script wrapper to execute this jar file named
 `plantuml`.  The contents can be as simple as:
 
 ```sh
-#!/bin/sh
+#!/usr/bin/env bash
 exec java -jar /path/to/plantuml-xxx.jar "$@"
 ```
 

--- a/integration-test/capture-test.sh
+++ b/integration-test/capture-test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 PH_BIN=$(realpath "$(dirname $0)/../adapter/ph/target/debug/ph")

--- a/integration-test/common_funcs.sh
+++ b/integration-test/common_funcs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 
 # Our PKI helper tool

--- a/integration-test/one-node-v6-test.sh
+++ b/integration-test/one-node-v6-test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 PH_BIN=$(realpath "$(dirname $0)/../adapter/ph/target/debug/ph")

--- a/tools/install_hooks.sh
+++ b/tools/install_hooks.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Tool to install the git pre-commit hooks. Can be run from any directory.
 
 HOOKS="pre-commit"

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Git pre-commit hooks. Checks to ensure code is formatted and compiles without warnings
 # when a user tries to commit. Can be over-ruled by running git commit with --no-verify


### PR DESCRIPTION
general change is `#!/bin/sh` --> `#!/usr/bin/env bash`

This change asks for the default bash entry binary from the env rather than assume it is in `/bin/` or `/usr/bin/`

This matters to mac because the default is bash3, so I need to install bash5. The only way to launch in bash5 is using the `env`.