### PR TITLE
Send echo request/replies and track latency + loss

### DIFF
--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -3,13 +3,18 @@ use crate::km::ZPIPair;
 use crate::km_multiplexor;
 use crate::logging::targets::LINK_STATE;
 use crate::mgmt;
+use crate::mgmt::core::SyncReqError;
 use crate::net_defs::IpAddress;
+use crate::sample_ring::SampleRing;
 use crate::special_peers;
 use crate::vs_worker;
 use crate::zdp::{ResponseCode, TerminateReason};
 
+use std::fmt::{Display, Formatter};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use thiserror::Error;
+use tokio::time::MissedTickBehavior;
 use tracing::*;
 use zpr::LinkId;
 use zpr::ZPI_ENCRYPTED_HEADER_FLAG;
@@ -177,11 +182,33 @@ pub enum LinkStatus {
     Down,
 }
 
+pub struct LinkData {
+    echo_success: u64, // Echo requests received response
+    echo_timeout: u64, // Echo requests timed out
+    echo_failure: u64, // Echo requests failed for other reasons
+    // TODO: configurable keep-alive period
+    // For now, keep-alives are attempted every 3 seconds
+    // Assuming no loss, 100 samples will store 5 minutes of latency data
+    latency_data: SampleRing<Duration, 100>,
+}
+
+impl LinkData {
+    pub fn new() -> Self {
+        Self {
+            echo_success: 0,
+            echo_timeout: 0,
+            echo_failure: 0,
+            latency_data: SampleRing::new(Duration::ZERO),
+        }
+    }
+}
+
 pub struct LinkStateMachine {
     state: LinkState,
     status: LinkStatus,
     silent: bool,
     agent_addresses: Vec<IpAddress>,
+    last_state_change: std::time::Instant,
 }
 
 impl LinkStateMachine {
@@ -191,7 +218,13 @@ impl LinkStateMachine {
             status: LinkStatus::Down,
             silent: false,
             agent_addresses: Default::default(),
+            last_state_change: std::time::Instant::now(),
         }
+    }
+
+    pub fn set_state(&mut self, new_state: LinkState) {
+        self.state = new_state;
+        self.last_state_change = std::time::Instant::now();
     }
 }
 
@@ -199,6 +232,7 @@ pub struct LinkStateWrapper {
     id: LinkId,
     link_type: LinkType,
     locked_fsm: Mutex<LinkStateMachine>,
+    pub locked_data: Mutex<LinkData>,
 }
 
 impl LinkStateWrapper {
@@ -207,12 +241,8 @@ impl LinkStateWrapper {
             id: new_id,
             link_type: new_link_type,
             locked_fsm: Mutex::new(LinkStateMachine::new()),
+            locked_data: Mutex::new(LinkData::new()),
         }
-    }
-
-    /// Query whether the link is up
-    pub fn get_status(&self) -> LinkStatus {
-        self.locked_fsm.lock().unwrap().status
     }
 
     /// Get the link's current state
@@ -272,7 +302,7 @@ impl LinkStateWrapper {
         // TODO: What configuration goes here?
         // For now, just set the link up and transition it to the inactive state
         locked_fsm.status = LinkStatus::Up;
-        locked_fsm.state = LinkState::Inactive;
+        locked_fsm.set_state(LinkState::Inactive);
 
         debug!(
             target: LINK_STATE,
@@ -296,7 +326,7 @@ impl LinkStateWrapper {
             ));
         }
 
-        locked_fsm.state = LinkState::Keying;
+        locked_fsm.set_state(LinkState::Keying);
 
         info!(target: LINK_STATE, "Link {link_id} started.  Keying in progress");
 
