### PR TITLE
make runners run on mac

### DIFF
--- a/adapter/runners/README.md
+++ b/adapter/runners/README.md
@@ -2,11 +2,15 @@
 
 Wrapper programs to make it easy to launch a node or adapter.
 
-These take care of setting up the TUN interface (but do not tear it down), as
-well as ensuring that the path for the control socket is created.
+These set up the local environment:
 
-Although you need to run these as root, they drop root before starting
-the packet handler. 
+* On linux, take care of setting up the TUN interface (but do not tear it
+down).
+* Ensure that the path for the control socket is created.
+
+You need to run these as root so that the TUN interface can be
+manipulated.  On linux this drops root privileges before starting the ph.
+On mac we keep root since the ph itself needs to bring up the TUN.
 
 
 ## Usage

--- a/adapter/runners/src/env.rs
+++ b/adapter/runners/src/env.rs
@@ -81,7 +81,7 @@ pub fn configure_env(config: &Path, dry_run: bool) -> Result<(), LaunchErr> {
     );
 
     // We always drop privs, even in dry run mode.
-    sys::get_platform().drop_privledges(&run_as_user, false)?;
+    sys::get_platform().drop_privileges(&run_as_user, false)?;
 
     // The control_path parent directories must exist. This can be set in the
     // config, or there is a default.  We do this after dropping privs since the

--- a/adapter/runners/src/env.rs
+++ b/adapter/runners/src/env.rs
@@ -39,12 +39,15 @@ pub fn configure_env(config: &Path, dry_run: bool) -> Result<(), LaunchErr> {
     }
     sys::get_platform().set_control_dir_owner_and_perms(&ctrl_path, &run_as_user, dry_run)?;
 
-    let node_addr_str = rdr.must_get_config_str_value_for_key(zpr::AGENT_ADDR_KEY)?;
-    let node_addr = node_addr_str.parse::<IpAddr>().or(Err(PCErr::KeyError(
-        "node_addr not valid IP address".to_string(),
-    )))?;
+    let tun_addr_str = rdr.must_get_config_str_value_for_key(zpr::AGENT_ADDR_KEY)?;
+    let tun_addr = tun_addr_str
+        .parse::<IpAddr>()
+        .or(Err(PCErr::KeyError(format!(
+            "{} not valid IP address",
+            zpr::AGENT_ADDR_KEY
+        ))))?;
 
-    let mask = match node_addr {
+    let mask = match tun_addr {
         IpAddr::V4(_ipv4) => zpr::IPV4_MASK,
         IpAddr::V6(_ipv6) => zpr::IPV6_MASK,
     };
@@ -62,6 +65,13 @@ pub fn configure_env(config: &Path, dry_run: bool) -> Result<(), LaunchErr> {
                 tun_name
             );
         }
+        // The ph will fail anyway, but might as well warn here too.
+        match tun_addr {
+            IpAddr::V4(_ipv4) => (),
+            IpAddr::V6(_ipv6) => {
+                println!("warning: IPv6 for agent_addr tunnel address is not supported on macos");
+            }
+        }
     }
 
     // TODO: We could check self_addr setting and make sure that we have the
@@ -76,7 +86,7 @@ pub fn configure_env(config: &Path, dry_run: bool) -> Result<(), LaunchErr> {
         );
     } else {
         // Create the tun interface, assign addresses etc.
-        sys::get_platform().create_tun(&tun_name, node_addr, mask, zpr::TUN_MTU, dry_run)?;
+        sys::get_platform().create_tun(&tun_name, tun_addr, mask, zpr::TUN_MTU, dry_run)?;
     }
 
     // Now drop root permissions.

--- a/adapter/runners/src/env.rs
+++ b/adapter/runners/src/env.rs
@@ -54,6 +54,16 @@ pub fn configure_env(config: &Path, dry_run: bool) -> Result<(), LaunchErr> {
         None => sys::get_platform().get_tun_ifname().to_string(),
     };
 
+    #[cfg(target_os = "macos")]
+    {
+        if !tun_name.is_empty() {
+            println!(
+                "warning: on macos it is reccommended to not set a tun name (found {})",
+                tun_name
+            );
+        }
+    }
+
     // TODO: We could check self_addr setting and make sure that we have the
     //       address there on an interface.
 

