### PR TITLE
all Packet buffers now boxed

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -4,7 +4,7 @@ use crate::counters::CounterType;
 use crate::fastpath;
 use crate::logging::targets::FLOW_MGMT;
 use crate::mgmt;
-use crate::packet::BufferPacket;
+use crate::packet::Packet;
 use crate::queues::AdapterManagerMessage;
 use std::num::NonZero;
 use std::sync::Arc;
@@ -26,7 +26,7 @@ pub async fn launch(asm: Arc<Assembly>, mut queue: mpsc::Receiver<AdapterManager
 }
 
 // RFC 6.5 § 6.3.11
-async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: BufferPacket) {
+async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
     let five_tuple = pkt.metadata().five_tuple();
 
     // if there's already an entry, this is a duplicate request

--- a/adapter/ph/src/adapter_tables.rs
+++ b/adapter/ph/src/adapter_tables.rs
@@ -5,7 +5,7 @@
 #![allow(dead_code)]
 
 use crate::defs::FiveTuple;
-use crate::packet::BufferPacket;
+use crate::packet::Packet;
 use crate::rcu::{RcuBox, RcuCslabEntryGuard};
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::mapref::one::Ref as DashMapRef;
@@ -23,7 +23,7 @@ pub struct AltPep {
 
 pub enum AltEntry {
     Active(AltPep),
-    Pending(BufferPacket),
+    Pending(Packet),
 }
 
 pub struct AgentLookupTable {

--- a/adapter/ph/src/agent_output_worker.rs
+++ b/adapter/ph/src/agent_output_worker.rs
@@ -41,14 +41,14 @@ pub async fn launch(config: Config, asm: Arc<Assembly>, tun: Arc<ZprTun>) {
                         // packet was too large or non-IP; drop
                         asm.counters[CounterType::OutPacksDrop].increment();
                         // reuse `buf`
-                        buf = pkt.destroy();
+                        buf = pkt.destroy().try_into().unwrap();
                         continue;
                     }
                 } else {
                     // No packet info, permit IP and IPv6 only (for now?)
                     if pkt.body()[0] >> 4 != 4 && pkt.body()[0] >> 4 != 6 {
                         asm.counters[CounterType::OutPacksDrop].increment();
-                        buf = pkt.destroy();
+                        buf = pkt.destroy().try_into().unwrap();
                         continue;
                     }
                 }

--- a/adapter/ph/src/buffer_stack.rs
+++ b/adapter/ph/src/buffer_stack.rs
@@ -1,4 +1,3 @@
-use std::ops::{Deref, DerefMut};
 use std::sync::Mutex;
 use tokio::sync::Notify;
 use zpr_ext::std::mem::{drop_guard, DropGuard};
@@ -28,21 +27,7 @@ pub struct BufferStack<const BUFSIZ: usize> {
 }
 
 /// Owning reference to a buffer allocated from the stack.
-pub struct Buffer<const BUFSIZ: usize>(Box<[u8; BUFSIZ]>);
-
-impl<const BUFSIZ: usize> Deref for Buffer<BUFSIZ> {
-    type Target = [u8; BUFSIZ];
-
-    fn deref(&self) -> &Self::Target {
-        self.0.deref()
-    }
-}
-
-impl<const BUFSIZ: usize> DerefMut for Buffer<BUFSIZ> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.deref_mut()
-    }
-}
+pub type Buffer<const BUFSIZ: usize> = Box<[u8; BUFSIZ]>;
 
 #[allow(dead_code)]
 impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
@@ -67,7 +52,7 @@ impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
                 let mut bufs = self.buffers.lock().unwrap();
 
                 match bufs.pop() {
-                    Some(buf) => break Buffer(buf),
+                    Some(buf) => break buf,
                     None => (),
                 }
 
@@ -95,7 +80,7 @@ impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
 
     /// Attempts to acquire a single buffer.  Does not block.
     pub fn try_get_buffer(&self) -> Option<Buffer<BUFSIZ>> {
-        self.buffers.lock().unwrap().pop().map(|b| Buffer(b))
+        self.buffers.lock().unwrap().pop()
     }
 
     /// Blocks until at least 1 buffer can be returned.
