### PR TITLE
add agent output requeue path

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -5,7 +5,7 @@ use crate::fastpath;
 use crate::logging::targets::FLOW_MGMT;
 use crate::mgmt;
 use crate::packet::Packet;
-use crate::queues::AdapterManagerMessage;
+use crate::queues::{AdapterManagerMessage, TryEnqueueError};
 use std::num::NonZero;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -123,11 +123,13 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, mut pkt: Packet) {
             };
 
             // now send out initial packet
-            fastpath::agent_output_post_classify(
-                asm,
-                initial_packet,
-                /* allow_bind_request */ false,
-            );
+            match asm.agent_output_requeue.try_enqueue_packet(initial_packet) {
+                Ok(()) => (),
+                Err(TryEnqueueError::Full(_pkt)) => {
+                    debug!(target: FLOW_MGMT, "Requeue backpressure on bind of {five_tuple}, dropping initial packet");
+                    asm.counters[CounterType::QueueBackpressure].increment();
+                }
+            }
         }
 
         Err(err) => {

--- a/adapter/ph/src/agent_output_worker.rs
+++ b/adapter/ph/src/agent_output_worker.rs
@@ -9,10 +9,11 @@ use crate::sys::TunPi;
 use crate::sys::ZprTun;
 use crate::zprtun;
 use std::sync::Arc;
+use tokio::net::UnixDatagram;
+use tokio::select;
 
 #[derive(Copy, Clone)]
 pub struct Config {
-    #[allow(dead_code)]
     pub worker_index: usize,
     pub batch_size: usize,
 }
@@ -21,7 +22,12 @@ fn is_ip(pi: TunPi) -> bool {
     pi.proto == net_defs::ethertype::IP || pi.proto == net_defs::ethertype::IPV6
 }
 
-pub async fn launch(config: Config, asm: Arc<Assembly>, tun: Arc<ZprTun>) {
+pub async fn launch(
+    config: Config,
+    asm: Arc<Assembly>,
+    tun: Arc<ZprTun>,
+    requeue_outq: UnixDatagram,
+) {
     let worker = Worker {
         config,
         asm: asm.clone(),
@@ -38,33 +44,67 @@ pub async fn launch(config: Config, asm: Arc<Assembly>, tun: Arc<ZprTun>) {
         // read & forward packets one at a time, no sense to batch really
         // since neither `read_buf()` nor `enqueue()` support it
         for mut buf in bufs.drain(..) {
-            let pkt = loop {
+            let (pkt, is_requeue) = loop {
                 let mut pkt = Packet::new(buf, config::DEFAULT_MESSAGE_HEADROOM);
-                tun.recv_buf(&mut pkt).await.unwrap();
-                if zprtun::TUN_HAS_PI {
-                    let pi = TunPi::read_pi(&mut pkt);
-                    if pi.strip || !is_ip(pi) {
-                        // packet was too large or non-IP; drop
-                        asm.counters[CounterType::OutPacksDrop].increment();
-                        // reuse `buf`
-                        buf = pkt.destroy().try_into().unwrap();
-                        continue;
+                let is_requeue;
+
+                select! {
+                    res = tun.recv_buf(&mut pkt) => {
+                        res.unwrap();
+
+                        if zprtun::TUN_HAS_PI {
+                            let pi = TunPi::read_pi(&mut pkt);
+                            if pi.strip || !is_ip(pi) {
+                                // packet was too large or non-IP; drop
+                                asm.counters[CounterType::OutPacksDrop].increment();
+                                // reuse `buf`
+                                buf = pkt.destroy().try_into().unwrap();
+                                continue;
+                            }
+                        } else {
+                            // No packet info, permit IP and IPv6 only (for now?)
+                            if pkt.body()[0] >> 4 != 4 && pkt.body()[0] >> 4 != 6 {
+                                asm.counters[CounterType::OutPacksDrop].increment();
+                                buf = pkt.destroy().try_into().unwrap();
+                                continue;
+                            }
+                        }
+
+                        is_requeue = false;
                     }
-                } else {
-                    // No packet info, permit IP and IPv6 only (for now?)
-                    if pkt.body()[0] >> 4 != 4 && pkt.body()[0] >> 4 != 6 {
-                        asm.counters[CounterType::OutPacksDrop].increment();
+
+                    _ = requeue_outq.readable() => {
                         buf = pkt.destroy().try_into().unwrap();
-                        continue;
+                        if let Err(err) = requeue_outq.try_recv(buf.as_mut()) {
+                            match err.kind() {
+                                std::io::ErrorKind::WouldBlock => {
+                                    continue;
+                                }
+
+                                _ => {
+                                    // FIXME: detect packet-too-large
+                                    panic!("unrecoverable I/O error {err}");
+                                }
+                            }
+                        }
+
+                        pkt = Packet::new_with_existing_metadata(buf);
+
+                        is_requeue = true;
                     }
                 }
 
-                break pkt;
+                break (pkt, is_requeue);
             };
 
-            asm.counters[CounterType::OutPacksRec].increment();
-
-            worker.process(pkt);
+            if is_requeue {
+                fastpath::agent_output_post_classify(
+                    &asm, pkt, /* allow_bind_request */ false,
+                );
+            } else {
+                asm.counters[CounterType::OutPacksRec].increment();
+                worker.process(pkt);
+            }
         }
     }
 }
@@ -80,6 +120,7 @@ impl Worker {
     /// The packet will be compressed, or trigger a Bind request.
     pub fn process(&self, mut pkt: Packet) {
         pkt.metadata_mut().ingress_link_id = zpr::LOCAL_AGENT_LINK_ID;
+        pkt.metadata_mut().ingress_lane_id = self.config.worker_index as u8;
 
         // determine five tuple
         let classification = match classifier::classify(&mut pkt) {

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -62,6 +62,7 @@ pub struct Assembly {
 
     pub agent_input: AgentInput,
     pub substrate_egress: SubstrateEgress,
+    pub agent_output_requeue: AgentOutputRequeue,
 
     pub vsconn: Option<libnode::vsconn::VSConnHandle>, // present only on nodes
 
@@ -323,6 +324,7 @@ pub mod test {
         pub buffer_stack: Option<BufferStack<{ config::PACKET_BUFFER_SIZE }>>,
         pub agent_input: Option<AgentInput>,
         pub substrate_egress: Option<SubstrateEgress>,
+        pub agent_output_requeue: Option<AgentOutputRequeue>,
         pub vsconn: Option<Option<libnode::vsconn::VSConnHandle>>,
         pub capture_queue: Option<Capture>,
         pub capture_worker: Option<CaptureWorker>,
@@ -369,6 +371,9 @@ pub mod test {
         let substrate_egress = builder
             .substrate_egress
             .unwrap_or_else(|| SubstrateEgress::new(Vec::new()));
+        let agent_output_requeue = builder
+            .agent_output_requeue
+            .unwrap_or_else(|| AgentOutputRequeue::new(Vec::new()));
         let vsconn = builder.vsconn.unwrap_or(None);
         let capture_queue = builder.capture_queue.unwrap_or_else(|| {
             let (cq_inq, _cq_outq) = mpsc::channel(1);
@@ -411,6 +416,7 @@ pub mod test {
             buffer_stack,
             agent_input,
             substrate_egress,
+            agent_output_requeue,
             vsconn,
             capture_queue,
             capture_worker,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -504,7 +504,7 @@ pub fn agent_output_post_classify(asm: &Assembly, mut pkt: Packet, allow_bind_re
         None => {
             if !allow_bind_request {
                 // avoid the (all-but purely theoretical) chance of a packet loop,
-                // when this is called from bind setup code
+                // when this is initiated due to a requeue from bind setup code
                 drop_and_count(asm, pkt, CounterType::OtherError);
                 return;
             }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -190,8 +190,9 @@ fn main() -> ExitCode {
     info!(target: STARTUP, "control socket bound to {:?}", config.control_path);
 
     //
-    // open TUN devices
+    // open TUN devices and agent requeue sockets
     //
+
     // HACK: If we are using a new TUN (requirement on MAC I think), we will set the address.
     let tun_addr = if !config.agent_addr.is_empty() && config.tun_if.is_none() {
         Some(config.agent_addr[0].clone())
@@ -211,6 +212,15 @@ fn main() -> ExitCode {
     };
     let tun_ctl = Box::new(tun_ctl::TunCtlImpl::new(tun_devs[0].clone()));
     tun_ctl.set_carrier(false).unwrap();
+
+    let mut agent_requeue_inqs = Vec::new();
+    let mut agent_requeue_outqs = Vec::new();
+    for _i in 0..topology_config.agent_output_concurrency {
+        let (inq, outq) = tokio::net::UnixDatagram::pair().unwrap();
+        // TODO: use get/setsockopt(SO_SNDBUF) to ensure we can transfer packets of PACKET_BUFFER_SIZE
+        agent_requeue_inqs.push(inq);
+        agent_requeue_outqs.push(outq);
+    }
 
     //
     // open substrate sockets
@@ -306,6 +316,7 @@ fn main() -> ExitCode {
         buffer_stack: BufferStack::new(buf_storage),
         agent_input: AgentInput::new(tun_devs.clone()),
         substrate_egress: SubstrateEgress::new(substrate_sockets.clone()),
+        agent_output_requeue: AgentOutputRequeue::new(agent_requeue_inqs),
         vsconn: vsconn.as_ref().map(|c| c.handle()),
         capture_queue: Capture::new(cap_inq),
         capture_worker: CaptureWorker::new(),
@@ -375,7 +386,9 @@ fn main() -> ExitCode {
     // start data path workers
     //
 
-    for (worker_index, tun_dev) in tun_devs.into_iter().enumerate() {
+    for (worker_index, (tun_dev, requeue)) in
+        tun_devs.into_iter().zip(agent_requeue_outqs).enumerate()
+    {
         js.spawn(agent_output_worker::launch(
             agent_output_worker::Config {
                 worker_index,
@@ -383,6 +396,7 @@ fn main() -> ExitCode {
             },
             asm.clone(),
             tun_dev,
+            requeue,
         ));
     }
 

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -165,9 +165,12 @@ pub struct PacketMetadata {
     /// which stream ID this packet is associated with
     pub ingress_stream_id: zpr::StreamId,
 
-    five_tuple: FiveTuple,
+    /// which fastpath lane this packet arrived on
+    pub ingress_lane_id: u8,
 
-    _padding: [u8; 2],
+    _padding: [u8; 1],
+
+    five_tuple: FiveTuple,
 }
 
 #[allow(dead_code)]

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -10,7 +10,7 @@ use std::net::SocketAddr;
 use std::result::Result;
 use std::sync::Arc;
 use std::time::SystemTime;
-use tokio::net::UdpSocket;
+use tokio::net::{UdpSocket, UnixDatagram};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::oneshot::error::RecvError;
@@ -203,6 +203,36 @@ impl SubstrateEgress {
     #[allow(dead_code)]
     pub fn fanout(&self) -> usize {
         self.sockets.len()
+    }
+}
+
+/// Used for requeueing agent output packets from mgmt.
+pub struct AgentOutputRequeue {
+    sockets: Box<[UnixDatagram]>,
+}
+
+impl AgentOutputRequeue {
+    pub fn new(sockets: impl IntoIterator<Item = UnixDatagram>) -> Self {
+        Self {
+            sockets: sockets.into_iter().collect(),
+        }
+    }
+
+    pub fn try_enqueue_packet(&self, packet: Packet) -> Result<(), TryEnqueueError<Packet>> {
+        let socket = self.select_socket(&packet);
+
+        match socket.try_send(packet.buffer()) {
+            Ok(_) => Ok(()),
+
+            Err(err) => match err.kind() {
+                ErrorKind::WouldBlock => Err(TryEnqueueError::Full(packet)),
+                _ => panic!("unrecoverable I/O error: {}", err),
+            },
+        }
+    }
+
+    fn select_socket(&self, packet: &Packet) -> &UnixDatagram {
+        &self.sockets[packet.metadata().ingress_lane_id as usize]
     }
 }
 


### PR DESCRIPTION
Each agent output worker gets a Unix-domain datagram socket, through which mgmt can re-inject agent packets to be forwarded.  This is used when re-sending the initial packet of a flow.  Previously, mgmt directly executed fastpath code.

This change is needed so that forthcoming changes which wholly separate the fastpath buffer stacks from mgmt do not result in fastpath code being duplicated or be highly parameterized to handle the two different packet buffer types.

Also fix bug whereby mgmt packet buffers were being added to fastpath buffer stack on initial agent packet re-send.