### PR TITLE
Patch to fix bug #671

### DIFF
--- a/visaservice/README.md
+++ b/visaservice/README.md
@@ -20,7 +20,7 @@ administrators. Access is protected by policy. The default port is TCP/8182 (see
 `core/pkg/vservice/constants.go`), and this uses the ZPR contact address of the
 adapter in front of the visa service.
 
-The API code is in `core/pkg/vservice/admin.go`.  
+The API code is in `core/pkg/vservice/admin.go`.
 
 API returns `application/json`, unless there is an error.
 
@@ -28,9 +28,26 @@ The separate binary `vs-admin` (in the `vs-admin` subdirectory) is a command
 line tool which uses the admin interface.
 
 
+**API Summary**
+
+| METHOD | PATH                                | EXPLAIN   |
+| ------ | -----                               | -------   |
+| GET    | `/admin/policies`                   | list policies    |
+| POST   | `/admin/policy`                     | install a policy |
+| GET    | `/admin/policy/{configID}/current`  | get the current policy for configuration |
+| GET    | `/admin/visas`                      | list visas       |
+| DELETE | `/admin/visas/{ID}`                 |  revoke a visa by its ID |
+| GET    | `/admin/agents`                     | list connected agents    |
+| DELETE | `/admin/agents/{CN}`                | revoke an agent (and all its visas) by adapter CN |
+| POST   | `/admin/revokes`                    | administer the revocation table |
+| GET    | `/admin/nodes`                      | list nodes |
+
+
+
+
 ### List policies `GET /admin/policies`
 
-Returns: 
+Returns:
 
 ```json
 [
@@ -75,7 +92,7 @@ filled in as follows:
 }
 ```
 
-Note that the `41` in the `format` field should be the current serialization ID for the policy schema.  
+Note that the `41` in the `format` field should be the current serialization ID for the policy schema.
 In the code this is `SerialVersion` which can be found in `mods/polio/const.go`.
 
 If you do set `version` then the admin service will ensure that the current
