### PR TITLE
nicer VSS message display in node debug output

### DIFF
--- a/adapter/ph/src/vss_worker.rs
+++ b/adapter/ph/src/vss_worker.rs
@@ -7,6 +7,6 @@ use tracing::*;
 
 pub async fn launch(_asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSSMsg>) {
     while let Some(msg) = queue.recv().await {
-        debug!(target: VISA_MGMT, "received VSS message {msg:?}; ignoring! (unimplemented)");
+        debug!(target: VISA_MGMT, "received VSS message {msg}; ignoring! (unimplemented)");
     }
 }

--- a/libnode/src/display.rs
+++ b/libnode/src/display.rs
@@ -9,97 +9,101 @@ impl fmt::Display for VSSMsg {
         match self {
             VSSMsg::PolicyInstall(pi) => write!(f, "PolicyInstall(policy_id: {:?})", pi.policy_id),
             VSSMsg::PushedRevocation(r) => write!(f, "Revocation(issuer_id: {:?})", r.issuer_id),
-            VSSMsg::PushedVisa(v) => {
-                write!(
-                    f,
-                    "PushedVisa(issuer_id: {}, hop_count: {}, visa: ",
-                    to_string_or(&v.issuer_id, "(none)"),
-                    to_string_or(&v.hop_count, "(none)")
-                )?;
-                summarize_visa(f, &v.visa)?;
+            VSSMsg::PushedVisa(vh) => {
+                write!(f, "PushedVisa(")?;
+                summarize_visa_hop(f, vh)?;
                 write!(f, ")")
             }
         }
     }
 }
 
+/// Human readable version of the MSSMsg which includes some interior details of the visa.
+fn summarize_visa_hop(f: &mut Formatter<'_>, vh: &vsapi::VisaHop) -> fmt::Result {
+    write!(
+        f,
+        "VisaHop(issuer_id: {}, hop_count: {}, visa: ",
+        to_string_or(&vh.issuer_id, "(none)"),
+        to_string_or(&vh.hop_count, "(none)")
+    )?;
+    match vh.visa {
+        Some(ref v) => summarize_visa(f, v),
+        None => write!(f, "(none)"),
+    }
+}
+
 /// Attempt to surface the most critical bits of a visa.
