### PR TITLE
Adding a ipv4-in-ipv6 processing to the compiler

### DIFF
--- a/visaservice/mods/zpl/doc/zplscalar.go
+++ b/visaservice/mods/zpl/doc/zplscalar.go
@@ -11,6 +11,7 @@ package doc
 import (
 	"fmt"
 	"math"
+	"net/netip"
 	"reflect"
 	"strconv"
 
@@ -462,6 +463,32 @@ func NewZplString(input interface{}) (ZplString, error) {
 // MustNewZplString is just like NewZplString but panics if construction fails.
 func MustNewZplString(input interface{}) ZplString {
 	z, err := NewZplString(input)
+	if err != nil {
+		panic(err)
+	}
+	return z
+}
+
+func NewIPv6Address(input interface{}) (ZplString, error) {
+	addr, err := NewZplString(input)
+	if err != nil {
+		return addr, err
+	}
+	// Special case for IPv4 addresses, reformat them as IPv4-in-IPv6.
+	if ipa, err := netip.ParseAddr(addr.String()); err != nil {
+		// Return possible error from ParseAddr if input is not an IP.
+		return ZplString{}, ZplScalarErrorf(addr, "invalid service address: %w", err)
+	} else {
+		if ipa.Is4() {
+			return NewZplString(fmt.Sprintf("::ffff:%s", addr.String()))
+		}
+	}
+
+	return addr, nil
+}
+
+func MustNewIPv6Address(input interface{}) ZplString {
+	z, err := NewIPv6Address(input)
 	if err != nil {
 		panic(err)
 	}

--- a/visaservice/mods/zpl/pp/preprocessor.go
+++ b/visaservice/mods/zpl/pp/preprocessor.go
@@ -956,7 +956,7 @@ func parseDSEndpointGeneral(epPath []yt.Node, allServices map[string]*doc.Scopin
 				return nil, err
 			}
 		case "address": // optional
-			if ep.Address, err = doc.NewZplString(childPath); err != nil {
+			if ep.Address, err = doc.NewIPv6Address(childPath); err != nil {
 				return nil, err
 			}
 			if err = doc.AssertValidZPRAddress(ep.Address.String()); err != nil {
@@ -1385,7 +1385,7 @@ func (pps *PPState) makeVisaService(visaServiceAddress string) (*doc.Component, 
 		Desc:     doc.MustNewZplString("visa service"),
 		Provider: vs.Provider,
 		// Auth:
-		Address:      doc.MustNewZplString(visaServiceAddress),
+		Address:      doc.MustNewIPv6Address(visaServiceAddress),
 		SingleTenant: doc.MustNewZplBoolean(true),
 		Decorator:    doc.MustNewZplBoolean(false),
 	}


### PR DESCRIPTION
Reflects changes made in https://github.com/org-zpr/zpr-prototype/pull/10

Related to point 3 in https://github.com/org-zpr/zpr-core/issues/597