@@ -116,7 +101,7 @@ impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
 
                 for _ in 0..to_get {
                     // note: intentional reversing!  keep bufs on top of stack hot
-                    bufs_out.push(Buffer(bufs.pop().unwrap()));
+                    bufs_out.push(bufs.pop().unwrap());
                 }
 
                 if to_get > 0 {
@@ -151,7 +136,7 @@ impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
 
         for _ in 0..to_get {
             // note: intentional reversing!  keep bufs on top of stack hot
-            bufs_out.push(Buffer(bufs.pop().unwrap()));
+            bufs_out.push(bufs.pop().unwrap());
         }
 
         to_get
@@ -161,7 +146,7 @@ impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
     pub fn put_buffer(&self, buf: Buffer<BUFSIZ>) {
         let mut bufs = self.buffers.lock().unwrap();
         let was_empty = bufs.is_empty();
-        bufs.push(buf.0);
+        bufs.push(buf);
         drop(bufs);
         if was_empty {
             self.notify.notify_waiters();
@@ -178,9 +163,9 @@ impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
             Some(first_buf) => {
                 let mut bufs = self.buffers.lock().unwrap();
                 let was_empty = bufs.is_empty();
-                bufs.push(first_buf.0);
+                bufs.push(first_buf);
                 for buf in it {
-                    bufs.push(buf.0);
+                    bufs.push(buf);
                 }
                 drop(bufs);
                 if was_empty {
@@ -208,7 +193,7 @@ mod tests {
         barrier.wait().await;
 
         // add a buffer
-        bs.put_buffer(Buffer(buf));
+        bs.put_buffer(buf);
 
         // allow gb_task to register for notifications
         barrier.wait().await;
@@ -238,7 +223,7 @@ mod tests {
         barrier.wait().await;
 
         // add a buffer
-        bs.put_buffer(Buffer(buf));
+        bs.put_buffer(buf);
 
         // allow gb_task to register for notifications
         barrier.wait().await;

--- a/adapter/ph/src/capture_worker.rs
+++ b/adapter/ph/src/capture_worker.rs
@@ -89,8 +89,11 @@ pub async fn launch(config: Config, asm: Arc<Assembly>, mut queue: mpsc::Receive
             None => (),
         }
 
-        asm.buffer_stack
-            .put_buffers(messages.drain(..).map(|cap_pack| cap_pack.packet.destroy()));
+        asm.buffer_stack.put_buffers(
+            messages
+                .drain(..)
+                .map(|cap_pack| cap_pack.packet.destroy().try_into().unwrap()),
+        );
     }
 }
 

--- a/adapter/ph/src/classifier.rs
+++ b/adapter/ph/src/classifier.rs
@@ -76,9 +76,7 @@ pub fn get_ip_version(body: &[u8]) -> u8 {
     (body[0] & IP_VERSION_MASK) >> 4
 }
 
-pub fn classify<PktBuf: packet::PacketBuffer>(
-    packet: &mut packet::Packet<PktBuf>,
-) -> Result<ClassifierResult, &'static str> {
+pub fn classify(packet: &mut packet::Packet) -> Result<ClassifierResult, &'static str> {
     let (metadata, body) = packet.metadata_mut_and_body_mut();
     classify_zdp(metadata, body)
 }
@@ -347,13 +345,14 @@ fn classify_unclassified(
 mod tests {
     use super::*;
     use crate::config;
+    use crate::packet::Packet;
     use bytes::BufMut;
     use zerocopy::FromZeros;
 
     #[test]
     fn test_non_ip() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         let packet_data = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
         packet.alloc_zeroed_headroom(packet_data.len());
         packet.body_mut().copy_from_slice(&packet_data);
@@ -372,8 +371,8 @@ mod tests {
 
     #[test]
     fn test_v4_tcp_success() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data =
             [
@@ -404,8 +403,8 @@ mod tests {
 
     #[test]
     fn test_v4_tcp_first_frag() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data =
             [
@@ -440,8 +439,8 @@ mod tests {
 
     #[test]
     fn test_v4_tcp_subsequent_frag() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data =
             [
@@ -476,8 +475,8 @@ mod tests {
 
     #[test]
     fn test_v4_truncated_l3() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data =
             [
@@ -499,8 +498,8 @@ mod tests {
 
     #[test]
     fn test_v4_ihl_too_small() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data =
             [
@@ -526,8 +525,8 @@ mod tests {
 
     #[test]
     fn test_v4_ihl_too_big() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data =
             [
@@ -555,8 +554,8 @@ mod tests {
 
     #[test]
     fn test_v6_tcp_success() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x0d, 0x68, 0x4a, 0x00, 0x28, 0x06, 0x40,
@@ -602,8 +601,8 @@ mod tests {
 
     #[test]
     fn test_v6_first_fragment() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 128);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 128);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x02, 0x12, 0x89, 0x00, 0x50, 0x2c, 0x40,
@@ -657,8 +656,8 @@ mod tests {
 
     #[test]
     fn test_v6_subsequent_fragment() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 128);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 128);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x02, 0x12, 0x89, 0x00, 0x18, 0x2c, 0x40,
@@ -706,8 +705,8 @@ mod tests {
     #[test]
     fn test_v6_with_routing_option() {
         // This packet presents an interesting problem of the inner IP being the "correct" one
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 128);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 128);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x0f, 0xbb, 0x74, 0x00, 0x60, 0x2b, 0x3f,
@@ -764,8 +763,8 @@ mod tests {
     #[test]
     fn test_option_length_error_v6() {
         // This packet presents an interesting problem of the inner IP being the "correct" one
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 128);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 128);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x0f, 0xbb, 0x74, 0x00, 0x38, 0x2b, 0x3f,
@@ -813,8 +812,8 @@ mod tests {
 
     #[test]
     fn test_header_length_error_v6() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         let packet_data = [0x60u8, 5u8, 4u8, 3u8, 2u8, 1u8, 0u8];
         packet.alloc_zeroed_headroom(packet_data.len());
         packet.body_mut().copy_from_slice(&packet_data);
@@ -832,8 +831,8 @@ mod tests {
 
     #[test]
     fn test_ipv4_mapped_src_error_v6() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x0d, 0x68, 0x4a, 0x00, 0x28, 0x06, 0x40,
@@ -855,8 +854,8 @@ mod tests {
 
     #[test]
     fn test_ipv4_mapped_dst_error_v6() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x0d, 0x68, 0x4a, 0x00, 0x28, 0x06, 0x40,
@@ -878,8 +877,8 @@ mod tests {
 
     #[test]
     fn test_payload_length_error_v6() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x0d, 0x68, 0x4a, 0x01, 0x28, 0x06, 0x40,
@@ -924,8 +923,8 @@ mod tests {
 
     #[test]
     fn test_jumbo_reject_v6() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x0d, 0x68, 0x4a, 0x00, 0x00, 0x00, 0x40,
@@ -966,8 +965,8 @@ mod tests {
 
     #[test]
     fn test_smalljumbo_reject_v6() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x0d, 0x68, 0x4a, 0x00, 0x00, 0x00, 0x40,
@@ -1009,8 +1008,8 @@ mod tests {
 
     #[test]
     fn test_empty_packet_v6() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x0d, 0x68, 0x4a, 0x00, 0x00, 0xFE, 0x40,
@@ -1053,8 +1052,8 @@ mod tests {
 
     #[test]
     fn test_tcp_truncated() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data = [
                 0x45, 0x00, 0x00, 0x20, 0x00, 0x01, 0x00, 0x00,
@@ -1084,8 +1083,8 @@ mod tests {
 
     #[test]
     fn test_tcp_data_offset_too_small() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data = [
                 0x45, 0x00, 0x00, 0x28, 0x00, 0x01, 0x00, 0x00,
@@ -1116,8 +1115,8 @@ mod tests {
 
     #[test]
     fn test_tcp_data_offset_too_big() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data = [
                 0x45, 0x00, 0x00, 0x28, 0x00, 0x01, 0x00, 0x00,
@@ -1150,8 +1149,8 @@ mod tests {
 
     #[test]
     fn test_udp_truncated() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET + 64);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET + 64);
         #[rustfmt::skip]
         let packet_data = [
                 0x45, 0x00, 0x00, 0x20, 0x00, 0x01, 0x00, 0x00,
@@ -1183,8 +1182,8 @@ mod tests {
 
     #[test]
     fn test_icmp() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET);
         #[rustfmt::skip]
         let packet_data = [
             0x45, 0x00, 0x00, 0x54, 0x22, 0x7C, 0x40, 0x00,
@@ -1217,8 +1216,8 @@ mod tests {
 
     #[test]
     fn test_icmpv6() {
-        let mut buf: [u8; config::PACKET_BUFFER_SIZE] = [0; config::PACKET_BUFFER_SIZE];
-        let mut packet = packet::Packet::new(&mut buf, packet::PACKET_BUFFER_MIN_BODY_OFFSET);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut packet = packet::Packet::new(buf, Packet::MIN_BODY_OFFSET);
         #[rustfmt::skip]
         let packet_data = [
             0x60, 0x00, 0x00, 0x00, 0x00, 0x20, 0x3A, 0xFF,

--- a/adapter/ph/src/compress.rs
+++ b/adapter/ph/src/compress.rs
@@ -3,7 +3,7 @@
 use crate::classifier;
 use crate::defs::FiveTuple;
 use crate::net_defs;
-use crate::packet::{Packet, PacketBuffer};
+use crate::packet::Packet;
 use bytes::Buf;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use zerocopy::*;
@@ -21,7 +21,7 @@ struct CompressedIPv6Header {
     pub hop_limit: u8,
 }
 
-fn compress_addrs_v4(pkt: &mut Packet<impl PacketBuffer>) {
+fn compress_addrs_v4(pkt: &mut Packet) {
     let hdr = classifier::IPv4Header::ref_from_prefix(pkt.body())
         .unwrap()
         .0;
@@ -55,12 +55,7 @@ fn compress_addrs_v4(pkt: &mut Packet<impl PacketBuffer>) {
     pkt.push_header(&[hl_zdpflags, dscp]);
 }
 
-fn expand_addrs_v4(
-    pkt: &mut Packet<impl PacketBuffer>,
-    proto: u8,
-    src_address: Ipv4Addr,
-    dst_address: Ipv4Addr,
-) {
+fn expand_addrs_v4(pkt: &mut Packet, proto: u8, src_address: Ipv4Addr, dst_address: Ipv4Addr) {
     let hl_zdpflags_tos = pkt.get_array::<2>();
     let hl_zdpflags = hl_zdpflags_tos[0];
     let tos = hl_zdpflags_tos[1];
@@ -103,7 +98,7 @@ fn expand_addrs_v4(
         .header_checksum = csum;
 }
 
-fn compress_addrs_v6(pkt: &mut Packet<impl PacketBuffer>) {
+fn compress_addrs_v6(pkt: &mut Packet) {
     let hdr = classifier::IPv6Header::ref_from_prefix(pkt.body())
         .unwrap()
         .0;
@@ -122,7 +117,7 @@ fn compress_addrs_v6(pkt: &mut Packet<impl PacketBuffer>) {
 }
 
 fn expand_addrs_v6(
-    pkt: &mut Packet<impl PacketBuffer>,
+    pkt: &mut Packet,
     next_header: u8,
     src_address: Ipv6Addr,
     dst_address: Ipv6Addr,
@@ -157,7 +152,7 @@ pub fn compress(
     compression_mode: CompressionMode,
     l3_type: L3Type,
     _l4_protocol: net_defs::IpProtocol,
-    pkt: &mut Packet<impl PacketBuffer>,
+    pkt: &mut Packet,
 ) {
     match l3_type {
         L3Type::Ipv4 => compress_addrs_v4(pkt),
@@ -171,11 +166,7 @@ pub fn compress(
 }
 
 /// Expand a packet.  Fills payload length from body length, so trailers (e.g. A2A MAC) must not be present.
-pub fn expand(
-    compression_mode: CompressionMode,
-    five_tuple: &FiveTuple,
-    pkt: &mut Packet<impl PacketBuffer>,
-) {
+pub fn expand(compression_mode: CompressionMode, five_tuple: &FiveTuple, pkt: &mut Packet) {
     match five_tuple.l3_type {
         L3Type::Ipv4 => expand_addrs_v4(
             pkt,
@@ -208,10 +199,9 @@ mod tests {
 
     #[test]
     fn test_round_trip() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-
         for &body in TEST_CASES {
-            let mut pkt = Packet::new(&mut buf, 256);
+            let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+            let mut pkt = Packet::new(buf, 256);
             pkt.put(body);
 
             let cls_res = classifier::classify(&mut pkt).unwrap();

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -13,7 +13,7 @@ use crate::km::Codec;
 use crate::km_noise::NOISE_PADLEN;
 use crate::logging::targets::DATAPATH;
 use crate::net_defs;
-use crate::packet::{BufferPacket, Packet, PacketBuffer};
+use crate::packet::Packet;
 use crate::queues::TryEnqueueError;
 use crate::zdp;
 use crate::zdp_ll;
@@ -29,20 +29,16 @@ use zpr_ext::std::num::NonZeroExt;
 use zpr_ext::zerocopy::*;
 
 /// Drop a packet and count the drop with the given reason.
-pub fn drop_and_count(asm: &Assembly, pkt: BufferPacket, reason: impl Into<CounterType>) {
+pub fn drop_and_count(asm: &Assembly, pkt: Packet, reason: impl Into<CounterType>) {
     let reason = reason.into();
     debug!(target: DATAPATH, "dropping packet because {reason}");
-    asm.buffer_stack.put_buffer(pkt.destroy());
+    asm.buffer_stack
+        .put_buffer(pkt.destroy().try_into().unwrap());
     asm.counters[reason.into()].increment();
 }
 
 /// Add the ZPI header to a packet.
-pub fn encap_zpi(
-    _asm: &Assembly,
-    _link_id: zpr::LinkId,
-    zpi: zpr::Zpi,
-    pkt: &mut Packet<impl PacketBuffer>,
-) {
+pub fn encap_zpi(_asm: &Assembly, _link_id: zpr::LinkId, zpi: zpr::Zpi, pkt: &mut Packet) {
     pkt.alloc_zeroed_header::<zdp::ZdpZpiHeader>().zpi = zpi;
 }
 
@@ -50,15 +46,15 @@ pub fn encap_zpi(
 /// The packet must be a complete ZDP message.
 /// Despite the &mut borrow, the packet will return materially unchanged.
 /// (It will have a link-layer header temporarily added to it.)
-pub fn maybe_capture(asm: &Assembly, dir: Direction, pkt: &mut Packet<impl PacketBuffer>) {
+pub fn maybe_capture(asm: &Assembly, dir: Direction, pkt: &mut Packet) {
     maybe_capture_batch(asm, dir, [pkt])
 }
 
 /// Batch packet capture.
-pub fn maybe_capture_batch<'a, PktBuf: PacketBuffer + 'a>(
+pub fn maybe_capture_batch<'a>(
     asm: &'a Assembly,
     dir: Direction,
-    pkts: impl IntoIterator<Item = &'a mut Packet<PktBuf>>,
+    pkts: impl IntoIterator<Item = &'a mut Packet>,
 ) {
     if !asm.flow_control.program_exists() {
         return;
@@ -95,7 +91,7 @@ pub fn maybe_capture_batch<'a, PktBuf: PacketBuffer + 'a>(
             }) {
                 Some(buf) => {
                     let orig_len = pkt.body().len();
-                    let pkt_clone: BufferPacket =
+                    let pkt_clone: Packet =
                         pkt.clone_prefix_into(buf, std::cmp::min(caplen, orig_len));
                     // remove direction indicator from beginning of packet
                     pkt.advance(std::mem::size_of::<zdp_ll::ZdpLinkP2P>());
@@ -108,7 +104,8 @@ pub fn maybe_capture_batch<'a, PktBuf: PacketBuffer + 'a>(
                         Ok(()) => num_captured += 1,
 
                         Err(TryEnqueueError::Full(ret_packet)) => {
-                            asm.buffer_stack.put_buffer(ret_packet.destroy());
+                            asm.buffer_stack
+                                .put_buffer(ret_packet.destroy().try_into().unwrap());
                             // No sense to try enqueuing more packets; exit the loop early.
                             break;
                         }
@@ -133,7 +130,8 @@ pub fn maybe_capture_batch<'a, PktBuf: PacketBuffer + 'a>(
     let num_dropped = pkts_iter.count();
 
     // Return any remaining buffers.
-    asm.buffer_stack.put_buffers(bufs.into_iter());
+    asm.buffer_stack
+        .put_buffers(bufs.into_iter().map(|buf| buf.try_into().unwrap()));
 
     match dir {
         Direction::Inbound => {
@@ -151,7 +149,7 @@ pub fn maybe_capture_batch<'a, PktBuf: PacketBuffer + 'a>(
 }
 
 /// Encrypt a ZDP packet according to its ZPI header (which is not encrypted).
-pub fn encrypt_null(pkt: &mut Packet<impl PacketBuffer>) {
+pub fn encrypt_null(pkt: &mut Packet) {
     // RFC 6.5 § 5.25.2
     pkt.put(
         net_defs::inet_checksum(&pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..]).as_slice(),
@@ -159,7 +157,7 @@ pub fn encrypt_null(pkt: &mut Packet<impl PacketBuffer>) {
 }
 
 /// Slap an HMAC onto the end of the packet.
-pub fn encrypt_hmac(send_hmac_key: [u8; 32], pkt: &mut Packet<impl PacketBuffer>) {
+pub fn encrypt_hmac(send_hmac_key: [u8; 32], pkt: &mut Packet) {
     let mut link_mac = [0u8; zdp::ZDP_PACKET_MAC_SIZE];
     link_mac[..zdp::ZDP_PACKET_MAC_SIZE].copy_from_slice(
         &blake3::keyed_hash(&send_hmac_key, pkt.body()).as_bytes()[..zdp::ZDP_PACKET_MAC_SIZE],
@@ -170,7 +168,7 @@ pub fn encrypt_hmac(send_hmac_key: [u8; 32], pkt: &mut Packet<impl PacketBuffer>
 pub fn encrypt_full(
     _asm: &Assembly,
     codec: &dyn Codec,
-    pkt: &mut Packet<impl PacketBuffer>,
+    pkt: &mut Packet,
 ) -> Result<(), km::EncryptionError> {
     // TODO: Could do some length checks here on the packet body.  Is it too short? Too long? Etc.
 
@@ -214,7 +212,7 @@ impl From<DecryptError> for CounterType {
 }
 
 /// Decrypt a ZDP packet according to its ZPI header (which is not removed).
-pub fn decrypt_null(pkt: &mut Packet<impl PacketBuffer>) -> Result<(), DecryptError> {
+pub fn decrypt_null(pkt: &mut Packet) -> Result<(), DecryptError> {
     // RFC 6.5 § 5.25.2
     if !net_defs::validate_inet_checksum(&pkt.body()[std::mem::size_of::<zdp::ZdpZpiHeader>()..]) {
         return Err(DecryptError::BadChecksum);
@@ -226,10 +224,7 @@ pub fn decrypt_null(pkt: &mut Packet<impl PacketBuffer>) -> Result<(), DecryptEr
 }
 
 /// Check and remove the link-2-link HMAC on the (presumed) transit packet.
-pub fn decrypt_hmac(
-    recv_hmac_key: [u8; 32],
-    pkt: &mut Packet<impl PacketBuffer>,
-) -> Result<(), DecryptError> {
+pub fn decrypt_hmac(recv_hmac_key: [u8; 32], pkt: &mut Packet) -> Result<(), DecryptError> {
     if pkt.body().len() < zdp::ZDP_PACKET_MAC_SIZE {
         return Err(DecryptError::BadStructure);
     }
@@ -253,7 +248,7 @@ pub fn decrypt_full(
     _asm: &Assembly,
     codec: &dyn Codec,
     padlen: usize,
-    pkt: &mut Packet<impl PacketBuffer>,
+    pkt: &mut Packet,
 ) -> Result<(), DecryptError> {
     if pkt.body().len() < 1 {
         return Err(DecryptError::BadStructure);
@@ -282,7 +277,7 @@ pub fn decrypt_full(
 fn substrate_egress_common(
     asm: &Assembly,
     link_id: zpr::LinkId,
-    pkt: &mut BufferPacket,
+    pkt: &mut Packet,
 ) -> Result<Option<zpr::SubstrateAddr>, km::EncryptionError> {
     // TODO: should we add ZDP header here also??
 
@@ -356,7 +351,7 @@ fn substrate_egress_common(
 
 /// Egress a ZDP packet on the given link ID, according to the given ZPI.
 /// The ZPI header will be added to the packet.
-pub fn substrate_egress(asm: &Assembly, link_id: zpr::LinkId, mut pkt: BufferPacket) {
+pub fn substrate_egress(asm: &Assembly, link_id: zpr::LinkId, mut pkt: Packet) {
     let dest_sa = match substrate_egress_common(asm, link_id, &mut pkt) {
         Ok(Some(dest_sa)) => dest_sa,
         Ok(None) => {
@@ -383,11 +378,7 @@ pub fn substrate_egress(asm: &Assembly, link_id: zpr::LinkId, mut pkt: BufferPac
 
 /// A blocking/async version of `substrate_egress()`, for management path use.
 /// Useful to ensure fairness under high load.
-pub async fn substrate_egress_blocking(
-    asm: &Assembly,
-    link_id: zpr::LinkId,
-    mut pkt: BufferPacket,
-) {
+pub async fn substrate_egress_blocking(asm: &Assembly, link_id: zpr::LinkId, mut pkt: Packet) {
     let dest_sa = match substrate_egress_common(asm, link_id, &mut pkt) {
         Ok(Some(dest_sa)) => dest_sa,
         Ok(None) => {
@@ -429,7 +420,7 @@ pub fn substrate_ingress(
     asm: &Assembly,
     #[cfg_attr(not(debug_assertions), allow(unused_variables))] worker_index: usize,
     peer_sa: &zpr::SubstrateAddr,
-    mut pkt: BufferPacket,
+    mut pkt: Packet,
 ) {
     asm.counters[CounterType::InPacksRec].increment();
 
@@ -608,7 +599,7 @@ pub fn substrate_ingress(
 pub fn agent_input(
     asm: &Assembly,
     tether_id: zpr::StreamId, // TODO: should we keep this in metadata? or per-flow header?
-    mut pkt: BufferPacket,
+    mut pkt: Packet,
 ) {
     // extract A2A MAC
     let Ok(a2a_hdr) = zdp::ZdpA2aHeader::read_from_buf(&mut pkt) else {
@@ -657,7 +648,7 @@ pub fn agent_input(
 
 /// Process uncompressed packet from the agent.
 /// The packet will be compressed, or trigger a Bind request.
-pub fn agent_output(asm: &Assembly, mut pkt: BufferPacket) {
+pub fn agent_output(asm: &Assembly, mut pkt: Packet) {
     pkt.metadata_mut().ingress_link_id = zpr::LOCAL_AGENT_LINK_ID;
 
     // determine five tuple
@@ -693,7 +684,7 @@ pub fn agent_output(asm: &Assembly, mut pkt: BufferPacket) {
 /// bind.  `allow_bind_request` should be true for "real" packets; false for
 /// packets re-injected from mgmt plane after fulfilling a bind request (so
 /// as to prevent the theoretical possibility of a packet loop).
-pub fn agent_output_post_classify(asm: &Assembly, mut pkt: BufferPacket, allow_bind_request: bool) {
+pub fn agent_output_post_classify(asm: &Assembly, mut pkt: Packet, allow_bind_request: bool) {
     let five_tuple = *pkt.metadata().five_tuple(); // TODO: convince borrow checker we don't need to copy this out
 
     // lookup five tuple in ALT
@@ -763,7 +754,7 @@ const _: () = assert!(adapter_next_hop_link(zpr::LOCAL_AGENT_LINK_ID) == zpr::DO
 const _: () = assert!(adapter_next_hop_link(zpr::DOCK_LINK_ID) == zpr::LOCAL_AGENT_LINK_ID);
 
 /// Forward compressed packet.
-pub fn forward(asm: &Assembly, mut pkt: BufferPacket) {
+pub fn forward(asm: &Assembly, mut pkt: Packet) {
     let egress_link_id;
     let egress_stream_id;
 
@@ -813,8 +804,8 @@ mod test {
 
     #[test]
     fn test_encrypt_decrypt_null() {
-        let mut buf = [0u8; PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 64);
+        let buf = Box::new([0u8; PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 64);
 
         pkt.put(&b"this is a test of encrypt zero"[..]);
 
@@ -832,8 +823,8 @@ mod test {
 
     #[test]
     fn test_add_and_check_hmac() {
-        let mut buf = [0u8; PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 64);
+        let buf = Box::new([0u8; PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 64);
 
         pkt.put(&b"this is a test of hmac"[..]);
         let key: [u8; 32] = [6u8; 32];
@@ -852,8 +843,8 @@ mod test {
 
     #[test]
     fn test_add_and_check_hmac_fail() {
-        let mut buf = [0u8; PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 64);
+        let buf = Box::new([0u8; PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 64);
 
         pkt.put(&b"this is a test of hmac"[..]);
         let key: [u8; 32] = [6u8; 32];

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -10,7 +10,7 @@
 
 use crate::config;
 use crate::logging::targets::KEY_MGMT;
-use crate::packet::{Packet, PacketBuffer};
+use crate::packet::Packet;
 use crate::zdp::{ZdpBaseHeader, ZdpPacketType, ZdpZpiHeader};
 use bytes::{BufMut, Bytes};
 use openssl::x509::X509;
@@ -707,10 +707,7 @@ impl Default for KmTransportSA {
 /// Helper function which is ZDP aware.  Does some error checking and leaves the ZPI
 /// in place.
 #[allow(dead_code)]
-pub fn encrypt_transport_zdp(
-    message: &mut Packet<impl PacketBuffer>,
-    codec: Arc<dyn Codec>,
-) -> KmResult<()> {
+pub fn encrypt_transport_zdp(message: &mut Packet, codec: Arc<dyn Codec>) -> KmResult<()> {
     if message.body().len()
         < std::mem::size_of::<ZdpZpiHeader>() + std::mem::size_of::<ZdpBaseHeader>()
     {
@@ -744,10 +741,7 @@ pub fn encrypt_transport_zdp(
 
 /// Helper function which is ZDP aware.  Does some error checking and leaves the ZPI in place.
 #[allow(dead_code)]
-pub fn decrypt_transport_zdp(
-    message: &mut Packet<impl PacketBuffer>,
-    codec: Arc<dyn Codec>,
-) -> KmResult<()> {
+pub fn decrypt_transport_zdp(message: &mut Packet, codec: Arc<dyn Codec>) -> KmResult<()> {
     if message.body().len() < 1 {
         return Err(KmError::ShortPacket);
     }
@@ -1099,8 +1093,8 @@ mod test {
             excess_length: 0u8,
             sequence_number: 0u16.into(),
         };
-        let mut buf = [0u8; PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 64);
+        let buf = Box::new([0u8; PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 64);
         //let hbytes = hdr.as_bytes();
         //pkt.body_mut()[0..hbytes.len()].copy_from_slice(&hbytes);
         hdr.write_to_buf(&mut pkt).unwrap();
@@ -1134,8 +1128,8 @@ mod test {
     async fn test_km_decrypt_transport_non_transit() {
         let codec = Arc::new(CopyCodec {});
 
-        let mut buf = [0u8; PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 64);
+        let buf = Box::new([0u8; PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 64);
 
         let hdr = ZdpBaseHeader {
             packet_type: ZdpPacketType::EchoRequest,

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -7,7 +7,7 @@ use crate::assembly::Assembly;
 use crate::config;
 use crate::counters::CounterType;
 use crate::fastpath;
-use crate::packet::{BufferPacket, Packet};
+use crate::packet::{Packet, PacketBuffer};
 use crate::zdp;
 use std::time::Duration;
 use thiserror::Error;
@@ -22,7 +22,7 @@ pub async fn send_non_flow_mgmt(
     asm: &Assembly,
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
-    packet: BufferPacket,
+    packet: Packet,
 ) {
     send_mgmt_helper(asm, link_id, packet_type, None, None, packet).await
 }
@@ -35,7 +35,7 @@ pub async fn send_per_flow_mgmt(
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
     stream_id: zpr::StreamId,
-    packet: BufferPacket,
+    packet: Packet,
 ) {
     send_mgmt_helper(asm, link_id, packet_type, Some(stream_id), None, packet).await
 }
@@ -45,7 +45,7 @@ pub async fn send_non_flow_mgmt_response(
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
     sequence_number: zpr::SeqNum,
-    packet: BufferPacket,
+    packet: Packet,
 ) {
     send_mgmt_helper(
         asm,
@@ -64,7 +64,7 @@ pub async fn send_per_flow_mgmt_response(
     packet_type: zdp::ZdpPacketType,
     stream_id: zpr::StreamId,
     sequence_number: zpr::SeqNum,
-    packet: BufferPacket,
+    packet: Packet,
 ) {
     send_mgmt_helper(
         asm,
@@ -83,7 +83,7 @@ async fn send_mgmt_helper(
     packet_type: zdp::ZdpPacketType,
     stream_id: Option<zpr::StreamId>,
     sequence_number: Option<zpr::SeqNum>,
-    mut packet: BufferPacket,
+    mut packet: Packet,
 ) {
     debug_assert_eq!(stream_id.is_some(), packet_type.is_per_flow());
 
@@ -113,8 +113,8 @@ pub async fn send_sync_non_flow_req(
     link_id: zpr::LinkId,
     zdp_request_type: zdp::ZdpPacketType,
     zdp_response_type: zdp::ZdpPacketType,
-    pkt_fn: impl Fn(&mut BufferPacket) + Send + 'static,
-) -> Result<BufferPacket, SyncReqError> {
+    pkt_fn: impl Fn(&mut Packet) + Send + 'static,
+) -> Result<Packet, SyncReqError> {
     send_sync_req_helper(
         asm,
         link_id,
@@ -137,8 +137,8 @@ pub async fn send_sync_per_flow_req(
     zdp_request_type: zdp::ZdpPacketType,
     zdp_response_type: zdp::ZdpPacketType,
     stream_id: zpr::StreamId,
-    pkt_fn: impl Fn(&mut BufferPacket /* FIXME: can relax to Packet<_> */) + Send + 'static,
-) -> Result<(zpr::StreamId, BufferPacket), SyncReqError> {
+    pkt_fn: impl Fn(&mut Packet) + Send + 'static,
+) -> Result<(zpr::StreamId, Packet), SyncReqError> {
     match send_sync_req_helper(
         asm,
         link_id,
@@ -181,8 +181,8 @@ async fn send_sync_req_helper(
     zdp_request_type: zdp::ZdpPacketType,
     zdp_response_type: zdp::ZdpPacketType,
     stream_id: Option<zpr::StreamId>,
-    pkt_fn: impl Fn(&mut BufferPacket /* FIXME: relax to Packet */) + 'static,
-) -> Result<BufferPacket, SyncReqError> {
+    pkt_fn: impl Fn(&mut Packet) + 'static,
+) -> Result<Packet, SyncReqError> {
     // acquire a permit to send a manamgement message
     let Some(peer_state) = asm.peer_table.get(link_id) else {
         return Err(SyncReqError::LinkClosed);
@@ -191,8 +191,8 @@ async fn send_sync_req_helper(
     let mut response_future = peer_state.sync_req_state.install_response_listener(&permit);
 
     for _i in 0..=config::DEFAULT_REQUEST_RETRY_COUNT {
-        let buf = drop_guard(asm.buffer_stack.get_buffer().await, |buf| {
-            asm.buffer_stack.put_buffer(buf)
+        let buf = drop_guard(asm.buffer_stack.get_buffer().await as PacketBuffer, |buf| {
+            asm.buffer_stack.put_buffer(buf.try_into().unwrap())
         });
         let mut packet = Packet::new_guarded(buf, config::DEFAULT_MESSAGE_HEADROOM);
         pkt_fn(&mut packet);
@@ -228,10 +228,10 @@ async fn send_sync_req_helper(
 // TODO: rename/move this
 fn match_received(
     asm: &Assembly,
-    response: Option<(zdp::ZdpPacketType, BufferPacket)>,
+    response: Option<(zdp::ZdpPacketType, Packet)>,
     err_type: SyncReqError,
     zdp_response_type: zdp::ZdpPacketType,
-) -> Result<BufferPacket, SyncReqError> {
+) -> Result<Packet, SyncReqError> {
     match response {
         Some((pkt_type, pkt)) => {
             if pkt_type != zdp_response_type {

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -7,7 +7,7 @@ use crate::fastpath;
 use crate::km_multiplexor;
 use crate::link_state::LinkType;
 use crate::logging::targets::{KEY_MGMT, ZDP};
-use crate::packet::BufferPacket;
+use crate::packet::Packet;
 use crate::queues;
 use crate::zdp;
 use bytes::Buf;
@@ -24,7 +24,7 @@ use zpr_ext::zerocopy::FromBytesExt;
 pub fn dispatch_mgmt_packet_with_addr(
     asm: &Arc<Assembly>,
     peer_sa: zpr::SubstrateAddr,
-    mut pkt: BufferPacket,
+    mut pkt: Packet,
 ) {
     match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
         Ok(base_hdr) if base_hdr.0.packet_type == zdp::ZdpPacketType::KeyManagement => {
@@ -54,7 +54,7 @@ pub fn dispatch_mgmt_packet_with_addr(
 ///
 /// This function does not block, and does not perform significant processing.
 /// It merely dispatches the management packet to the correct queue.
-pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, mut pkt: BufferPacket) {
+pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, mut pkt: Packet) {
     match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
         Ok((base_hdr, _)) if base_hdr.packet_type == zdp::ZdpPacketType::KeyManagement => {
             pkt.advance(std::mem::size_of::<zdp::ZdpBaseHeader>());
@@ -88,7 +88,7 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, mut pkt: BufferPacket
     }
 }
 
-fn handle_response(asm: &Assembly, mut pkt: BufferPacket) -> HandleMgmtResult {
+fn handle_response(asm: &Assembly, mut pkt: Packet) -> HandleMgmtResult {
     let Ok(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };
@@ -115,7 +115,7 @@ fn handle_response(asm: &Assembly, mut pkt: BufferPacket) -> HandleMgmtResult {
 
 // ZPI and Base header is already gone by the time we get here.  So we expect
 // to parse starting from the KeyManagement header.
-fn handle_key_management(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> HandleMgmtResult {
+fn handle_key_management(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
     let Ok(km_hdr) = zdp::ZdpKeyManagementHeader::read_from_buf(&mut pkt) else {
         error!(target: ZDP, "KeyManagement packet arrived with unparseable header");
         return Err((HandleMgmtError::BadStructure, pkt));
@@ -154,7 +154,8 @@ fn handle_key_management(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> HandleMg
             return Err((HandleMgmtError::KeyManagementError(format!("{e:?}")), pkt));
         }
     };
-    asm.buffer_stack.put_buffer(pkt.destroy());
+    asm.buffer_stack
+        .put_buffer(pkt.destroy().try_into().unwrap());
 
     Ok(())
 }

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -8,7 +8,7 @@ use crate::defs::*;
 use crate::link_state::LinkEvent;
 use crate::logging::targets::{FLOW_MGMT, REPORTING, ZDP};
 use crate::net_defs::IpAddress;
-use crate::packet::{BufferPacket, Packet};
+use crate::packet::Packet;
 use crate::zdp;
 use bytes::{Buf, BufMut};
 use std::num::NonZero;
@@ -39,10 +39,10 @@ impl From<HandleMgmtError> for counters::CounterType {
     }
 }
 
-pub type HandleMgmtResult = Result<(), (HandleMgmtError, BufferPacket)>;
+pub type HandleMgmtResult = Result<(), (HandleMgmtError, Packet)>;
 
 /// handle a Report message (RFC 6.5 § 6.3.13)
-pub async fn handle_report(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> HandleMgmtResult {
+pub async fn handle_report(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpReportHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };
@@ -58,19 +58,21 @@ pub async fn handle_report(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> Handle
             std::str::from_utf8(&pkt.body()[..report_data_length]).unwrap()
         );
     }
-    asm.buffer_stack.put_buffer(pkt.destroy());
+    asm.buffer_stack
+        .put_buffer(pkt.destroy().try_into().unwrap());
     Ok(())
 }
 
 /// handle a Discard message (RFC 6.5 § 6.3.1)
-pub async fn handle_discard(asm: &Arc<Assembly>, pkt: BufferPacket) -> HandleMgmtResult {
+pub async fn handle_discard(asm: &Arc<Assembly>, pkt: Packet) -> HandleMgmtResult {
     // TODO print to debug log, when implemented
     info!(
         target: REPORTING,
         "Discard message received from {}",
         pkt.metadata().ingress_link_id
     );
-    asm.buffer_stack.put_buffer(pkt.destroy());
+    asm.buffer_stack
+        .put_buffer(pkt.destroy().try_into().unwrap());
     Ok(())
 }
 
@@ -78,7 +80,7 @@ pub async fn handle_discard(asm: &Arc<Assembly>, pkt: BufferPacket) -> HandleMgm
 pub async fn handle_terminate_request(
     asm: &Arc<Assembly>,
     seq_num: zpr::SeqNum,
-    mut pkt: BufferPacket,
+    mut pkt: Packet,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
     let Ok(hdr) = zdp::ZdpTerminateLinkRequestHeader::read_from_buf(&mut pkt) else {
@@ -120,7 +122,7 @@ pub async fn handle_terminate_request(
 pub async fn handle_terminate_indication(
     asm: &Arc<Assembly>,
     _seq_num: zpr::SeqNum,
-    mut pkt: BufferPacket,
+    mut pkt: Packet,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
     let Ok(hdr) = zdp::ZdpTerminateLinkIndicationHeader::read_from_buf(&mut pkt) else {
@@ -140,7 +142,7 @@ pub async fn handle_terminate_indication(
 pub async fn handle_hello_request(
     asm: &Arc<Assembly>,
     seq_num: zpr::SeqNum,
-    pkt: BufferPacket,
+    pkt: Packet,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
@@ -172,7 +174,7 @@ pub async fn handle_hello_request(
 pub async fn handle_hello_response(
     asm: &Arc<Assembly>,
     _seq_num: zpr::SeqNum,
-    mut pkt: BufferPacket,
+    mut pkt: Packet,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
@@ -189,7 +191,8 @@ pub async fn handle_hello_response(
         return Err((HandleMgmtError::LinkStateError, pkt));
     };
 
-    asm.buffer_stack.put_buffer(pkt.destroy());
+    asm.buffer_stack
+        .put_buffer(pkt.destroy().try_into().unwrap());
     Ok(())
 }
 
@@ -197,7 +200,7 @@ pub async fn handle_hello_response(
 pub async fn handle_register_agent_address_request(
     asm: &Arc<Assembly>,
     seq_num: zpr::SeqNum,
-    mut pkt: BufferPacket,
+    mut pkt: Packet,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
@@ -257,7 +260,7 @@ pub async fn handle_register_agent_address_request(
 pub async fn handle_register_agent_address_response(
     asm: &Arc<Assembly>,
     _seq_num: zpr::SeqNum,
-    pkt: BufferPacket,
+    pkt: Packet,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
     debug!(target: ZDP, "Received Register Agent Address Response for link {ingress_link_id}");
@@ -275,7 +278,7 @@ pub async fn handle_register_agent_address_response(
 pub async fn handle_bind_agent_address_request(
     asm: &Arc<Assembly>,
     seq_num: zpr::SeqNum,
-    mut pkt: BufferPacket,
+    mut pkt: Packet,
 ) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpBindAgentAddressRequestHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
@@ -433,7 +436,8 @@ pub async fn handle_bind_agent_address_request(
                     assembly::AddRouteError::PeerGone,
                 )) => {
                     // peer went away; don't bother responding
-                    asm.buffer_stack.put_buffer(rsp_pkt.destroy());
+                    asm.buffer_stack
+                        .put_buffer(rsp_pkt.destroy().try_into().unwrap());
                     return Ok(());
                 }
 

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -8,7 +8,7 @@ use crate::counters::CounterType;
 use crate::defs::*;
 use crate::fastpath;
 use crate::logging::targets::ZDP;
-use crate::packet::{self, Packet};
+use crate::packet::Packet;
 use crate::zdp;
 use bytes::{Buf, BufMut};
 use std::net::IpAddr;
@@ -64,7 +64,8 @@ pub async fn send_hello_request(asm: &Assembly, link_id: zpr::LinkId) -> Result<
             };
             let status = hdr.status;
             debug!(target: ZDP, "Received HelloResponse, status: {status}");
-            asm.buffer_stack.put_buffer(hello_res.destroy());
+            asm.buffer_stack
+                .put_buffer(hello_res.destroy().try_into().unwrap());
             Ok(())
         }
 
@@ -122,7 +123,8 @@ pub async fn send_register_agent_address_request(
                 "Received RegisterAgentAddressResponse, status: {}",
                 hdr.status_code
             );
-            asm.buffer_stack.put_buffer(register_res.destroy());
+            asm.buffer_stack
+                .put_buffer(register_res.destroy().try_into().unwrap());
         }
 
         Err(err) => {
@@ -165,7 +167,8 @@ pub async fn send_terminate_request<'a, 'pktbuf>(
             };
             let resp_code = hdr.response_code;
             info!("Received TerminateLinkResponse, status: {:?}", resp_code);
-            asm.buffer_stack.put_buffer(terminate_res.destroy());
+            asm.buffer_stack
+                .put_buffer(terminate_res.destroy().try_into().unwrap());
             Ok(resp_code)
         }
 
@@ -261,7 +264,8 @@ pub async fn send_bind_agent_address_request(
 
             match hdr.status_code {
                 zdp::ZdpBindAgentAddressResponseHeader::STATUS_CODE_SUCCESS => {
-                    asm.buffer_stack.put_buffer(resp.destroy());
+                    asm.buffer_stack
+                        .put_buffer(resp.destroy().try_into().unwrap());
                     Ok(tether_id)
                 }
 
@@ -277,7 +281,8 @@ pub async fn send_bind_agent_address_request(
                     };
                     let msg: Box<str> = msg.into();
 
-                    asm.buffer_stack.put_buffer(resp.destroy());
+                    asm.buffer_stack
+                        .put_buffer(resp.destroy().try_into().unwrap());
                     Err(BindAgentAddressError::BindAgentAddressError(msg))
                 }
 
@@ -297,9 +302,9 @@ pub async fn send_bind_agent_address_request(
 pub async fn send_report(asm: &Assembly, link_id: zpr::LinkId, report: &str) {
     // TODO this condition will need to be adjusted when we have complete ZPR packets
     // with the information at the end of the packet at well
-    if packet::PACKET_BUFFER_MAX_BODY_SIZE - config::DEFAULT_MESSAGE_HEADROOM < report.len() {
+    /*if packet::PACKET_BUFFER_MAX_BODY_SIZE - config::DEFAULT_MESSAGE_HEADROOM < report.len() {
         return;
-    }
+    }*/  // CTP FIXME
     let buf = asm.buffer_stack.get_buffer().await;
     let mut pkt = Packet::new(buf, config::DEFAULT_MESSAGE_HEADROOM);
     let hdr = pkt.alloc_zeroed_header::<zdp::ZdpReportHeader>();

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -3,7 +3,7 @@ use crate::counters::CounterType;
 use crate::fastpath;
 use crate::logging::targets::ZDP;
 use crate::mgmt::handlers::{self, HandleMgmtError, HandleMgmtResult};
-use crate::packet::BufferPacket;
+use crate::packet::Packet;
 use crate::queues::MgmtProcessorMessage;
 use crate::zdp::*;
 use std::sync::Arc;
@@ -43,7 +43,7 @@ pub async fn launch(
     }
 }
 
-async fn handle_packet(asm: &Arc<Assembly>, mut pkt: BufferPacket) -> HandleMgmtResult {
+async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
     let Ok(base_hdr) = ZdpBaseHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -6,11 +6,10 @@
 //!
 //! For usage examples see the [Packet] documentation.
 
-use crate::config;
 use crate::defs::*;
 use crate::net_defs::*;
 use bytes::buf;
-use std::mem::{size_of, size_of_val};
+use std::mem::size_of;
 use zerocopy::*;
 use zpr;
 use zpr::L3Type;
@@ -146,29 +145,13 @@ use zpr_ext::std::mem::DropGuard;
 /// }
 /// ```
 
-/// A generic packet type, backed by any sort of buffer.
-///
-/// Use this type in functions which operate only on the contents of a packet,
-/// and do not interact with the buffer stack in any way.
-pub struct Packet<PktBuf> {
-    buf: PktBuf,
-}
+/// Packet backing buffers are heap-allocated slices.
+pub type PacketBuffer = Box<[u8]>;
 
-/// Blanket trait capturing all the traits needed to act as a packet backing buffer.
-pub trait PacketBuffer:
-    std::ops::DerefMut<Target = [u8; config::PACKET_BUFFER_SIZE]> + Send
-{
+/// A generic packet type, backed by a heap-allocated buffer.
+pub struct Packet {
+    buf: PacketBuffer,
 }
-impl<PktBuf: std::ops::DerefMut<Target = [u8; config::PACKET_BUFFER_SIZE]> + Send> PacketBuffer
-    for PktBuf
-{
-}
-
-/// A `Packet` backed specifically by a `Buffer` from the buffer stack.
-///
-/// Use this type in any code which moves a packet through the packet processing
-/// pipeline (ultimately starting from, or ending with, the buffer stack).
-pub type BufferPacket = Packet<crate::buffer_stack::Buffer<{ config::PACKET_BUFFER_SIZE }>>;
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout)]
 #[repr(C)]
@@ -249,31 +232,36 @@ impl std::fmt::Debug for PacketMetadata {
     }
 }
 
-const _: () = assert!(
-    size_of::<PacketMetadata>() <= config::PACKET_BUFFER_SIZE,
-    "Metadata must be shorter than the packet buffer"
-);
-
-pub const PACKET_BUFFER_MIN_BODY_OFFSET: usize = size_of::<PacketMetadata>();
-
-/// The maximum size packet body which can be referenced by a `Packet`.
 #[allow(dead_code)]
-pub const PACKET_BUFFER_MAX_BODY_SIZE: usize =
-    config::PACKET_BUFFER_SIZE - PACKET_BUFFER_MIN_BODY_OFFSET;
+impl Packet {
+    pub const MIN_BODY_OFFSET: usize = size_of::<PacketMetadata>();
 
-#[allow(dead_code)]
-impl<PktBuf: PacketBuffer> Packet<PktBuf> {
+    /// The maximum size packet body which can be referenced by this `Packet`.
+    pub const fn max_body_size(&self) -> usize {
+        Self::max_body_size_for(self.buf.len())
+    }
+
+    /// The maximum size packet body which can be referenced by a `Packet`
+    /// whose backing buffer is the given length.
+    pub const fn max_body_size_for(buf_size: usize) -> usize {
+        buf_size - Self::MIN_BODY_OFFSET
+    }
+
     /// Initialize a buffer as a packet buffer, returning an exclusive handle to it.
     /// `headroom` indicates room to keep free at packet start for possible extension.
-    pub fn new(buf: PktBuf, headroom: usize) -> Self {
-        Self::new_with_existing_data(buf, PACKET_BUFFER_MIN_BODY_OFFSET + headroom, 0)
+    pub fn new(buf: PacketBuffer, headroom: usize) -> Self {
+        assert!(
+            buf.len() >= size_of::<PacketMetadata>(),
+            "packet buffer must be large enough to contain metadata"
+        );
+        Self::new_with_existing_data(buf, Self::MIN_BODY_OFFSET + headroom, 0)
     }
 
     /// Same as `new()`, but accepts a `DropGuard`-protected buffer, and produces
     /// a `DropGuard`-protected packet buffer, so manually calling `destroy()`
     /// is unnecessary.
-    pub fn new_guarded<B: DropGuard<PktBuf> + Send>(
-        buf: B,
+    pub fn new_guarded(
+        buf: impl DropGuard<PacketBuffer> + Send,
         headroom: usize,
     ) -> impl DropGuard<Self> + Send {
         buf.map(move |b| Self::new(b, headroom), |p| p.destroy())
@@ -281,17 +269,17 @@ impl<PktBuf: PacketBuffer> Packet<PktBuf> {
 
     /// Consumes a packet handle, returning the underlying buffer.
     #[must_use]
-    pub fn destroy(self) -> PktBuf {
+    pub fn destroy(self) -> PacketBuffer {
         self.buf
     }
 
     /// Initialize a buffer with existing packet data as a packet buffer.
     /// `offset` is offset of data within buffer.
-    /// It must be at least equal to `PACKET_BUFFER_MIN_BODY_OFFSET`.
-    pub fn new_with_existing_data(buf: PktBuf, offset: usize, len: usize) -> Self {
-        assert!(offset >= PACKET_BUFFER_MIN_BODY_OFFSET);
-        assert!(len <= size_of_val(&*buf));
-        assert!(offset <= size_of_val(&*buf) - len);
+    /// It must be at least equal to `Self::MIN_BODY_OFFSET`.
+    pub fn new_with_existing_data(buf: PacketBuffer, offset: usize, len: usize) -> Self {
+        assert!(offset >= Self::MIN_BODY_OFFSET);
+        assert!(len <= buf.len());
+        assert!(offset <= buf.len() - len);
         let mut pkt = Packet { buf };
         let md = pkt.metadata_mut();
         md.offset = offset;
@@ -302,42 +290,34 @@ impl<PktBuf: PacketBuffer> Packet<PktBuf> {
     }
 
     /// Copy this packet's metadata, data and layout into a new buffer, returning a handle for it.
-    pub fn clone_into<OtherPktBuf: PacketBuffer>(&self, buf: OtherPktBuf) -> Packet<OtherPktBuf> {
+    pub fn clone_into(&self, buf: PacketBuffer) -> Packet {
         self.clone_prefix_into_with_headroom(buf, self.headroom_available(), self.body().len())
     }
 
     /// Like `clone_into()`, but only copy a prefix of the packet's data.
-    pub fn clone_prefix_into<OtherPktBuf: PacketBuffer>(
-        &self,
-        buf: OtherPktBuf,
-        len: usize,
-    ) -> Packet<OtherPktBuf> {
+    pub fn clone_prefix_into(&self, buf: PacketBuffer, len: usize) -> Packet {
         self.clone_prefix_into_with_headroom(buf, self.headroom_available(), len)
     }
 
     /// Copy this packet's metadata and data into a new buffer, returning a handle for it.
     /// The packet body will be positioned to leave the specified amount of headroom in the new buffer.
-    pub fn clone_into_with_headroom<OtherPktBuf: PacketBuffer>(
-        &self,
-        buf: OtherPktBuf,
-        headroom: usize,
-    ) -> Packet<OtherPktBuf> {
+    pub fn clone_into_with_headroom(&self, buf: PacketBuffer, headroom: usize) -> Packet {
         self.clone_prefix_into_with_headroom(buf, headroom, self.body().len())
     }
 
     /// Like `clone_into_with_headroom()`, but only copy a prefix of the packet's data.
-    pub fn clone_prefix_into_with_headroom<OtherPktBuf: PacketBuffer>(
+    pub fn clone_prefix_into_with_headroom(
         &self,
-        mut buf: OtherPktBuf,
+        mut buf: PacketBuffer,
         headroom: usize,
         len: usize,
-    ) -> Packet<OtherPktBuf> {
+    ) -> Packet {
         let body = self.body();
         assert!(len <= body.len());
-        assert!(headroom <= size_of_val(&*buf) - len - PACKET_BUFFER_MIN_BODY_OFFSET);
+        assert!(headroom <= buf.len() - len - Self::MIN_BODY_OFFSET);
         buf[..size_of::<PacketMetadata>()]
             .copy_from_slice(&self.buf[..size_of::<PacketMetadata>()]);
-        let offset = PACKET_BUFFER_MIN_BODY_OFFSET + headroom;
+        let offset = Self::MIN_BODY_OFFSET + headroom;
         buf[offset..offset + len].copy_from_slice(body);
         let mut pkt = Packet { buf };
         pkt.metadata_mut().offset = offset;
@@ -349,7 +329,7 @@ impl<PktBuf: PacketBuffer> Packet<PktBuf> {
     pub fn metadata(&self) -> &PacketMetadata {
         let opt = PacketMetadata::ref_from_bytes(&self.buf[..size_of::<PacketMetadata>()]);
         unsafe {
-            // SAFETY: we know this fits in PACKET_BUFFER_SIZE
+            // SAFETY: we know this fits in our buffer
             opt.unwrap_unchecked()
         }
     }
@@ -358,7 +338,7 @@ impl<PktBuf: PacketBuffer> Packet<PktBuf> {
     pub fn metadata_mut(&mut self) -> &mut PacketMetadata {
         let opt = PacketMetadata::mut_from_bytes(&mut self.buf[..size_of::<PacketMetadata>()]);
         unsafe {
-            // SAFETY: we know this fits in PACKET_BUFFER_SIZE
+            // SAFETY: we know this fits in our buffer
             opt.unwrap_unchecked()
         }
     }
@@ -382,7 +362,7 @@ impl<PktBuf: PacketBuffer> Packet<PktBuf> {
         let (md, bd) = self.buf.split_at_mut(size_of::<PacketMetadata>());
         let opt = PacketMetadata::mut_from_bytes(md);
         let md = unsafe {
-            // SAFETY: we know this fits in PACKET_BUFFER_SIZE
+            // SAFETY: we know this fits in our buffer
             opt.unwrap_unchecked()
         };
         let offset = md.offset - size_of::<PacketMetadata>();
@@ -392,7 +372,7 @@ impl<PktBuf: PacketBuffer> Packet<PktBuf> {
 
     /// Returns the amount of space available for extension of the start of the packet.
     pub fn headroom_available(&self) -> usize {
-        self.metadata().offset - PACKET_BUFFER_MIN_BODY_OFFSET
+        self.metadata().offset - Self::MIN_BODY_OFFSET
     }
 
     /// Extend the start of the packet into available headroom by the given amount,
@@ -467,7 +447,7 @@ impl<PktBuf: PacketBuffer> Packet<PktBuf> {
     }
 }
 
-impl<PktBuf: PacketBuffer> buf::Buf for Packet<PktBuf> {
+impl buf::Buf for Packet {
     //! Reading from a `Packet` using the `Buf` interface consumes data
     //! from the front of the packet.
 
@@ -492,14 +472,14 @@ impl<PktBuf: PacketBuffer> buf::Buf for Packet<PktBuf> {
     }
 }
 
-unsafe impl<PktBuf: PacketBuffer> buf::BufMut for Packet<PktBuf> {
+unsafe impl buf::BufMut for Packet {
     //! Writing to a `Packet` using the `BufMut` interface appends data
     //! into the tailroom and the end of the packet.
 
     /// This indicates how much tailroom is remaining.
     fn remaining_mut(&self) -> usize {
         let md = self.metadata();
-        size_of_val(&*self.buf) - (md.offset + md.len)
+        self.buf.len() - (md.offset + md.len)
     }
 
     /// Provides a reference to a portion of the remaining tailroom.
@@ -517,7 +497,7 @@ unsafe impl<PktBuf: PacketBuffer> buf::BufMut for Packet<PktBuf> {
     }
 }
 
-impl<PktBuf: PacketBuffer> std::fmt::Debug for Packet<PktBuf> {
+impl std::fmt::Debug for Packet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         writeln!(f, "\n=== Begin dumping packet info ===")?;
         self.metadata().fmt(f)?;
@@ -529,104 +509,108 @@ impl<PktBuf: PacketBuffer> std::fmt::Debug for Packet<PktBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config;
     use bytes::{Buf, BufMut};
 
     #[test]
     fn lifetime_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let pkt = Packet::new(&mut buf, 0);
-        let ptr_buf = pkt.destroy().as_ptr();
-        assert_eq!(ptr_buf, (&buf).as_ptr());
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let ptr_buf = buf.as_ptr();
+        let pkt = Packet::new(buf, 0);
+        let ptr_buf2 = pkt.destroy().as_ptr();
+        assert_eq!(ptr_buf2, ptr_buf);
     }
 
     #[test]
     fn basic_headroom_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let pkt = Packet::new(&mut buf, 123);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let pkt = Packet::new(buf, 123);
         assert_eq!(pkt.headroom_available(), 123);
     }
 
     #[test]
     fn max_headroom_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let new_coke = Packet::new(&mut buf, PACKET_BUFFER_MAX_BODY_SIZE);
-        assert_eq!(new_coke.headroom_available(), PACKET_BUFFER_MAX_BODY_SIZE);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let new_coke = Packet::new(buf, Packet::max_body_size_for(config::PACKET_BUFFER_SIZE));
+        assert_eq!(new_coke.headroom_available(), new_coke.max_body_size());
     }
 
     #[test]
     #[should_panic]
     fn too_much_headroom_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        Packet::new(&mut buf, PACKET_BUFFER_MAX_BODY_SIZE + 1);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        Packet::new(
+            buf,
+            Packet::max_body_size_for(config::PACKET_BUFFER_SIZE) + 1,
+        );
     }
 
     #[test]
     #[should_panic]
     fn way_too_much_headroom_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        Packet::new(&mut buf, usize::MAX);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        Packet::new(buf, usize::MAX);
     }
 
     #[test]
     #[should_panic]
     fn existing_data_way_too_large_offset() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        Packet::new_with_existing_data(&mut buf, usize::MAX, 0);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        Packet::new_with_existing_data(buf, usize::MAX, 0);
     }
 
     #[test]
     #[should_panic]
     fn existing_data_way_too_large_len() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET, usize::MAX);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        Packet::new_with_existing_data(buf, Packet::MIN_BODY_OFFSET, usize::MAX);
     }
 
     #[test]
     #[should_panic]
     fn existing_data_too_small_offset() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        Packet::new_with_existing_data(&mut buf, std::mem::size_of::<PacketMetadata>() - 1, 0);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        Packet::new_with_existing_data(buf, std::mem::size_of::<PacketMetadata>() - 1, 0);
     }
 
     #[test]
     fn existing_data() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let offset = PACKET_BUFFER_MIN_BODY_OFFSET + 123;
+        let mut buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let offset = Packet::MIN_BODY_OFFSET + 123;
         let data = [1, 2, 3, 4, 5, 6, 7, 8].as_slice();
         buf[offset..offset + 8].copy_from_slice(data);
-        let pkt = Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET + 123, 8);
+        let pkt = Packet::new_with_existing_data(buf, Packet::MIN_BODY_OFFSET + 123, 8);
         assert_eq!(pkt.body(), data);
     }
 
     #[test]
     fn clone_headroom_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let pkt = Packet::new(&mut buf, 123);
-        let mut buf2 = [0u8; config::PACKET_BUFFER_SIZE];
-        let pkt2 = pkt.clone_into(&mut buf2);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let pkt = Packet::new(buf, 123);
+        let buf2 = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let pkt2 = pkt.clone_into(buf2);
         assert_eq!(pkt2.headroom_available(), 123);
     }
 
     #[test]
     fn clone_adjusted_headroom_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let pkt = Packet::new(&mut buf, 123);
-        let mut buf2 = [0u8; config::PACKET_BUFFER_SIZE];
-        let pkt2 = pkt.clone_into_with_headroom(&mut buf2, 456);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let pkt = Packet::new(buf, 123);
+        let buf2 = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let pkt2 = pkt.clone_into_with_headroom(buf2, 456);
         assert_eq!(pkt2.headroom_available(), 456);
     }
 
     #[test]
     fn clone_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let offset = PACKET_BUFFER_MIN_BODY_OFFSET + 123;
+        let mut buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let offset = Packet::MIN_BODY_OFFSET + 123;
         let data = [1, 2, 3, 4, 5, 6, 7, 8].as_slice();
         buf[offset..offset + 8].copy_from_slice(data);
-        let mut pkt =
-            Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET + 123, 8);
+        let mut pkt = Packet::new_with_existing_data(buf, Packet::MIN_BODY_OFFSET + 123, 8);
         pkt.metadata_mut().ingress_stream_id = 100;
-        let mut buf2 = [0u8; config::PACKET_BUFFER_SIZE];
-        let pkt2 = pkt.clone_into_with_headroom(&mut buf2, 456);
+        let buf2 = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let pkt2 = pkt.clone_into_with_headroom(buf2, 456);
         assert_eq!(
             pkt.metadata().ingress_stream_id,
             pkt2.metadata().ingress_stream_id
@@ -636,8 +620,8 @@ mod tests {
 
     #[test]
     fn alloc_headroom_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 123);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 123);
         let hdr = pkt.alloc_zeroed_headroom(123);
         for &mut x in hdr {
             assert_eq!(x, 0);
@@ -647,23 +631,23 @@ mod tests {
     #[test]
     #[should_panic]
     fn alloc_too_much_headroom_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 123);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 123);
         pkt.alloc_zeroed_headroom(124);
     }
 
     #[test]
     #[should_panic]
     fn alloc_way_too_much_headroom_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 0);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 0);
         pkt.alloc_zeroed_headroom(usize::MAX);
     }
 
     #[test]
     fn write_header_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 4);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 4);
         let data: [u8; 4] = [1, 2, 3, 4];
         *pkt.alloc_zeroed_header() = data;
         assert_eq!(pkt.body()[..4], data);
@@ -671,23 +655,21 @@ mod tests {
 
     #[test]
     fn buf_read_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let offset = PACKET_BUFFER_MIN_BODY_OFFSET + 123;
+        let mut buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let offset = Packet::MIN_BODY_OFFSET + 123;
         let data = [1, 2, 3, 4, 5, 6, 7, 8].as_slice();
         buf[offset..offset + 8].copy_from_slice(data);
-        let mut pkt =
-            Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET + 123, 8);
+        let mut pkt = Packet::new_with_existing_data(buf, Packet::MIN_BODY_OFFSET + 123, 8);
         assert_eq!(pkt.get_u64(), 0x0102030405060708u64);
     }
 
     #[test]
     fn buf_read_twice_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let offset = PACKET_BUFFER_MIN_BODY_OFFSET + 123;
+        let mut buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let offset = Packet::MIN_BODY_OFFSET + 123;
         let data = [1, 2, 3, 4, 5, 6, 7, 8].as_slice();
         buf[offset..offset + 8].copy_from_slice(data);
-        let mut pkt =
-            Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET + 123, 8);
+        let mut pkt = Packet::new_with_existing_data(buf, Packet::MIN_BODY_OFFSET + 123, 8);
         assert_eq!(pkt.get_u32(), 0x01020304u32);
         assert_eq!(pkt.get_u32(), 0x05060708u32);
     }
@@ -695,27 +677,26 @@ mod tests {
     #[test]
     #[should_panic]
     fn buf_read_too_much_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let offset = PACKET_BUFFER_MIN_BODY_OFFSET + 123;
+        let mut buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let offset = Packet::MIN_BODY_OFFSET + 123;
         let data = [1, 2, 3, 4, 5, 6, 7].as_slice();
         buf[offset..offset + 8].copy_from_slice(data);
-        let mut pkt =
-            Packet::new_with_existing_data(&mut buf, PACKET_BUFFER_MIN_BODY_OFFSET + 123, 8);
+        let mut pkt = Packet::new_with_existing_data(buf, Packet::MIN_BODY_OFFSET + 123, 8);
         let _ = pkt.get_u64();
     }
 
     #[test]
     fn buf_write_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 0);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 0);
         pkt.put_u64(0x0102030405060708u64);
         assert_eq!(pkt.body(), [1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
     #[test]
     fn buf_write_twice_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 0);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 0);
         pkt.put_u32(0x01020304u32);
         pkt.put_u32(0x05060708u32);
         assert_eq!(pkt.body(), [1, 2, 3, 4, 5, 6, 7, 8]);
@@ -724,15 +705,15 @@ mod tests {
     #[test]
     #[should_panic]
     fn buf_write_no_tail_room_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, PACKET_BUFFER_MAX_BODY_SIZE);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, Packet::max_body_size_for(config::PACKET_BUFFER_SIZE));
         pkt.put_u8(1);
     }
 
     #[test]
     fn shrink_by_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 0);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 0);
         pkt.put_u64(0x0102030405060708u64);
         pkt.shrink_by(2);
         assert_eq!(pkt.body(), [1, 2, 3, 4, 5, 6]);
@@ -741,8 +722,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn shrink_by_too_much_test() {
-        let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
-        let mut pkt = Packet::new(&mut buf, 0);
+        let buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let mut pkt = Packet::new(buf, 0);
         pkt.put_u64(0x0102030405060708u64);
         pkt.shrink_by(10);
     }

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -1,7 +1,7 @@
 //! Queues (i.e., frontend interface) for each stage of the system.
 
 use crate::net_defs;
-use crate::packet::{BufferPacket, Packet, PacketBuffer};
+use crate::packet::Packet;
 use crate::sys::TunPi;
 use crate::sys::ZprTun;
 use crate::test_packet::*;
@@ -22,7 +22,7 @@ pub enum TryEnqueueError<T> {
 }
 
 pub enum MgmtProcessorMessage {
-    Packet(BufferPacket),
+    Packet(Packet),
     TestPacket(TestPacket),
 }
 
@@ -38,10 +38,7 @@ impl MgmtProcessor {
         Self { sender }
     }
 
-    pub fn try_enqueue_packet(
-        &self,
-        packet: BufferPacket,
-    ) -> Result<(), TryEnqueueError<BufferPacket>> {
+    pub fn try_enqueue_packet(&self, packet: Packet) -> Result<(), TryEnqueueError<Packet>> {
         match self.sender.try_send(MgmtProcessorMessage::Packet(packet)) {
             Ok(()) => Ok(()),
 
@@ -89,7 +86,7 @@ impl AgentInput {
         }
     }
 
-    pub fn try_enqueue_packet<P: DropGuard<BufferPacket>>(
+    pub fn try_enqueue_packet<P: DropGuard<Packet>>(
         &self,
         mut packet: P,
     ) -> Result<(), TryEnqueueError<P>> {
@@ -134,7 +131,7 @@ impl SubstrateEgress {
         }
     }
 
-    pub async fn enqueue_packet<P: DropGuard<BufferPacket>>(
+    pub async fn enqueue_packet<P: DropGuard<Packet>>(
         &self,
         packet: P,
         dest_sa: zpr::SubstrateAddr,
@@ -160,7 +157,7 @@ impl SubstrateEgress {
     }
 
     // TODO: batch enqueue
-    pub fn try_enqueue_packet<P: DropGuard<BufferPacket>>(
+    pub fn try_enqueue_packet<P: DropGuard<Packet>>(
         &self,
         packet: P,
         dest_sa: zpr::SubstrateAddr,
@@ -189,7 +186,7 @@ impl SubstrateEgress {
 
     fn select_socket_and_set_flowinfo(
         &self,
-        packet: &Packet<impl PacketBuffer>,
+        packet: &Packet,
         mut dest_sa: zpr::SubstrateAddr,
     ) -> (&UdpSocket, std::net::SocketAddr) {
         match &mut dest_sa {
@@ -211,7 +208,7 @@ impl SubstrateEgress {
 
 /// Capture will intercept packets in the PH and dump them into a file for debugging purposes
 pub struct CapPacket {
-    pub packet: BufferPacket,
+    pub packet: Packet,
     pub timestamp: SystemTime,
     pub orig_len: usize,
 }
@@ -227,12 +224,7 @@ impl Capture {
 
     /// Blocks until packet is enqueued
     #[allow(dead_code)]
-    pub async fn enqueue_packet(
-        &self,
-        packet: BufferPacket,
-        timestamp: SystemTime,
-        orig_len: usize,
-    ) {
+    pub async fn enqueue_packet(&self, packet: Packet, timestamp: SystemTime, orig_len: usize) {
         let cap_pack: CapPacket = CapPacket {
             packet,
             timestamp,
@@ -244,10 +236,10 @@ impl Capture {
     /// Does not block
     pub fn try_enqueue_packet(
         &self,
-        packet: BufferPacket,
+        packet: Packet,
         timestamp: SystemTime,
         orig_len: usize,
-    ) -> Result<(), TryEnqueueError<BufferPacket>> {
+    ) -> Result<(), TryEnqueueError<Packet>> {
         let cap_pack: CapPacket = CapPacket {
             packet,
             timestamp,
@@ -262,8 +254,8 @@ impl Capture {
 }
 
 pub enum MgmtDispatchMessage {
-    WithLink(BufferPacket), // Link ID stored in packet metadata
-    WithAddr(zpr::SubstrateAddr, BufferPacket),
+    WithLink(Packet), // Link ID stored in packet metadata
+    WithAddr(zpr::SubstrateAddr, Packet),
 }
 
 pub struct MgmtDispatch {
@@ -277,8 +269,8 @@ impl MgmtDispatch {
 
     pub fn try_dispatch_mgmt_packet_with_link(
         &self,
-        packet: BufferPacket,
-    ) -> Result<(), TryEnqueueError<BufferPacket>> {
+        packet: Packet,
+    ) -> Result<(), TryEnqueueError<Packet>> {
         debug_assert_ne!(packet.metadata().ingress_link_id, 0);
         match self.sender.try_send(MgmtDispatchMessage::WithLink(packet)) {
             Ok(()) => Ok(()),
@@ -297,8 +289,8 @@ impl MgmtDispatch {
     pub fn try_dispatch_mgmt_packet_with_addr(
         &self,
         peer_sa: &zpr::SubstrateAddr,
-        packet: BufferPacket,
-    ) -> Result<(), TryEnqueueError<BufferPacket>> {
+        packet: Packet,
+    ) -> Result<(), TryEnqueueError<Packet>> {
         debug_assert_eq!(packet.metadata().ingress_link_id, 0);
         match self
             .sender
@@ -319,7 +311,7 @@ impl MgmtDispatch {
 }
 
 pub enum AdapterManagerMessage {
-    RequestTetherId(BufferPacket),
+    RequestTetherId(Packet),
 }
 
 pub struct AdapterManager {
@@ -342,10 +334,7 @@ impl AdapterManager {
     /// the ALT, and an attempt will be made to send the specified packet.
     ///
     /// The specified packet must have already been classified.
-    pub fn try_request_tether_id(
-        &self,
-        packet: BufferPacket,
-    ) -> Result<(), TryEnqueueError<BufferPacket>> {
+    pub fn try_request_tether_id(&self, packet: Packet) -> Result<(), TryEnqueueError<Packet>> {
         match self
             .sender
             .try_send(AdapterManagerMessage::RequestTetherId(packet))

--- a/adapter/ph/src/sync_req.rs
+++ b/adapter/ph/src/sync_req.rs
@@ -1,5 +1,5 @@
 use crate::logging::targets::ZDP;
-use crate::packet::BufferPacket;
+use crate::packet::Packet;
 use crate::zdp;
 use std::future::Future;
 use std::sync::Mutex as StdMutex;
@@ -21,7 +21,7 @@ struct WindowState {
     next_seq_num: zpr::SeqNum,
 }
 
-pub type Response = (zdp::ZdpPacketType, BufferPacket);
+pub type Response = (zdp::ZdpPacketType, Packet);
 
 pub struct Permit<'a> {
     /// use our lock on the window state as a semaphore
@@ -108,11 +108,7 @@ impl SyncReqState {
         self.listener_state.lock().unwrap().response_listener = None;
     }
 
-    pub fn forward_response(
-        &self,
-        seq_num: zpr::SeqNum,
-        response: Response,
-    ) -> Result<(), BufferPacket> {
+    pub fn forward_response(&self, seq_num: zpr::SeqNum, response: Response) -> Result<(), Packet> {
         let listener = &mut self.listener_state.lock().unwrap().response_listener;
         match listener {
             Some((expected_seq_num, _)) => {


### PR DESCRIPTION
Simplify the Packet infrastructure by getting rid of support for arbitrary backing buffers.  All backing buffers are now simply `Box<[u8]>` values, i.e. variable-sized heap allocations.

The high-level consequence of this is there are now fewer weird `Packet` types, and code is mostly simpler.  The one place code got slightly more complex is, because `BufferStack` still works with fixed-size arrays, putting buffers back into the stack requires a `.try_into().unwrap()` to convert the `Box<[u8]>` back into a `Box<u8; config::PACKET_BUFFER_SIZE>`.  (The opposite conversion cannot fail and is automatic.)

The low-level consequence is the `Packet` type is now not simply a pointer to a packet buffer, but a pointer + length pair.  The performance consequences of this I believe should be minimal.