-fn summarize_visa(f: &mut Formatter<'_>, visa: &Option<vsapi::Visa>) -> fmt::Result {
-    match visa {
-        Some(v) => {
-            let mut icmp = false;
-            let proto: String;
-            let sport: String;
-            let dport: String;
+fn summarize_visa(f: &mut Formatter<'_>, v: &vsapi::Visa) -> fmt::Result {
+    let mut icmp = false;
+    let proto: String;
+    let sport: String;
+    let dport: String;
 
-            match v.dock_pep {
-                Some(pep) => match pep {
-                    vsapi::PEPIndex::UDP | vsapi::PEPIndex::TCP => {
-                        match &v.tcpudp_pep_args {
-                            Some(args) => {
-                                sport = to_string_or(&args.source_port, "(?)");
-                                dport = to_string_or(&args.dest_port, "(?)");
-                            }
-                            None => {
-                                sport = "(none)".to_string();
-                                dport = "(none)".to_string();
-                            }
-                        }
-                        if pep == vsapi::PEPIndex::UDP {
-                            proto = "UDP".to_string();
-                        } else {
-                            proto = "TCP".to_string();
-                        }
+    match v.dock_pep {
+        Some(pep) => match pep {
+            vsapi::PEPIndex::UDP | vsapi::PEPIndex::TCP => {
+                match &v.tcpudp_pep_args {
+                    Some(args) => {
+                        sport = to_string_or(&args.source_port, "(?)");
+                        dport = to_string_or(&args.dest_port, "(?)");
                     }
-                    vsapi::PEPIndex::ICMP => {
-                        icmp = true;
-                        proto = "ICMP".to_string();
-                        match &v.icmp_pep_args {
-                            Some(args) => {
-                                sport = to_string_or(&args.icmp_type_code, "(?)");
-                                dport = "".to_string();
-                            }
-                            None => {
-                                sport = "(none)".to_string();
-                                dport = "(none)".to_string();
-                            }
-                        }
+                    None => {
+                        sport = "(none)".to_string();
+                        dport = "(none)".to_string();
                     }
-                    _ => {
-                        proto = "(invalid)".to_string();
-                        sport = "(?)".to_string();
-                        dport = "(?)".to_string();
-                    }
-                },
-                None => {
-                    proto = "(none)".to_string();
-                    sport = "(?)".to_string();
-                    dport = "(?)".to_string();
                 }
-            };
-
-            if icmp {
-                write!(
-                    f,
-                    "{} / [{}] -> [{}] type {}",
-                    proto,
-                    opt_ip_to_str(&v.source),
-                    opt_ip_to_str(&v.dest),
-                    sport
-                )
-            } else {
-                write!(
-                    f,
-                    "{} / [{}]:{} -> [{}]:{}",
-                    proto,
-                    opt_ip_to_str(&v.source),
-                    sport,
-                    opt_ip_to_str(&v.dest),
-                    dport
-                )
+                if pep == vsapi::PEPIndex::UDP {
+                    proto = "UDP".to_string();
+                } else {
+                    proto = "TCP".to_string();
+                }
             }
+            vsapi::PEPIndex::ICMP => {
+                icmp = true;
+                proto = "ICMP".to_string();
+                match &v.icmp_pep_args {
+                    Some(args) => {
+                        sport = to_string_or(&args.icmp_type_code, "(?)");
+                        dport = "".to_string();
+                    }
+                    None => {
+                        sport = "(none)".to_string();
+                        dport = "(none)".to_string();
+                    }
+                }
+            }
+            _ => {
+                proto = "(invalid)".to_string();
+                sport = "(?)".to_string();
+                dport = "(?)".to_string();
+            }
+        },
+        None => {
+            proto = "(none)".to_string();
+            sport = "(?)".to_string();
+            dport = "(?)".to_string();
         }
-        None => write!(f, "(None)"),
+    };
+
+    if icmp {
+        write!(
+            f,
+            "{}<{}>/[{}]->[{}]",
+            proto,
+            sport,
+            opt_ip_to_str(&v.source),
+            opt_ip_to_str(&v.dest)
+        )
+    } else {
+        write!(
+            f,
+            "{}/[{}]:{}->[{}]:{}",
+            proto,
+            opt_ip_to_str(&v.source),
+            sport,
+            opt_ip_to_str(&v.dest),
+            dport
+        )
     }
 }
 

--- a/libnode/src/display.rs
+++ b/libnode/src/display.rs
@@ -1,37 +1,29 @@
-use std::net::IpAddr;
 use std::fmt::{self, Formatter};
+use std::net::IpAddr;
 
 use crate::vss::VSSMsg;
 
-
-/// Very terse string format of a VSSMsg.
+/// Human readable version of the MSSMsg which includes some interior details of the visa.
 impl fmt::Display for VSSMsg {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             VSSMsg::PolicyInstall(pi) => write!(f, "PolicyInstall(policy_id: {:?})", pi.policy_id),
-            VSSMsg::PushedVisa(v) => write!(f, "Visa(issuer_id: {:?})", v.issuer_id),
             VSSMsg::PushedRevocation(r) => write!(f, "Revocation(issuer_id: {:?})", r.issuer_id),
-        }
-    }
-}
-
-impl fmt::Debug for VSSMsg {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            VSSMsg::PolicyInstall(pi) => write!(f, "PolicyInstall({:?})", pi),
             VSSMsg::PushedVisa(v) => {
-                write!(f, "PushedVisa(issuer_id: {}, hop_count: {}, visa: ",
-                    to_string_or(&v.issuer_id, "(none)"), to_string_or(&v.hop_count, "(none)"))?;
+                write!(
+                    f,
+                    "PushedVisa(issuer_id: {}, hop_count: {}, visa: ",
+                    to_string_or(&v.issuer_id, "(none)"),
+                    to_string_or(&v.hop_count, "(none)")
+                )?;
                 summarize_visa(f, &v.visa)?;
                 write!(f, ")")
             }
-            VSSMsg::PushedRevocation(r) => write!(f, "Revocation({:?})", r),
         }
     }
 }
 
-
-/// Attempt to surface the most critical bits of a visa ... for use in our debug log.
+/// Attempt to surface the most critical bits of a visa.
 fn summarize_visa(f: &mut Formatter<'_>, visa: &Option<vsapi::Visa>) -> fmt::Result {
     match visa {
         Some(v) => {
@@ -78,7 +70,7 @@ fn summarize_visa(f: &mut Formatter<'_>, visa: &Option<vsapi::Visa>) -> fmt::Res
                         sport = "(?)".to_string();
                         dport = "(?)".to_string();
                     }
-                }
+                },
                 None => {
                     proto = "(none)".to_string();
                     sport = "(?)".to_string();
@@ -87,18 +79,29 @@ fn summarize_visa(f: &mut Formatter<'_>, visa: &Option<vsapi::Visa>) -> fmt::Res
             };
 
             if icmp {
-                write!(f, "{} / [{}] -> [{}] type {}", proto,
-                    opt_ip_to_str(&v.source), opt_ip_to_str(&v.dest), sport)
+                write!(
+                    f,
+                    "{} / [{}] -> [{}] type {}",
+                    proto,
+                    opt_ip_to_str(&v.source),
+                    opt_ip_to_str(&v.dest),
+                    sport
+                )
             } else {
-                write!(f, "{} / [{}]:{} -> [{}]:{}", proto,
-                    opt_ip_to_str(&v.source), sport,
-                    opt_ip_to_str(&v.dest), dport)
+                write!(
+                    f,
+                    "{} / [{}]:{} -> [{}]:{}",
+                    proto,
+                    opt_ip_to_str(&v.source),
+                    sport,
+                    opt_ip_to_str(&v.dest),
+                    dport
+                )
             }
         }
         None => write!(f, "(None)"),
     }
 }
-
 
 /// Return string form of an optional IP address.
 fn opt_ip_to_str(ipa: &Option<Vec<u8>>) -> String {
@@ -108,17 +111,16 @@ fn opt_ip_to_str(ipa: &Option<Vec<u8>>) -> String {
             ip_addr.to_string()
         }
         Some(ip) if ip.len() == 16 => {
-            let ip_addr = IpAddr::from([ip[0], ip[1], ip[2], ip[3], ip[4], ip[5], ip[6], ip[7],
-                                        ip[8], ip[9], ip[10], ip[11], ip[12], ip[13], ip[14], ip[15]]);
+            let ip_addr = IpAddr::from([
+                ip[0], ip[1], ip[2], ip[3], ip[4], ip[5], ip[6], ip[7], ip[8], ip[9], ip[10],
+                ip[11], ip[12], ip[13], ip[14], ip[15],
+            ]);
             ip_addr.to_string()
         }
-        Some(_) => {
-            "(invalid IP address)a".to_string()
-        }
+        Some(_) => "(invalid IP address)a".to_string(),
         None => "(none)".to_string(),
     }
 }
-
 
 /// Get a string representation of an optional value or a default `none_str` as provided.
 fn to_string_or<T>(opt: &Option<T>, none_str: &str) -> String

--- a/libnode/src/display.rs
+++ b/libnode/src/display.rs
@@ -1,0 +1,132 @@
+use std::net::IpAddr;
+use std::fmt::{self, Formatter};
+
+use crate::vss::VSSMsg;
+
+
+/// Very terse string format of a VSSMsg.
+impl fmt::Display for VSSMsg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            VSSMsg::PolicyInstall(pi) => write!(f, "PolicyInstall(policy_id: {:?})", pi.policy_id),
+            VSSMsg::PushedVisa(v) => write!(f, "Visa(issuer_id: {:?})", v.issuer_id),
+            VSSMsg::PushedRevocation(r) => write!(f, "Revocation(issuer_id: {:?})", r.issuer_id),
+        }
+    }
+}
+
+impl fmt::Debug for VSSMsg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            VSSMsg::PolicyInstall(pi) => write!(f, "PolicyInstall({:?})", pi),
+            VSSMsg::PushedVisa(v) => {
+                write!(f, "PushedVisa(issuer_id: {}, hop_count: {}, visa: ",
+                    to_string_or(&v.issuer_id, "(none)"), to_string_or(&v.hop_count, "(none)"))?;
+                summarize_visa(f, &v.visa)?;
+                write!(f, ")")
+            }
+            VSSMsg::PushedRevocation(r) => write!(f, "Revocation({:?})", r),
+        }
+    }
+}
+
+
+/// Attempt to surface the most critical bits of a visa ... for use in our debug log.
+fn summarize_visa(f: &mut Formatter<'_>, visa: &Option<vsapi::Visa>) -> fmt::Result {
+    match visa {
+        Some(v) => {
+            let mut icmp = false;
+            let proto: String;
+            let sport: String;
+            let dport: String;
+
+            match v.dock_pep {
+                Some(pep) => match pep {
+                    vsapi::PEPIndex::UDP | vsapi::PEPIndex::TCP => {
+                        match &v.tcpudp_pep_args {
+                            Some(args) => {
+                                sport = to_string_or(&args.source_port, "(?)");
+                                dport = to_string_or(&args.dest_port, "(?)");
+                            }
+                            None => {
+                                sport = "(none)".to_string();
+                                dport = "(none)".to_string();
+                            }
+                        }
+                        if pep == vsapi::PEPIndex::UDP {
+                            proto = "UDP".to_string();
+                        } else {
+                            proto = "TCP".to_string();
+                        }
+                    }
+                    vsapi::PEPIndex::ICMP => {
+                        icmp = true;
+                        proto = "ICMP".to_string();
+                        match &v.icmp_pep_args {
+                            Some(args) => {
+                                sport = to_string_or(&args.icmp_type_code, "(?)");
+                                dport = "".to_string();
+                            }
+                            None => {
+                                sport = "(none)".to_string();
+                                dport = "(none)".to_string();
+                            }
+                        }
+                    }
+                    _ => {
+                        proto = "(invalid)".to_string();
+                        sport = "(?)".to_string();
+                        dport = "(?)".to_string();
+                    }
+                }
+                None => {
+                    proto = "(none)".to_string();
+                    sport = "(?)".to_string();
+                    dport = "(?)".to_string();
+                }
+            };
+
+            if icmp {
+                write!(f, "{} / [{}] -> [{}] type {}", proto,
+                    opt_ip_to_str(&v.source), opt_ip_to_str(&v.dest), sport)
+            } else {
+                write!(f, "{} / [{}]:{} -> [{}]:{}", proto,
+                    opt_ip_to_str(&v.source), sport,
+                    opt_ip_to_str(&v.dest), dport)
+            }
+        }
+        None => write!(f, "(None)"),
+    }
+}
+
+
+/// Return string form of an optional IP address.
+fn opt_ip_to_str(ipa: &Option<Vec<u8>>) -> String {
+    match ipa {
+        Some(ip) if ip.len() == 4 => {
+            let ip_addr = IpAddr::from([ip[0], ip[1], ip[2], ip[3]]);
+            ip_addr.to_string()
+        }
+        Some(ip) if ip.len() == 16 => {
+            let ip_addr = IpAddr::from([ip[0], ip[1], ip[2], ip[3], ip[4], ip[5], ip[6], ip[7],
+                                        ip[8], ip[9], ip[10], ip[11], ip[12], ip[13], ip[14], ip[15]]);
+            ip_addr.to_string()
+        }
+        Some(_) => {
+            "(invalid IP address)a".to_string()
+        }
+        None => "(none)".to_string(),
+    }
+}
+
+
+/// Get a string representation of an optional value or a default `none_str` as provided.
+fn to_string_or<T>(opt: &Option<T>, none_str: &str) -> String
+where
+    T: fmt::Display + Sized,
+{
+    match opt {
+        Some(v) => v.to_string(),
+        None => none_str.to_string(),
+    }
+}