--- a/adapter/runners/src/env.rs
+++ b/adapter/runners/src/env.rs
@@ -46,7 +46,7 @@ pub fn configure_env(config: &Path, dry_run: bool) -> Result<(), LaunchErr> {
     {
         if !tun_name.is_empty() {
             println!(
-                "warning: on macos it is reccommended to not set a tun name (found {})",
+                "warning: on macos it is recommended to not set a tun name (found {})",
                 tun_name
             );
         }

--- a/adapter/runners/src/env.rs
+++ b/adapter/runners/src/env.rs
@@ -24,21 +24,6 @@ pub fn configure_env(config: &Path, dry_run: bool) -> Result<(), LaunchErr> {
         }
     };
 
-    // The control_path parent directories must exist. This can be set in the
-    // config, or there is a default.
-    let ctrl_path =
-        match rdr.get_config_str_value_for_section_and_key("global", zpr::CONTROL_PATH_KEY) {
-            Ok(Some(path)) => PathBuf::from(path),
-            Ok(None) => sys::get_data_home(),
-            Err(e) => return Err(LaunchErr::PCError(e)),
-        };
-    if dry_run {
-        println!("mkdir -p {}", ctrl_path.display());
-    } else {
-        fs::create_dir_all(&ctrl_path)?;
-    }
-    sys::get_platform().set_control_dir_owner_and_perms(&ctrl_path, &run_as_user, dry_run)?;
-
     let tun_addr_str = rdr.must_get_config_str_value_for_key(zpr::AGENT_ADDR_KEY)?;
     let tun_addr = tun_addr_str
         .parse::<IpAddr>()
@@ -94,7 +79,37 @@ pub fn configure_env(config: &Path, dry_run: bool) -> Result<(), LaunchErr> {
         "dropping root permissions, switching to user {}",
         run_as_user
     );
-    sys::get_platform().drop_privledges(&run_as_user, dry_run)?;
+
+    // We always drop privs, even in dry run mode.
+    sys::get_platform().drop_privledges(&run_as_user, false)?;
+
+    // The control_path parent directories must exist. This can be set in the
+    // config, or there is a default.  We do this after dropping privs since the
+    // path depends on the user. This means that sometimes user will need to manually
+    // step in here and create the directories.
+    let ctrl_path =
+        match rdr.get_config_str_value_for_section_and_key("global", zpr::CONTROL_PATH_KEY) {
+            Ok(Some(path)) => PathBuf::from(path),
+            Ok(None) => sys::get_data_home(),
+            Err(e) => return Err(LaunchErr::PCError(e)),
+        };
+    if dry_run {
+        println!("mkdir -p {}", ctrl_path.display());
+    } else {
+        fs::create_dir_all(&ctrl_path).or_else(|e| {
+            println!(
+                "tip: create {} manually or set a different value of {} in your config",
+                ctrl_path.display(),
+                zpr::CONTROL_PATH_KEY
+            );
+            Err(LaunchErr::FileError(format!(
+                "unable to create control path: {}: {}",
+                ctrl_path.display(),
+                e
+            )))
+        })?;
+    }
+    sys::get_platform().set_control_dir_owner_and_perms(&ctrl_path, &run_as_user, dry_run)?;
 
     Ok(())
 }

