### PR TITLE
add and use two_way_queue

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -1,23 +1,25 @@
 use crate::adapter_tables::{AltEntry, AltPep};
 use crate::assembly::{Assembly, PhMode};
 use crate::counters::CounterType;
-use crate::fastpath;
 use crate::logging::targets::FLOW_MGMT;
 use crate::mgmt;
-use crate::packet::Packet;
+use crate::packet::{Packet, PacketBuffer};
 use crate::queues::{AdapterManagerMessage, TryEnqueueError};
+use crate::two_way_queue;
 use std::num::NonZero;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 use tracing::*;
 use zpr;
 
-pub async fn launch(asm: Arc<Assembly>, mut queue: mpsc::Receiver<AdapterManagerMessage>) {
-    while let Some(msg) = queue.recv().await {
-        match msg {
+pub async fn launch(
+    asm: Arc<Assembly>,
+    mut queue: two_way_queue::Receiver<AdapterManagerMessage, PacketBuffer>,
+) {
+    while let Some(mut msg) = queue.recv().await {
+        match &mut *msg {
             AdapterManagerMessage::RequestTetherId(pkt) => {
                 let mgmt_pkt = Packet::new_with_existing_metadata(pkt.buffer().clone());
-                fastpath::drop_and_count(&asm, pkt, CounterType::DispatchedToMgmt);
+                drop(msg);
 
                 // for now, perform these sequentially...
                 // ideally, we place these into a JoinSet,

--- a/adapter/ph/src/agent_output_worker.rs
+++ b/adapter/ph/src/agent_output_worker.rs
@@ -1,13 +1,18 @@
+use crate::adapter_tables::AltEntry;
 use crate::assembly::Assembly;
 use crate::classifier::{self, ClassifierResult};
+use crate::compress;
 use crate::config;
 use crate::counters::*;
 use crate::fastpath;
 use crate::net_defs;
 use crate::packet::Packet;
+use crate::queues::{AdapterManager, TryEnqueueError};
 use crate::sys::TunPi;
 use crate::sys::ZprTun;
+use crate::zdp;
 use crate::zprtun;
+use bytes::BufMut;
 use std::sync::Arc;
 use tokio::net::UnixDatagram;
 use tokio::select;
@@ -15,6 +20,8 @@ use tokio::select;
 #[derive(Copy, Clone)]
 pub struct Config {
     pub worker_index: usize,
+    pub buffer_count: usize,
+    #[allow(dead_code)]
     pub batch_size: usize,
 }
 
@@ -28,18 +35,35 @@ pub async fn launch(
     tun: Arc<ZprTun>,
     requeue_outq: UnixDatagram,
 ) {
-    let worker = Worker {
+    let mut worker = Worker {
         config,
         asm: asm.clone(),
+        adapter_manager: asm.adapter_manager.clone(),
     };
 
     let mut bufs = Vec::new();
 
     loop {
-        // grab some buffers from the pool
-        asm.buffer_stack
-            .get_buffers(config.batch_size, &mut bufs)
-            .await;
+        // process the return buffer queue
+        worker
+            .adapter_manager
+            .try_recv_return_buffers(&mut bufs, config.buffer_count);
+        asm.buffer_stack.put_buffers(bufs.drain(..));
+
+        // grab some buffers from the pool;
+        // if none are available immediately, also wait on the return buffer queue
+        select! {
+            biased;
+
+            _ = asm.buffer_stack
+                .get_buffers(config.batch_size - bufs.len(), &mut bufs) => (),
+
+            buf = worker.adapter_manager.async_recv_return_buffer() => {
+                // weird two-step approach necessitated by bufs ownership issue with select
+                bufs.push(buf);
+                worker.adapter_manager.try_recv_return_buffers(&mut bufs, config.batch_size - 1);
+            }
+        }
 
         // read & forward packets one at a time, no sense to batch really
         // since neither `read_buf()` nor `enqueue()` support it
@@ -98,12 +122,10 @@ pub async fn launch(
             };
 
             if is_requeue {
-                fastpath::agent_output_post_classify(
-                    &asm, pkt, /* allow_bind_request */ false,
-                );
+                worker.process_packet_post_classify(pkt, /* allow_bind_request */ false);
             } else {
                 asm.counters[CounterType::OutPacksRec].increment();
-                worker.process(pkt);
+                worker.process_packet(pkt);
             }
         }
     }
@@ -113,12 +135,13 @@ struct Worker {
     #[allow(dead_code)]
     config: Config,
     asm: Arc<Assembly>,
+    adapter_manager: AdapterManager,
 }
 
 impl Worker {
     /// Process uncompressed packet from the agent.
     /// The packet will be compressed, or trigger a Bind request.
-    pub fn process(&self, mut pkt: Packet) {
+    pub fn process_packet(&mut self, mut pkt: Packet) {
         pkt.metadata_mut().ingress_link_id = zpr::LOCAL_AGENT_LINK_ID;
         pkt.metadata_mut().ingress_lane_id = self.config.worker_index as u8;
 
@@ -147,6 +170,71 @@ impl Worker {
             }
         }
 
-        fastpath::agent_output_post_classify(&self.asm, pkt, /* allow_bind_request */ true);
+        self.process_packet_post_classify(pkt, /* allow_bind_request */ true);
+    }
+
+    /// Post-classification portion of `agent_output` function.  Used for
+    /// re-injecting already-classified packets e.g.  which were held
+    /// awaiting bind.  `allow_bind_request` should be `true` for "real"
+    /// packets; `false` for packets re-injected from mgmt plane after
+    /// fulfilling a bind request (so as to prevent the theoretical
+    /// possibility of a packet loop).
+    pub fn process_packet_post_classify(&mut self, mut pkt: Packet, allow_bind_request: bool) {
+        let five_tuple = *pkt.metadata().five_tuple(); // TODO: convince borrow checker we don't need to copy this out
+
+        // lookup five tuple in ALT
+        match self.asm.alt.get(&five_tuple) {
+            Some(entry) => match &*entry {
+                AltEntry::Active(pep) => {
+                    // compute A2A MAC
+                    // TODO: use actual A2A SAID & keyed hash
+                    let a2a_said: zpr::A2aSaid = 0;
+                    let a2a_mac_size = zdp::ZDP_A2A_MAC_SIZE; // TODO: may be smaller depending on A2A SAID
+                    let mut a2a_mac = [0u8; zdp::ZDP_A2A_MAC_SIZE];
+                    // SECURITY: truncating BLAKE3 is safe
+                    a2a_mac[..a2a_mac_size]
+                        .copy_from_slice(&blake3::hash(pkt.body()).as_bytes()[..a2a_mac_size]);
+
+                    // compress packet
+                    compress::compress(
+                        pep.compression_mode,
+                        five_tuple.l3_type,
+                        five_tuple.l4_protocol,
+                        &mut pkt,
+                    );
+
+                    // append A2A MAC
+                    pkt.put(&a2a_mac[..a2a_mac_size]);
+                    pkt.alloc_zeroed_header::<zdp::ZdpA2aHeader>().a2a_said = a2a_said;
+
+                    pkt.metadata_mut().ingress_stream_id = pep.tether_id;
+
+                    // forward packet on
+                    fastpath::forward(&self.asm, pkt);
+                }
+
+                AltEntry::Pending(_) => {
+                    // Bind request pending; drop this packet
+                    fastpath::drop_and_count(&self.asm, pkt, CounterType::DroppedAwaitingBind);
+                }
+            },
+
+            None => {
+                if !allow_bind_request {
+                    // avoid the (all-but purely theoretical) chance of a packet loop,
+                    // when this is initiated due to a requeue from bind setup code
+                    fastpath::drop_and_count(&self.asm, pkt, CounterType::OtherError);
+                    return;
+                }
+
+                // issue bind request
+                match self.adapter_manager.try_request_tether_id(pkt) {
+                    Ok(()) => self.asm.counters[CounterType::AgentSlowpath].increment(),
+                    Err(TryEnqueueError::Full(pkt)) => {
+                        fastpath::drop_and_count(&self.asm, pkt, CounterType::QueueBackpressure)
+                    }
+                }
+            }
+        }
     }
 }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -58,7 +58,7 @@ pub struct Assembly {
     // Shared resources.  These may be accessed by any part of the system.
     pub agent_addresses: Vec<IpAddr>,
 
-    pub buffer_stack: BufferStack<{ config::PACKET_BUFFER_SIZE }>,
+    pub buffer_stack: BufferStack,
 
     pub agent_input: AgentInput,
     pub substrate_egress: SubstrateEgress,
@@ -291,6 +291,7 @@ pub mod test {
 
     use super::*;
     use crate::config::TopologyConfig;
+    use crate::two_way_queue;
     use std::net::Ipv4Addr;
     use tokio::sync::mpsc;
 
@@ -300,7 +301,7 @@ pub mod test {
         pub ph_mode: Option<PhMode>,
         pub topology_config: Option<TopologyConfig>,
         pub agent_addresses: Option<Vec<IpAddr>>,
-        pub buffer_stack: Option<BufferStack<{ config::PACKET_BUFFER_SIZE }>>,
+        pub buffer_stack: Option<BufferStack>,
         pub agent_input: Option<AgentInput>,
         pub substrate_egress: Option<SubstrateEgress>,
         pub agent_output_requeue: Option<AgentOutputRequeue>,
@@ -341,7 +342,7 @@ pub mod test {
             .agent_addresses
             .unwrap_or(Vec::from([IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]));
         let buffer_stack = builder.buffer_stack.unwrap_or_else(|| {
-            let buf_storage = vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]); 0];
+            let buf_storage = vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]) as Box<[_]>; 0];
             BufferStack::new(buf_storage)
         });
         let agent_input = builder
@@ -375,11 +376,11 @@ pub mod test {
             .dlt
             .unwrap_or_else(|| adapter_tables::DockLookupTable::new());
         let mgmt_dispatch = builder.mgmt_dispatch.unwrap_or_else(|| {
-            let (md_inq, _md_outq) = mpsc::channel(1);
+            let (md_inq, _md_outq) = two_way_queue::two_way_queue(1);
             MgmtDispatch::new(md_inq)
         });
         let adapter_manager = builder.adapter_manager.unwrap_or_else(|| {
-            let (am_inq, _am_outq) = mpsc::channel(1);
+            let (am_inq, _am_outq) = two_way_queue::two_way_queue(1);
             AdapterManager::new(am_inq)
         });
         let km_state = builder.km_state.unwrap_or_else(|| {

--- a/adapter/ph/src/buffer_stack.rs
+++ b/adapter/ph/src/buffer_stack.rs
@@ -21,21 +21,19 @@ macro_rules! test_barrier_wait {
 
 /// This is used by the ingress stage to allocate buffers for incoming
 /// packets.  Buffers are reused in a LIFO manner to promote cache reuse.
-pub struct BufferStack<const BUFSIZ: usize> {
-    buffers: Mutex<Vec<Box<[u8; BUFSIZ]>>>,
+pub struct BufferStack {
+    buffers: Mutex<Vec<Box<[u8]>>>,
     notify: Notify,
 }
 
 /// Owning reference to a buffer allocated from the stack.
-pub type Buffer<const BUFSIZ: usize> = Box<[u8; BUFSIZ]>;
+pub type Buffer = Box<[u8]>;
 
 #[allow(dead_code)]
-impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
-    pub const BUFFER_SIZE: usize = BUFSIZ;
-
+impl BufferStack {
     pub fn new<I>(bufs: I) -> Self
     where
-        I: IntoIterator<Item = Box<[u8; BUFSIZ]>>,
+        I: IntoIterator<Item = Box<[u8]>>,
     {
         Self {
             buffers: Mutex::new(bufs.into_iter().collect()),
@@ -44,7 +42,7 @@ impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
     }
 
     /// Blocks until a single buffer can be returned.
-    pub async fn get_buffer(&self) -> Buffer<BUFSIZ> {
+    pub async fn get_buffer(&self) -> Buffer {
         loop {
             test_barrier_wait!();
 
@@ -74,19 +72,19 @@ impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
     /// Same as `get_buffer()`, but returns the buffer in a `DropGuard`
     /// which will automatically return the buffer to the pool if it goes
     /// out of scope.
-    pub async fn get_buffer_guarded(&self) -> impl DropGuard<Buffer<BUFSIZ>> + '_ {
+    pub async fn get_buffer_guarded(&self) -> impl DropGuard<Buffer> + '_ {
         drop_guard(self.get_buffer().await, |buf| self.put_buffer(buf))
     }
 
     /// Attempts to acquire a single buffer.  Does not block.
-    pub fn try_get_buffer(&self) -> Option<Buffer<BUFSIZ>> {
+    pub fn try_get_buffer(&self) -> Option<Buffer> {
         self.buffers.lock().unwrap().pop()
     }
 
     /// Blocks until at least 1 buffer can be returned.
     /// Returns up to n buffers.
     /// Exception: if n is 0, returns immediately with no buffers.
-    pub async fn get_buffers(&self, n: usize, bufs_out: &mut Vec<Buffer<BUFSIZ>>) -> usize {
+    pub async fn get_buffers(&self, n: usize, bufs_out: &mut Vec<Buffer>) -> usize {
         if n == 0 {
             return 0;
         }
@@ -125,7 +123,7 @@ impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
 
     /// Does not block.  May return 0 if no buffers could be returned.
     /// Returns up to n buffers.
-    pub fn try_get_buffers(&self, n: usize, bufs_out: &mut Vec<Buffer<BUFSIZ>>) -> usize {
+    pub fn try_get_buffers(&self, n: usize, bufs_out: &mut Vec<Buffer>) -> usize {
         if n == 0 {
             return 0;
         }
@@ -143,7 +141,7 @@ impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
     }
 
     /// Returns a single buffer.  Does not block.
-    pub fn put_buffer(&self, buf: Buffer<BUFSIZ>) {
+    pub fn put_buffer(&self, buf: Buffer) {
         let mut bufs = self.buffers.lock().unwrap();
         let was_empty = bufs.is_empty();
         bufs.push(buf);
@@ -156,7 +154,7 @@ impl<const BUFSIZ: usize> BufferStack<BUFSIZ> {
     /// Returns all buffers in the given collection.  Does not block.
     pub fn put_buffers<I>(&self, bufs_in: I)
     where
-        I: IntoIterator<Item = Buffer<BUFSIZ>>,
+        I: IntoIterator<Item = Buffer>,
     {
         let mut it = bufs_in.into_iter();
         match it.next() {
@@ -185,7 +183,7 @@ mod tests {
     #[tokio::test]
     async fn get_buffer_notify_race() {
         let buf = Box::new([0u8; 1]);
-        let bs = Box::leak(Box::new(BufferStack::<1>::new([])));
+        let bs = Box::leak(Box::new(BufferStack::new([])));
         let barrier = Box::leak(Box::new(tokio::sync::Barrier::new(2)));
         let gb_task = tokio::task::spawn(BARRIER.scope(barrier, bs.get_buffer()));
 
@@ -212,7 +210,7 @@ mod tests {
     #[tokio::test]
     async fn get_buffers_notify_race() {
         let buf = Box::new([0u8; 1]);
-        let bs = Box::leak(Box::new(BufferStack::<1>::new([])));
+        let bs = Box::leak(Box::new(BufferStack::new([])));
         let barrier = Box::leak(Box::new(tokio::sync::Barrier::new(2)));
         let gb_task = tokio::task::spawn(BARRIER.scope(barrier, async {
             let mut vec = Vec::new();

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -68,6 +68,7 @@ pub struct Config {
 
 /// Configuration of data path & control plane topology.
 pub struct TopologyConfig {
+    /// Number of packet buffers to allocate per fastpath worker.
     pub buffer_count: usize,
 
     pub substrate_ingress_concurrency: usize,

--- a/adapter/ph/src/counters.rs
+++ b/adapter/ph/src/counters.rs
@@ -81,7 +81,8 @@ pub enum CounterType {
     DroppedNoSA,          // no security association on link
     InternalRoutingError, // a packet ended up somewhere it shouldn't have due to a coding error
 
-    DispatchedToMgmt, // exited fastpath, sent to mgmt
+    DispatchedToMgmt, // exited fastpath from substrate ingress, sent to mgmt
+    AgentSlowpath,    // exited fastpath from agent output, sent to mgmt
     BadMgmtResponse,
     UnexpectedMgmtResponse,
 
@@ -139,6 +140,7 @@ impl CounterType {
 
             // Management packets
             Self::DispatchedToMgmt => "Dispatched to Management",
+            Self::AgentSlowpath => "Agent Slowpath",
             Self::BadMgmtResponse => "Bad Management Response",
             Self::UnexpectedMgmtResponse => "Unexpected Management Response",
 

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -3,7 +3,6 @@
 //! General rule: no fastpath operation may block.
 //! This implies that all functions here must be non-async.
 
-use crate::adapter_tables::AltEntry;
 use crate::assembly::{Assembly, PhMode};
 use crate::config;
 use crate::counters::CounterType;
@@ -31,6 +30,14 @@ pub fn drop_and_count(asm: &Assembly, pkt: Packet, reason: impl Into<CounterType
     debug!(target: DATAPATH, "dropping packet because {reason}");
     asm.buffer_stack
         .put_buffer(pkt.destroy().try_into().unwrap());
+    asm.counters[reason].increment();
+}
+
+/// Drop a heap-allocated packet and count the drop with the given reason.
+pub fn drop_and_count_heap(asm: &Assembly, pkt: Packet, reason: impl Into<CounterType>) {
+    let reason = reason.into();
+    debug!(target: DATAPATH, "dropping packet because {reason}");
+    drop(pkt);
     asm.counters[reason].increment();
 }
 
@@ -379,12 +386,12 @@ pub async fn substrate_egress_blocking(asm: &Assembly, link_id: zpr::LinkId, mut
     let dest_sa = match substrate_egress_common(asm, link_id, &mut pkt) {
         Ok(Some(dest_sa)) => dest_sa,
         Ok(None) => {
-            drop_and_count(asm, pkt, CounterType::PeerRemoved);
+            drop_and_count_heap(asm, pkt, CounterType::PeerRemoved);
             return;
         }
         Err(err) => {
             error!(target: DATAPATH, "egress: link {}: encryption error: {}", link_id, err);
-            drop_and_count(asm, pkt, CounterType::EncryptionFailure);
+            drop_and_count_heap(asm, pkt, CounterType::EncryptionFailure);
             return;
         }
     };
@@ -392,14 +399,16 @@ pub async fn substrate_egress_blocking(asm: &Assembly, link_id: zpr::LinkId, mut
     match asm
         .substrate_egress
         .enqueue_packet(
-            drop_guard(pkt, |p| drop_and_count(asm, p, CounterType::OutPacksSent)),
+            drop_guard(pkt, |p| {
+                drop_and_count_heap(asm, p, CounterType::OutPacksSent)
+            }),
             dest_sa,
         )
         .await
     {
         Ok(()) => (),
         Err(pkt) => {
-            drop_and_count(asm, pkt.into_inner(), CounterType::OutPacksErr);
+            drop_and_count_heap(asm, pkt.into_inner(), CounterType::OutPacksErr);
         }
     }
 }
@@ -452,70 +461,6 @@ pub fn agent_input(
         Ok(()) => (),
         Err(TryEnqueueError::Full(pkt)) => {
             drop_and_count(asm, pkt.into_inner(), CounterType::InPacksDrop)
-        }
-    }
-}
-
-/// Post-classification portion of `agent_output` function.  Used for
-/// re-injecting already-classified packets e.g.  which were held awaiting
-/// bind.  `allow_bind_request` should be true for "real" packets; false for
-/// packets re-injected from mgmt plane after fulfilling a bind request (so
-/// as to prevent the theoretical possibility of a packet loop).
-pub fn agent_output_post_classify(asm: &Assembly, mut pkt: Packet, allow_bind_request: bool) {
-    let five_tuple = *pkt.metadata().five_tuple(); // TODO: convince borrow checker we don't need to copy this out
-
-    // lookup five tuple in ALT
-    match asm.alt.get(&five_tuple) {
-        Some(entry) => match &*entry {
-            AltEntry::Active(pep) => {
-                // compute A2A MAC
-                // TODO: use actual A2A SAID & keyed hash
-                let a2a_said: zpr::A2aSaid = 0;
-                let a2a_mac_size = zdp::ZDP_A2A_MAC_SIZE; // TODO: may be smaller depending on A2A SAID
-                let mut a2a_mac = [0u8; zdp::ZDP_A2A_MAC_SIZE];
-                // SECURITY: truncating BLAKE3 is safe
-                a2a_mac[..a2a_mac_size]
-                    .copy_from_slice(&blake3::hash(pkt.body()).as_bytes()[..a2a_mac_size]);
-
-                // compress packet
-                compress::compress(
-                    pep.compression_mode,
-                    five_tuple.l3_type,
-                    five_tuple.l4_protocol,
-                    &mut pkt,
-                );
-
-                // append A2A MAC
-                pkt.put(&a2a_mac[..a2a_mac_size]);
-                pkt.alloc_zeroed_header::<zdp::ZdpA2aHeader>().a2a_said = a2a_said;
-
-                pkt.metadata_mut().ingress_stream_id = pep.tether_id;
-
-                // forward packet on
-                forward(asm, pkt);
-            }
-
-            AltEntry::Pending(_) => {
-                // Bind request pending; drop this packet
-                drop_and_count(asm, pkt, CounterType::DroppedAwaitingBind);
-            }
-        },
-
-        None => {
-            if !allow_bind_request {
-                // avoid the (all-but purely theoretical) chance of a packet loop,
-                // when this is initiated due to a requeue from bind setup code
-                drop_and_count(asm, pkt, CounterType::OtherError);
-                return;
-            }
-
-            // issue bind request
-            match asm.adapter_manager.try_request_tether_id(pkt) {
-                Ok(()) => (),
-                Err(TryEnqueueError::Full(pkt)) => {
-                    drop_and_count(asm, pkt, CounterType::QueueBackpressure)
-                }
-            }
         }
     }
 }

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -376,7 +376,7 @@ mod test {
         let (km_tx, mut km_rx) = mpsc::channel(4);
         let km_state = KmState::new(km_tx, km_sig_tx);
 
-        let buf_storage = vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]); 8];
+        let buf_storage = vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]) as Box<[_]>; 8];
         let buffer_stack = BufferStack::new(buf_storage);
 
         let mut builder = TestAssemblyBuilder::new();

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -55,6 +55,7 @@ mod sync_req;
 mod sys;
 mod test_packet;
 mod tun_ctl;
+mod two_way_queue;
 mod vs_worker;
 mod vss_worker;
 mod zdp;
@@ -152,11 +153,12 @@ fn main() -> ExitCode {
     let topology_config = config::TopologyConfig::default();
 
     let buf_storage =
-        vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]); topology_config.buffer_count];
+        vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]) as Box<[_]>; topology_config.buffer_count];
 
     let (cap_inq, cap_outq) = mpsc::channel(topology_config.capture_queue_size);
-    let (md_inq, md_outq) = mpsc::channel(topology_config.mgmt_dispatch_queue_size);
-    let (am_inq, am_outq) = mpsc::channel(topology_config.adapter_manager_queue_size);
+    let (md_inq, md_outq) = two_way_queue::two_way_queue(topology_config.mgmt_dispatch_queue_size);
+    let (am_inq, am_outq) =
+        two_way_queue::two_way_queue(topology_config.adapter_manager_queue_size);
     let (km_sig_inq, km_sig_outq) = mpsc::channel(topology_config.km_signal_queue_size);
     let (km_inq, km_outq) = mpsc::channel(topology_config.km_message_queue_size);
 
@@ -392,6 +394,7 @@ fn main() -> ExitCode {
         js.spawn(agent_output_worker::launch(
             agent_output_worker::Config {
                 worker_index,
+                buffer_count: asm.topology_config.buffer_count,
                 batch_size: asm.topology_config.agent_output_batch_size,
             },
             asm.clone(),
@@ -415,6 +418,7 @@ fn main() -> ExitCode {
         js.spawn(substrate_ingress_worker::launch(
             substrate_ingress_worker::Config {
                 worker_index,
+                buffer_count: asm.topology_config.buffer_count,
                 batch_size: asm.topology_config.substrate_ingress_batch_size,
             },
             asm.clone(),

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -56,8 +56,6 @@ pub async fn send_echo_request(asm: &Assembly, link_id: zpr::LinkId) -> Result<(
         core::count_event(asm, &mut echo, CounterType::BadStructure);
         return Err(SyncReqError::ProtocolError);
     };
-    asm.buffer_stack
-        .put_buffer(echo.destroy().try_into().unwrap());
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt_dispatch_worker.rs
+++ b/adapter/ph/src/mgmt_dispatch_worker.rs
@@ -1,23 +1,23 @@
 //! Code which handles dispatching management packets from fastpath.
 
 use crate::assembly::Assembly;
-use crate::counters;
-use crate::fastpath;
 use crate::mgmt::dispatch;
+use crate::packet::PacketBuffer;
 use crate::queues::MgmtDispatchMessage;
+use crate::two_way_queue;
 use std::sync::Arc;
-use tokio::sync::mpsc;
 
-pub async fn launch(asm: Arc<Assembly>, mut queue: mpsc::Receiver<MgmtDispatchMessage>) {
-    while let Some(msg) = queue.recv().await {
-        match msg {
-            MgmtDispatchMessage::WithLink(mut pkt) => {
-                dispatch::dispatch_mgmt_packet_with_link(&asm, &mut pkt);
-                fastpath::drop_and_count(&asm, pkt, counters::CounterType::DispatchedToMgmt);
+pub async fn launch(
+    asm: Arc<Assembly>,
+    mut queue: two_way_queue::Receiver<MgmtDispatchMessage, PacketBuffer>,
+) {
+    while let Some(mut msg) = queue.recv().await {
+        match &mut *msg {
+            MgmtDispatchMessage::WithLink(pkt) => {
+                dispatch::dispatch_mgmt_packet_with_link(&asm, pkt);
             }
-            MgmtDispatchMessage::WithAddr(peer_sa, mut pkt) => {
-                dispatch::dispatch_mgmt_packet_with_addr(&asm, peer_sa, &mut pkt);
-                fastpath::drop_and_count(&asm, pkt, counters::CounterType::DispatchedToMgmt);
+            MgmtDispatchMessage::WithAddr(peer_sa, pkt) => {
+                dispatch::dispatch_mgmt_packet_with_addr(&asm, *peer_sa, pkt);
             }
         }
     }

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -1,10 +1,11 @@
 //! Queues (i.e., frontend interface) for each stage of the system.
 
 use crate::net_defs;
-use crate::packet::Packet;
+use crate::packet::{Packet, PacketBuffer};
 use crate::sys::TunPi;
 use crate::sys::ZprTun;
 use crate::test_packet::*;
+use crate::two_way_queue;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::result::Result;
@@ -288,26 +289,36 @@ pub enum MgmtDispatchMessage {
     WithAddr(zpr::SubstrateAddr, Packet),
 }
 
+impl two_way_queue::TwoWayReturnable<MgmtDispatchMessage> for PacketBuffer {
+    fn convert(value: MgmtDispatchMessage) -> Self {
+        match value {
+            MgmtDispatchMessage::WithLink(pkt) => pkt.destroy(),
+            MgmtDispatchMessage::WithAddr(_, pkt) => pkt.destroy(),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct MgmtDispatch {
-    sender: mpsc::Sender<MgmtDispatchMessage>,
+    sender: two_way_queue::Sender<MgmtDispatchMessage, PacketBuffer>,
 }
 
 impl MgmtDispatch {
-    pub fn new(sender: mpsc::Sender<MgmtDispatchMessage>) -> Self {
+    pub fn new(sender: two_way_queue::Sender<MgmtDispatchMessage, PacketBuffer>) -> Self {
         Self { sender }
     }
 
     pub fn try_dispatch_mgmt_packet_with_link(
-        &self,
+        &mut self,
         packet: Packet,
     ) -> Result<(), TryEnqueueError<Packet>> {
         debug_assert_ne!(packet.metadata().ingress_link_id, 0);
         match self.sender.try_send(MgmtDispatchMessage::WithLink(packet)) {
             Ok(()) => Ok(()),
 
-            Err(TrySendError::Closed(_)) => panic!("mgmt dispatch channel closed"),
+            Err(two_way_queue::TrySendError::Closed(_)) => panic!("mgmt dispatch channel closed"),
 
-            Err(TrySendError::Full(msg)) => {
+            Err(two_way_queue::TrySendError::Full(msg)) => {
                 let MgmtDispatchMessage::WithLink(pkt) = msg else {
                     unreachable!()
                 };
@@ -317,7 +328,7 @@ impl MgmtDispatch {
     }
 
     pub fn try_dispatch_mgmt_packet_with_addr(
-        &self,
+        &mut self,
         peer_sa: &zpr::SubstrateAddr,
         packet: Packet,
     ) -> Result<(), TryEnqueueError<Packet>> {
@@ -328,9 +339,9 @@ impl MgmtDispatch {
         {
             Ok(()) => Ok(()),
 
-            Err(TrySendError::Closed(_)) => panic!("mgmt dispatch channel closed"),
+            Err(two_way_queue::TrySendError::Closed(_)) => panic!("mgmt dispatch channel closed"),
 
-            Err(TrySendError::Full(msg)) => {
+            Err(two_way_queue::TrySendError::Full(msg)) => {
                 let MgmtDispatchMessage::WithAddr(_, pkt) = msg else {
                     unreachable!()
                 };
@@ -338,18 +349,54 @@ impl MgmtDispatch {
             }
         }
     }
+
+    #[allow(dead_code)]
+    pub fn recv_return_buffers(&mut self, returns: &mut Vec<PacketBuffer>, limit: usize) -> usize {
+        self.sender.blocking_recv_many_returns(returns, limit)
+    }
+
+    #[allow(dead_code)]
+    pub fn try_recv_return_buffers(
+        &mut self,
+        returns: &mut Vec<PacketBuffer>,
+        limit: usize,
+    ) -> usize {
+        self.sender.try_recv_many_returns(returns, limit)
+    }
+
+    #[allow(dead_code)]
+    pub async fn async_recv_return_buffers(
+        &mut self,
+        returns: &mut Vec<PacketBuffer>,
+        limit: usize,
+    ) -> usize {
+        self.sender.recv_many_returns(returns, limit).await
+    }
+
+    pub async fn async_recv_return_buffer(&mut self) -> PacketBuffer {
+        self.sender.recv_return().await
+    }
 }
 
 pub enum AdapterManagerMessage {
     RequestTetherId(Packet),
 }
 
+impl two_way_queue::TwoWayReturnable<AdapterManagerMessage> for PacketBuffer {
+    fn convert(value: AdapterManagerMessage) -> Self {
+        match value {
+            AdapterManagerMessage::RequestTetherId(pkt) => pkt.destroy(),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct AdapterManager {
-    sender: mpsc::Sender<AdapterManagerMessage>,
+    sender: two_way_queue::Sender<AdapterManagerMessage, PacketBuffer>,
 }
 
 impl AdapterManager {
-    pub fn new(sender: mpsc::Sender<AdapterManagerMessage>) -> Self {
+    pub fn new(sender: two_way_queue::Sender<AdapterManagerMessage, PacketBuffer>) -> Self {
         Self { sender }
     }
 
@@ -364,20 +411,47 @@ impl AdapterManager {
     /// the ALT, and an attempt will be made to send the specified packet.
     ///
     /// The specified packet must have already been classified.
-    pub fn try_request_tether_id(&self, packet: Packet) -> Result<(), TryEnqueueError<Packet>> {
+    pub fn try_request_tether_id(&mut self, packet: Packet) -> Result<(), TryEnqueueError<Packet>> {
         match self
             .sender
             .try_send(AdapterManagerMessage::RequestTetherId(packet))
         {
             Ok(()) => Ok(()),
 
-            Err(TrySendError::Closed(_)) => panic!("adapter manager channel closed"),
+            Err(two_way_queue::TrySendError::Closed(_)) => panic!("adapter manager channel closed"),
 
-            Err(TrySendError::Full(msg)) => match msg {
+            Err(two_way_queue::TrySendError::Full(msg)) => match msg {
                 AdapterManagerMessage::RequestTetherId(packet) => {
                     Err(TryEnqueueError::Full(packet))
                 }
             },
         }
+    }
+
+    #[allow(dead_code)]
+    pub fn recv_return_buffers(&mut self, returns: &mut Vec<PacketBuffer>, limit: usize) -> usize {
+        self.sender.blocking_recv_many_returns(returns, limit)
+    }
+
+    #[allow(dead_code)]
+    pub fn try_recv_return_buffers(
+        &mut self,
+        returns: &mut Vec<PacketBuffer>,
+        limit: usize,
+    ) -> usize {
+        self.sender.try_recv_many_returns(returns, limit)
+    }
+
+    #[allow(dead_code)]
+    pub async fn async_recv_return_buffers(
+        &mut self,
+        returns: &mut Vec<PacketBuffer>,
+        limit: usize,
+    ) -> usize {
+        self.sender.recv_many_returns(returns, limit).await
+    }
+
+    pub async fn async_recv_return_buffer(&mut self) -> PacketBuffer {
+        self.sender.recv_return().await
     }
 }

--- a/adapter/ph/src/substrate_ingress_worker.rs
+++ b/adapter/ph/src/substrate_ingress_worker.rs
@@ -6,12 +6,13 @@ use crate::fastpath;
 use crate::km_noise::NOISE_PADLEN;
 use crate::logging::targets::DATAPATH;
 use crate::packet::Packet;
-use crate::queues::TryEnqueueError;
+use crate::queues::{MgmtDispatch, TryEnqueueError};
 use crate::zdp;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::UdpSocket;
+use tokio::select;
 use tracing::*;
 use zerocopy::FromBytes;
 use zpr_ext::std::num::NonZeroExt;
@@ -20,22 +21,41 @@ use zpr_ext::zerocopy::*;
 #[derive(Copy, Clone)]
 pub struct Config {
     pub worker_index: usize,
+    pub buffer_count: usize,
+    #[allow(dead_code)]
     pub batch_size: usize,
 }
 
 pub async fn launch(config: Config, asm: Arc<Assembly>, socket: Arc<UdpSocket>) {
-    let worker = Worker {
+    let mut worker = Worker {
         config,
         asm: asm.clone(),
+        mgmt_dispatch: asm.mgmt_dispatch.clone(),
     };
 
     let mut bufs = Vec::new();
 
     loop {
-        // grab some buffers from the pool
-        asm.buffer_stack
-            .get_buffers(config.batch_size, &mut bufs)
-            .await;
+        // process the return buffer queue
+        worker
+            .mgmt_dispatch
+            .try_recv_return_buffers(&mut bufs, config.buffer_count);
+        asm.buffer_stack.put_buffers(bufs.drain(..));
+
+        // grab some buffers from the pool;
+        // if none are available immediately, also wait on the return buffer queue
+        select! {
+            biased;
+
+            _ = asm.buffer_stack
+                .get_buffers(config.batch_size - bufs.len(), &mut bufs) => (),
+
+            buf = worker.mgmt_dispatch.async_recv_return_buffer() => {
+                // weird two-step approach necessitated by bufs ownership issue with select
+                bufs.push(buf);
+                let _ = worker.mgmt_dispatch.try_recv_return_buffers(&mut bufs, config.batch_size - 1);
+            }
+        }
 
         // TODO: batch receive
         for buf in bufs.drain(..) {
@@ -76,11 +96,12 @@ const AGENT_PACKET_FLOW_TRACKER: std::sync::LazyLock<
 struct Worker {
     config: Config,
     asm: Arc<Assembly>,
+    mgmt_dispatch: MgmtDispatch,
 }
 
 impl Worker {
     /// Process packets ingressing from the specified address.
-    pub fn process_packet(&self, peer_sa: &zpr::SubstrateAddr, mut pkt: Packet) {
+    pub fn process_packet(&mut self, peer_sa: &zpr::SubstrateAddr, mut pkt: Packet) {
         self.asm.counters[CounterType::InPacksRec].increment();
 
         pkt.metadata_mut().ingress_link_id =
@@ -191,11 +212,10 @@ impl Worker {
         // send it off to be processed as a potential new link.
         if pkt.metadata().ingress_link_id == zpr::LINK_ID_UNKNOWN {
             match self
-                .asm
                 .mgmt_dispatch
                 .try_dispatch_mgmt_packet_with_addr(peer_sa, pkt)
             {
-                Ok(()) => (),
+                Ok(()) => self.asm.counters[CounterType::DispatchedToMgmt].increment(),
                 Err(TryEnqueueError::Full(pkt)) => {
                     fastpath::drop_and_count(&self.asm, pkt, CounterType::QueueBackpressure)
                 }
@@ -225,12 +245,8 @@ impl Worker {
             // TODO: should we peel off the ZDP header here??
             // (instead of this silly code to restore it?)
             *pkt.alloc_zeroed_header() = base_hdr;
-            match self
-                .asm
-                .mgmt_dispatch
-                .try_dispatch_mgmt_packet_with_link(pkt)
-            {
-                Ok(()) => (),
+            match self.mgmt_dispatch.try_dispatch_mgmt_packet_with_link(pkt) {
+                Ok(()) => self.asm.counters[CounterType::DispatchedToMgmt].increment(),
                 Err(TryEnqueueError::Full(pkt)) => {
                     fastpath::drop_and_count(&self.asm, pkt, CounterType::QueueBackpressure)
                 }

--- a/adapter/ph/src/two_way_queue.rs
+++ b/adapter/ph/src/two_way_queue.rs
@@ -1,0 +1,222 @@
+//! "Two-way" queue.
+//!
+//! This multi-producer single-consumer queue differs from a standard queue
+//! in that it does not transfer ownership of the items sent through it.
+//! Rather, the consumer gets a (mutable) reference-only view of the item.
+//! When the consumer is done with the item, its ownership is returned to
+//! the producer which sent it through a return queue.  Items are returned
+//! in the same order in which they are sent.
+//!
+//! Conceptually, one can think of this queue as a ring buffer in which the
+//! consumer leaves items for the producer to later take back.
+//!
+//! Additional to the above functionality, the forward and return types may
+//! differ if `TwoWayReturnable<Forward>` is implemented for the reverse
+//! type.  (This is chosen instead of using `From` so that non-default conversions
+//! can be used.)
+
+#![allow(dead_code)]
+
+use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
+use std::ops::{Deref, DerefMut};
+use tokio::sync::mpsc;
+
+/// Trait representing a type which can be returned through a `TwoWayQueue`.
+pub trait TwoWayReturnable<T> {
+    /// Convert the received item into one to be returned to the producer.
+    fn convert(value: T) -> Self;
+}
+
+impl<T> TwoWayReturnable<T> for T {
+    fn convert(value: T) -> Self {
+        value
+    }
+}
+
+pub enum TrySendError<T> {
+    Full(T),
+    Closed(T),
+}
+
+pub enum TryRecvReturnError {
+    Empty,
+    Disconnected,
+}
+
+/// The producer half of a two-way queue.
+pub struct Sender<T, U> {
+    outgoing_q: mpsc::Sender<(T, mpsc::UnboundedSender<U>)>,
+    outgoing_return_q: mpsc::UnboundedSender<U>,
+    incoming_return_q: mpsc::UnboundedReceiver<U>,
+    outstanding: usize,
+}
+
+impl<T, U> Sender<T, U> {
+    /// Try to send an item.  Note that it is possible for the queue
+    /// to appear full for the reason that there are outstanding returns.
+    pub fn try_send(&mut self, item: T) -> Result<(), TrySendError<T>> {
+        match self
+            .outgoing_q
+            .try_send((item, self.outgoing_return_q.clone()))
+        {
+            Ok(()) => {
+                self.outstanding += 1;
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Full((item, _))) => Err(TrySendError::Full(item)),
+            Err(mpsc::error::TrySendError::Closed((item, _))) => Err(TrySendError::Closed(item)),
+        }
+    }
+
+    /// Receive a single returned item.  Blocks until there is such an item.
+    ///
+    /// Panics if called when no items are outstanding.
+    pub fn blocking_recv_return(&mut self) -> U {
+        assert!(self.outstanding > 0);
+        let ret = self.incoming_return_q.blocking_recv().unwrap();
+        self.outstanding -= 1;
+        return ret;
+    }
+
+    /// Receive up to `limit` returned items.  Blocks until at least one item can be returned.
+    ///
+    /// Immediately returns 0 if-and-only-if `limit` is 0.
+    ///
+    /// Panics if called when no items are outstanding.
+    pub fn blocking_recv_many_returns(&mut self, returns: &mut Vec<U>, limit: usize) -> usize {
+        assert!(self.outstanding > 0 || limit == 0);
+        let ret = self.incoming_return_q.blocking_recv_many(returns, limit);
+        self.outstanding -= ret;
+        return ret;
+    }
+
+    /// Try to receive a single returned item.  Does not block, returning
+    /// `None` if no items are immediately available (possibly because none
+    /// are outstanding).
+    pub fn try_recv_return(&mut self) -> Option<U> {
+        let ret = self.incoming_return_q.try_recv().ok();
+        if ret.is_some() {
+            self.outstanding -= 1;
+        }
+        return ret;
+    }
+
+    /// Try to receive up to `limit` returned items.  Does not block,
+    /// returning 0 if no items are immediately available (possibly because
+    /// none are outstanding).
+    pub fn try_recv_many_returns(&mut self, returns: &mut Vec<U>, limit: usize) -> usize {
+        for i in 0..limit {
+            match self.incoming_return_q.try_recv() {
+                Ok(item) => returns.push(item),
+                Err(_) => {
+                    self.outstanding -= i;
+                    return i;
+                }
+            }
+        }
+
+        self.outstanding -= limit;
+        return limit;
+    }
+
+    /// Async version of `blocking_recv_return()`.
+    pub async fn recv_return(&mut self) -> U {
+        let ret = self.incoming_return_q.recv().await.unwrap();
+        self.outstanding -= 1;
+        return ret;
+    }
+
+    /// Async version of `blocking_recv_many_returns()`.
+    pub async fn recv_many_returns(&mut self, returns: &mut Vec<U>, limit: usize) -> usize {
+        let ret = self.incoming_return_q.recv_many(returns, limit).await;
+        self.outstanding -= ret;
+        return ret;
+    }
+}
+
+impl<T, U> Clone for Sender<T, U> {
+    fn clone(&self) -> Self {
+        let (outgoing_return_q, incoming_return_q) = mpsc::unbounded_channel();
+        Self {
+            outgoing_q: self.outgoing_q.clone(),
+            outgoing_return_q,
+            incoming_return_q,
+            outstanding: 0,
+        }
+    }
+}
+
+/// The consumer half of a two-way queue.
+pub struct Receiver<T, U> {
+    incoming_q: mpsc::Receiver<(T, mpsc::UnboundedSender<U>)>,
+}
+
+impl<T, U> Receiver<T, U>
+where
+    U: TwoWayReturnable<T>,
+{
+    /// Asynchronously receive a single item from the producer.
+    ///
+    /// Returns `None` if-and-only-if the producer has closed its half.
+    ///
+    /// The item will be protected by the returned `ItemGuard`, and will be
+    /// returned to the producer when the `ItemGuard` is dropped.
+    ///
+    /// If `U` implements `TwoWayReturnable<T>`, then the item will be
+    /// transformed using `TwoWayReturnable::convert()` on its way back to
+    /// the producer.
+    pub async fn recv(&mut self) -> Option<ItemGuard<'_, T, U>> {
+        let (item, outgoing_return_q) = self.incoming_q.recv().await?;
+        Some(ItemGuard {
+            item: ManuallyDrop::new(item),
+            outgoing_return_q,
+            receiver: PhantomData,
+        })
+    }
+}
+
+/// Guard for an item received from a two-way queue.
+pub struct ItemGuard<'a, T, U: TwoWayReturnable<T>> {
+    item: ManuallyDrop<T>,
+    outgoing_return_q: mpsc::UnboundedSender<U>,
+    receiver: PhantomData<&'a Receiver<T, U>>,
+}
+
+impl<T, U: TwoWayReturnable<T>> Deref for ItemGuard<'_, T, U> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.item
+    }
+}
+
+impl<T, U: TwoWayReturnable<T>> DerefMut for ItemGuard<'_, T, U> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.item
+    }
+}
+
+impl<T, U: TwoWayReturnable<T>> Drop for ItemGuard<'_, T, U> {
+    fn drop(&mut self) {
+        // SAFETY: because we are in the destructor, `take()` can never be called again
+        let _ = self
+            .outgoing_return_q
+            .send(U::convert(unsafe { ManuallyDrop::take(&mut self.item) }));
+    }
+}
+
+/// Construct a send-receive pair for a two-way queue.
+pub fn two_way_queue<T, U>(buffer: usize) -> (Sender<T, U>, Receiver<T, U>) {
+    let (outgoing_q, incoming_q) = mpsc::channel(buffer);
+    let (outgoing_return_q, incoming_return_q) = mpsc::unbounded_channel();
+    (
+        Sender {
+            outgoing_q,
+            outgoing_return_q,
+            incoming_return_q,
+            outstanding: 0,
+        },
+        Receiver { incoming_q },
+    )
+}

--- a/integration-test/one-node-test.sh
+++ b/integration-test/one-node-test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export RUST_BACKTRACE=1
+
 PH_BIN=$(realpath "$(dirname $0)/../adapter/ph/target/debug/ph")
 PH_DEBUG_BIN=$(realpath "$(dirname $0)/../adapter/ph-debug/target/debug/ph-debug")
 VS_BIN=$(realpath "$(dirname $0)/../visaservice/core/build/vservice")


### PR DESCRIPTION
two_way_queue is a special type of queue used for sending packets from datapath to mgmt.  Packets are send zero-copy (i.e. owned) to mgmt, but only exposed to mgmt as a reference.  Mgmt must copy the packet if it wants to hold it long-term.  When mgmt is done with the original packet, it is destructed into a buffer and returned to datapath.

This means that datapath retains ownership of all datapath packets.  This patch thus also ensures that mgmt is no longer interacting with the buffer stack, in preparation for making the buffer stack local per datapath lane.

This also means that mgmt and datapath now only communicate exclusively through queues, and nonblocking shared-memory operations (e.g. RCU).