### PR TITLE
mgmt: all packets live on heap

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -16,23 +16,26 @@ pub async fn launch(asm: Arc<Assembly>, mut queue: mpsc::Receiver<AdapterManager
     while let Some(msg) = queue.recv().await {
         match msg {
             AdapterManagerMessage::RequestTetherId(pkt) => {
+                let mgmt_pkt = Packet::new_with_existing_metadata(pkt.buffer().clone());
+                fastpath::drop_and_count(&asm, pkt, CounterType::DispatchedToMgmt);
+
                 // for now, perform these sequentially...
                 // ideally, we place these into a JoinSet,
                 // but let's work out how message sequencing works before doing that!!
-                do_request_tether_id(&asm, pkt).await;
+                do_request_tether_id(&asm, mgmt_pkt).await;
             }
         }
     }
 }
 
 // RFC 6.5 § 6.3.11
-async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
+async fn do_request_tether_id(asm: &Arc<Assembly>, mut pkt: Packet) {
     let five_tuple = pkt.metadata().five_tuple();
 
     // if there's already an entry, this is a duplicate request
     // (NOTE: we should be the only ones modifying this table!)
     if asm.alt.get(five_tuple).is_some() {
-        fastpath::drop_and_count(asm, pkt, CounterType::DroppedAwaitingBind);
+        mgmt::core::count_event(asm, &mut pkt, CounterType::DroppedAwaitingBind);
         return;
     }
 
@@ -46,7 +49,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
 
     if dock_link_id != zpr::LINK_ID_UNKNOWN && !asm.is_link_ready(dock_link_id) {
         debug!(target: FLOW_MGMT, "Link {dock_link_id} is not ready to receive traffic yet");
-        fastpath::drop_and_count(asm, pkt, CounterType::DroppedNoSA);
+        mgmt::core::count_event(asm, &mut pkt, CounterType::DroppedNoSA);
         return;
     }
 

--- a/adapter/ph/src/counters.rs
+++ b/adapter/ph/src/counters.rs
@@ -81,6 +81,7 @@ pub enum CounterType {
     DroppedNoSA,          // no security association on link
     InternalRoutingError, // a packet ended up somewhere it shouldn't have due to a coding error
 
+    DispatchedToMgmt, // exited fastpath, sent to mgmt
     BadMgmtResponse,
     UnexpectedMgmtResponse,
 
@@ -127,6 +128,7 @@ impl CounterType {
             Self::DroppedNoSA => "Dropped No Security Association",
             Self::InternalRoutingError => "Internal Routing Error",
 
+            Self::DispatchedToMgmt => "Dispatched to Management",
             Self::BadMgmtResponse => "Bad Management Response",
             Self::UnexpectedMgmtResponse => "Unexpected Management Response",
 

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -34,7 +34,7 @@ pub fn drop_and_count(asm: &Assembly, pkt: Packet, reason: impl Into<CounterType
     debug!(target: DATAPATH, "dropping packet because {reason}");
     asm.buffer_stack
         .put_buffer(pkt.destroy().try_into().unwrap());
-    asm.counters[reason.into()].increment();
+    asm.counters[reason].increment();
 }
 
 /// Add the ZPI header to a packet.

--- a/adapter/ph/src/logging.rs
+++ b/adapter/ph/src/logging.rs
@@ -29,6 +29,7 @@ pub mod targets {
     pub const FLOW_MGMT: &str = "flow_mgmt";
     pub const KEY_MGMT: &str = "key_mgmt";
     pub const LINK_STATE: &str = "link_state";
+    pub const MGMT_EVENTS: &str = "mgmt_events";
     pub const PEER_MGMT: &str = "peer_mgmt";
     pub const REPORTING: &str = "reporting";
     pub const RPC: &str = "rpc";
@@ -37,8 +38,19 @@ pub mod targets {
     pub const ZDP: &str = "zdp";
 
     pub const ALL_TARGETS: &[&str] = &[
-        ALL, CAPTURE, DATAPATH, FLOW_MGMT, KEY_MGMT, LINK_STATE, PEER_MGMT, REPORTING, RPC,
-        STARTUP, VISA_MGMT, ZDP,
+        ALL,
+        CAPTURE,
+        DATAPATH,
+        FLOW_MGMT,
+        KEY_MGMT,
+        LINK_STATE,
+        MGMT_EVENTS,
+        PEER_MGMT,
+        REPORTING,
+        RPC,
+        STARTUP,
+        VISA_MGMT,
+        ZDP,
     ];
 }
 

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -7,14 +7,31 @@ use crate::assembly::Assembly;
 use crate::config;
 use crate::counters::CounterType;
 use crate::fastpath;
-use crate::packet::{Packet, PacketBuffer};
+use crate::packet::Packet;
 use crate::zdp;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::time::sleep;
+use tracing::*;
 use zpr;
-use zpr_ext::std::mem::{drop_guard, DropGuard};
 use zpr_ext::zerocopy::FromBytesExt;
+
+/// Helper to allocate a new Packet with default parameters from the heap.
+pub fn new_heap_packet() -> Packet {
+    Packet::new(
+        Box::new([0u8; config::PACKET_BUFFER_SIZE]),
+        config::DEFAULT_MESSAGE_HEADROOM,
+    )
+}
+
+pub fn count_event(
+    asm: &Assembly,
+    _pkt: &mut Packet, // for later support of per-packet event recording
+    event: CounterType,
+) {
+    debug!(target: crate::logging::targets::MGMT_EVENTS, "packet event {event}");
+    asm.counters[event].increment();
+}
 
 /// Send a unidirectional non-flow management message on the given link.
 /// The packet should contain only the message body.
@@ -191,10 +208,7 @@ async fn send_sync_req_helper(
     let mut response_future = peer_state.sync_req_state.install_response_listener(&permit);
 
     for _i in 0..=config::DEFAULT_REQUEST_RETRY_COUNT {
-        let buf = drop_guard(asm.buffer_stack.get_buffer().await as PacketBuffer, |buf| {
-            asm.buffer_stack.put_buffer(buf.try_into().unwrap())
-        });
-        let mut packet = Packet::new_guarded(buf, config::DEFAULT_MESSAGE_HEADROOM);
+        let mut packet = new_heap_packet();
         pkt_fn(&mut packet);
 
         send_mgmt_helper(
@@ -203,7 +217,7 @@ async fn send_sync_req_helper(
             zdp_request_type,
             stream_id,
             Some(permit.seq_num()),
-            packet.into_inner(),
+            packet,
         )
         .await;
 
@@ -233,9 +247,9 @@ fn match_received(
     zdp_response_type: zdp::ZdpPacketType,
 ) -> Result<Packet, SyncReqError> {
     match response {
-        Some((pkt_type, pkt)) => {
+        Some((pkt_type, mut pkt)) => {
             if pkt_type != zdp_response_type {
-                fastpath::drop_and_count(asm, pkt, CounterType::BadMgmtResponse);
+                count_event(asm, &mut pkt, CounterType::BadMgmtResponse);
                 return Err(SyncReqError::ProtocolError);
             }
             return Ok(pkt);

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -1,9 +1,8 @@
 //! Code which handles dispatching management packets from fastpath.
 
-use super::handlers::{HandleMgmtError, HandleMgmtResult}; // TODO: make our own error type
+use super::core;
 use crate::assembly::Assembly;
 use crate::counters::CounterType;
-use crate::fastpath;
 use crate::km_multiplexor;
 use crate::link_state::LinkType;
 use crate::logging::targets::{KEY_MGMT, ZDP};
@@ -24,7 +23,7 @@ use zpr_ext::zerocopy::FromBytesExt;
 pub fn dispatch_mgmt_packet_with_addr(
     asm: &Arc<Assembly>,
     peer_sa: zpr::SubstrateAddr,
-    mut pkt: Packet,
+    pkt: &mut Packet,
 ) {
     match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
         Ok(base_hdr) if base_hdr.0.packet_type == zdp::ZdpPacketType::KeyManagement => {
@@ -34,18 +33,17 @@ pub fn dispatch_mgmt_packet_with_addr(
             // tether?
             let Some(ingress_link_id) = asm.start_tether(&peer_sa, LinkType::NodeToAdapter).ok()
             else {
-                return fastpath::drop_and_count(&asm, pkt, CounterType::UnknownPeer);
+                core::count_event(asm, pkt, CounterType::UnknownPeer);
+                return;
             };
 
             pkt.metadata_mut().ingress_link_id = ingress_link_id.get();
 
-            match handle_key_management(asm, pkt) {
-                Ok(()) => (),
-                Err((err, pkt)) => fastpath::drop_and_count(&asm, pkt, err),
-            }
+            handle_key_management(asm, pkt);
         }
         _ => {
-            return fastpath::drop_and_count(&asm, pkt, CounterType::UnknownPeer);
+            core::count_event(asm, pkt, CounterType::UnknownPeer);
+            return;
         }
     }
 }
@@ -54,43 +52,37 @@ pub fn dispatch_mgmt_packet_with_addr(
 ///
 /// This function does not block, and does not perform significant processing.
 /// It merely dispatches the management packet to the correct queue.
-pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, mut pkt: Packet) {
+pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
     match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
         Ok((base_hdr, _)) if base_hdr.packet_type == zdp::ZdpPacketType::KeyManagement => {
             pkt.advance(std::mem::size_of::<zdp::ZdpBaseHeader>());
-
-            match handle_key_management(asm, pkt) {
-                Ok(()) => (),
-                Err((err, pkt)) => fastpath::drop_and_count(&asm, pkt, err),
-            }
+            handle_key_management(asm, pkt);
         }
 
-        Ok((base_hdr, _)) if base_hdr.packet_type.is_response() => {
-            match handle_response(asm, pkt) {
-                Ok(()) => (),
-                Err((err, pkt)) => fastpath::drop_and_count(&asm, pkt, err),
-            }
-        }
+        Ok((base_hdr, _)) if base_hdr.packet_type.is_response() => handle_response(asm, pkt),
 
         _ => {
             let Some(peer_state) = asm.peer_table.get(pkt.metadata().ingress_link_id) else {
-                fastpath::drop_and_count(&asm, pkt, CounterType::PeerRemoved);
+                core::count_event(asm, pkt, CounterType::PeerRemoved);
                 return;
             };
 
-            match peer_state.mgmt_processor.try_enqueue_packet(pkt) {
+            let mgmt_pkt = Packet::new_with_existing_metadata(pkt.buffer().clone());
+            match peer_state.mgmt_processor.try_enqueue_packet(mgmt_pkt) {
                 Ok(()) => (),
-                Err(queues::TryEnqueueError::Full(pkt)) => {
-                    fastpath::drop_and_count(&asm, pkt, CounterType::QueueBackpressure);
+                Err(queues::TryEnqueueError::Full(_mgmt_pkt)) => {
+                    core::count_event(asm, pkt, CounterType::QueueBackpressure);
+                    return;
                 }
             }
         }
     }
 }
 
-fn handle_response(asm: &Assembly, mut pkt: Packet) -> HandleMgmtResult {
-    let Ok(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+fn handle_response(asm: &Assembly, pkt: &mut Packet) {
+    let Ok(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(pkt) else {
+        core::count_event(asm, pkt, CounterType::BadStructure);
+        return;
     };
 
     let packet_type = base_hdr.packet_type;
@@ -104,21 +96,30 @@ fn handle_response(asm: &Assembly, mut pkt: Packet) -> HandleMgmtResult {
     // Gets the designated sender, attempts to send the response, if not drops
     // the packet and increments corresponding counter
     let Some(peer_state) = asm.peer_table.get(pkt.metadata().ingress_link_id) else {
-        return Err((HandleMgmtError::UnexpectedMgmtResponse, pkt));
+        core::count_event(asm, pkt, CounterType::UnexpectedMgmtResponse);
+        return;
     };
 
-    peer_state
+    let mgmt_pkt = Packet::new_with_existing_metadata(pkt.buffer().clone());
+    match peer_state
         .sync_req_state
-        .forward_response(seq_num, (packet_type, pkt))
-        .map_err(|pkt| (HandleMgmtError::UnexpectedMgmtResponse, pkt))
+        .forward_response(seq_num, (packet_type, mgmt_pkt))
+    {
+        Ok(()) => (),
+        Err(_mgmt_pkt) => {
+            core::count_event(asm, pkt, CounterType::UnexpectedMgmtResponse);
+            return;
+        }
+    }
 }
 
 // ZPI and Base header is already gone by the time we get here.  So we expect
 // to parse starting from the KeyManagement header.
-fn handle_key_management(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
-    let Ok(km_hdr) = zdp::ZdpKeyManagementHeader::read_from_buf(&mut pkt) else {
+fn handle_key_management(asm: &Arc<Assembly>, pkt: &mut Packet) {
+    let Ok(km_hdr) = zdp::ZdpKeyManagementHeader::read_from_buf(pkt) else {
         error!(target: ZDP, "KeyManagement packet arrived with unparseable header");
-        return Err((HandleMgmtError::BadStructure, pkt));
+        core::count_event(asm, pkt, CounterType::BadStructure);
+        return;
     };
 
     if !km_hdr.is_noise() {
@@ -127,16 +128,15 @@ fn handle_key_management(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResu
             "KeyManagement packet not using NOISE - type is {}",
             km_hdr.message_type
         );
-        return Err((
-            HandleMgmtError::UnknownKeyManagementType(km_hdr.message_type.into()),
-            pkt,
-        ));
+        core::count_event(asm, pkt, CounterType::OtherError);
+        return;
     }
 
     let km_msg_len = usize::from(km_hdr.message_length);
     if pkt.remaining() < km_msg_len {
         error!(target: KEY_MGMT, "KeyManagement packet arrived with truncated payload");
-        return Err((HandleMgmtError::BadStructure, pkt));
+        core::count_event(asm, pkt, CounterType::BadStructure);
+        return;
     }
 
     match km_multiplexor::handle_inbound_km_msg(
@@ -151,11 +151,8 @@ fn handle_key_management(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResu
                 "key management handling failed on link {}: {e:?}",
                 pkt.metadata().ingress_link_id,
             );
-            return Err((HandleMgmtError::KeyManagementError(format!("{e:?}")), pkt));
+            core::count_event(asm, pkt, CounterType::OtherError);
+            return;
         }
     };
-    asm.buffer_stack
-        .put_buffer(pkt.destroy().try_into().unwrap());
-
-    Ok(())
 }

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -19,10 +19,7 @@ use zpr_ext::zerocopy::{FromBytesExt, IntoBytesExt};
 
 pub enum HandleMgmtError {
     UnknownType(u8),
-    UnexpectedMgmtResponse,
     BadStructure,
-    UnknownKeyManagementType(u16),
-    KeyManagementError(String),
     LinkStateError,
 }
 
@@ -30,10 +27,7 @@ impl From<HandleMgmtError> for counters::CounterType {
     fn from(err: HandleMgmtError) -> Self {
         match err {
             HandleMgmtError::UnknownType(_type) => Self::UnknownType,
-            HandleMgmtError::UnexpectedMgmtResponse => Self::UnexpectedMgmtResponse,
             HandleMgmtError::BadStructure => Self::BadStructure,
-            HandleMgmtError::UnknownKeyManagementType(_type) => Self::OtherError,
-            HandleMgmtError::KeyManagementError(_desc) => Self::OtherError,
             HandleMgmtError::LinkStateError => Self::OtherError,
         }
     }
@@ -42,7 +36,7 @@ impl From<HandleMgmtError> for counters::CounterType {
 pub type HandleMgmtResult = Result<(), (HandleMgmtError, Packet)>;
 
 /// handle a Report message (RFC 6.5 § 6.3.13)
-pub async fn handle_report(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
+pub async fn handle_report(_asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpReportHeader::read_from_buf(&mut pkt) else {
         return Err((HandleMgmtError::BadStructure, pkt));
     };
@@ -58,21 +52,17 @@ pub async fn handle_report(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtRe
             std::str::from_utf8(&pkt.body()[..report_data_length]).unwrap()
         );
     }
-    asm.buffer_stack
-        .put_buffer(pkt.destroy().try_into().unwrap());
     Ok(())
 }
 
 /// handle a Discard message (RFC 6.5 § 6.3.1)
-pub async fn handle_discard(asm: &Arc<Assembly>, pkt: Packet) -> HandleMgmtResult {
+pub async fn handle_discard(_asm: &Arc<Assembly>, pkt: Packet) -> HandleMgmtResult {
     // TODO print to debug log, when implemented
     info!(
         target: REPORTING,
         "Discard message received from {}",
         pkt.metadata().ingress_link_id
     );
-    asm.buffer_stack
-        .put_buffer(pkt.destroy().try_into().unwrap());
     Ok(())
 }
 
@@ -191,8 +181,6 @@ pub async fn handle_hello_response(
         return Err((HandleMgmtError::LinkStateError, pkt));
     };
 
-    asm.buffer_stack
-        .put_buffer(pkt.destroy().try_into().unwrap());
     Ok(())
 }
 
@@ -436,8 +424,6 @@ pub async fn handle_bind_agent_address_request(
                     assembly::AddRouteError::PeerGone,
                 )) => {
                     // peer went away; don't bother responding
-                    asm.buffer_stack
-                        .put_buffer(rsp_pkt.destroy().try_into().unwrap());
                     return Ok(());
                 }
 

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -3,12 +3,9 @@
 
 use super::core;
 use crate::assembly::Assembly;
-use crate::config;
 use crate::counters::CounterType;
 use crate::defs::*;
-use crate::fastpath;
 use crate::logging::targets::ZDP;
-use crate::packet::Packet;
 use crate::zdp;
 use bytes::{Buf, BufMut};
 use std::net::IpAddr;
@@ -24,8 +21,7 @@ pub async fn send_key_management(
     km_id: zpr::KmId,
     payload: &[u8],
 ) {
-    let buf = asm.buffer_stack.get_buffer().await;
-    let mut pkt = Packet::new(buf, config::DEFAULT_MESSAGE_HEADROOM);
+    let mut pkt = core::new_heap_packet();
 
     let km_hdr = pkt.alloc_zeroed_header::<zdp::ZdpKeyManagementHeader>();
     km_hdr.message_type = km_id.into();
@@ -39,8 +35,7 @@ pub async fn send_key_management(
 #[allow(dead_code)]
 /// send a Discard message (RFC 6.5 § 6.3.1)
 pub async fn send_discard(asm: &Assembly, link_id: zpr::LinkId) {
-    let buf = asm.buffer_stack.get_buffer().await;
-    let pkt = Packet::new(buf, config::DEFAULT_MESSAGE_HEADROOM);
+    let pkt = core::new_heap_packet();
     core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::Discard, pkt).await;
 }
 
@@ -59,13 +54,11 @@ pub async fn send_hello_request(asm: &Assembly, link_id: zpr::LinkId) -> Result<
     match response {
         Ok(mut hello_res) => {
             let Ok(hdr) = zdp::ZdpHelloResponseHeader::read_from_buf(&mut hello_res) else {
-                fastpath::drop_and_count(asm, hello_res, CounterType::BadStructure);
+                core::count_event(asm, &mut hello_res, CounterType::BadStructure);
                 return Err(());
             };
             let status = hdr.status;
             debug!(target: ZDP, "Received HelloResponse, status: {status}");
-            asm.buffer_stack
-                .put_buffer(hello_res.destroy().try_into().unwrap());
             Ok(())
         }
 
@@ -115,7 +108,7 @@ pub async fn send_register_agent_address_request(
             let Ok(hdr) =
                 zdp::ZdpRegisterAgentAddressResponseHeader::read_from_buf(&mut register_res)
             else {
-                fastpath::drop_and_count(asm, register_res, CounterType::BadStructure);
+                core::count_event(asm, &mut register_res, CounterType::BadStructure);
                 return Err(());
             };
             debug!(
@@ -123,8 +116,6 @@ pub async fn send_register_agent_address_request(
                 "Received RegisterAgentAddressResponse, status: {}",
                 hdr.status_code
             );
-            asm.buffer_stack
-                .put_buffer(register_res.destroy().try_into().unwrap());
         }
 
         Err(err) => {
@@ -162,13 +153,11 @@ pub async fn send_terminate_request<'a, 'pktbuf>(
         Ok(mut terminate_res) => {
             let Ok(hdr) = zdp::ZdpTerminateLinkResponseHeader::read_from_buf(&mut terminate_res)
             else {
-                fastpath::drop_and_count(asm, terminate_res, CounterType::BadStructure);
+                core::count_event(asm, &mut terminate_res, CounterType::BadStructure);
                 return Err(());
             };
             let resp_code = hdr.response_code;
             info!("Received TerminateLinkResponse, status: {:?}", resp_code);
-            asm.buffer_stack
-                .put_buffer(terminate_res.destroy().try_into().unwrap());
             Ok(resp_code)
         }
 
@@ -185,8 +174,7 @@ pub async fn send_terminate_indication<'a, 'pktbuf>(
     link_id: zpr::LinkId,
     reason: zdp::TerminateReason,
 ) {
-    let buf = asm.buffer_stack.get_buffer().await;
-    let mut pkt = Packet::new(buf, config::DEFAULT_MESSAGE_HEADROOM);
+    let mut pkt = core::new_heap_packet();
     let hdr = pkt.alloc_zeroed_header::<zdp::ZdpTerminateLinkIndicationHeader>();
     hdr.reason_code = reason;
     core::send_non_flow_mgmt(
@@ -258,36 +246,30 @@ pub async fn send_bind_agent_address_request(
     match response {
         Ok((tether_id, mut resp)) => {
             let Ok(hdr) = zdp::ZdpBindAgentAddressResponseHeader::read_from_buf(&mut resp) else {
-                fastpath::drop_and_count(asm, resp, CounterType::BadStructure);
+                core::count_event(asm, &mut resp, CounterType::BadStructure);
                 return Err(BindAgentAddressError::BadStructure);
             };
 
             match hdr.status_code {
-                zdp::ZdpBindAgentAddressResponseHeader::STATUS_CODE_SUCCESS => {
-                    asm.buffer_stack
-                        .put_buffer(resp.destroy().try_into().unwrap());
-                    Ok(tether_id)
-                }
+                zdp::ZdpBindAgentAddressResponseHeader::STATUS_CODE_SUCCESS => Ok(tether_id),
 
                 zdp::ZdpBindAgentAddressResponseHeader::STATUS_CODE_OTHER => {
                     if hdr.info_len as usize > resp.remaining() {
-                        fastpath::drop_and_count(asm, resp, CounterType::BadStructure);
+                        core::count_event(asm, &mut resp, CounterType::BadStructure);
                         return Err(BindAgentAddressError::BadStructure);
                     }
 
                     let Ok(msg) = std::str::from_utf8(&resp.body()[..hdr.info_len as usize]) else {
-                        fastpath::drop_and_count(asm, resp, CounterType::BadStructure);
+                        core::count_event(asm, &mut resp, CounterType::BadStructure);
                         return Err(BindAgentAddressError::BadStructure);
                     };
                     let msg: Box<str> = msg.into();
 
-                    asm.buffer_stack
-                        .put_buffer(resp.destroy().try_into().unwrap());
                     Err(BindAgentAddressError::BindAgentAddressError(msg))
                 }
 
                 _ => {
-                    fastpath::drop_and_count(asm, resp, CounterType::BadStructure);
+                    core::count_event(asm, &mut resp, CounterType::BadStructure);
                     Err(BindAgentAddressError::BadStructure)
                 }
             }
@@ -305,8 +287,7 @@ pub async fn send_report(asm: &Assembly, link_id: zpr::LinkId, report: &str) {
     /*if packet::PACKET_BUFFER_MAX_BODY_SIZE - config::DEFAULT_MESSAGE_HEADROOM < report.len() {
         return;
     }*/  // CTP FIXME
-    let buf = asm.buffer_stack.get_buffer().await;
-    let mut pkt = Packet::new(buf, config::DEFAULT_MESSAGE_HEADROOM);
+    let mut pkt = core::new_heap_packet();
     let hdr = pkt.alloc_zeroed_header::<zdp::ZdpReportHeader>();
     hdr.report_data_length = (report.len() as u16).into();
     pkt.put(report.as_bytes());

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -254,9 +254,7 @@ pub async fn send_bind_agent_address_request(
             };
 
             match hdr.status_code {
-                zdp::ResponseCode::Success => {
-                    Ok(tether_id)
-                }
+                zdp::ResponseCode::Success => Ok(tether_id),
 
                 zdp::ResponseCode::Other => {
                     if hdr.info_len as usize > resp.remaining() {

--- a/adapter/ph/src/mgmt_dispatch_worker.rs
+++ b/adapter/ph/src/mgmt_dispatch_worker.rs
@@ -1,6 +1,8 @@
 //! Code which handles dispatching management packets from fastpath.
 
 use crate::assembly::Assembly;
+use crate::counters;
+use crate::fastpath;
 use crate::mgmt::dispatch;
 use crate::queues::MgmtDispatchMessage;
 use std::sync::Arc;
@@ -9,11 +11,13 @@ use tokio::sync::mpsc;
 pub async fn launch(asm: Arc<Assembly>, mut queue: mpsc::Receiver<MgmtDispatchMessage>) {
     while let Some(msg) = queue.recv().await {
         match msg {
-            MgmtDispatchMessage::WithLink(pkt) => {
-                dispatch::dispatch_mgmt_packet_with_link(&asm, pkt);
+            MgmtDispatchMessage::WithLink(mut pkt) => {
+                dispatch::dispatch_mgmt_packet_with_link(&asm, &mut pkt);
+                fastpath::drop_and_count(&asm, pkt, counters::CounterType::DispatchedToMgmt);
             }
-            MgmtDispatchMessage::WithAddr(peer_sa, pkt) => {
-                dispatch::dispatch_mgmt_packet_with_addr(&asm, peer_sa, pkt);
+            MgmtDispatchMessage::WithAddr(peer_sa, mut pkt) => {
+                dispatch::dispatch_mgmt_packet_with_addr(&asm, peer_sa, &mut pkt);
+                fastpath::drop_and_count(&asm, pkt, counters::CounterType::DispatchedToMgmt);
             }
         }
     }

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -1,7 +1,7 @@
 use crate::assembly::Assembly;
 use crate::counters::CounterType;
-use crate::fastpath;
 use crate::logging::targets::ZDP;
+use crate::mgmt;
 use crate::mgmt::handlers::{self, HandleMgmtError, HandleMgmtResult};
 use crate::packet::Packet;
 use crate::queues::MgmtProcessorMessage;
@@ -24,17 +24,17 @@ pub async fn launch(
 ) {
     while let Some(msg) = queue.recv().await {
         match msg {
-            MgmtProcessorMessage::Packet(pkt) => {
+            MgmtProcessorMessage::Packet(mut pkt) => {
                 // Drop packets which are intended for a link other than the one we are assigned to,
                 // since processing them here will violate concurrency assumptions.
                 if pkt.metadata().ingress_link_id != config.link_id.get() {
-                    fastpath::drop_and_count(&asm, pkt, CounterType::InternalRoutingError);
+                    mgmt::core::count_event(&asm, &mut pkt, CounterType::InternalRoutingError);
                     continue;
                 }
 
                 match handle_packet(&asm, pkt).await {
                     Ok(()) => (),
-                    Err((err, pkt)) => fastpath::drop_and_count(&asm, pkt, err),
+                    Err((err, mut pkt)) => mgmt::core::count_event(&asm, &mut pkt, err.into()),
                 }
             }
 

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -273,6 +273,11 @@ impl Packet {
         self.buf
     }
 
+    /// Return a reference to the underlying buffer.
+    pub fn buffer(&self) -> &PacketBuffer {
+        &self.buf
+    }
+
     /// Initialize a buffer with existing packet data as a packet buffer.
     /// `offset` is offset of data within buffer.
     /// It must be at least equal to `Self::MIN_BODY_OFFSET`.
@@ -286,6 +291,16 @@ impl Packet {
         md.len = len;
         md.ingress_link_id = 0;
         md.ingress_stream_id = 0;
+        pkt
+    }
+
+    /// Initialize a buffer with existing packet data and metadata as a packet buffer.
+    pub fn new_with_existing_metadata(buf: PacketBuffer) -> Self {
+        let pkt = Packet { buf };
+        let md = pkt.metadata();
+        assert!(md.offset >= Self::MIN_BODY_OFFSET);
+        assert!(md.len <= pkt.buf.len());
+        assert!(md.offset <= pkt.buf.len() - md.len);
         pkt
     }
 


### PR DESCRIPTION
Here I create a strict boundary between fastpath and mgmt: as soon as mgmt gets a Packet from fastpath, it copies it into a heap-allocated Packet and returns the original to the buffer stack.  So beside the boundaries, the rest of mgmt simply works with heap-allocated packets and does not interact with the buffer stack.

Also I introduced a notion of "mgmt events" which can be counted.  (Right now this uses the same counters array as fastpath but these could diverge later.)  This way, every packet dispatched to mgmt is counted as such (`DispatchedToMgmt` counter), thus ending its "fastpath lifetime".  Mgmt then can count whatever events it needs to for the packet (which, unlike fastpath, notably doesn't explicitly include dropping said packet, since now in mgmt, the packets are heap-allocated and can be cloned or dropped arbitrarily).

Next step is to rework the mgmt queues such that the queues retain packet ownership and all packets are then forced to be returned to fastpath.  That then opens the door for fastpath to move away from tokio.