### PR TITLE
Only support IPv6 inside of the adapter.

### DIFF
--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -552,7 +552,7 @@ impl LinkStateWrapper {
                     let connect_req = libnode::vsapi::ConnectRequest {
                         connection_id: Some(123), // unused
                         dock_addr: Some(
-                            IpAddress::new_from_std(&asm.agent_addresses[0]).into_v4_or_v6_octets(),
+                            IpAddress::new_from_std(&asm.agent_addresses[0]).v6.to_vec(),
                         ),
                         claims: Some(
                             [

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -78,14 +78,6 @@ impl IpAddress {
             IpAddr::V6(v6) => Self::new_from_std_v6(v6),
         }
     }
-
-    pub fn into_v4_or_v6_octets(&self) -> Vec<u8> {
-        if self.is_v4() {
-            self.read_as_v4().into()
-        } else {
-            self.v6.into()
-        }
-    }
 }
 
 impl From<Ipv4Addr> for IpAddress {


### PR DESCRIPTION
Implements https://github.com/org-zpr/zpr-core/issues/597#issuecomment-2546443692 and deletes the method.