### PR TITLE
Use OS threads for substrate ingress

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "zpr-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "libc",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -20,7 +20,7 @@ enumset = "1.1.5"
 hdrhistogram = { version = "7.5.4" }
 libc = { version = "0.2.155" }
 libnode = { path = "../../libnode" }
-nix = { version = "0.29.0", features = ["ioctl", "net"] }
+nix = { version = "0.29.0", features = ["ioctl", "net", "poll"] }
 open-enum = { version = "0.5.1" }
 openssl = { version = "0.10.64" }
 openssl-sys = { version = "0.9.102" }
@@ -47,10 +47,8 @@ tokio-tun = { version = "0.11.5" }
 # may need going forward.
 tun = { version = "=0.7.1", features = ["async"] }
 
-
 [dev-dependencies]
 rand = "0.8.5"
-
 
 [features]
 default = ["rcu-crossbeam-epoch"]
@@ -60,3 +58,8 @@ rcu-mutex-arc = []
 rcu-crossbeam-epoch = ["dep:crossbeam-epoch"]
 rcu-aarc = ["dep:aarc"]
 
+[profile.dev]
+panic="abort"
+
+[profile.release]
+panic="abort"

--- a/adapter/ph/src/logging.rs
+++ b/adapter/ph/src/logging.rs
@@ -37,6 +37,8 @@ pub mod targets {
     pub const VISA_MGMT: &str = "visa_mgmt";
     pub const ZDP: &str = "zdp";
 
+    pub use libnode::logging::targets::*;
+
     pub const ALL_TARGETS: &[&str] = &[
         ALL,
         CAPTURE,
@@ -50,6 +52,8 @@ pub mod targets {
         RPC,
         STARTUP,
         VISA_MGMT,
+        VS_RPC,
+        VSS_RPC,
         ZDP,
     ];
 }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -9,7 +9,6 @@ use std::path::Path;
 use std::process;
 use std::process::ExitCode;
 use std::sync::Arc;
-use tokio::net::UdpSocket;
 use tokio::net::UnixListener;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
@@ -225,7 +224,7 @@ fn main() -> ExitCode {
     // open substrate sockets
     //
 
-    let mut substrate_sockets = Vec::new();
+    let mut substrate_sockets: Vec<Arc<std::net::UdpSocket>> = Vec::new();
 
     for _i in 0..topology_config.substrate_ingress_concurrency {
         let socket = socket2::Socket::new(
@@ -247,8 +246,13 @@ fn main() -> ExitCode {
             config.self_addr.set_port(port);
             info!(target: STARTUP, "assigned substrate UDP port {port}");
         }
-        substrate_sockets.push(Arc::new(UdpSocket::from_std(socket.into()).unwrap()));
+        substrate_sockets.push(Arc::new(socket.into()));
     }
+
+    let tokio_substrate_sockets: Box<[_]> = substrate_sockets
+        .iter()
+        .map(|s| Arc::new(tokio::net::UdpSocket::from_std(s.try_clone().unwrap()).unwrap()))
+        .collect();
 
     //
     // configure packet steering for better load balancing
@@ -316,7 +320,7 @@ fn main() -> ExitCode {
         topology_config,
         agent_addresses: config.agent_addr,
         agent_input: AgentInput::new(tun_devs.clone()),
-        substrate_egress: SubstrateEgress::new(substrate_sockets.clone()),
+        substrate_egress: SubstrateEgress::new(tokio_substrate_sockets),
         agent_output_requeue: AgentOutputRequeue::new(agent_requeue_inqs),
         vsconn: vsconn.as_ref().map(|c| c.handle()),
         capture_queue: Capture::new(cap_inq),
@@ -415,17 +419,24 @@ fn main() -> ExitCode {
         );
     }
 
+    let mut fastpath_threads = Vec::new();
+
     let substrate_ingress_worker_config = FastpathWorkerConfig {
         buffer_count: asm.topology_config.buffer_count,
         batch_size: asm.topology_config.substrate_ingress_batch_size,
     };
     for (worker_index, socket) in substrate_sockets.into_iter().enumerate() {
-        js.spawn(substrate_ingress_worker::launch(
-            substrate_ingress_worker_config,
-            worker_index,
-            asm.clone(),
-            socket,
-        ));
+        let builder = std::thread::Builder::new().name(format!("ingress {worker_index}"));
+        fastpath_threads.push(
+            builder
+                .spawn(substrate_ingress_worker::launch(
+                    substrate_ingress_worker_config,
+                    worker_index,
+                    asm.clone(),
+                    socket,
+                ))
+                .unwrap(),
+        );
     }
 
     cap_outq.set_nonblocking(true).unwrap();
@@ -498,6 +509,10 @@ fn main() -> ExitCode {
             res.unwrap();
         }
     });
+
+    for th in fastpath_threads {
+        th.join().unwrap();
+    }
 
     info!(target: STARTUP, "exiting");
 

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -249,11 +249,6 @@ fn main() -> ExitCode {
         substrate_sockets.push(Arc::new(socket.into()));
     }
 
-    let tokio_substrate_sockets: Box<[_]> = substrate_sockets
-        .iter()
-        .map(|s| Arc::new(tokio::net::UdpSocket::from_std(s.try_clone().unwrap()).unwrap()))
-        .collect();
-
     //
     // configure packet steering for better load balancing
     //
@@ -320,7 +315,7 @@ fn main() -> ExitCode {
         topology_config,
         agent_addresses: config.agent_addr,
         agent_input: AgentInput::new(tun_devs.clone()),
-        substrate_egress: SubstrateEgress::new(tokio_substrate_sockets),
+        substrate_egress: SubstrateEgress::new(substrate_sockets.iter().cloned()),
         agent_output_requeue: AgentOutputRequeue::new(agent_requeue_inqs),
         vsconn: vsconn.as_ref().map(|c| c.handle()),
         capture_queue: Capture::new(cap_inq),

--- a/adapter/ph/src/packet_steering.rs
+++ b/adapter/ph/src/packet_steering.rs
@@ -1,6 +1,6 @@
 //! OS-level control of steering packets into sockets.
 
-use tokio::net::UdpSocket;
+use std::net::UdpSocket;
 
 #[allow(dead_code)]
 pub enum SteeringMethod {
@@ -38,7 +38,7 @@ mod os_impl {
     use std::io;
     use std::mem::{offset_of, size_of};
     use zpr;
-    use zpr_ext::tokio::net::UdpSocketExt;
+    use zpr_ext::std::net::UdpSocketExt;
 
     pub fn set_steering(
         sock: &UdpSocket,

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -8,11 +8,12 @@ use crate::test_packet::*;
 use crate::two_way_queue;
 use bytes::Buf;
 use std::io::ErrorKind;
-use std::net::SocketAddr;
+use std::net::{SocketAddr, UdpSocket};
+use std::os::unix::net::UnixDatagram as StdUnixDatagram;
 use std::result::Result;
 use std::sync::Arc;
 use std::time::SystemTime;
-use tokio::net::{UdpSocket, UnixDatagram};
+use tokio::net::UnixDatagram as TokioUnixDatagram;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::oneshot::error::RecvError;
@@ -127,6 +128,7 @@ pub struct SubstrateEgress {
 }
 
 impl SubstrateEgress {
+    /// Sockets must be marked non-blocking by caller.
     pub fn new(sockets: impl IntoIterator<Item = Arc<UdpSocket>>) -> Self {
         Self {
             sockets: sockets.into_iter().collect(),
@@ -140,7 +142,8 @@ impl SubstrateEgress {
     ) -> Result<(), ()> {
         let (socket, dest_sockaddr) = self.select_socket_and_set_flowinfo(packet, dest_sa);
 
-        match socket.send_to(packet.body(), dest_sockaddr).await {
+        // FIXME: make this actually blocking
+        match socket.send_to(packet.body(), dest_sockaddr) {
             Ok(_) => Ok(()),
 
             Err(err) => {
@@ -166,7 +169,7 @@ impl SubstrateEgress {
     ) -> Result<(), TryEnqueueError> {
         let (socket, dest_sockaddr) = self.select_socket_and_set_flowinfo(packet, dest_sa);
 
-        match socket.try_send_to(packet.body(), dest_sockaddr) {
+        match socket.send_to(packet.body(), dest_sockaddr) {
             Ok(_) => Ok(()),
 
             Err(err) => {
@@ -175,7 +178,9 @@ impl SubstrateEgress {
                         panic!("unrecoverable I/O error: {}", err)
                     }
 
-                    ErrorKind::WouldBlock => Err(TryEnqueueError::Full(())),
+                    ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
+                        Err(TryEnqueueError::Full(()))
+                    }
 
                     // most other network errors are temporary; return packet to caller
                     // TODO: it would be nice to report to the user _why_ packets aren't moving;
@@ -210,11 +215,11 @@ impl SubstrateEgress {
 
 /// Used for requeueing agent output packets from mgmt.
 pub struct AgentOutputRequeue {
-    sockets: Box<[UnixDatagram]>,
+    sockets: Box<[TokioUnixDatagram]>,
 }
 
 impl AgentOutputRequeue {
-    pub fn new(sockets: impl IntoIterator<Item = UnixDatagram>) -> Self {
+    pub fn new(sockets: impl IntoIterator<Item = TokioUnixDatagram>) -> Self {
         Self {
             sockets: sockets.into_iter().collect(),
         }
@@ -233,18 +238,18 @@ impl AgentOutputRequeue {
         }
     }
 
-    fn select_socket(&self, packet: &Packet) -> &UnixDatagram {
+    fn select_socket(&self, packet: &Packet) -> &TokioUnixDatagram {
         &self.sockets[packet.metadata().ingress_lane_id as usize]
     }
 }
 
 /// Capture will intercept packets in the PH and dump them into a file for debugging purposes
 pub struct Capture {
-    sender: std::os::unix::net::UnixDatagram,
+    sender: StdUnixDatagram,
 }
 
 impl Capture {
-    pub fn new(sender: std::os::unix::net::UnixDatagram) -> Self {
+    pub fn new(sender: StdUnixDatagram) -> Self {
         sender.set_nonblocking(true).unwrap();
         Self { sender }
     }

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -361,31 +361,16 @@ impl MgmtDispatch {
         }
     }
 
-    #[allow(dead_code)]
     pub fn recv_return_buffers(&mut self, returns: &mut Vec<PacketBuffer>, limit: usize) -> usize {
         self.sender.blocking_recv_many_returns(returns, limit)
     }
 
-    #[allow(dead_code)]
     pub fn try_recv_return_buffers(
         &mut self,
         returns: &mut Vec<PacketBuffer>,
         limit: usize,
     ) -> usize {
         self.sender.try_recv_many_returns(returns, limit)
-    }
-
-    pub async fn async_recv_return_buffers(
-        &mut self,
-        returns: &mut Vec<PacketBuffer>,
-        limit: usize,
-    ) -> usize {
-        self.sender.recv_many_returns(returns, limit).await
-    }
-
-    #[allow(dead_code)]
-    pub async fn async_recv_return_buffer(&mut self) -> PacketBuffer {
-        self.sender.recv_return().await
     }
 }
 

--- a/adapter/ph/src/substrate_ingress_worker.rs
+++ b/adapter/ph/src/substrate_ingress_worker.rs
@@ -3,18 +3,26 @@ use crate::config;
 use crate::counters::*;
 use crate::fastpath::{FastpathWorker, FastpathWorkerConfig};
 use crate::packet::Packet;
+use nix::poll;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
+use std::net::UdpSocket;
+use std::os::fd::AsFd;
 use std::sync::Arc;
-use tokio::net::UdpSocket;
+use zpr_ext::std::net::UdpSocketExt;
 
-pub async fn launch(
+pub fn launch(
     config: FastpathWorkerConfig,
     worker_index: usize,
     asm: Arc<Assembly>,
     socket: Arc<UdpSocket>,
-) {
-    let mut worker = FastpathWorker::new(config, worker_index, asm.clone());
+) -> impl FnOnce() {
+    let worker = FastpathWorker::new(config, worker_index, asm.clone());
+    move || substrate_ingress_main(worker, &socket)
+}
+
+fn substrate_ingress_main(mut worker: FastpathWorker, socket: &UdpSocket) {
+    let mut poll_fd = poll::PollFd::new(socket.as_fd(), poll::PollFlags::POLLIN);
 
     loop {
         // process the return buffer queue
@@ -22,29 +30,43 @@ pub async fn launch(
             // if we are out of buffers, block
             worker
                 .mgmt_dispatch
-                .async_recv_return_buffers(&mut worker.buffers, worker.config.buffer_count)
-                .await;
+                .recv_return_buffers(&mut worker.buffers, worker.config.buffer_count);
         } else {
             worker
                 .mgmt_dispatch
                 .try_recv_return_buffers(&mut worker.buffers, worker.config.buffer_count);
         }
 
+        let _n = match poll::poll(std::slice::from_mut(&mut poll_fd), poll::PollTimeout::NONE)
+            .map_err(|err| std::io::Error::from_raw_os_error(err as i32))
+        {
+            Ok(n) => n,
+            Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+            ret @ Err(_) => ret.unwrap(),
+        };
+
         // TODO: batch receive
         let mut pkt = Packet::new(
             worker.buffers.pop().unwrap(),
             config::DEFAULT_MESSAGE_HEADROOM,
         );
-        let mut sender = match socket.recv_buf_from(&mut pkt).await {
+
+        let mut sender = match socket.recv_buf_from(&mut pkt) {
             Ok((_size, sender)) => sender,
 
             Err(err) => {
                 match err.kind() {
-                    ErrorKind::ConnectionRefused => {
-                        // FIXME: do something with this later...
-                        worker.drop_and_count(pkt, CounterType::InPacksDrop);
+                    ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
+                        worker.buffers.push(pkt.destroy());
                         continue;
                     }
+
+                    // FIXME: do something with this later...
+                    ErrorKind::ConnectionRefused => {
+                        worker.buffers.push(pkt.destroy());
+                        continue;
+                    }
+
                     _ => panic!("got socket error {}", err),
                 }
             }

--- a/adapter/ph/src/sys/linux/zprtun.rs
+++ b/adapter/ph/src/sys/linux/zprtun.rs
@@ -1,4 +1,4 @@
-use crate::zprtun::ZPRTunError;
+use crate::zprtun::ZprTunError;
 use bytes::buf;
 use nix::ioctl_write_ptr;
 use std::io;
@@ -27,7 +27,7 @@ impl ZprTun {
         ifname: Option<String>,
         concurrency: usize,
         address: Option<IpAddr>,
-    ) -> std::result::Result<Vec<Self>, ZPRTunError> {
+    ) -> std::result::Result<Vec<Self>, ZprTunError> {
         let mut bldr = TunBuilder::new();
         if let Some(ifname) = ifname {
             bldr = bldr.name(&ifname);
@@ -36,13 +36,13 @@ impl ZprTun {
             match addr {
                 IpAddr::V4(ipa) => bldr = bldr.address(ipa),
                 IpAddr::V6(_) => {
-                    return Err(ZPRTunError::PlatformError("IPv6 not supported".to_string()))
+                    return Err(ZprTunError::PlatformError("IPv6 not supported".to_string()))
                 }
             }
         }
         let tok_tun_devs = bldr
             .try_build_mq(concurrency)
-            .or_else(|e| Err(ZPRTunError::PlatformError(e.to_string())))?;
+            .or_else(|e| Err(ZprTunError::PlatformError(e.to_string())))?;
 
         Ok(tok_tun_devs.into_iter().map(ZprTun).collect())
     }
@@ -83,9 +83,9 @@ impl ZprTun {
     }
 
     #[allow(dead_code)]
-    pub fn set_address(&mut self, _addr: IpAddr) -> std::result::Result<(), ZPRTunError> {
+    pub fn set_address(&mut self, _addr: IpAddr) -> std::result::Result<(), ZprTunError> {
         // This needs work -- the linux tun API only allows address to be set at construction time.
-        Err(ZPRTunError::PlatformError(
+        Err(ZprTunError::PlatformError(
             "cannot set TUN address after creation".to_string(),
         ))
     }

--- a/adapter/ph/src/sys/macos/zprtun.rs
+++ b/adapter/ph/src/sys/macos/zprtun.rs
@@ -1,4 +1,4 @@
-use crate::zprtun::{ZPRTunError, DEFAULT_TUN_MTU};
+use crate::zprtun::{ZprTunError, DEFAULT_TUN_MTU};
 use bytes::buf;
 use std::net::IpAddr;
 use std::result::Result;
@@ -13,9 +13,9 @@ impl From<AsyncDevice> for ZprTun {
     }
 }
 
-impl From<tun::Error> for ZPRTunError {
+impl From<tun::Error> for ZprTunError {
     fn from(e: tun::Error) -> Self {
-        ZPRTunError::PlatformError(e.to_string())
+        ZprTunError::PlatformError(e.to_string())
     }
 }
 
@@ -27,7 +27,7 @@ impl ZprTun {
         ifname: Option<String>,
         concurrency: usize,
         address: Option<IpAddr>,
-    ) -> std::result::Result<Vec<Self>, ZPRTunError> {
+    ) -> std::result::Result<Vec<Self>, ZprTunError> {
         let mut config = tun::Configuration::default();
         if let Some(name) = ifname {
             config.tun_name(&name);
@@ -38,7 +38,7 @@ impl ZprTun {
             config.address(addr);
         }
         if concurrency <= 0 || concurrency > 1 {
-            return Err(ZPRTunError::PlatformError(String::from(
+            return Err(ZprTunError::PlatformError(String::from(
                 "on macos concurrency (queues) must be 1",
             )));
         }
@@ -70,11 +70,11 @@ impl ZprTun {
     }
 
     #[allow(dead_code)]
-    pub fn set_address(&mut self, addr: IpAddr) -> Result<(), ZPRTunError> {
+    pub fn set_address(&mut self, addr: IpAddr) -> Result<(), ZprTunError> {
         let idev = &mut *(self.0);
         match idev.set_address(addr) {
             Ok(_) => Ok(()),
-            Err(e) => Err(ZPRTunError::PlatformError(e.to_string())),
+            Err(e) => Err(ZprTunError::PlatformError(e.to_string())),
         }
     }
 }

--- a/adapter/ph/src/zprtun.rs
+++ b/adapter/ph/src/zprtun.rs
@@ -9,9 +9,9 @@ use crate::sys::TunPi;
 #[allow(dead_code)]
 pub const DEFAULT_TUN_MTU: u16 = 1400;
 
-/// Error type used by some ZPRTun functions across platform implementations.
+/// Error type used by some ZprTun functions across platform implementations.
 #[derive(thiserror::Error, Debug)]
-pub enum ZPRTunError {
+pub enum ZprTunError {
     #[error("{0}")]
     IoError(#[from] std::io::Error),
 

--- a/zpr-ext/Cargo.lock
+++ b/zpr-ext/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "zpr-ext"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "libc",

--- a/zpr-ext/Cargo.toml
+++ b/zpr-ext/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "zpr-ext"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]
 bytes = { version = "1.7.1", optional = true }
 libc = { version = "0.2.155" }
-nix = { version = "0.29.0", features = ["ioctl", "net", "socket"], optional = true }
+nix = { version = "0.29.0", features = ["ioctl", "net", "socket"] }
 tokio = { version = "1.37.0", features = ["net"], optional = true }
 zerocopy = { version = "0.8.3", optional = true }
 
@@ -17,5 +17,5 @@ tokio = { version = "1.37.0", features = ["macros", "time", "rt"] }
 # Each feature flag is the name of a library the user is already using
 # and would like to have "extended".
 bytes = ["dep:bytes"]
-tokio = ["dep:tokio", "dep:nix"]
+tokio = ["dep:tokio"]
 zerocopy = ["dep:zerocopy"]

--- a/zpr-ext/src/std.rs
+++ b/zpr-ext/src/std.rs
@@ -1,4 +1,5 @@
 pub mod mem;
+pub mod net;
 pub mod num;
 pub mod os;
 pub mod vec;

--- a/zpr-ext/src/std/net.rs
+++ b/zpr-ext/src/std/net.rs
@@ -7,10 +7,19 @@ use nix::sys::socket;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::fd::AsRawFd;
 
+#[cfg(feature = "bytes")]
+use bytes::BufMut;
+
 pub trait UdpSocketExt {
     fn mtu(&self) -> io::Result<u32>;
+
     #[cfg(any(doc, target_os = "android", target_os = "linux"))]
     fn attach_reuse_port_cbpf(&self, filter: &[libc::sock_filter]) -> io::Result<()>;
+
+    #[cfg(feature = "bytes")]
+    fn recv_buf(&self, buf: &mut impl BufMut) -> io::Result<usize>;
+    #[cfg(feature = "bytes")]
+    fn recv_buf_from(&self, buf: &mut impl BufMut) -> io::Result<(usize, std::net::SocketAddr)>;
 }
 
 impl UdpSocketExt for UdpSocket {
@@ -57,5 +66,33 @@ impl UdpSocketExt for UdpSocket {
         } else {
             Ok(())
         }
+    }
+
+    #[cfg(feature = "bytes")]
+    fn recv_buf(&self, buf: &mut impl BufMut) -> io::Result<usize> {
+        let chunk = buf.chunk_mut();
+        // SAFETY: we will only be writing to this chunk
+        let chunk =
+            unsafe { &mut *(chunk as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+        let recvd = self.recv(chunk)?;
+        // SAFETY: `recv` has written to the first `recvd` bytes of `buf`
+        unsafe {
+            buf.advance_mut(recvd);
+        }
+        Ok(recvd)
+    }
+
+    #[cfg(feature = "bytes")]
+    fn recv_buf_from(&self, buf: &mut impl BufMut) -> io::Result<(usize, std::net::SocketAddr)> {
+        let chunk = buf.chunk_mut();
+        // SAFETY: we will only be writing to this chunk
+        let chunk =
+            unsafe { &mut *(chunk as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+        let (recvd, from) = self.recv_from(chunk)?;
+        // SAFETY: `recv` has written to the first `recvd` bytes of `buf`
+        unsafe {
+            buf.advance_mut(recvd);
+        }
+        Ok((recvd, from))
     }
 }

--- a/zpr-ext/src/std/net.rs
+++ b/zpr-ext/src/std/net.rs
@@ -1,0 +1,61 @@
+use std::io;
+use std::net::UdpSocket;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use nix::sys::socket;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::os::fd::AsRawFd;
+
+pub trait UdpSocketExt {
+    fn mtu(&self) -> io::Result<u32>;
+    #[cfg(any(doc, target_os = "android", target_os = "linux"))]
+    fn attach_reuse_port_cbpf(&self, filter: &[libc::sock_filter]) -> io::Result<()>;
+}
+
+impl UdpSocketExt for UdpSocket {
+    /// Retrieve the socket's current known path MTU.
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    fn mtu(&self) -> io::Result<u32> {
+        match socket::getsockopt(self, socket::sockopt::IpMtu) {
+            Ok(mtu) => Ok(mtu as u32),
+            Err(errno) => Err(io::Error::from(errno)),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn mtu(&self) -> io::Result<u32> {
+        // TODO:
+        // For mac I need to get the interface name and then call
+        // an ioctl to get MTU.
+        return Ok(1400);
+    }
+
+    #[cfg(any(doc, target_os = "android", target_os = "linux"))]
+    fn attach_reuse_port_cbpf(&self, filter: &[libc::sock_filter]) -> io::Result<()> {
+        let fprog = libc::sock_fprog {
+            len: filter.len() as u16,
+            filter: filter.as_ptr().cast_mut(),
+        };
+
+        let fprog_ptr = (&fprog as *const libc::sock_fprog).cast();
+        let fprog_size = std::mem::size_of_val(&fprog) as libc::socklen_t;
+
+        // SAFETY: `fprog_ptr` and `fprog_size` are of the appropriate type for SOL_SOCKET:SO_ATTACH_REUSEPORT_CBPF
+        let res = unsafe {
+            libc::setsockopt(
+                self.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_ATTACH_REUSEPORT_CBPF,
+                fprog_ptr,
+                fprog_size,
+            )
+        };
+
+        if res < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
This has the issue that we are sharing a socket between datapath and mgmt, which causes lots of CPU usage by Tokio since it keeps thinking the socket is "ready"… (for nothing Tokio actually needs it for!).  A forthcoming change will address this.

We also switch to std UDP sockets for substrate egress.  For now, this means mgmt egress is now non-blocking, when we'd prefer it to block if the queue is full.  Will address that in a forthcoming patch.