### PR TITLE
use the real sha of github actions and configure dependabot to keep them up to date.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10

--- a/.github/workflows/go-visaservice.yml
+++ b/.github/workflows/go-visaservice.yml
@@ -24,7 +24,7 @@ jobs:
     container:
       image: docker://ghcr.io/org-zpr/38f3bb925e5e:latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     - name: Build
       timeout-minutes: 5

--- a/.github/workflows/rust-adapter.yml
+++ b/.github/workflows/rust-adapter.yml
@@ -24,8 +24,8 @@ jobs:
   ph-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: Swatinem/rust-cache@91863c7bb91512f5b1911a1095863bde3deb5670 # v2
       with:
         workspaces: |
           adapter/ph
@@ -69,8 +69,8 @@ jobs:
   ph-debug-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: Swatinem/rust-cache@91863c7bb91512f5b1911a1095863bde3deb5670 # v2
       with:
         workspaces: |
           adapter/ph
@@ -91,7 +91,7 @@ jobs:
     needs: [ph-debug-build]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check format
       timeout-minutes: 5
       run: |
@@ -102,7 +102,7 @@ jobs:
     needs: [ph-debug-build]
     runs-on: ubuntu-latest
     steps: 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check warnings 
       timeout-minutes: 5
       run: |
@@ -114,7 +114,7 @@ jobs:
     needs: [ph-debug-build]
     runs-on: ubuntu-latest
     steps: 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check test warnings
       timeout-minutes: 5
       run: |
@@ -127,8 +127,8 @@ jobs:
     needs: [ph-build, ph-debug-build]
     runs-on: ubuntu-latest
     steps: 
-    - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: Swatinem/rust-cache@91863c7bb91512f5b1911a1095863bde3deb5670 # v2
       with:
         workspaces: |
           adapter/ph
@@ -156,8 +156,8 @@ jobs:
     needs: [ph-build, ph-debug-build]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: Swatinem/rust-cache@91863c7bb91512f5b1911a1095863bde3deb5670 # v2
       with:
         workspaces: |
           adapter/ph

--- a/.github/workflows/rust-cbpfrs.yml
+++ b/.github/workflows/rust-cbpfrs.yml
@@ -19,7 +19,7 @@ jobs:
   cbpf-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Build + test cbpf
       timeout-minutes: 5
       run: |
@@ -32,7 +32,7 @@ jobs:
     needs: [cbpf-build]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check format
       timeout-minutes: 5
       run: |
@@ -43,7 +43,7 @@ jobs:
     needs: [cbpf-build]
     runs-on: ubuntu-latest
     steps: 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check warnings
       timeout-minutes: 5
       run: |
@@ -54,7 +54,7 @@ jobs:
     needs: [cbpf-build]
     runs-on: ubuntu-latest
     steps: 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check test warnings
       timeout-minutes: 5
       run: |

--- a/.github/workflows/rust-cslab.yml
+++ b/.github/workflows/rust-cslab.yml
@@ -19,7 +19,7 @@ jobs:
   cslab-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Build + test cbpf
       timeout-minutes: 5
       run: |
@@ -31,7 +31,7 @@ jobs:
     needs: [cslab-build]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check format
       timeout-minutes: 5
       run: |
@@ -42,7 +42,7 @@ jobs:
     needs: [cslab-build]
     runs-on: ubuntu-latest
     steps: 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check warnings
       timeout-minutes: 5
       run: |
@@ -53,7 +53,7 @@ jobs:
     needs: [cslab-build]
     runs-on: ubuntu-latest
     steps: 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check test warnings
       timeout-minutes: 5
       run: |

--- a/.github/workflows/rust-libnode.yml
+++ b/.github/workflows/rust-libnode.yml
@@ -23,7 +23,7 @@ jobs:
     container:
       image: docker://ghcr.io/org-zpr/38f3bb925e5e:latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     - name: Prepare Rust
       timeout-minutes: 5

--- a/.github/workflows/rust-visaservice.yml
+++ b/.github/workflows/rust-visaservice.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       image: docker://ghcr.io/org-zpr/38f3bb925e5e:latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     - name: Prepare Rust
       timeout-minutes: 5

--- a/.github/workflows/rust-zprext.yml
+++ b/.github/workflows/rust-zprext.yml
@@ -19,7 +19,7 @@ jobs:
   zpr-ext-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Build + test cbpf
       timeout-minutes: 5
       run: |
@@ -31,7 +31,7 @@ jobs:
     needs: [zpr-ext-build]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check format
       timeout-minutes: 5
       run: |
@@ -42,7 +42,7 @@ jobs:
     needs: [zpr-ext-build]
     runs-on: ubuntu-latest
     steps: 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check warnings
       timeout-minutes: 5
       run: |
@@ -53,7 +53,7 @@ jobs:
     needs: [zpr-ext-build]
     runs-on: ubuntu-latest
     steps: 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check test warnings
       timeout-minutes: 5
       run: |


### PR DESCRIPTION
This will cause github to create PRs to us to keep things in sync with the tag comment on the action.

See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

Fixes https://github.com/org-zpr/zpr-core/issues/608