### PR TITLE
Add logging targets to help

### DIFF
--- a/adapter/ph/src/logging.rs
+++ b/adapter/ph/src/logging.rs
@@ -23,6 +23,7 @@ pub mod targets {
     // understanding of why X is acting the way it is (even if the bug
     // ultimately lies with a dependency of X).
 
+    pub const ALL: &str = "all";
     pub const CAPTURE: &str = "capture";
     pub const DATAPATH: &str = "datapath";
     pub const FLOW_MGMT: &str = "flow_mgmt";
@@ -34,6 +35,11 @@ pub mod targets {
     pub const STARTUP: &str = "startup";
     pub const VISA_MGMT: &str = "visa_mgmt";
     pub const ZDP: &str = "zdp";
+
+    pub const ALL_TARGETS: &[&str] = &[
+        ALL, CAPTURE, DATAPATH, FLOW_MGMT, KEY_MGMT, LINK_STATE, PEER_MGMT, REPORTING, RPC,
+        STARTUP, VISA_MGMT, ZDP,
+    ];
 }
 
 fn create_target_filter<T>(
@@ -49,7 +55,7 @@ where
     targets = targets.with_default(Level::INFO);
 
     for target in debug.into_iter() {
-        if target == "ALL" {
+        if target == targets::ALL {
             targets = targets.with_default(Level::DEBUG);
         } else {
             targets = targets.with_target(target, Level::DEBUG);
@@ -57,7 +63,7 @@ where
     }
 
     for target in quiet.into_iter() {
-        if target == "ALL" {
+        if target == targets::ALL {
             targets = targets.with_default(Level::ERROR);
         } else {
             targets = targets.with_target(target, Level::ERROR);

--- a/adapter/ph/src/main_args.rs
+++ b/adapter/ph/src/main_args.rs
@@ -5,6 +5,7 @@
 
 use crate::assembly::PhMode;
 use crate::config::Config;
+use crate::logging::targets::*;
 use clap::{Args, Parser, Subcommand};
 use serde::Deserialize;
 use std::io::Read;
@@ -97,12 +98,12 @@ pub struct CommonArgs {
     #[arg(long, short = 'z')]
     agent_addr: Vec<IpAddr>,
 
-    /// Enable debug logging for specified targets, or ALL
-    #[arg(long, short = 'd')]
+    /// Enable debug logging for specified targets
+    #[arg(long, short = 'd', value_parser = clap::builder::PossibleValuesParser::new(ALL_TARGETS))]
     debug: Vec<String>,
 
-    /// Disable info & warnings for specified targets, or ALL
-    #[arg(long, short = 'q')]
+    /// Disable info & warnings for specified targets
+    #[arg(long, short = 'q', value_parser = clap::builder::PossibleValuesParser::new(ALL_TARGETS))]
     quiet: Vec<String>,
 }
 
@@ -626,8 +627,8 @@ mod test {
         private_key_file = "tests/private_key.pem"
         tun_if = "tun23"
         agent_addr = [ "10.0.0.1" ]
-        debug = [ "FOO" ]
-        quiet = [ "BAR" ]
+        debug = [ "capture" ]
+        quiet = [ "all" ]
 
         [adapter]
         node_addr = "192.168.0.2:5000"
@@ -659,8 +660,11 @@ mod test {
             Some(PathBuf::from("tests/private_key.pem"))
         );
         assert_eq!(config.global.tun_if, Some("tun23".to_string()));
-        assert_eq!(config.global.debug, Some(Vec::from(["FOO".to_string()])));
-        assert_eq!(config.global.quiet, Some(Vec::from(["BAR".to_string()])));
+        assert_eq!(
+            config.global.debug,
+            Some(Vec::from(["capture".to_string()]))
+        );
+        assert_eq!(config.global.quiet, Some(Vec::from(["all".to_string()])));
 
         assert_eq!(
             config.adapter.node_addr,
@@ -691,8 +695,8 @@ mod test {
         certificate_file = "tests/certificate.pem"
         private_key_file = "tests/private_key.pem"
         tun_if = "tun23"
-        debug = [ "FOO" ]
-        quiet = [ "BAR" ]
+        debug = [ "flow_mgmt" ]
+        quiet = [ "rpc" ]
         "#;
 
         let tmpfile = TempFile::new_toml(&tomltxt);
@@ -720,8 +724,11 @@ mod test {
             Some(PathBuf::from("tests/private_key.pem"))
         );
         assert_eq!(config.global.tun_if, Some("tun23".to_string()));
-        assert_eq!(config.global.debug, Some(Vec::from(["FOO".to_string()])));
-        assert_eq!(config.global.quiet, Some(Vec::from(["BAR".to_string()])));
+        assert_eq!(
+            config.global.debug,
+            Some(Vec::from(["flow_mgmt".to_string()]))
+        );
+        assert_eq!(config.global.quiet, Some(Vec::from(["rpc".to_string()])));
     }
 
     #[test]
@@ -735,8 +742,8 @@ mod test {
         private_key_file = "$PKFILE"
         tun_if = "tun23"
         agent_addr = [ "10.0.0.1" ]
-        debug = [ "FOO" ]
-        quiet = [ "BAR" ]
+        debug = [ "link_state" ]
+        quiet = [ "startup" ]
 
         [adapter]
         node_addr = "192.168.0.2:5000"
@@ -774,8 +781,8 @@ mod test {
         assert_eq!(config.certificate_file, cert_file.get_path());
         assert_eq!(config.private_key_file, pk_file.get_path());
         assert_eq!(config.tun_if, Some("tun23".to_string()));
-        assert_eq!(config.debug, Vec::from(["FOO".to_string()]));
-        assert_eq!(config.quiet, Vec::from(["BAR".to_string()]));
+        assert_eq!(config.debug, Vec::from(["link_state".to_string()]));
+        assert_eq!(config.quiet, Vec::from(["startup".to_string()]));
 
         assert_eq!(
             config.node_addr,
@@ -922,9 +929,9 @@ mod test {
             "--tun-if",
             "tun23",
             "-d",
-            "FOO",
+            "peer_mgmt",
             "-q",
-            "BAR",
+            "reporting",
         ];
 
         let (pmode, config) = argparse(Some(args)).unwrap();
@@ -940,8 +947,8 @@ mod test {
         assert_eq!(config.certificate_file, cert_file.get_path());
         assert_eq!(config.private_key_file, pk_file.get_path());
         assert_eq!(config.tun_if, Some("tun23".to_string()));
-        assert_eq!(config.debug, Vec::from(["FOO".to_string()]));
-        assert_eq!(config.quiet, Vec::from(["BAR".to_string()]));
+        assert_eq!(config.debug, Vec::from(["peer_mgmt".to_string()]));
+        assert_eq!(config.quiet, Vec::from(["reporting".to_string()]));
 
         assert_eq!(
             config.node_addr,


### PR DESCRIPTION
Resolves #612 

```sjaffer ~/repos/zpr-core/adapter/ph (main) > ./target/debug/ph adapter --help
Start the handler in adapter mode

Usage: ph adapter [OPTIONS]

Options:
  -c, --config-file <PATH>
          Path to adapter configuration file (any options specified on command line will override configuration file)
      --control-path <DOMAIN_SOCKET_PATH>
          Unix domain socket path for the "control" interface
  -a, --self-addr <ADDR:PORT>
          For a node this is listen substrate address for dock, for adapter it is best to leave this at its default setting (0.0.0.0:0)
      --ca-file <PATH>
          Certificate of the Certificate Authority
      --certificate-file <PATH>
          Certificate including the noise public key, signed by the authority
  -k, --private-key-file <PATH>
          Path to the noise private key file (PEM format)
  -i, --tun-if <DEVICE>
          TUN device to use, eg "tun1" (leave blank for automatic selection -- the default)
  -z, --agent-addr <AGENT_ADDR>
          ZPR address (no port) of the adapter (must match your TUN address)
  -d, --debug <DEBUG>
          Enable debug logging for specified targets [possible values: all, capture, datapath, flow_mgmt, key_mgmt, link_state, peer_mgmt, reporting, rpc, startup, visa_mgmt, zdp]
  -q, --quiet <QUIET>
          Disable info & warnings for specified targets [possible values: all, capture, datapath, flow_mgmt, key_mgmt, link_state, peer_mgmt, reporting, rpc, startup, visa_mgmt, zdp]
  -N, --node-addr <ADDR:PORT>
          Substrate address of the node to connect to
  -b, --node-public-key-file <PATH>
          PEM file holding the nodes noise public key
  -h, --help
          Print help
```