### PR TITLE
use Unix domain socket as capture queue

### DIFF
--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -356,7 +356,7 @@ pub mod test {
             .unwrap_or_else(|| AgentOutputRequeue::new(Vec::new()));
         let vsconn = builder.vsconn.unwrap_or(None);
         let capture_queue = builder.capture_queue.unwrap_or_else(|| {
-            let (cq_inq, _cq_outq) = mpsc::channel(1);
+            let (cq_inq, _cq_outq) = std::os::unix::net::UnixDatagram::pair().unwrap();
             Capture::new(cq_inq)
         });
         let capture_worker = builder

--- a/adapter/ph/src/capture_worker.rs
+++ b/adapter/ph/src/capture_worker.rs
@@ -1,38 +1,39 @@
 use crate::assembly::Assembly;
+use crate::config;
 use crate::logging::targets::CAPTURE;
 use crate::pcap_writer::*;
-use crate::queues::CapPacket;
 use std::io;
 use std::sync::Arc;
 use tokio::fs::File;
-use tokio::sync::{mpsc, Mutex};
+use tokio::net::UnixDatagram;
+use tokio::sync::Mutex;
 use tracing::error;
 
 pub struct CaptureWorker {
-    inner_cap: Mutex<InnerCap>,
+    inner: Mutex<Inner>,
 }
 
-struct InnerCap {
+struct Inner {
     savefile: Option<PcapWriter<File>>,
 }
 
 impl CaptureWorker {
     pub fn new() -> Self {
         Self {
-            inner_cap: InnerCap { savefile: None }.into(),
+            inner: Inner { savefile: None }.into(),
         }
     }
 
     pub async fn open_capture_file(&self, file: File) -> Result<(), io::Error> {
-        let mut inner_cap = self.inner_cap.lock().await;
+        let mut inner = self.inner.lock().await;
         let mut savefile = PcapWriter::open(file, linktype::USER0).await?;
         savefile.flush().await?;
-        inner_cap.savefile = Some(savefile);
+        inner.savefile = Some(savefile);
         Ok(())
     }
 
     pub async fn flush_capture_file(&self) -> Result<(), io::Error> {
-        let savefile = &mut self.inner_cap.lock().await.savefile;
+        let savefile = &mut self.inner.lock().await.savefile;
         match savefile {
             Some(ref mut savefile) => savefile.flush().await,
             None => Ok(()),
@@ -40,7 +41,7 @@ impl CaptureWorker {
     }
 
     pub async fn close_capture_file(&self) -> Result<(), io::Error> {
-        match self.inner_cap.lock().await.savefile.take() {
+        match self.inner.lock().await.savefile.take() {
             Some(savefile) => {
                 savefile.close().await?;
             }
@@ -51,27 +52,29 @@ impl CaptureWorker {
 
     #[allow(dead_code)]
     pub async fn query_savefile(&self) -> bool {
-        self.inner_cap.lock().await.savefile.is_some()
+        self.inner.lock().await.savefile.is_some()
     }
 }
 
 #[derive(Copy, Clone)]
 pub struct Config {
+    #[allow(dead_code)]
     pub batch_size: usize,
 }
 
-pub async fn launch(config: Config, asm: Arc<Assembly>, mut queue: mpsc::Receiver<CapPacket>) {
-    let mut messages = Vec::new();
+pub async fn launch(_config: Config, asm: Arc<Assembly>, queue: UnixDatagram) {
+    let mut buf = [0u8; config::PACKET_BUFFER_SIZE];
 
-    // Batch accepts values from capture queue and writes them to the savefile
-    while let _count @ 1.. = queue.recv_many(&mut messages, config.batch_size).await {
-        let mut state = asm.capture_worker.inner_cap.lock().await;
+    // TODO: batch processing (only take lock once per batch)
+    while let Ok(size) = queue.recv(&mut buf).await {
+        let mut state = asm.capture_worker.inner.lock().await;
 
         match &mut state.savefile {
             Some(ref mut savefile) => {
                 // Write the packets out.  If the queue is empty, force a flush
                 // to make sure these packets get written out in timely fashion.
-                match savefile_write_batch(savefile, messages.iter(), queue.is_empty()).await {
+                // TODO: use poll to determine queue emptiness
+                match savefile_write_batch(savefile, &[&buf[..size]], true).await {
                     Ok(()) => (),
 
                     Err(err) => {
@@ -88,22 +91,16 @@ pub async fn launch(config: Config, asm: Arc<Assembly>, mut queue: mpsc::Receive
 
             None => (),
         }
-
-        asm.buffer_stack.put_buffers(
-            messages
-                .drain(..)
-                .map(|cap_pack| cap_pack.packet.destroy().try_into().unwrap()),
-        );
     }
 }
 
 async fn savefile_write_batch<'a>(
     savefile: &'a mut PcapWriter<File>,
-    cap_packs: impl IntoIterator<Item = &'a CapPacket>,
+    packets: &[&[u8]],
     force_flush: bool,
 ) -> io::Result<()> {
-    for cap_pack in cap_packs.into_iter() {
-        savefile_write(savefile, cap_pack).await?;
+    for packet in packets {
+        savefile.write_raw(packet).await?;
     }
 
     // Note, we don't actually care _when_ the flush completes, just that
@@ -114,14 +111,4 @@ async fn savefile_write_batch<'a>(
     }
 
     Ok(())
-}
-
-async fn savefile_write(savefile: &mut PcapWriter<File>, cap_pack: &CapPacket) -> io::Result<()> {
-    let packet = PcapPacket {
-        timestamp: cap_pack.timestamp,
-        orig_len: cap_pack.orig_len,
-        data: cap_pack.packet.body(),
-    };
-
-    savefile.write(&packet).await
 }

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -78,6 +78,7 @@ pub struct TopologyConfig {
     pub agent_output_batch_size: usize,
     pub capture_batch_size: usize,
 
+    #[allow(dead_code)] // see TODO in main
     pub capture_queue_size: usize,
     pub mgmt_dispatch_queue_size: usize,
     pub adapter_manager_queue_size: usize,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -71,57 +71,27 @@ pub fn maybe_capture_batch<'a>(
 
     let mut pkts_iter = pkts.into_iter();
 
-    // Preallocate buffers according to size hint.
-    let desired_bufs = pkts_iter.size_hint().0;
-    let mut bufs = Vec::new();
-    let acquired_bufs = asm.buffer_stack.try_get_buffers(desired_bufs, &mut bufs);
-    // If we got shortchanged, don't bother later checking again.
-    let out_of_bufs = acquired_bufs < desired_bufs;
-
     for pkt in &mut pkts_iter {
-        // Clones packet into capture queue after adding direction to beginning of packet
+        // Copies packet body into capture queue after adding direction to beginning of packet
         let ll_hdr = pkt.alloc_zeroed_header::<zdp_ll::ZdpLinkP2P>();
         ll_hdr.direction = zdp_ll::encode_direction(dir);
 
         // FIXME: ideally, take an RCU reference to the program once on function entry
         let caplen = asm.flow_control.check_packet(pkt.body()) as usize;
         if caplen > 0 {
-            match bufs.pop().or_else(|| {
-                if out_of_bufs {
-                    None
-                } else {
-                    asm.buffer_stack.try_get_buffer()
-                }
-            }) {
-                Some(buf) => {
-                    let orig_len = pkt.body().len();
-                    let pkt_clone: Packet =
-                        pkt.clone_prefix_into(buf, std::cmp::min(caplen, orig_len));
-                    // remove direction indicator from beginning of packet
-                    pkt.advance(std::mem::size_of::<zdp_ll::ZdpLinkP2P>());
+            let res = asm
+                .capture_queue
+                .try_enqueue_packet(pkt, capture_time, caplen);
 
-                    // Checks to see if the packet enqueue was successful
-                    match asm
-                        .capture_queue
-                        .try_enqueue_packet(pkt_clone, capture_time, orig_len)
-                    {
-                        Ok(()) => num_captured += 1,
+            // remove direction indicator from beginning of packet
+            pkt.advance(std::mem::size_of::<zdp_ll::ZdpLinkP2P>());
 
-                        Err(TryEnqueueError::Full(ret_packet)) => {
-                            asm.buffer_stack
-                                .put_buffer(ret_packet.destroy().try_into().unwrap());
-                            // No sense to try enqueuing more packets; exit the loop early.
-                            break;
-                        }
-                    };
-                }
+            // Checks to see if the packet enqueue was successful
+            match res {
+                Ok(()) => num_captured += 1,
 
-                None => {
-                    // remove direction indicator from beginning of packet
-                    pkt.advance(std::mem::size_of::<zdp_ll::ZdpLinkP2P>());
-                    // No sense to try acquiring more buffers; exit the loop early.
-                    break;
-                }
+                // No sense to try enqueuing more packets; exit the loop early.
+                Err(TryEnqueueError::Full(())) => break,
             }
         } else {
             num_filtered += 1;
@@ -132,10 +102,6 @@ pub fn maybe_capture_batch<'a>(
 
     // If we exited early, there are remaining packets we won't be capturing.
     let num_dropped = pkts_iter.count();
-
-    // Return any remaining buffers.
-    asm.buffer_stack
-        .put_buffers(bufs.into_iter().map(|buf| buf.try_into().unwrap()));
 
     match dir {
         Direction::Inbound => {

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -155,7 +155,8 @@ fn main() -> ExitCode {
     let buf_storage =
         vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]) as Box<[_]>; topology_config.buffer_count];
 
-    let (cap_inq, cap_outq) = mpsc::channel(topology_config.capture_queue_size);
+    // TODO: use get/setsockopt(SO_SNDBUF) to ensure we can buffer `capture_queue_size` packets
+    let (cap_inq, cap_outq) = std::os::unix::net::UnixDatagram::pair().unwrap();
     let (md_inq, md_outq) = two_way_queue::two_way_queue(topology_config.mgmt_dispatch_queue_size);
     let (am_inq, am_outq) =
         two_way_queue::two_way_queue(topology_config.adapter_manager_queue_size);
@@ -426,12 +427,13 @@ fn main() -> ExitCode {
         ));
     }
 
+    cap_outq.set_nonblocking(true).unwrap();
     js.spawn(capture_worker::launch(
         capture_worker::Config {
             batch_size: asm.topology_config.capture_batch_size,
         },
         asm.clone(),
-        cap_outq,
+        tokio::net::UnixDatagram::from_std(cap_outq).unwrap(),
     ));
 
     if ph_mode == PhMode::Node {

--- a/adapter/ph/src/pcap_writer.rs
+++ b/adapter/ph/src/pcap_writer.rs
@@ -6,7 +6,7 @@
 use std::io;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
-use zerocopy::{Immutable, IntoBytes, KnownLayout};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// Represents an open PCAP writer.
 pub struct PcapWriter<W: AsyncWrite> {
@@ -34,16 +34,30 @@ struct PcapHdr {
     network: u32,
 }
 
-#[derive(IntoBytes, Immutable, KnownLayout)]
+#[derive(Clone, Copy, FromBytes, IntoBytes, Immutable, KnownLayout)]
 #[repr(C)]
-struct PcaprecHdr {
+pub struct PcaprecHdr {
     ts_sec: u32,
     ts_usec: u32,
     incl_len: u32,
     orig_len: u32,
 }
 
+impl PcaprecHdr {
+    pub fn new(timestamp: SystemTime, incl_len: usize, orig_len: usize) -> Self {
+        let ts = timestamp.duration_since(UNIX_EPOCH).unwrap_or_default();
+
+        Self {
+            ts_sec: ts.as_secs() as u32,
+            ts_usec: ts.subsec_micros() as u32,
+            incl_len: std::cmp::min(incl_len, u32::MAX as usize) as u32,
+            orig_len: std::cmp::min(orig_len, u32::MAX as usize) as u32,
+        }
+    }
+}
+
 /// A packet to be written out.
+#[allow(dead_code)]
 pub struct PcapPacket<'a> {
     pub timestamp: SystemTime,
     pub orig_len: usize,
@@ -107,30 +121,44 @@ impl<W: AsyncWrite + Unpin> PcapWriter<W> {
     }
 
     /// Write a packet to the PCAP writer.
+    #[allow(dead_code)]
     pub async fn write(&mut self, packet: &PcapPacket<'_>) -> io::Result<()> {
-        if packet.data.len() > MAX_SNAPLEN {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "packet too large",
-            ));
-        }
+        self.write_preformatted(
+            &PcaprecHdr::new(packet.timestamp, packet.data.len(), packet.orig_len),
+            &packet.data,
+        )
+        .await
+    }
 
-        let ts = packet
-            .timestamp
-            .duration_since(UNIX_EPOCH)
-            .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    /// Write a packet to the PCAP writer, with preformatted header.
+    ///
+    /// If `data` is longer than `hdr.incl_len`, it will be truncated.
+    /// If `data` is shorter than `hdr.incl_len`, `incl_len` will be adjusted to match.
+    pub async fn write_preformatted(&mut self, hdr: &PcaprecHdr, data: &[u8]) -> io::Result<()> {
+        let data_len_u32 = std::cmp::min(data.len(), u32::MAX as usize) as u32;
 
         let hdr = PcaprecHdr {
-            ts_sec: ts.as_secs() as u32,
-            ts_usec: ts.subsec_micros() as u32,
-            incl_len: packet.data.len() as u32,
-            orig_len: packet.orig_len as u32,
+            incl_len: std::cmp::min(hdr.incl_len, data_len_u32),
+            ..*hdr
         };
 
         self.writer.write_all(hdr.as_bytes()).await?;
-        self.writer.write_all(packet.data).await?;
+        self.writer.write_all(&data[..hdr.incl_len as usize]).await
+    }
 
-        Ok(())
+    /// Write a raw PCAP packet to the PCAP writer.
+    ///
+    /// The first 16 bytes of `pcap_data` should be a `PcaprecHdr`.
+    /// The remainder should be the packet to be recorded.
+    ///
+    /// `incl_len` and the packet data length are adjusted as per
+    /// `write_preformatted()`.
+    pub async fn write_raw(&mut self, pcap_data: &[u8]) -> io::Result<()> {
+        let Ok((hdr, data)) = PcaprecHdr::ref_from_prefix(pcap_data) else {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "bad pcap data"));
+        };
+
+        self.write_preformatted(hdr, data).await
     }
 
     pub async fn flush(&mut self) -> io::Result<()> {

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -6,6 +6,7 @@ use crate::sys::TunPi;
 use crate::sys::ZprTun;
 use crate::test_packet::*;
 use crate::two_way_queue;
+use bytes::Buf;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::result::Result;
@@ -18,7 +19,7 @@ use tokio::sync::oneshot::error::RecvError;
 use zpr;
 use zpr_ext::std::mem::DropGuard;
 
-pub enum TryEnqueueError<T> {
+pub enum TryEnqueueError<T = ()> {
     Full(T),
 }
 
@@ -238,48 +239,58 @@ impl AgentOutputRequeue {
 }
 
 /// Capture will intercept packets in the PH and dump them into a file for debugging purposes
-pub struct CapPacket {
-    pub packet: Packet,
-    pub timestamp: SystemTime,
-    pub orig_len: usize,
-}
-
 pub struct Capture {
-    sender: mpsc::Sender<CapPacket>,
+    sender: std::os::unix::net::UnixDatagram,
 }
 
 impl Capture {
-    pub fn new(sender: mpsc::Sender<CapPacket>) -> Self {
+    pub fn new(sender: std::os::unix::net::UnixDatagram) -> Self {
+        sender.set_nonblocking(true).unwrap();
         Self { sender }
     }
 
-    /// Blocks until packet is enqueued
-    #[allow(dead_code)]
-    pub async fn enqueue_packet(&self, packet: Packet, timestamp: SystemTime, orig_len: usize) {
-        let cap_pack: CapPacket = CapPacket {
-            packet,
-            timestamp,
-            orig_len,
-        };
-        self.sender.send(cap_pack).await.unwrap();
-    }
-
-    /// Does not block
+    /// Try to send a packet to the capture system.
+    /// Only `incl_len` bytes will be captured.  (If this is larger than the
+    /// actual packet length, it is reduced accordingly.)
+    /// Does not block.
+    ///
+    /// NOTE: requires mut reference to the packet, but the packet is
+    /// materially unchanged.  Simply, a 16-byte header is briefly added to
+    /// and then removed from it.
     pub fn try_enqueue_packet(
         &self,
-        packet: Packet,
+        packet: &mut Packet,
         timestamp: SystemTime,
-        orig_len: usize,
-    ) -> Result<(), TryEnqueueError<Packet>> {
-        let cap_pack: CapPacket = CapPacket {
-            packet,
-            timestamp,
-            orig_len,
-        };
-        match self.sender.try_send(cap_pack) {
-            Ok(()) => Ok(()),
-            Err(TrySendError::Closed(_)) => panic!("capture channel closed"),
-            Err(TrySendError::Full(cap_pack)) => Err(TryEnqueueError::Full(cap_pack.packet)),
+        incl_len: usize,
+    ) -> Result<(), TryEnqueueError> {
+        let incl_len = std::cmp::min(incl_len, packet.remaining());
+
+        let hdr = crate::pcap_writer::PcaprecHdr::new(timestamp, incl_len, packet.remaining());
+
+        // temporarily add header
+        // TODO: instead of requiring a &mut Packet,
+        // we can instead accept any &[u8] and use vectored send
+        // once we it becomes stable
+        packet.push_header(&hdr);
+
+        // does not block, as we've set O_NONBLOCK in `new()`
+        let res = self.sender.send(
+            &packet.body()[..std::mem::size_of::<crate::pcap_writer::PcaprecHdr>() + incl_len],
+        );
+
+        // remove temporary header
+        packet.advance(std::mem::size_of::<crate::pcap_writer::PcaprecHdr>());
+
+        match res {
+            Ok(_) => Ok(()),
+
+            Err(err) => match err.kind() {
+                ErrorKind::WouldBlock => Err(TryEnqueueError::Full(())),
+                ErrorKind::ConnectionRefused | ErrorKind::BrokenPipe => {
+                    panic!("capture channel closed")
+                }
+                _ => panic!("unrecoverable I/O error: {}", err),
+            },
         }
     }
 }


### PR DESCRIPTION
Rather than allocating buffers to copy packets into and shuttling them to/from the capture worker via a queue, now we simply copy the packets directly into the capture queue (with the pcap header already in place).  Now, only fastpath ever owns packet buffers.