@@ -315,7 +345,7 @@ impl LinkStateWrapper {
             }
             LinkType::NodeToNode => {
                 error!(target: LINK_STATE, "Error: Node to node not supported yet");
-                locked_fsm.state = LinkState::Error;
+                locked_fsm.set_state(LinkState::Error);
                 Err(LinkStateError::OperationNotSupportedYet)
             }
             LinkType::NodeToAdapter => {
@@ -380,7 +410,7 @@ impl LinkStateWrapper {
 
         debug!(target: LINK_STATE, "Link {link_id} finished keying.  Starting hello");
 
-        locked_fsm.state = LinkState::Helloing;
+        locked_fsm.set_state(LinkState::Helloing);
         drop(locked_fsm);
         self.maybe_send_hello(asm);
         Ok(())
@@ -410,12 +440,12 @@ impl LinkStateWrapper {
         let link_id = self.id;
         match (self.link_type, locked_fsm.state) {
             (LinkType::NodeToNode, LinkState::Helloing) => {
-                locked_fsm.state = LinkState::Active;
+                locked_fsm.set_state(LinkState::Active);
                 debug!(target: LINK_STATE, "Link {link_id} finished helloing.  Becoming active");
                 Ok(())
             }
             (LinkType::NodeToAdapter, LinkState::Helloing) => {
-                locked_fsm.state = LinkState::RegisterAA;
+                locked_fsm.set_state(LinkState::RegisterAA);
                 debug!(
                     target: LINK_STATE,
                     "Link {link_id} finished helloing.  Waiting on register agent address"
@@ -453,7 +483,7 @@ impl LinkStateWrapper {
 
         match (self.link_type, locked_fsm.state) {
             (LinkType::AdapterToNode, LinkState::Helloing) => {
-                locked_fsm.state = LinkState::RegisterAA;
+                locked_fsm.set_state(LinkState::RegisterAA);
                 debug!(
                     target: LINK_STATE,
                     "Link {link_id} finished helloing.  Sending register agent address"
@@ -463,7 +493,7 @@ impl LinkStateWrapper {
                 Ok(())
             }
             (LinkType::NodeToNode, LinkState::Helloing) => {
-                locked_fsm.state = LinkState::Active;
+                locked_fsm.set_state(LinkState::Active);
                 debug!(target: LINK_STATE, "Link {link_id} finished helloing.  Becoming active");
                 Ok(())
             }
@@ -525,7 +555,7 @@ impl LinkStateWrapper {
                 match vs_worker::build_connect_request(asm, link_id, addr) {
                     Ok(Some(conn_req)) => Ok(vs_worker::authorize_connect(asm, link_id, conn_req)),
                     Ok(None) => {
-                        locked_fsm.state = LinkState::Active;
+                        locked_fsm.set_state(LinkState::Active);
                         debug!(
                             target: LINK_STATE,
                             "Link {link_id} (Visa Service) received agent address.  Becoming active, no authorization required"
@@ -547,7 +577,7 @@ impl LinkStateWrapper {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         match (self.link_type, locked_fsm.state) {
             (LinkType::NodeToAdapter, LinkState::RegisterAA) => {
-                locked_fsm.state = LinkState::Active;
+                locked_fsm.set_state(LinkState::Active);
                 debug!(target: LINK_STATE, "Link {link_id} authorized.  Becoming active");
                 drop(locked_fsm);
                 self.run_active(&asm)
@@ -570,7 +600,7 @@ impl LinkStateWrapper {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         match (self.link_type, locked_fsm.state) {
             (LinkType::AdapterToNode, LinkState::RegisterAA) => {
-                locked_fsm.state = LinkState::Active;
+                locked_fsm.set_state(LinkState::Active);
                 asm.tun_ctl.set_carrier(true).unwrap();
                 debug!(
                     target: LINK_STATE,
@@ -612,7 +642,7 @@ impl LinkStateWrapper {
                 "terminate".to_string(),
             ))
         } else {
-            locked_fsm.state = LinkState::Closing;
+            locked_fsm.set_state(LinkState::Closing);
             Ok(())
         }
     }
@@ -629,7 +659,7 @@ impl LinkStateWrapper {
         info!(target: LINK_STATE,"Initiating shutdown on link {link_id}");
 
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
-        locked_fsm.state = LinkState::Closing;
+        locked_fsm.set_state(LinkState::Closing);
         let task_asm = asm.clone();
         tokio::task::spawn_local(async move {
             let _ = send_terminate_request(&task_asm, link_id, reason).await;
@@ -655,7 +685,7 @@ impl LinkStateWrapper {
                 }
                 locked_fsm.agent_addresses.clear();
                 locked_fsm.silent = false;
-                locked_fsm.state = LinkState::Inactive;
+                locked_fsm.set_state(LinkState::Inactive);
                 info!("Link {link_id} has fully shut down");
             }
             LinkState::Resetting => {
@@ -705,7 +735,7 @@ impl LinkStateWrapper {
                 "terminate indication".to_string(),
             )),
             (LinkState::Inactive, TerminateReason::Reset) => {
-                locked_fsm.state = LinkState::Closing;
+                locked_fsm.set_state(LinkState::Closing);
                 Ok(self.clean_up_link_state(asm))
             }
             (LinkState::Inactive, _) => Err(LinkStateError::UnexpectedTransition(
@@ -713,7 +743,7 @@ impl LinkStateWrapper {
                 "terminate indication".to_string(),
             )),
             (_, _) => {
-                locked_fsm.state = LinkState::Closing;
+                locked_fsm.set_state(LinkState::Closing);
                 Ok(self.clean_up_link_state(asm))
             }
         }
@@ -751,7 +781,7 @@ impl LinkStateWrapper {
             "Resetting link {link_id} from state {:?}",
             locked_fsm.state
         );
-        locked_fsm.state = LinkState::Resetting;
+        locked_fsm.set_state(LinkState::Resetting);
 
         let task_asm = asm.clone();
         tokio::task::spawn_local(async move {
@@ -770,14 +800,50 @@ impl LinkStateWrapper {
                 "Resetting link {link_id} from state {:?}",
                 locked_fsm.state
             );
-            locked_fsm.state = LinkState::Resetting;
+            locked_fsm.set_state(LinkState::Resetting);
             let _ = send_terminate_indication(&asm, link_id, TerminateReason::Reset).await;
         }
     }
 
-    pub fn run_active(&self, _asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
-        debug!(target: LINK_STATE, "Link {} entering active state", self.id);
-        // TODO send echoes
+    pub fn run_active(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
+        let link_id = self.id;
+        let task_asm = asm.clone();
+        debug!(target: LINK_STATE, "Link {link_id} entering active state");
+        tokio::task::spawn_local(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(3));
+            interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            while task_asm.is_link_ready(link_id) {
+                interval.tick().await;
+                let start_time = Instant::now();
+                let response = mgmt::requests::send_echo_request(&task_asm, link_id).await;
+                let Some(peer) = task_asm.peer_table.get(link_id) else {
+                    return;
+                };
+                match response {
+                    Ok(()) => {
+                        let mut link_data = peer.link_state_machine.locked_data.lock().unwrap();
+                        link_data.echo_success += 1;
+                        link_data
+                            .latency_data
+                            .add(Instant::now().duration_since(start_time));
+                    }
+                    Err(SyncReqError::Timeout) => {
+                        peer.link_state_machine
+                            .locked_data
+                            .lock()
+                            .unwrap()
+                            .echo_timeout += 1
+                    }
+                    Err(_) => {
+                        peer.link_state_machine
+                            .locked_data
+                            .lock()
+                            .unwrap()
+                            .echo_failure += 1
+                    }
+                }
+            }
+        });
         Ok(())
     }
 }
@@ -810,5 +876,62 @@ async fn send_terminate_request(
             asm.process_link_state_event(link_id, LinkEvent::ReceivedTerminateResponse(response))?;
             Ok(())
         }
+    }
+}
+
+impl Display for LinkStateWrapper {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // FIXME: This doesn't print link ID because the caller is printing link ID
+        // followed by substrate addr, which is out of scope for this display function
+        write!(f, "{}", self.locked_fsm.lock().unwrap())?;
+        if self.get_state() == LinkState::Active {
+            write!(f, "{}", self.locked_data.lock().unwrap())?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for LinkStateMachine {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.agent_addresses.is_empty() {
+            write!(f, "  Agent Addresses: None\n")?;
+        } else {
+            write!(f, "  Agent Addresses: [ {}", self.agent_addresses[0])?;
+            for addr in &self.agent_addresses[1..self.agent_addresses.len()] {
+                write!(f, ", {}", addr)?;
+            }
+            write!(f, " ]\n")?;
+        }
+
+        // TODO: Format time since last state change better
+        write!(
+            f,
+            "  State: {:?} (for {:?})\n",
+            self.state,
+            Instant::now().duration_since(self.last_state_change)
+        )?;
+        write!(f, "  Status: {:?}\n", self.status)
+    }
+}
+
+impl Display for LinkData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let (total, count) = self.latency_data.get_total_and_count();
+        let average = if count > 0 {
+            total.div_f64(count as f64)
+        } else {
+            Duration::ZERO
+        };
+
+        write!(f, "  Echo stats:\n")?;
+        write!(f, "    Successes: {}\n", self.echo_success)?;
+        write!(f, "    Timeouts: {}\n", self.echo_timeout)?;
+        write!(f, "    Other failures: {}\n", self.echo_failure)?;
+        write!(
+            f,
+            "    Latency: Min {:?}, Max {:?}, Avg {average:?}\n",
+            self.latency_data.get_min(),
+            self.latency_data.get_max(),
+        )
     }
 }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -47,6 +47,7 @@ mod peer_table;
 mod queues;
 mod rcu;
 mod rpc_worker;
+mod sample_ring;
 mod signal_worker;
 mod special_peers;
 mod substrate_ingress_worker;

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -66,6 +66,28 @@ pub async fn handle_discard(_asm: &Arc<Assembly>, pkt: Packet) -> HandleMgmtResu
     Ok(())
 }
 
+/// handle an Echo Request message (RFC 6.5 § 6.3.2)
+pub async fn handle_echo_request(
+    asm: &Arc<Assembly>,
+    seq_num: zpr::SeqNum,
+    pkt: Packet,
+) -> HandleMgmtResult {
+    let ingress_link_id = pkt.metadata().ingress_link_id;
+    let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
+    let _hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpEchoHeader>();
+
+    super::core::send_non_flow_mgmt_response(
+        asm,
+        ingress_link_id,
+        zdp::ZdpPacketType::EchoResponse,
+        seq_num,
+        rsp_pkt,
+    )
+    .await;
+
+    Ok(())
+}
+
 /// handle a Terminate Request (RFC 6.5 § 6.3.3)
 pub async fn handle_terminate_request(
     asm: &Arc<Assembly>,

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -6,6 +6,7 @@ use crate::assembly::Assembly;
 use crate::counters::CounterType;
 use crate::defs::*;
 use crate::logging::targets::ZDP;
+use crate::mgmt::core::SyncReqError;
 use crate::zdp;
 use bytes::{Buf, BufMut};
 use std::net::IpAddr;
@@ -37,6 +38,27 @@ pub async fn send_key_management(
 pub async fn send_discard(asm: &Assembly, link_id: zpr::LinkId) {
     let pkt = core::new_heap_packet();
     core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::Discard, pkt).await;
+}
+
+/// send an Echo Request and wait for the Response (RFC 6.5 § 6.3.2)
+pub async fn send_echo_request(asm: &Assembly, link_id: zpr::LinkId) -> Result<(), SyncReqError> {
+    let mut echo = core::send_sync_non_flow_req(
+        asm,
+        link_id,
+        zdp::ZdpPacketType::EchoRequest,
+        zdp::ZdpPacketType::EchoResponse,
+        move |_packet| {},
+    )
+    .await?;
+
+    // TODO: Break these apart
+    let Ok(_) = zdp::ZdpEchoHeader::read_from_buf(&mut echo) else {
+        core::count_event(asm, &mut echo, CounterType::BadStructure);
+        return Err(SyncReqError::ProtocolError);
+    };
+    asm.buffer_stack
+        .put_buffer(echo.destroy().try_into().unwrap());
+    Ok(())
 }
 
 /// send a Hello Request and wait for the Response (RFC 6.5 § 6.3.4)

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -81,6 +81,8 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
 
             ZdpPacketType::Discard => handlers::handle_discard(asm, pkt).await,
 
+            ZdpPacketType::EchoRequest => handlers::handle_echo_request(asm, seq_num, pkt).await,
+
             ZdpPacketType::KeyManagement => {
                 panic!("unexpected Key Management message in mgmt processor")
             }

--- a/adapter/ph/src/rpc_worker.rs
+++ b/adapter/ph/src/rpc_worker.rs
@@ -7,7 +7,7 @@
 
 use crate::assembly::Assembly;
 use crate::config;
-use crate::link_state::LinkEvent;
+use crate::link_state::{LinkEvent, LinkState};
 use crate::logging::targets::RPC;
 use crate::test_packet::TestPacketMetrics;
 use crate::zdp::TerminateReason;
@@ -470,17 +470,14 @@ fn show_link(asm: &Arc<Assembly>, link_id: LinkId) -> String {
     match asm.peer_table.get(link_id) {
         Some(peer) => {
             let lsm = &peer.link_state_machine;
+
             format!(
                 "Link {link_id} info:
-  SubstrateAddr: {}
-  State: {:?}
-  Status {:?}\n",
-                peer.substrate_addr,
-                lsm.get_state(),
-                lsm.get_status()
+  Substrate Address: {}\n{}",
+                peer.substrate_addr, lsm,
             )
         }
-        None => format!("No suck link {link_id}\n"),
+        None => format!("No such link {link_id}\n"),
     }
 }
 

--- a/adapter/ph/src/sample_ring.rs
+++ b/adapter/ph/src/sample_ring.rs
@@ -1,0 +1,60 @@
+use std::ops::AddAssign;
+
+/// Simple struct that stores last SIZE samples of some data, overwriting the oldest after that
+pub struct SampleRing<Type, const SIZE: usize> {
+    pub samples: [Type; SIZE],
+    next_sample_idx: usize,
+    num_samples: usize,
+}
+
+impl<Type: std::marker::Copy + std::cmp::Ord + AddAssign, const SIZE: usize>
+    SampleRing<Type, SIZE>
+{
+    pub fn new(init: Type) -> Self {
+        Self {
+            samples: [init; SIZE],
+            next_sample_idx: 0,
+            num_samples: 0,
+        }
+    }
+
+    /// Add a new sample to the ring
+    pub fn add(&mut self, sample: Type) {
+        self.samples[self.next_sample_idx] = sample;
+        self.next_sample_idx = (self.next_sample_idx + 1) % SIZE;
+        self.num_samples = std::cmp::min(SIZE, self.num_samples + 1);
+    }
+
+    /// Get the min value from the data collected
+    pub fn get_min(&self) -> Type {
+        let mut min = self.samples[0];
+        if self.num_samples > 1 {
+            for sample in &self.samples[1..self.num_samples] {
+                min = std::cmp::min(min, *sample);
+            }
+        }
+        min
+    }
+
+    /// Get the max value from the data collected
+    pub fn get_max(&self) -> Type {
+        let mut max = self.samples[0];
+        if self.num_samples > 1 {
+            for sample in &self.samples[1..self.num_samples] {
+                max = std::cmp::max(max, *sample);
+            }
+        }
+        max
+    }
+
+    /// Return total and count of data stored so that an average can be calculated
+    pub fn get_total_and_count(&self) -> (Type, usize) {
+        let mut running_total = self.samples[0];
+        if self.num_samples > 1 {
+            for sample in &self.samples[1..self.num_samples] {
+                running_total.add_assign(*sample);
+            }
+        }
+        (running_total, self.num_samples)
+    }
+}


### PR DESCRIPTION
Once the link becomes active, it begins sending echo requests to its partner every 3 seconds (in the future this will be configurable).  For each echo request, we track whether or not we got a response (success/failure counters) and how long it took to get a response (round trip time).  All of those stats, plus time since last link state change are now available in the `link show <id>` command through the debug tool.