--- a/libnode/src/lib.rs
+++ b/libnode/src/lib.rs
@@ -5,3 +5,4 @@ mod vscli;
 pub use vsapi;
 pub mod vsconn;
 pub mod vss;
+pub mod display;

--- a/libnode/src/lib.rs
+++ b/libnode/src/lib.rs
@@ -3,6 +3,6 @@ pub mod logging;
 pub mod m2;
 mod vscli;
 pub use vsapi;
+pub mod display;
 pub mod vsconn;
 pub mod vss;
-pub mod display;

--- a/libnode/src/vss.rs
+++ b/libnode/src/vss.rs
@@ -3,8 +3,9 @@
 //! Really doesn't do very much except for translate incoming visa service
 //! messages into enums on a channel.
 
+
 use std::fmt::{self, Formatter};
-use std::net::SocketAddr;
+use std::net::{SocketAddr, IpAddr};
 use thrift::protocol::{TBinaryInputProtocolFactory, TBinaryOutputProtocolFactory};
 use thrift::protocol::{TInputProtocolFactory, TOutputProtocolFactory};
 use thrift::server::TServer;
@@ -24,7 +25,6 @@ use vsapi::{
 pub const DEFAULT_VSS_PORT: u16 = 8183;
 
 /// Messages from the visa service. These wrap the thrift message types.
-#[derive(Debug)]
 #[allow(dead_code)]
 pub enum VSSMsg {
     /// Indicates a policy has been installed.
@@ -37,15 +37,6 @@ pub enum VSSMsg {
     PushedRevocation(VisaRevocation),
 }
 
-impl fmt::Display for VSSMsg {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            VSSMsg::PolicyInstall(pi) => write!(f, "PolicyInstall(policy_id: {:?})", pi.policy_id),
-            VSSMsg::PushedVisa(v) => write!(f, "Visa(issuer_id: {:?})", v.issuer_id),
-            VSSMsg::PushedRevocation(r) => write!(f, "Revocation(issuer_id: {:?})", r.issuer_id),
-        }
-    }
-}
 
 /// The VisaSupportHandlerImpl is a light wrapper around the thrift
 /// VisaSupportService client code which takes the messages from the