@@ -91,6 +108,142 @@ Returns the config ID and version:
 }
 ```
 
+### List visas `GET /admin/visas`
+
+Returns a brief summary of each live visa. Note that unlike all other time values in the API which are
+seconds since the epoch, the expiration value on visas is **milliseconds** since the epoch.
+
+
+Returns:
+
+```json
+[
+    {
+        "dest": "127.0.0.1",
+        "expires": 1738991722149,
+        "id": 8,
+        "source": "fd5a:5052:90de::1"
+    },
+    {
+        "dest": "fd5a:5052:90de::1",
+        "expires": 1738991842150,
+        "id": 9,
+        "source": "127.0.0.1"
+    }
+]
+```
+
+
+### List agents `GET /admin/agents`
+
+Get a brief summary of connected agents.
+
+
+Returns:
+
+```json
+[
+    {
+        "cn": "vs.zpr",
+        "ctime": 1738948830,
+        "ident": "bee171ebaf1741b2c9879c730ed4abe0873ff42a25b116e74be6ef71be7322ee",
+        "node": false,
+        "zpr_addr": "127.0.0.1"
+    },
+    {
+        "cn": "node.zpr.org",
+        "ctime": 1738948942,
+        "ident": "36e16f0a83c9a3274ce991f7561b1b445910de5c8cbb16b1e7f9de166f34342d",
+        "node": true,
+        "zpr_addr": "fd5a:5052:90de::1"
+    }
+]
+```
+
+
+### List nodes `GET /admin/nodes`
+
+Get a brief summary of connected nodes.
+
+
+Returns:
+
+```json
+[
+    {
+        "cn": "node.zpr.org",
+        "connect_requests": 0,
+        "ctime": 1738948942,
+        "in_sync": true,
+        "last_contact": 1738949250,
+        "pending": 0,
+        "visa_requests": 0,
+        "zpr_addr": "fd5a:5052:90de::1"
+    }
+]
+```
+
+
+### Revoke visas by ID `DELETE /admin/visas/{ID}`
+
+Send a delete request to revoke a visa by its issuer ID.
+
+```bash
+DELETE /admin/visas/22
+```
+
+Returns:
+
+```json
+{
+    "revoked": "22",
+    "count": 1
+}
+```
+
+### Revoke CN access and associated visas `DELETE /admin/agents/{CN}`
+
+Sends a delete request to revoke access to an adapter by its CN. Also revokes
+any visas associatd with the adapter.
+
+```bash
+DELETE /admin/agents/foo.zpr.org
+```
+
+Returns:
+
+```jason
+{
+    "revoked": "foo.zor.org",
+    "count": 8,
+}
+```
+
+Where `count` is the number of visas that were revoked.
+
+
+### Clear the revocations table `/admin/revokes`
+
+The visa service keeps track of recovations when they are made on adapter CNs or
+authtication keys.  To clear the revocation table you can post a message to
+`/admin/revokes`.
+
+The JSON object to send looks like:
+
+```json
+{
+    "clear_all": true
+}
+
+```
+
+The return value includes the number of entries removed from the revocation table, for example:
+
+```json
+{
+    "clear_count": 10
+}
+```
 
 
 ## Visa Service API

--- a/visaservice/core/pkg/vservice/adb/agentdb.go
+++ b/visaservice/core/pkg/vservice/adb/agentdb.go
@@ -56,7 +56,16 @@ type PeerRecord struct {
 		WantConfigID      uint64
 		LastPushConfigID  uint64
 		LastPushPolicyVer uint64
+		LastSyncConfigID  uint64 // used by the bring-node-into-policy-sync system
+		LastSyncPolicyVer uint64
+		LastSyncVisasExp  time.Time
 	}
+}
+
+type PeerSyncDetails struct {
+	ConfigID        uint64
+	PolicyVersion   uint64
+	VisasExpiration time.Time
 }
 
 type Ipv6Addr [16]byte
@@ -366,6 +375,35 @@ func (db *AgentDB) BufferItemsForNode(addr netip.Addr, items []*PushItem) {
 			}
 		}
 	}
+}
+
+func (db *AgentDB) GetPeerSyncDetails(nodeAddr netip.Addr) *PeerSyncDetails {
+	db.RLock()
+	defer db.RUnlock()
+	if rec, ok := db.agentsV6toHr[nodeAddr.As16()]; ok {
+		if rec.node && rec.Peer != nil {
+			return &PeerSyncDetails{
+				ConfigID:        rec.Peer.State.LastSyncConfigID,
+				PolicyVersion:   rec.Peer.State.LastSyncPolicyVer,
+				VisasExpiration: rec.Peer.State.LastSyncVisasExp,
+			}
+		}
+	}
+	return nil
+}
+
+func (db *AgentDB) SetPeerSyncDetails(nodeAddr netip.Addr, polVersion, configID uint64, visasExpiration time.Time) error {
+	db.Lock()
+	defer db.Unlock()
+	if rec, ok := db.agentsV6toHr[nodeAddr.As16()]; ok {
+		if rec.node && rec.Peer != nil {
+			rec.Peer.State.LastSyncConfigID = configID
+			rec.Peer.State.LastSyncPolicyVer = polVersion
+			rec.Peer.State.LastSyncVisasExp = visasExpiration
+			return nil
+		}
+	}
+	return fmt.Errorf("node not found")
 }
 
 // Check the peer update status and set it to the given new value only if it is in the expected state.

--- a/visaservice/core/pkg/vservice/adb/agentdb.go
+++ b/visaservice/core/pkg/vservice/adb/agentdb.go
@@ -41,6 +41,18 @@ type HostRecordBrief struct {
 	Node    bool       `json:"node"`
 }
 
+// This type also shared with the visa admin api.
+type NodeRecordBrief struct {
+	InSync          bool       `json:"in_sync"`
+	Pending         uint32     `json:"pending"`
+	CTime           int64      `json:"ctime"`        // unix seconds
+	LastContact     int64      `json:"last_contact"` // unix seconds
+	VisaRequests    uint64     `json:"visa_requests"`
+	ConnectRequests uint64     `json:"connect_requests"`
+	ZPRAddr         netip.Addr `json:"zpr_addr"`
+	Cn              string     `json:"cn"`
+}
+
 // The visa-service "peers" are always nodes.
 type PeerRecord struct {
 	APIKey               string
@@ -228,6 +240,7 @@ func (db *AgentDB) GetNodeList() []netip.Addr {
 	return list
 }
 
+// Copies all the agent records into "brief" format and returns them.
 func (db *AgentDB) CloneToBrief() []*HostRecordBrief {
 	db.RLock()
 	defer db.RUnlock()
@@ -246,6 +259,38 @@ func (db *AgentDB) CloneToBrief() []*HostRecordBrief {
 			Ident:   rec.Agent.GetIdentity(),
 			Node:    rec.node,
 		})
+	}
+	return list
+}
+
+// Copies all the node records into "brief" format and returns them.
+func (db *AgentDB) CloneNodesToBrief() []*NodeRecordBrief {
+	db.RLock()
+	defer db.RUnlock()
+	var list []*NodeRecordBrief
+	for _, rec := range db.agentsV6toHr {
+		if rec.node {
+			brief := &NodeRecordBrief{
+				CTime:           rec.CTime.Unix(),
+				Cn:              "",
+				ZPRAddr:         rec.ZPRAddr,
+				LastContact:     0,
+				VisaRequests:    0,
+				ConnectRequests: 0,
+				InSync:          false,
+			}
+			if claim, ok := rec.Agent.GetAuthedClaims()[agent.KAttrCN]; ok {
+				brief.Cn = claim.V
+			}
+			if rec.Peer != nil {
+				if !rec.Peer.LastContactTime.IsZero() {
+					brief.LastContact = rec.Peer.LastContactTime.Unix()
+				}
+				brief.InSync = rec.Peer.IsInSync()
+				brief.Pending = uint32(rec.Peer.pending.Size())
+			}
+			list = append(list, brief)
+		}
 	}
 	return list
 }

--- a/visaservice/core/pkg/vservice/admin.go
+++ b/visaservice/core/pkg/vservice/admin.go
@@ -66,6 +66,7 @@ type VSApi interface {
 	InstallPolicy(*polio.ContainedPolicy) (string, uint64, error) // returns (version, config_id, error)
 	ListVisas() []*VisaDescriptor
 	ListAdapters() []*adb.HostRecordBrief
+	ListNodes() []*adb.NodeRecordBrief
 	ClearAllRevokes() uint32
 	RevokeVisa(uint64) error
 	RevokeCN(string) uint32
@@ -108,6 +109,7 @@ func (svc *AdminService) StartAdminService(listenAddr netip.Addr, port int) erro
 	router.HandleFunc("/admin/agents", svc.handleListAgents).Methods("GET")
 	router.HandleFunc("/admin/agents/{CN}", svc.handleRevokeAgentByCN).Methods("DELETE")
 	router.HandleFunc("/admin/revokes", svc.handleRevokeAdmin).Methods("POST")
+	router.HandleFunc("/admin/nodes", svc.handleListNodes).Methods("GET")
 
 	addrPort := netip.AddrPortFrom(listenAddr, uint16(port))
 	server := http.Server{
@@ -271,6 +273,15 @@ func (svc *AdminService) handleListAgents(w http.ResponseWriter, r *http.Request
 	}
 	w.Header().Add("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(adapterList)
+}
+
+func (svc *AdminService) handleListNodes(w http.ResponseWriter, r *http.Request) {
+	nodeList := svc.vsi.ListNodes()
+	if nodeList == nil {
+		nodeList = []*adb.NodeRecordBrief{} // return an empty array, not an empty body.
+	}
+	w.Header().Add("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(nodeList)
 }
 
 func (svc *AdminService) handleRevokeVisaByID(w http.ResponseWriter, r *http.Request) {

--- a/visaservice/core/pkg/vservice/service.go
+++ b/visaservice/core/pkg/vservice/service.go
@@ -258,11 +258,16 @@ func (s *VisaService) ListAdapters() []*adb.HostRecordBrief {
 	return s.service.inst.agentDB.CloneToBrief()
 }
 
+func (s *VisaService) ListNodes() []*adb.NodeRecordBrief {
+	return s.service.inst.agentDB.CloneNodesToBrief()
+}
+
 // Implements an interface needed by the admin service.
 func (s *VisaService) ClearAllRevokes() uint32 {
 	return s.authService.ClearAllRevokes()
 }
 
+// Implements an interface needed by the admin service.
 func (s *VisaService) RevokeVisa(vid uint64) error {
 	// Since revoking a visa just removes it from visa service table and
 	// notifies network, I don't bother writing it to the in-memory
@@ -270,6 +275,7 @@ func (s *VisaService) RevokeVisa(vid uint64) error {
 	return s.service.inst.revokeVisaByID(vid)
 }
 
+// Implements an interface needed by the admin service.
 func (s *VisaService) RevokeCN(cn string) uint32 {
 	// First update our memory so that if the CN shows up later it will fail.
 	s.log.Info("revoke CN", "cn", cn)

--- a/visaservice/core/pkg/vservice/vsinst-node.go
+++ b/visaservice/core/pkg/vservice/vsinst-node.go
@@ -3,12 +3,14 @@ package vservice
 import (
 	"fmt"
 	"net/netip"
+	"time"
 
 	"golang.org/x/net/context"
 	snip "zpr.org/vs/pkg/ip"
 	"zpr.org/vs/pkg/policy"
-	"zpr.org/vsapi"
 	"zpr.org/vs/pkg/vservice/adb"
+	"zpr.org/vsapi"
+	"zpr.org/vsx/snio/vsio"
 )
 
 // Called by InstallPolicy
@@ -29,6 +31,17 @@ func (vs *VSInst) installPolicyWithVisasForNodes(pp *policy.Policy, configID uin
 func (vs *VSInst) installPolicyWithVisasForNode(nodeAddr netip.Addr, pp *policy.Policy, configID uint64) error {
 	var visas []*vsapi.VisaHop
 	var vssPort uint16
+
+	// We may have recently tried this operation and buffered the visas.
+	// If so, we do not want to regenerate the visas and buffer duplicates.
+	// So we track our attempts to bring node into sync.
+	if syncDeets := vs.agentDB.GetPeerSyncDetails(nodeAddr); syncDeets != nil {
+		if syncDeets.PolicyVersion == pp.VersionNumber() && syncDeets.ConfigID == configID && time.Until(syncDeets.VisasExpiration) > 30*time.Minute {
+			// Skip.
+			vs.log.Debug("skipping policy install for node: already pending", "node", nodeAddr, "time_until_expires", time.Until(syncDeets.VisasExpiration))
+			return nil
+		}
+	}
 
 	serviceAddr := vs.agentDB.GetNodeVSSAddr(nodeAddr)
 	if serviceAddr == "" {
@@ -74,6 +87,20 @@ func (vs *VSInst) installPolicyWithVisasForNode(nodeAddr netip.Addr, pp *policy.
 			vs.log.Warn("failed to generate a visa-support-service visa for the node", "reason", vsr.Reason)
 		} else {
 			visas = append(visas, vsr.Visa)
+		}
+	}
+
+	if len(visas) > 0 {
+		var first_expire time.Time
+		for _, vh := range visas {
+			vt := vsio.VToTime(vh.Visa.Expires)
+			if first_expire.IsZero() || first_expire.After(vt) {
+				first_expire = vt
+			}
+		}
+		// Update our state so we remember that we have tried this before.
+		if err := vs.agentDB.SetPeerSyncDetails(nodeAddr, pp.VersionNumber(), configID, first_expire); err != nil {
+			vs.log.WithError(err).Warn("failed to set peer sync details", "node", nodeAddr)
 		}
 	}
 

--- a/visaservice/core/pkg/vservice/vsinst-node.go
+++ b/visaservice/core/pkg/vservice/vsinst-node.go
@@ -35,58 +35,61 @@ func (vs *VSInst) installPolicyWithVisasForNode(nodeAddr netip.Addr, pp *policy.
 	// We may have recently tried this operation and buffered the visas.
 	// If so, we do not want to regenerate the visas and buffer duplicates.
 	// So we track our attempts to bring node into sync.
+	needs_visas := true
 	if syncDeets := vs.agentDB.GetPeerSyncDetails(nodeAddr); syncDeets != nil {
 		if syncDeets.PolicyVersion == pp.VersionNumber() && syncDeets.ConfigID == configID && time.Until(syncDeets.VisasExpiration) > 30*time.Minute {
 			// Skip.
-			vs.log.Debug("skipping policy install for node: already pending", "node", nodeAddr, "time_until_expires", time.Until(syncDeets.VisasExpiration))
-			return nil
+			vs.log.Debug("detected previously generated visas for node", "node", nodeAddr, "time_until_expires", time.Until(syncDeets.VisasExpiration))
+			needs_visas = false
 		}
 	}
 
-	serviceAddr := vs.agentDB.GetNodeVSSAddr(nodeAddr)
-	if serviceAddr == "" {
-		return fmt.Errorf("no support service addr for node")
-	}
-	if ap, err := netip.ParseAddrPort(serviceAddr); err == nil {
-		vssPort = ap.Port()
-		if vssPort == 0 {
-			// Problem!
-			return fmt.Errorf("misconfiguration - VSS reported port is zero (service_address = %v)", serviceAddr)
+	if needs_visas {
+		serviceAddr := vs.agentDB.GetNodeVSSAddr(nodeAddr)
+		if serviceAddr == "" {
+			return fmt.Errorf("no support service addr for node")
 		}
-		// The node tells the visa service its service address for the VSS. We assume that
-		// the address part matches the node address. That may not always be true but we
-		// confirm that here with an error message.
-		if ap.Addr() != nodeAddr {
-			vs.log.Error("node address does not match VSS address: VS->VSS visa will fail", "node", nodeAddr, "service_addr", serviceAddr)
+		if ap, err := netip.ParseAddrPort(serviceAddr); err == nil {
+			vssPort = ap.Port()
+			if vssPort == 0 {
+				// Problem!
+				return fmt.Errorf("misconfiguration - VSS reported port is zero (service_address = %v)", serviceAddr)
+			}
+			// The node tells the visa service its service address for the VSS. We assume that
+			// the address part matches the node address. That may not always be true but we
+			// confirm that here with an error message.
+			if ap.Addr() != nodeAddr {
+				vs.log.Error("node address does not match VSS address: VS->VSS visa will fail", "node", nodeAddr, "service_addr", serviceAddr)
+			}
+		} else {
+			return fmt.Errorf("invalid serice address for VSS: %v", serviceAddr)
 		}
-	} else {
-		return fmt.Errorf("invalid serice address for VSS: %v", serviceAddr)
-	}
 
-	{
-		vs.log.Info("generating a new visa-service visa for the node->VS", "node_addr_src", nodeAddr, "vs_addr_dest", vs.localAddr)
-		pktData := snip.NewTCPConnect(nodeAddr, 0, vs.localAddr, VisaServicePort)
-		vs.log.Debug("invoking request-visa for part of policy install (1/2)", "for_node", nodeAddr)
-		vsr, err := vs.doRequestVisa(context.Background(), nodeAddr, pktData, 0, pp.VersionNumber())
-		if err != nil {
-			vs.log.WithError(err).Warn("failed to generate a visa-service visa for the node", "node_addr", nodeAddr)
-		} else if vsr.Status != vsapi.StatusCode_SUCCESS {
-			vs.log.Warn("failed to generate a visa-service visa for the node", "node", nodeAddr, "reason", vsr.Reason)
-		} else {
-			visas = append(visas, vsr.Visa)
+		{
+			vs.log.Info("generating a new visa-service visa for the node->VS", "node_addr_src", nodeAddr, "vs_addr_dest", vs.localAddr)
+			pktData := snip.NewTCPConnect(nodeAddr, 0, vs.localAddr, VisaServicePort)
+			vs.log.Debug("invoking request-visa for part of policy install (1/2)", "for_node", nodeAddr)
+			vsr, err := vs.doRequestVisa(context.Background(), nodeAddr, pktData, 0, pp.VersionNumber())
+			if err != nil {
+				vs.log.WithError(err).Warn("failed to generate a visa-service visa for the node", "node_addr", nodeAddr)
+			} else if vsr.Status != vsapi.StatusCode_SUCCESS {
+				vs.log.Warn("failed to generate a visa-service visa for the node", "node", nodeAddr, "reason", vsr.Reason)
+			} else {
+				visas = append(visas, vsr.Visa)
+			}
 		}
-	}
-	{
-		vs.log.Info("generating a new visa-support-service visa for the VS->node", "vs_addr_src", vs.localAddr, "node_addr_dest", nodeAddr)
-		pktData := snip.NewTCPConnect(vs.localAddr, 0, nodeAddr, vssPort)
-		vs.log.Debug("invoking request-visa for part of policy install (2/2)", "for_node", nodeAddr)
-		vsr, err := vs.doRequestVisa(context.Background(), vs.localAddr, pktData, 0, pp.VersionNumber())
-		if err != nil {
-			vs.log.WithError(err).Warn("failed to generate a visa-service visa for the node")
-		} else if vsr.Status != vsapi.StatusCode_SUCCESS {
-			vs.log.Warn("failed to generate a visa-support-service visa for the node", "reason", vsr.Reason)
-		} else {
-			visas = append(visas, vsr.Visa)
+		{
+			vs.log.Info("generating a new visa-support-service visa for the VS->node", "vs_addr_src", vs.localAddr, "node_addr_dest", nodeAddr)
+			pktData := snip.NewTCPConnect(vs.localAddr, 0, nodeAddr, vssPort)
+			vs.log.Debug("invoking request-visa for part of policy install (2/2)", "for_node", nodeAddr)
+			vsr, err := vs.doRequestVisa(context.Background(), vs.localAddr, pktData, 0, pp.VersionNumber())
+			if err != nil {
+				vs.log.WithError(err).Warn("failed to generate a visa-service visa for the node")
+			} else if vsr.Status != vsapi.StatusCode_SUCCESS {
+				vs.log.Warn("failed to generate a visa-support-service visa for the node", "reason", vsr.Reason)
+			} else {
+				visas = append(visas, vsr.Visa)
+			}
 		}
 	}
 
@@ -106,12 +109,15 @@ func (vs *VSInst) installPolicyWithVisasForNode(nodeAddr netip.Addr, pp *policy.
 
 	if err := vs.updateNode(nodeAddr, pp.VersionNumber(), configID, visas); err != nil {
 		// Failed to update, stuff them in the push buffer.
-		vs.log.WithError(err).Warn("failed to update node during a policy install -- buffering", "node", nodeAddr)
-		item := adb.PushItem{
-			NodeAddr: nodeAddr,
-			Visas:    visas,
+		vs.log.WithError(err).Warn("failed to update node during a policy install", "node", nodeAddr)
+		if len(visas) > 0 {
+			vs.log.Debug("buffering vs visas for node", "node", nodeAddr, "visa_count", len(visas))
+			item := adb.PushItem{
+				NodeAddr: nodeAddr,
+				Visas:    visas,
+			}
+			vs.agentDB.BufferItemsForNode(nodeAddr, []*adb.PushItem{&item})
 		}
-		vs.agentDB.BufferItemsForNode(nodeAddr, []*adb.PushItem{&item})
 		return err
 	}
 	return nil
@@ -157,6 +163,7 @@ func (vs *VSInst) updateNode(nodeAddr netip.Addr, policyVer uint64, configID uin
 			goto RELEASE_UPDATE
 		}
 	}
+	vs.agentDB.SetNodeContactTime(nodeAddr, time.Now())
 
 	// Success!
 	_ = vs.agentDB.SetPeerLastPolicyState(nodeAddr, policyVer, configID)

--- a/visaservice/vs-admin/src/apitypes.rs
+++ b/visaservice/vs-admin/src/apitypes.rs
@@ -28,11 +28,23 @@ pub struct VisaDescriptor {
 #[derive(Deserialize)]
 #[allow(dead_code)]
 pub struct HostRecordBrief {
-    ctime: i64, // unix SECONDS (not millis)
-    cn: String,
-    zpr_addr: String,
-    ident: String,
-    node: bool,
+    pub ctime: i64, // unix SECONDS (not millis)
+    pub cn: String,
+    pub zpr_addr: String,
+    pub ident: String,
+    pub node: bool,
+}
+
+#[derive(Deserialize)]
+pub struct NodeRecordBrief {
+    pub pending: u32,
+    pub ctime: i64,
+    pub last_contact: i64, // unix SECONDS
+    pub visa_requests: u64,
+    pub connect_requests: u64,
+    pub cn: String,
+    pub zpr_addr: String,
+    pub in_sync: bool,
 }
 
 #[derive(Deserialize)]
@@ -95,6 +107,59 @@ impl fmt::Display for HostRecordBrief {
             } else {
                 "".normal()
             },
+        )
+    }
+}
+
+impl fmt::Display for NodeRecordBrief {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let ts: DateTime<Utc> = DateTime::from_timestamp(self.ctime, 0).unwrap();
+        let last_contact: DateTime<Utc> = DateTime::from_timestamp(self.last_contact, 0).unwrap();
+        write!(
+            f,
+            "{} {}{}{} @ {} {} {} {} {}",
+            self.cn,
+            "(created: ".dimmed(),
+            ts.to_rfc3339_opts(SecondsFormat::Secs, true).cyan(),
+            ")".dimmed(),
+            self.zpr_addr.yellow(),
+            if self.pending > 0 {
+                format!("[{} pending]", self.pending).red()
+            } else {
+                "".normal()
+            },
+            format!(
+                "{}{}",
+                "SYNC:".dimmed(),
+                if self.in_sync {
+                    "YES".green()
+                } else {
+                    "NO".red()
+                }
+            ),
+            format!(
+                "{} {}",
+                "last_contact:".dimmed(),
+                if self.last_contact == 0 {
+                    "never".to_string().red()
+                } else {
+                    last_contact
+                        .to_rfc3339_opts(SecondsFormat::Secs, true)
+                        .cyan()
+                }
+            ),
+            // '[visas: VAL' '|' 'connects: VAL]'
+            format!(
+                "{} {} {}",
+                format!("{}{}", "[vreqs:".dimmed(), self.visa_requests),
+                "|".dimmed(),
+                format!(
+                    "{}{}{}",
+                    "creqs:".dimmed(),
+                    self.connect_requests,
+                    "]".dimmed()
+                ),
+            ),
         )
     }
 }

--- a/visaservice/vs-admin/src/main.rs
+++ b/visaservice/vs-admin/src/main.rs
@@ -16,7 +16,7 @@ use reqwest::tls::Certificate;
 use reqwest::StatusCode;
 
 use apitypes::RevokeResponse;
-use apitypes::{HostRecordBrief, VisaDescriptor};
+use apitypes::{HostRecordBrief, NodeRecordBrief, VisaDescriptor};
 use apitypes::{PolicyBundle, PolicyListEntry, PolicyVersion};
 use apitypes::{RevokeAdminRequest, RevokeAdminResponse};
 
@@ -71,6 +71,10 @@ enum SubCmd {
     /// List agents
     #[command()]
     Agents,
+
+    /// List Nodes
+    #[command()]
+    Nodes,
 }
 
 #[derive(Args)]
@@ -127,6 +131,11 @@ fn main() {
         }
         Some(SubCmd::Agents) => {
             list_agents(&args.svc_url, ca_cert).unwrap_or_else(|e| {
+                eprintln!("{} {}", "Error: ".red(), e);
+            });
+        }
+        Some(SubCmd::Nodes) => {
+            list_nodes(&args.svc_url, ca_cert).unwrap_or_else(|e| {
                 eprintln!("{} {}", "Error: ".red(), e);
             });
         }
@@ -404,6 +413,41 @@ fn list_agents(api_url: &str, cert: Certificate) -> Result<(), Box<dyn std::erro
     Ok(())
 }
 
+fn list_nodes(api_url: &str, cert: Certificate) -> Result<(), Box<dyn std::error::Error>> {
+    let cb = reqwest::blocking::ClientBuilder::new()
+        .add_root_certificate(cert)
+        .danger_accept_invalid_certs(true)
+        .timeout(Duration::from_secs(10));
+    let client = cb.build()?;
+
+    let resp = client.get(format!("{}/admin/nodes", api_url)).send()?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "error (status {:?}:{}) : {}",
+            resp.status(),
+            reason_for(resp.status()),
+            resp.text()?
+        )
+        .into());
+    }
+
+    let entries: Vec<NodeRecordBrief> = resp.json()?;
+
+    println!(
+        "{}",
+        format!(
+            "🐎 found {} node{}",
+            entries.len(),
+            if entries.len() == 1 { "" } else { "s" }
+        )
+        .magenta()
+    );
+    for nr in entries {
+        println!("{nr}");
+    }
+    Ok(())
+}
+
 fn clear_revokes(api_url: &str, cert: Certificate) -> Result<(), Box<dyn std::error::Error>> {
     let cb = reqwest::blocking::ClientBuilder::new()
         .add_root_certificate(cert)
@@ -432,7 +476,7 @@ fn clear_revokes(api_url: &str, cert: Certificate) -> Result<(), Box<dyn std::er
     println!("  {}", "SUCCESS".bold().green());
     print!("     {} {}", "COUNT:".bold(), rr.clear_count);
     if rr.clear_count == 0 {
-        println!(" {}",  "(no revokes found)".yellow());
+        println!(" {}", "(no revokes found)".yellow());
     } else {
         println!();
     }


### PR DESCRIPTION
VS was not very thoughtful about creating access visas for nodes when the first attempt to install visas fails.  Now it keeps track of its attempts and will not needlessly re-create access visas.

- Added a new admin call to list out node details
- updated readme