--- a/adapter/runners/src/errors.rs
+++ b/adapter/runners/src/errors.rs
@@ -13,4 +13,7 @@ pub enum LaunchErr {
 
     #[error("io error: {0}")]
     IoError(#[from] std::io::Error),
+
+    #[error("file error: {0}")]
+    FileError(String),
 }

--- a/adapter/runners/src/sys/linux.rs
+++ b/adapter/runners/src/sys/linux.rs
@@ -78,12 +78,12 @@ impl Platform for LinuxPlatform {
     fn create_tun(
         &self,
         tun_name: &str,
-        node_addr: IpAddr,
+        tun_addr: IpAddr,
         mask: u8,
         mtu: usize,
         dry_run: bool,
     ) -> Result<(), PlatformErr> {
-        let addr_and_mask = format!("{}/{}", node_addr, mask);
+        let addr_and_mask = format!("{}/{}", tun_addr, mask);
         {
             let mut c = Command::new("ip");
             c.arg("tuntap")

--- a/adapter/runners/src/sys/linux.rs
+++ b/adapter/runners/src/sys/linux.rs
@@ -30,7 +30,7 @@ impl Platform for LinuxPlatform {
         common::set_control_dir_owner_and_perms(ctrl_path, username, dry_run)
     }
 
-    fn drop_privledges(&self, username: &str, dry_run: bool) -> Result<(), PlatformErr> {
+    fn drop_privileges(&self, username: &str, dry_run: bool) -> Result<(), PlatformErr> {
         let user = get_user_by_name(username)
             .ok_or(PlatformErr::OsError(format!("user {} not found", username)))?;
         if dry_run {

--- a/adapter/runners/src/sys/linux.rs
+++ b/adapter/runners/src/sys/linux.rs
@@ -1,11 +1,10 @@
-use nix::sys::stat;
 use nix::unistd::{self, Gid, Uid};
 use users::get_user_by_name;
 
 use std::net::IpAddr;
-use std::os::unix::process::CommandExt;
 use std::process::Command;
 
+use crate::sys::unix as common;
 use crate::sys::{Platform, PlatformErr};
 
 const DEFAULT_TUN_NAME: &str = "tun0";
@@ -14,7 +13,7 @@ pub struct LinuxPlatform {}
 
 impl Platform for LinuxPlatform {
     fn has_root_perms(&self) -> bool {
-        Uid::effective().is_root()
+        common::has_root_perms()
     }
 
     // TODO: in future could have code to find an unused tun
@@ -28,48 +27,7 @@ impl Platform for LinuxPlatform {
         username: &str,
         dry_run: bool,
     ) -> Result<(), PlatformErr> {
-        match get_user_by_name(username) {
-            None => {
-                return Err(PlatformErr::OsError(format!("user {} not found", username)));
-            }
-            Some(user) => {
-                if dry_run {
-                    println!(
-                        "chown {}:{} {}",
-                        user.uid(),
-                        user.primary_group_id(),
-                        ctrl_path.display()
-                    );
-                } else {
-                    unistd::chown(
-                        ctrl_path,
-                        Some(Uid::from_raw(user.uid())),
-                        Some(Gid::from_raw(user.primary_group_id())),
-                    )
-                    .map_err(|e| PlatformErr::OsError(format!("chown failed: {}", e)))?;
-                }
-            }
-        };
-
-        // Now set perm to 775
-        if dry_run {
-            println!("chmod 775 {}", ctrl_path.display());
-            return Ok(());
-        }
-
-        let dirfd = nix::fcntl::open(
-            ctrl_path,
-            nix::fcntl::OFlag::O_DIRECTORY,
-            nix::sys::stat::Mode::S_IRWXU,
-        )
-        .map_err(|e| PlatformErr::OsError(format!("open failed on {:?}: {}", ctrl_path, e)))?;
-
-        stat::fchmod(
-            dirfd,
-            stat::Mode::S_IRWXU | stat::Mode::S_IRWXG | stat::Mode::S_IROTH | stat::Mode::S_IXOTH,
-        )
-        .map_err(|e| PlatformErr::OsError(format!("fchmod failed: {}", e)))?;
-        Ok(())
+        common::set_control_dir_owner_and_perms(ctrl_path, username, dry_run)
     }
 
     fn drop_privledges(&self, username: &str, dry_run: bool) -> Result<(), PlatformErr> {
@@ -185,12 +143,7 @@ impl Platform for LinuxPlatform {
         Ok(())
     }
 
-    fn exec(&self, mut cmd: Command, dry_run: bool) -> Result<(), PlatformErr> {
-        if dry_run {
-            println!("exec {:?}", cmd);
-            return Ok(());
-        }
-        let err = cmd.exec();
-        Err(PlatformErr::IoError(err))
+    fn exec(&self, cmd: Command, dry_run: bool) -> Result<(), PlatformErr> {
+        common::exec(cmd, dry_run)
     }
 }

--- a/adapter/runners/src/sys/macos.rs
+++ b/adapter/runners/src/sys/macos.rs
@@ -33,6 +33,7 @@ impl Platform for MacosPlatform {
         common::set_control_dir_owner_and_perms(ctrl_path, username, dry_run)
     }
 
+    // On macos we do not drop since we need root to create the TUN interface.
     fn drop_privledges(&self, _username: &str, dry_run: bool) -> Result<(), PlatformErr> {
         if dry_run {
             println!("drop_privledges is NOP on macos");
@@ -42,17 +43,27 @@ impl Platform for MacosPlatform {
 
     fn create_tun(
         &self,
-        _tun_name: &str,
+        tun_name: &str,
         _tun_addr: IpAddr,
         _mask: u8,
         _mtu: usize,
         dry_run: bool,
     ) -> Result<(), PlatformErr> {
-        // On mac, best to create tun in the PH.
+        // On mac, best (only possible?) to create tun in the PH.
         if dry_run {
-            println!("create_tun is NOP on macos");
+            if tun_name.is_empty() {
+                println!("create_tun: does nothing on macos");
+            } else {
+                println!("will fail with error: on macos tun should be created by ph");
+            }
         }
-        Ok(())
+        if !tun_name.is_empty() {
+            Err(PlatformErr::OsError(
+                "on macos tun should be created by ph: do not set tun_if".to_string(),
+            ))
+        } else {
+            Ok(())
+        }
     }
 
     fn exec(&self, cmd: Command, dry_run: bool) -> Result<(), PlatformErr> {

--- a/adapter/runners/src/sys/macos.rs
+++ b/adapter/runners/src/sys/macos.rs
@@ -1,45 +1,61 @@
+use crate::sys::unix as common;
+use crate::sys::{Platform, PlatformErr};
 use std::net::IpAddr;
 use std::process::Command;
-
-use crate::sys::{Platform, PlatformErr};
-
-const DEFAULT_TUN_NAME: &str = "tun0";
 
 pub struct MacosPlatform {}
 
 impl Platform for MacosPlatform {
+    // TODO: is same as linux
     fn has_root_perms(&self) -> bool {
-        panic!("has_root_perms not implemented for macos");
+        common::has_root_perms()
     }
 
+    // On macos it's best to not set a tun name. The mac tun network code will create one.
     fn get_tun_ifname(&self) -> String {
-        DEFAULT_TUN_NAME.to_string()
+        return String::new();
     }
 
     fn is_tun_exist(&self, tun_name: &str) -> bool {
-        panic!("is_tun_exist not implemented for macos");
+        Command::new("ifconfig")
+            .arg(tun_name)
+            .status()
+            .unwrap()
+            .success()
+    }
+
+    fn set_control_dir_owner_and_perms(
+        &self,
+        ctrl_path: &std::path::PathBuf,
+        username: &str,
+        dry_run: bool,
+    ) -> Result<(), PlatformErr> {
+        common::set_control_dir_owner_and_perms(ctrl_path, username, dry_run)
+    }
+
+    fn drop_privledges(&self, _username: &str, dry_run: bool) -> Result<(), PlatformErr> {
+        if dry_run {
+            println!("drop_privledges is NOP on macos");
+        }
+        Ok(())
     }
 
     fn create_tun(
         &self,
-        tun_name: &str,
-        node_addr: IpAddr,
-        mask: u8,
-        mtu: usize,
+        _tun_name: &str,
+        _tun_addr: IpAddr,
+        _mask: u8,
+        _mtu: usize,
         dry_run: bool,
     ) -> Result<(), PlatformErr> {
+        // On mac, best to create tun in the PH.
         if dry_run {
-            println!("will panic due to create_tun not implemented for macos");
-            return Ok(());
+            println!("create_tun is NOP on macos");
         }
-        panic!("create_tun not implemented for macos");
+        Ok(())
     }
 
     fn exec(&self, cmd: Command, dry_run: bool) -> Result<(), PlatformErr> {
-        if dry_run {
-            println!("will panic due to exec not implemented for macos");
-            return Ok(());
-        }
-        panic!("exec not implemented for macos");
+        common::exec(cmd, dry_run)
     }
 }

--- a/adapter/runners/src/sys/macos.rs
+++ b/adapter/runners/src/sys/macos.rs
@@ -34,9 +34,9 @@ impl Platform for MacosPlatform {
     }
 
     // On macos we do not drop since we need root to create the TUN interface.
-    fn drop_privledges(&self, _username: &str, dry_run: bool) -> Result<(), PlatformErr> {
+    fn drop_privileges(&self, _username: &str, dry_run: bool) -> Result<(), PlatformErr> {
         if dry_run {
-            println!("drop_privledges is NOP on macos");
+            println!("drop_privileges is NOP on macos");
         }
         Ok(())
     }

--- a/adapter/runners/src/sys/mod.rs
+++ b/adapter/runners/src/sys/mod.rs
@@ -45,8 +45,8 @@ pub trait Platform {
         dry_run: bool,
     ) -> Result<(), PlatformErr>;
 
-    /// Drop root privledges by switching to the given OS user.
-    fn drop_privledges(&self, username: &str, dry_run: bool) -> Result<(), PlatformErr>;
+    /// Drop root privileges by switching to the given OS user.
+    fn drop_privileges(&self, username: &str, dry_run: bool) -> Result<(), PlatformErr>;
 
     /// Create a TUN interface with the given name, IP address, mask, and MTU.
     fn create_tun(

--- a/adapter/runners/src/sys/mod.rs
+++ b/adapter/runners/src/sys/mod.rs
@@ -5,6 +5,9 @@ use std::process::Command;
 
 use thiserror::Error;
 
+#[cfg(target_family = "unix")]
+pub(crate) mod unix;
+
 #[cfg(target_os = "linux")]
 pub(crate) mod linux;
 
@@ -49,7 +52,7 @@ pub trait Platform {
     fn create_tun(
         &self,
         tun_name: &str,
-        node_addr: IpAddr,
+        tun_addr: IpAddr,
         mask: u8,
         mtu: usize,
         dry_run: bool,

--- a/adapter/runners/src/sys/unix.rs
+++ b/adapter/runners/src/sys/unix.rs
@@ -1,0 +1,72 @@
+//! unix.rs - platform functions common amoung the unix family of OSes.
+
+use nix::sys::stat;
+use nix::unistd::{self, Gid, Uid};
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+use users::get_user_by_name;
+
+use crate::sys::PlatformErr;
+
+pub fn has_root_perms() -> bool {
+    Uid::effective().is_root()
+}
+
+pub fn set_control_dir_owner_and_perms(
+    ctrl_path: &std::path::PathBuf,
+    username: &str,
+    dry_run: bool,
+) -> Result<(), PlatformErr> {
+    match get_user_by_name(username) {
+        None => {
+            return Err(PlatformErr::OsError(format!("user {} not found", username)));
+        }
+        Some(user) => {
+            if dry_run {
+                println!(
+                    "chown {}:{} {}",
+                    user.uid(),
+                    user.primary_group_id(),
+                    ctrl_path.display()
+                );
+            } else {
+                unistd::chown(
+                    ctrl_path,
+                    Some(Uid::from_raw(user.uid())),
+                    Some(Gid::from_raw(user.primary_group_id())),
+                )
+                .map_err(|e| PlatformErr::OsError(format!("chown failed: {}", e)))?;
+            }
+        }
+    };
+
+    // Now set perm to 775
+    if dry_run {
+        println!("chmod 775 {}", ctrl_path.display());
+        return Ok(());
+    }
+
+    let dirfd = nix::fcntl::open(
+        ctrl_path,
+        nix::fcntl::OFlag::O_DIRECTORY,
+        nix::sys::stat::Mode::S_IRWXU,
+    )
+    .map_err(|e| PlatformErr::OsError(format!("open failed on {:?}: {}", ctrl_path, e)))?;
+
+    stat::fchmod(
+        dirfd,
+        stat::Mode::S_IRWXU | stat::Mode::S_IRWXG | stat::Mode::S_IROTH | stat::Mode::S_IXOTH,
+    )
+    .map_err(|e| PlatformErr::OsError(format!("fchmod failed: {}", e)))?;
+    Ok(())
+}
+
+pub fn exec(mut cmd: Command, dry_run: bool) -> Result<(), PlatformErr> {
+    if dry_run {
+        println!("exec {:?}", cmd);
+        return Ok(());
+    }
+    let err = cmd.exec();
+    Err(PlatformErr::IoError(err))
+}


### PR DESCRIPTION
Ensure that the runners run on mac.

Due to our network libs in use, the mac version works a bit differently from linux: on mac you must not create the tun interface before running.  Also, annoyingly the mac library we are using for tun does not handle IPv6.