--- a/libnode/src/vss.rs
+++ b/libnode/src/vss.rs
@@ -3,9 +3,7 @@
 //! Really doesn't do very much except for translate incoming visa service
 //! messages into enums on a channel.
 
-
-use std::fmt::{self, Formatter};
-use std::net::{SocketAddr, IpAddr};
+use std::net::SocketAddr;
 use thrift::protocol::{TBinaryInputProtocolFactory, TBinaryOutputProtocolFactory};
 use thrift::protocol::{TInputProtocolFactory, TOutputProtocolFactory};
 use thrift::server::TServer;
@@ -36,7 +34,6 @@ pub enum VSSMsg {
     /// Pushed visa revokcations from the visa service.
     PushedRevocation(VisaRevocation),
 }
-
 
 /// The VisaSupportHandlerImpl is a light wrapper around the thrift
 /// VisaSupportService client code which takes the messages from the

--- a/visaservice/vs-client/Cargo.lock
+++ b/visaservice/vs-client/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "vsapi"
 version = "0.1.0"
-source = "git+ssh://git@github.com/org-zpr/zpr-vsapi-rs.git#81a49b2766b9dbd87c9391d7a85651c421d6338b"
+source = "git+https://github.com/org-zpr/zpr-vsapi-rs.git?tag=v0.1.0#530670142c70bf6e21ad93a3d6dadf15e8a0387e"
 dependencies = [
  "thrift",
 ]

--- a/visaservice/vs-client/src/vssd.rs
+++ b/visaservice/vs-client/src/vssd.rs
@@ -37,17 +37,7 @@ async fn _run_vss(listen_sock: SocketAddr) -> Result<(), VssError> {
                 break;
             }
             Some(vss_msg) = vss_rx.recv() => {
-                match vss_msg {
-                    vss::VSSMsg::PolicyInstall(pi) => {
-                        info!("VSS policy install: {:?}", pi);
-                    }
-                    vss::VSSMsg::PushedVisa(v) => {
-                        info!("VSS pushed visa: issuer_id={:?}", v.issuer_id);
-                    }
-                    _ => {
-                        info!("VSConn::run received VSS message: {:?}", vss_msg);
-                    }
-                }
+                info!("VSConn::run received VSS message: {vss_msg}");
             }
         }
     }


### PR DESCRIPTION
Make the node output of the vss message easier to read.  New format looks like this:

`2025-01-29T16:31:59.811989Z DEBUG visa_mgmt: received VSS message PushedVisa(VisaHop(issuer_id: 8, hop_count: 99, visa: TCP/[fd5a:5052:90de::1]:0->[fd5a:5052::1]:5002); ignoring! (unimplemented)
`

