### PR TITLE
compiler parses periods and other improvements

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -193,6 +193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +918,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "colored",
  "hex",
  "nix",
  "openssl",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 base64 = "0.22.1"
 chrono = "0.4.39"
 clap = { version = "4.5.23", features = ["derive"] }
+colored = "3.0.0"
 hex = "0.4.3"
 nix = { version = "0.29.0", features = ["hostname"] }
 openssl = "0.10.68"

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,19 +1,19 @@
 # ZPL Compiler
 
-Can compile simple (new) ZPL into binary policies that the prototype visa service 
+Can compile simple (new) ZPL into binary policies that the prototype visa service
 can process.
 
 ## Example usage
 
 ```bash
-./zpc -k path/to/rsa-key.pem path/to/policy.zpl 
+./zpc -k path/to/rsa-key.pem path/to/policy.zpl
 ```
 
 - That RSA key in the invocation is used to sign the binary policy so
   must match the one that the visa service is configured with.
 - By default the _configuration_ for the ZPL policy will be found in a
   file with the same name as the ZPL file but with the `zplc` extension.
-  If you want to loca configuration from somewhre else, use 
+  If you want to loca configuration from somewhre else, use
   `-c path/to/config.zplc` argument.
 - Help is available via `zpc -h`
 
@@ -25,13 +25,13 @@ Note that this is just enough grammer to meet current compiler needs.
 
 
 
-
-
 ```
 
 ignored-tokens  : 'a', 'an'
 
-statement       : ( allow-statement | define-statement ) + '\n'
+statement       : ( allow-statement | define-statement ) + <eos>
+
+eos             : EOF | '\n' | '.'
 
 allow-statement : 'allow' + <device-clause> + 'with' + <user-clause> + 'to access' + <service-clause>
 
@@ -50,7 +50,7 @@ attr-list       : attribute | attribute + and + attribute...
 
 attr-name-list  : attr-name-expr  [ + and + attr-name-expr ]... [ + 'from' source-name]
 
-atrr-name-expr  : attr-name 
+atrr-name-expr  : attr-name
                   | tuple
                   | 'optional' + ( attr-name | ( 'tags' | 'tag' ) + attr-name-list )
                   | 'multiple' + attr-name
@@ -60,11 +60,11 @@ attribute       : tuple | attr-name
 
 tuple           : attr-name + ':' + attr-value
 
-attr-name       : string | ns-name + '.' + name
+attr-name       : string | name
 
 attr-value      : string | integer
 
-ns-name         : string | ns-name + '.' + string
+name            : string | [ <name> + '.' + <name> ]
 
 class-name      : string
 class-name-syn  : string

--- a/compiler/src/allow.rs
+++ b/compiler/src/allow.rs
@@ -104,7 +104,7 @@ pub fn parse_allow(
                             parse_state.device_clause = Some(dc);
                         }
                         _ => {
-                            return Err(CompilationError::ParseError(
+                            return Err(CompilationError::AllowStmtParseError(
                                 format!("not a user or device clause: '{}'", cn),
                                 parse_state.root_tok.line,
                                 parse_state.root_tok.col,
@@ -120,7 +120,7 @@ pub fn parse_allow(
                         let dc = ps.to_clause("device")?;
                         parse_state.device_clause = Some(dc);
                     } else {
-                        return Err(CompilationError::ParseError(
+                        return Err(CompilationError::AllowStmtParseError(
                             format!("not a device clause: '{}'", cn),
                             parse_state.root_tok.line,
                             parse_state.root_tok.col,
@@ -130,7 +130,7 @@ pub fn parse_allow(
 
                 // Hmm what's this?
                 _ => {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::AllowStmtParseError(
                         format!("expected a TO or WITH, found '{:?}'", tok.tt),
                         parse_state.root_tok.line,
                         parse_state.root_tok.col,
@@ -140,7 +140,7 @@ pub fn parse_allow(
         }
         None => {
             // end of tokens!
-            return Err(CompilationError::ParseError(
+            return Err(CompilationError::AllowStmtParseError(
                 "expected a TO or WITH not EOF".to_string(),
                 parse_state.root_tok.line,
                 parse_state.root_tok.col,
@@ -165,7 +165,7 @@ pub fn parse_allow(
                 classes_map,
             )? {
                 // Hmm, a non error failure?
-                return Err(CompilationError::ParseError(
+                return Err(CompilationError::AllowStmtParseError(
                     "expected a user clause to follow WITH".to_string(),
                     tok.line,
                     tok.col,
@@ -205,7 +205,7 @@ fn validate_clause(
     classes_map: &HashMap<String, Class>,
 ) -> Result<(), CompilationError> {
     if ac.user.with_attr_count(classes_map) + ac.device.with_attr_count(classes_map) == 0 {
-        return Err(CompilationError::ParseError(
+        return Err(CompilationError::AllowStmtParseError(
             "user and/or device must specify at least one discriminating attribute".to_string(),
             ac.user.class_tok.line,
             ac.user.class_tok.col,
@@ -276,7 +276,7 @@ where
 
     let cn = ps.class_name.as_ref().unwrap();
     if classes_map.get(cn).unwrap().flavor != ClassFlavor::Service {
-        return Err(CompilationError::ParseError(
+        return Err(CompilationError::AllowStmtParseError(
             format!("not a service class: '{}'", cn),
             pa_state.root_tok.line,
             pa_state.root_tok.col,
@@ -342,7 +342,7 @@ impl PState {
 
     fn to_clause(&self, kind: &str) -> Result<Clause, CompilationError> {
         if self.class_name.is_none() {
-            return Err(CompilationError::ParseError(
+            return Err(CompilationError::AllowStmtParseError(
                 format!("expected a class name in a {} clause", kind),
                 self.root_tok.line,
                 self.root_tok.col,
@@ -389,8 +389,8 @@ impl PState {
                 TokenType::Literal(s) => {
                     // This could be a class name or a tag name.
                     if let Some(class) = classes.get(s) {
-                        // We already have a class name.
                         if self.class_name.is_some() {
+                            // We already have a class name.
                             let tok = tokens.next().unwrap();
                             return Err(CompilationError::MultipleClassNames(
                                 format!("found class '{class}' but class already set: {context}"),
@@ -410,7 +410,7 @@ impl PState {
                     // We used to support a postfix form of attributes but no longer.
                     // If we see this we report an error to help people covert old ZPL.
                     let tok = tokens.next().unwrap();
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::AllowStmtParseError(
                         format!(
                             "postfix attribute form using WITH no longer supported: {}",
                             context
@@ -430,7 +430,7 @@ impl PState {
             };
         }
         if tcount == 0 {
-            return Err(CompilationError::ParseError(
+            return Err(CompilationError::AllowStmtParseError(
                 format!("{} is empty", context),
                 self.root_tok.line,
                 self.root_tok.col,
@@ -438,7 +438,7 @@ impl PState {
         }
 
         if self.class_name.is_none() {
-            return Err(CompilationError::ParseError(
+            return Err(CompilationError::AllowStmtParseError(
                 format!("expected a class name in {}", context),
                 self.root_tok.line,
                 self.root_tok.col,

--- a/compiler/src/compilation.rs
+++ b/compiler/src/compilation.rs
@@ -6,6 +6,7 @@ use openssl::rsa::Rsa;
 use prost::Message;
 
 use crate::config_api::ConfigApi;
+use crate::context::CompilationCtx;
 use crate::crypto::{sha256_of_file, sign_pkcs1v15_sha256};
 use crate::errors::CompilationError;
 use crate::lex::tokenize;
@@ -20,6 +21,7 @@ pub const CONTAINER_VERSION: u32 = 1121;
 /// Create one of these with the [CompilationBuilder].
 pub struct Compilation {
     pub verbose: bool,
+    werror: bool,
     pub source_zpl: PathBuf,
     pub source_config: PathBuf,
     pub output_file: PathBuf,
@@ -35,41 +37,42 @@ impl Compilation {
     }
 
     /// Create a policy from the ZPL source and configuration.
-    pub fn compile(&self) -> Result<(), CompilationError> {
+    pub fn compile(&mut self) -> Result<(), CompilationError> {
+        let cctx = CompilationCtx::new(self.verbose, self.werror);
         if self.verbose {
             println!(
                 "compiling {:?} with config {:?}",
                 self.source_zpl, self.source_config
             );
         }
-        let cfg =
-            ConfigApi::new_from_toml_file(&self.source_config, self.verbose).map_err(|e| {
-                CompilationError::ConfigError(format!(
-                    "failed to load configuration from {:?}: {}",
-                    self.source_config, e
-                ))
-            })?;
+        let cfg = ConfigApi::new_from_toml_file(&self.source_config, &cctx).map_err(|e| {
+            CompilationError::ConfigError(format!(
+                "failed to load configuration from {:?}: {}",
+                self.source_config, e
+            ))
+        })?;
 
-        let tokens = tokenize(&self.source_zpl)?;
+        let tz = tokenize(&self.source_zpl, &cctx)?;
         if self.verbose {
-            println!("parsed {} tokens:", tokens.len());
-            for t in &tokens {
+            println!("parsed {} tokens:", tz.tokens.len());
+            for t in &tz.tokens {
                 println!("   {:?}", t);
             }
             println!();
         }
 
-        let mut policy = parse(tokens, self.verbose)?;
+        let pr = parse(tz.tokens, &cctx)?;
+        let mut policy = pr.policy;
         let policy_digest = sha256_of_file(&self.source_zpl)?;
         policy.digest = Some(policy_digest);
 
-        let fabric = weave(&self, &cfg, &policy)?;
+        let fabric = weave(&self, &cfg, &policy, &cctx)?;
         if self.verbose {
             println!();
             println!("fabric production:\n{}", fabric);
         }
 
-        println!("ℤ parse successful");
+        cctx.info("parse successful");
         if self.parse_only {
             return Ok(());
         }
@@ -77,14 +80,13 @@ impl Compilation {
         let mut builder = PolicyBuilder::new(self.verbose);
         builder.with_max_visa_lifetime(Duration::from_secs(60 * 60 * 12)); // 12 hours (TODO: Should come from config)
 
-        builder.with_fabric(&fabric)?;
+        builder.with_fabric(&fabric, &cctx)?;
 
         let pol = builder.build()?;
-        println!("ℤ build successful");
+        cctx.info("build successful");
 
-        let pcontainer = self.contain_policy(&pol)?;
-        self.write_container(&pcontainer, &self.output_file)?;
-
+        let pcontainer = self.contain_policy(&pol, &cctx)?;
+        self.write_container(&pcontainer, &self.output_file, &cctx)?;
         Ok(())
     }
 
@@ -93,6 +95,7 @@ impl Compilation {
         &self,
         container: &polio::PolicyContainer,
         file: &Path,
+        ctx: &CompilationCtx,
     ) -> Result<(), CompilationError> {
         let mut buf = Vec::new();
         buf.reserve(container.encoded_len());
@@ -105,14 +108,15 @@ impl Compilation {
                 file, e
             ))
         })?;
-        println!("ℤ wrote {}", &file.display());
+        ctx.info(&format!("wrote {}", &file.display()));
         Ok(())
     }
 
     /// Create the container struct and optionally sign the policy with the private key.
     fn contain_policy(
-        &self,
+        &mut self,
         pol: &polio::Policy,
+        ctx: &CompilationCtx,
     ) -> Result<polio::PolicyContainer, CompilationError> {
         let mut buf = Vec::new();
         buf.reserve(pol.encoded_len());
@@ -127,7 +131,9 @@ impl Compilation {
                 signature = sign_pkcs1v15_sha256(key, &buf)?;
             }
             None => {
-                println!("warning: policy not signed, use `--key <pemfile>` to specify a private key for signing");
+                ctx.warn(
+                    "policy not signed, use `--key <pemfile>` to specify a private key for signing",
+                )?;
                 signature = Vec::new();
             }
         }
@@ -153,6 +159,7 @@ pub struct CompilationBuilder {
     source_zpl: PathBuf,
     source_config: Option<PathBuf>,
     verbose: bool,
+    werror: bool,
     private_key: Option<Rsa<Private>>,
     parse_only: bool,
     output_directory: Option<PathBuf>,
@@ -172,6 +179,12 @@ impl CompilationBuilder {
     /// Enable verbose console output from the compilation process.
     pub fn verbose(mut self, verbose: bool) -> Self {
         self.verbose = verbose;
+        self
+    }
+
+    /// If set true, treat warnings as errors and halt compilation when they occur.
+    pub fn werror(mut self, werror: bool) -> Self {
+        self.werror = werror;
         self
     }
 
@@ -238,6 +251,7 @@ impl CompilationBuilder {
 
         Compilation {
             verbose: self.verbose,
+            werror: self.werror,
             source_zpl: self.source_zpl,
             source_config: config,
             output_file,
@@ -319,7 +333,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, BASIC_CONFIG).expect("failed to write config file");
 
-        let compilation = Compilation::builder(zpl_file)
+        let mut compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();
@@ -347,7 +361,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, BASIC_CONFIG).expect("failed to write config file");
 
-        let compilation = Compilation::builder(zpl_file)
+        let mut compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();
@@ -400,7 +414,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, zplc).expect("failed to write config file");
 
-        let compilation = Compilation::builder(zpl_file)
+        let mut compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();
@@ -427,7 +441,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, BASIC_CONFIG).expect("failed to write config file");
 
-        let compilation = Compilation::builder(zpl_file)
+        let mut compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();
@@ -456,7 +470,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, BASIC_CONFIG).expect("failed to write config file");
 
-        let compilation = Compilation::builder(zpl_file)
+        let mut compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();
@@ -485,7 +499,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, BASIC_CONFIG).expect("failed to write config file");
 
-        let compilation = Compilation::builder(zpl_file)
+        let mut compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();

--- a/compiler/src/compilation.rs
+++ b/compiler/src/compilation.rs
@@ -37,7 +37,7 @@ impl Compilation {
     }
 
     /// Create a policy from the ZPL source and configuration.
-    pub fn compile(&mut self) -> Result<(), CompilationError> {
+    pub fn compile(&self) -> Result<(), CompilationError> {
         let cctx = CompilationCtx::new(self.verbose, self.werror);
         if self.verbose {
             println!(
@@ -114,7 +114,7 @@ impl Compilation {
 
     /// Create the container struct and optionally sign the policy with the private key.
     fn contain_policy(
-        &mut self,
+        &self,
         pol: &polio::Policy,
         ctx: &CompilationCtx,
     ) -> Result<polio::PolicyContainer, CompilationError> {
@@ -333,7 +333,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, BASIC_CONFIG).expect("failed to write config file");
 
-        let mut compilation = Compilation::builder(zpl_file)
+        let compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();
@@ -361,7 +361,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, BASIC_CONFIG).expect("failed to write config file");
 
-        let mut compilation = Compilation::builder(zpl_file)
+        let compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();
@@ -414,7 +414,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, zplc).expect("failed to write config file");
 
-        let mut compilation = Compilation::builder(zpl_file)
+        let compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();
@@ -441,7 +441,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, BASIC_CONFIG).expect("failed to write config file");
 
-        let mut compilation = Compilation::builder(zpl_file)
+        let compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();
@@ -470,7 +470,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, BASIC_CONFIG).expect("failed to write config file");
 
-        let mut compilation = Compilation::builder(zpl_file)
+        let compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();
@@ -499,7 +499,7 @@ mod test {
         let cfg_file = tempdir.path.join("test.zplc");
         std::fs::write(&cfg_file, BASIC_CONFIG).expect("failed to write config file");
 
-        let mut compilation = Compilation::builder(zpl_file)
+        let compilation = Compilation::builder(zpl_file)
             .config(&cfg_file)
             .verbose(true)
             .build();

--- a/compiler/src/config.rs
+++ b/compiler/src/config.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use ring::digest::Digest;
 use toml::Table;
 
+use crate::context::CompilationCtx;
 use crate::crypto::sha256;
 use crate::errors::CompilationError;
 use crate::protocols::{self, IanaProtocol, IcmpFlowType, Protocol};
@@ -38,6 +39,12 @@ pub struct Config {
     pub trusted_services: Vec<TrustedService>,
     pub protocols: HashMap<String, Protocol>,
     pub services: Vec<Service>,
+}
+
+/// ConfigParse holds state during a parse of the config toml.
+struct ConfigParse {
+    digest: Digest,
+    ctoml: Table,
 }
 
 /// Service table
@@ -119,107 +126,231 @@ impl Config {
 }
 
 /// Parse and do some (light) error checking on the ZPL TOML configuration.
-pub fn load_config(path: &Path) -> Result<Config, CompilationError> {
+pub fn load_config(path: &Path, ctx: &CompilationCtx) -> Result<Config, CompilationError> {
     let cstr = std::fs::read_to_string(path).map_err(|e| CompilationError::Io(e))?;
-    parse_config(&cstr)
+    parse_config(&cstr, ctx)
 }
 
 /// Parse config from the toml string `cstr`.
-pub fn parse_config(cstr: &str) -> Result<Config, CompilationError> {
-    let digest = sha256(&cstr);
-
-    let ctoml = cstr
-        .parse::<Table>()
-        .map_err(|e| CompilationError::TomlError(e))?;
-
-    let config = Config {
-        digest,
-        resolver: parse_resolver(&ctoml)?,
-        nodes: parse_nodes(&ctoml)?,
-        visa_service: parse_visa_service(&ctoml)?,
-        trusted_services: parse_trusted_services(&ctoml)?,
-        protocols: parse_protocols(&ctoml)?,
-        services: parse_services(&ctoml)?,
-    };
-    Ok(config)
+pub fn parse_config(cstr: &str, ctx: &CompilationCtx) -> Result<Config, CompilationError> {
+    let mut parser = ConfigParse::new_from_toml_str(cstr)?;
+    parser.parse(ctx)
 }
 
-/// Parse the resolver section which is optional.  The defualt is just
-/// to have an `resolver.order` set to [hosts, dns].  The hosts section is optional, but
-/// if present is mapping of hostnames to IP addresses.
-fn parse_resolver(ctoml: &Table) -> Result<Resolver, CompilationError> {
-    if !ctoml.contains_key("resolver") {
-        return Ok(Resolver::default());
-    }
-    let r = ctoml["resolver"]
-        .as_table()
-        .ok_or(err_config!("error reading resolver section"))?;
-    let mut order_vec = Vec::new();
-    if !r.contains_key("order") {
-        // Default order is hosts, dns
-        order_vec.push("hosts".to_string());
-        order_vec.push("dns".to_string());
-    } else {
-        let order = r["order"]
-            .as_array()
-            .ok_or(err_config!("resolver.order must be an array"))?;
-        for o in order {
-            order_vec.push(
-                o.as_str()
-                    .ok_or(err_config!("problem with order array"))?
-                    .to_string(),
-            );
-        }
+impl ConfigParse {
+    fn new_from_toml_str(cstr: &str) -> Result<ConfigParse, CompilationError> {
+        let digest = sha256(&cstr);
+
+        let ctoml = cstr
+            .parse::<Table>()
+            .map_err(|e| CompilationError::TomlError(e))?;
+
+        Ok(ConfigParse { digest, ctoml })
     }
 
-    let hosts = if r.contains_key("hosts") {
-        match r["hosts"].as_table() {
-            Some(h) => {
-                let mut hosts_map = HashMap::new();
-                for (k, v) in h {
-                    hosts_map.insert(
-                        k.to_string(),
-                        v.as_str()
-                            .ok_or(CompilationError::ConfigError(format!(
-                                "invalid hosts entry {}",
-                                k
-                            )))?
-                            .to_string(),
-                    );
-                }
-                Some(hosts_map)
+    fn parse(&mut self, ctx: &CompilationCtx) -> Result<Config, CompilationError> {
+        let resolver = self.parse_resolver()?;
+        let nodes = self.parse_nodes()?;
+        let visa_service = self.parse_visa_service(ctx)?;
+        let trusted_services = self.parse_trusted_services(ctx)?;
+        let protocols = self.parse_protocols(ctx)?;
+        let services = self.parse_services(ctx)?;
+
+        Ok(Config {
+            digest: self.digest,
+            resolver,
+            nodes,
+            visa_service,
+            trusted_services,
+            protocols,
+            services,
+        })
+    }
+
+    /// Parse the resolver section which is optional.  The defualt is just
+    /// to have an `resolver.order` set to [hosts, dns].  The hosts section is optional, but
+    /// if present is mapping of hostnames to IP addresses.
+    fn parse_resolver(&self) -> Result<Resolver, CompilationError> {
+        if !self.ctoml.contains_key("resolver") {
+            return Ok(Resolver::default());
+        }
+        let r = self.ctoml["resolver"]
+            .as_table()
+            .ok_or(err_config!("error reading resolver section"))?;
+        let mut order_vec = Vec::new();
+        if !r.contains_key("order") {
+            // Default order is hosts, dns
+            order_vec.push("hosts".to_string());
+            order_vec.push("dns".to_string());
+        } else {
+            let order = r["order"]
+                .as_array()
+                .ok_or(err_config!("resolver.order must be an array"))?;
+            for o in order {
+                order_vec.push(
+                    o.as_str()
+                        .ok_or(err_config!("problem with order array"))?
+                        .to_string(),
+                );
             }
-            None => None,
         }
-    } else {
-        None
-    };
 
-    Ok(Resolver {
-        order: order_vec,
-        hosts: hosts,
-    })
-}
+        let hosts = if r.contains_key("hosts") {
+            match r["hosts"].as_table() {
+                Some(h) => {
+                    let mut hosts_map = HashMap::new();
+                    for (k, v) in h {
+                        hosts_map.insert(
+                            k.to_string(),
+                            v.as_str()
+                                .ok_or(CompilationError::ConfigError(format!(
+                                    "invalid hosts entry {}",
+                                    k
+                                )))?
+                                .to_string(),
+                        );
+                    }
+                    Some(hosts_map)
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
 
-/// Parse all the nodes.<ID> sections. There must be at least one.
-fn parse_nodes(ctoml: &Table) -> Result<HashMap<String, Node>, CompilationError> {
-    if !ctoml.contains_key("nodes") {
-        return Err(err_config!("missing section: nodes"));
+        Ok(Resolver {
+            order: order_vec,
+            hosts: hosts,
+        })
     }
-    let nodes = ctoml["nodes"]
-        .as_table()
-        .ok_or(err_config!("error reading nodes section"))?;
-    // Within "nodes" each KEY is a node ID that is a table.
-    let mut node_map = HashMap::new();
-    for (node_id, v) in nodes {
-        let n = parse_node(
-            node_id,
-            v.as_table()
-                .ok_or(err_config!("node {} is not a table", node_id))?,
-        )?;
-        node_map.insert(node_id.to_string(), n);
+
+    /// Parse all the nodes.<ID> sections. There must be at least one.
+    fn parse_nodes(&self) -> Result<HashMap<String, Node>, CompilationError> {
+        if !self.ctoml.contains_key("nodes") {
+            return Err(err_config!("missing section: nodes"));
+        }
+        let nodes = self.ctoml["nodes"]
+            .as_table()
+            .ok_or(err_config!("error reading nodes section"))?;
+        // Within "nodes" each KEY is a node ID that is a table.
+        let mut node_map = HashMap::new();
+        for (node_id, v) in nodes {
+            let n = parse_node(
+                node_id,
+                v.as_table()
+                    .ok_or(err_config!("node {} is not a table", node_id))?,
+            )?;
+            node_map.insert(node_id.to_string(), n);
+        }
+        Ok(node_map)
     }
-    Ok(node_map)
+
+    /// Parse the very basic visa_service section.
+    fn parse_visa_service(
+        &mut self,
+        ctx: &CompilationCtx,
+    ) -> Result<VisaService, CompilationError> {
+        if !self.ctoml.contains_key("visa_service") {
+            return Err(err_config!("missing section: visa_service"));
+        }
+        let vs = self.ctoml["visa_service"]
+            .as_table()
+            .ok_or(err_config!("error reading visa_service section"))?;
+        if !vs.contains_key("dock_node") {
+            return Err(err_config!("visa_service missing dock_node"));
+        }
+        let dock_node_id = vs["dock_node"]
+            .as_str()
+            .ok_or(err_config!("visa_service missing dock_node"))?
+            .to_string();
+
+        let admin_attrs = if vs.contains_key("admin_attrs") {
+            let tuples = vs["admin_attrs"]
+                .as_array()
+                .ok_or(err_config!("visa_service missing admin_attrs list"))?;
+            tuples_to_tuple_str_vec("visa_service", tuples)?
+        } else {
+            ctx.warn("visa service has no admin_attrs")?;
+            Vec::new()
+        };
+        Ok(VisaService {
+            dock_node_id,
+            admin_attrs,
+        })
+    }
+
+    /// Parse the trusted_services.<ID> tables.  Currently I am reserving the ID of "default" for the
+    /// sort of built-in certificate authority based authentication mechanism.
+    fn parse_trusted_services(
+        &mut self,
+        ctx: &CompilationCtx,
+    ) -> Result<Vec<TrustedService>, CompilationError> {
+        if !self.ctoml.contains_key("trusted_services") {
+            ctx.warn("no trusted services in configuration")?;
+            return Ok(Vec::new());
+        }
+        let ts = self.ctoml["trusted_services"]
+            .as_table()
+            .ok_or(err_config!("error reading trusted_services section"))?;
+        let mut trusted_services = Vec::new();
+        for (ts_id, v) in ts {
+            let ts = parse_trusted_service(
+                ts_id,
+                v.as_table()
+                    .ok_or(err_config!("trusted_service {} is not a table", ts_id))?,
+            )?;
+            trusted_services.push(ts);
+        }
+        Ok(trusted_services)
+    }
+
+    /// Parse the protocols.<ID> tables.
+    fn parse_protocols(
+        &mut self,
+        ctx: &CompilationCtx,
+    ) -> Result<HashMap<String, Protocol>, CompilationError> {
+        if !self.ctoml.contains_key("protocols") {
+            ctx.warn("no protocols in configuration")?;
+            return Ok(HashMap::new());
+        }
+        let prots = self.ctoml["protocols"]
+            .as_table()
+            .ok_or(err_config!("error reading protocols section"))?;
+        let mut protocols = HashMap::new();
+        for (prot_id, v) in prots {
+            if protocols.contains_key(prot_id) {
+                return Err(err_config!("duplicate protocol id: {}", prot_id));
+            }
+            let prot = parse_protocol(
+                prot_id,
+                v.as_table()
+                    .ok_or(err_config!("protocol {} is not a table", prot_id))?,
+            )?;
+            protocols.insert(prot_id.to_string(), prot);
+        }
+        Ok(protocols)
+    }
+
+    /// Parse the services.<ID> tables
+    fn parse_services(&mut self, ctx: &CompilationCtx) -> Result<Vec<Service>, CompilationError> {
+        if !self.ctoml.contains_key("services") {
+            ctx.warn("no services in configuration")?;
+            return Ok(Vec::new());
+        }
+        let services = self.ctoml["services"]
+            .as_table()
+            .ok_or(err_config!("error reading services section"))?;
+        let mut ret = Vec::new();
+        for (sid, v) in services {
+            let s = parse_service(
+                sid,
+                v.as_table()
+                    .ok_or(err_config!("service {} is not a table", sid))?,
+            )?;
+            ret.push(s);
+        }
+        Ok(ret)
+    }
 }
 
 fn require_key(ctx: &str, table: &Table, key: &str) -> Result<(), CompilationError> {
@@ -346,37 +477,6 @@ fn parse_interface(ifname: &str, iface: &Table) -> Result<Interface, Compilation
     }
 }
 
-/// Parse the very basic visa_service section.
-fn parse_visa_service(ctoml: &Table) -> Result<VisaService, CompilationError> {
-    if !ctoml.contains_key("visa_service") {
-        return Err(err_config!("missing section: visa_service"));
-    }
-    let vs = ctoml["visa_service"]
-        .as_table()
-        .ok_or(err_config!("error reading visa_service section"))?;
-    if !vs.contains_key("dock_node") {
-        return Err(err_config!("visa_service missing dock_node"));
-    }
-    let dock_node_id = vs["dock_node"]
-        .as_str()
-        .ok_or(err_config!("visa_service missing dock_node"))?
-        .to_string();
-
-    let admin_attrs = if vs.contains_key("admin_attrs") {
-        let tuples = vs["admin_attrs"]
-            .as_array()
-            .ok_or(err_config!("visa_service missing admin_attrs list"))?;
-        tuples_to_tuple_str_vec("visa_service", tuples)?
-    } else {
-        println!("warning: visa service has no admin_attrs");
-        Vec::new()
-    };
-    Ok(VisaService {
-        dock_node_id,
-        admin_attrs,
-    })
-}
-
 fn tuples_to_tuple_str_vec(
     ctx: &str,
     tuples: &Vec<toml::Value>,
@@ -404,28 +504,6 @@ fn tuples_to_tuple_str_vec(
         svec.push((p0, p1));
     }
     Ok(svec)
-}
-
-/// Parse the trusted_services.<ID> tables.  Currently I am reserving the ID of "default" for the
-/// sort of built-in certificate authority based authentication mechanism.
-fn parse_trusted_services(ctoml: &Table) -> Result<Vec<TrustedService>, CompilationError> {
-    if !ctoml.contains_key("trusted_services") {
-        println!("warning: no trusted services in configuration");
-        return Ok(Vec::new());
-    }
-    let ts = ctoml["trusted_services"]
-        .as_table()
-        .ok_or(err_config!("error reading trusted_services section"))?;
-    let mut trusted_services = Vec::new();
-    for (ts_id, v) in ts {
-        let ts = parse_trusted_service(
-            ts_id,
-            v.as_table()
-                .ok_or(err_config!("trusted_service {} is not a table", ts_id))?,
-        )?;
-        trusted_services.push(ts);
-    }
-    Ok(trusted_services)
 }
 
 // Parse an individual trusted_service table.
@@ -547,30 +625,6 @@ fn parse_string_array(ts: &Table, key: &str, ctx: &str) -> Result<Vec<String>, C
     Ok(ret)
 }
 
-/// Parse the protocols.<ID> tables.
-fn parse_protocols(ctoml: &Table) -> Result<HashMap<String, Protocol>, CompilationError> {
-    if !ctoml.contains_key("protocols") {
-        println!("warning: no protocols in configuration");
-        return Ok(HashMap::new());
-    }
-    let prots = ctoml["protocols"]
-        .as_table()
-        .ok_or(err_config!("error reading protocols section"))?;
-    let mut protocols = HashMap::new();
-    for (prot_id, v) in prots {
-        if protocols.contains_key(prot_id) {
-            return Err(err_config!("duplicate protocol id: {}", prot_id));
-        }
-        let prot = parse_protocol(
-            prot_id,
-            v.as_table()
-                .ok_or(err_config!("protocol {} is not a table", prot_id))?,
-        )?;
-        protocols.insert(prot_id.to_string(), prot);
-    }
-    Ok(protocols)
-}
-
 /// Parse an individual protocol table.
 fn parse_protocol(prot_id: &str, prot: &Table) -> Result<Protocol, CompilationError> {
     let protocol_name = prot["protocol"]
@@ -645,27 +699,6 @@ fn parse_protocol(prot_id: &str, prot: &Table) -> Result<Protocol, CompilationEr
         port,
         icmp,
     })
-}
-
-/// Parse the services.<ID> tables
-fn parse_services(ctoml: &Table) -> Result<Vec<Service>, CompilationError> {
-    if !ctoml.contains_key("services") {
-        println!("warning: no services in configuration");
-        return Ok(Vec::new());
-    }
-    let services = ctoml["services"]
-        .as_table()
-        .ok_or(err_config!("error reading services section"))?;
-    let mut ret = Vec::new();
-    for (sid, v) in services {
-        let s = parse_service(
-            sid,
-            v.as_table()
-                .ok_or(err_config!("service {} is not a table", sid))?,
-        )?;
-        ret.push(s);
-    }
-    Ok(ret)
 }
 
 /// Parse the very bare bones individual service table.
@@ -760,19 +793,13 @@ fn toml_as_u8(v: &toml::Value) -> Option<u8> {
 mod test {
     use super::*;
 
-    fn parse_toml(tstr: &str) -> toml::map::Map<String, toml::Value> {
-        tstr.parse::<Table>()
-            .map_err(|e| CompilationError::TomlError(e))
-            .unwrap()
-    }
-
     #[test]
     fn test_parse_resolver_empty() {
         let tstr = r#"
         [resolver]
         "#;
-        let ctoml = parse_toml(tstr);
-        let r = parse_resolver(&ctoml);
+        let cparser = ConfigParse::new_from_toml_str(tstr).unwrap();
+        let r = cparser.parse_resolver();
         assert!(r.is_ok());
         let r = r.unwrap();
         assert_eq!(r.order.len(), 2);
@@ -790,8 +817,8 @@ mod test {
         "n0" = "1.2.3.4"
         "n1.foo" = "5.6.7.8"
         "#;
-        let ctoml = parse_toml(tstr);
-        let r = parse_resolver(&ctoml);
+        let cparser = ConfigParse::new_from_toml_str(tstr).unwrap();
+        let r = cparser.parse_resolver();
         assert!(r.is_ok());
         let r = r.unwrap();
         assert_eq!(r.order.len(), 3);
@@ -817,8 +844,8 @@ mod test {
         eth0.netaddr = "1.2.3.4:2000"
         eth1.netaddr = "foo.addr:9000"
         "#;
-        let ctoml = parse_toml(tstr);
-        let nodes = parse_nodes(&ctoml);
+        let cparser = ConfigParse::new_from_toml_str(tstr).unwrap();
+        let nodes = cparser.parse_nodes();
         assert!(nodes.is_ok(), "{:?}", nodes);
         let nodes = nodes.unwrap();
         assert_eq!(nodes.len(), 1);
@@ -853,8 +880,9 @@ mod test {
         [visa_service]
         dock_node = "n0"
         "#;
-        let ctoml = parse_toml(tstr);
-        let vs = parse_visa_service(&ctoml);
+        let mut cparser = ConfigParse::new_from_toml_str(tstr).unwrap();
+        let ctx = CompilationCtx::default();
+        let vs = cparser.parse_visa_service(&ctx);
         assert!(vs.is_ok());
         let vs = vs.unwrap();
         assert_eq!(vs.dock_node_id, "n0");
@@ -867,8 +895,9 @@ mod test {
         dock_node = "n0"
         admin_attrs = [["cn", "foo"], ["bar", "baz"]]
         "#;
-        let ctoml = parse_toml(tstr);
-        let vs = parse_visa_service(&ctoml);
+        let mut cparser = ConfigParse::new_from_toml_str(tstr).unwrap();
+        let ctx = CompilationCtx::default();
+        let vs = cparser.parse_visa_service(&ctx);
         assert!(vs.is_ok());
         let vs = vs.unwrap();
         assert_eq!(vs.dock_node_id, "n0");
@@ -887,8 +916,9 @@ mod test {
         [trusted_services.default]
         cert_path = "foo.pem"
         "#;
-        let ctoml = parse_toml(tstr);
-        let services = parse_trusted_services(&ctoml);
+        let mut cparser = ConfigParse::new_from_toml_str(tstr).unwrap();
+        let ctx = CompilationCtx::default();
+        let services = cparser.parse_trusted_services(&ctx);
         assert!(services.is_ok());
         let services = services.unwrap();
         assert_eq!(services.len(), 1);
@@ -913,8 +943,9 @@ mod test {
         returns_attributes = ["a", "c"]
         identity_attributes = ["c"]
         "#;
-        let ctoml = parse_toml(tstr);
-        let services = parse_trusted_services(&ctoml);
+        let mut cparser = ConfigParse::new_from_toml_str(tstr).unwrap();
+        let ctx = CompilationCtx::default();
+        let services = cparser.parse_trusted_services(&ctx);
         assert!(services.is_err());
 
         // and with api succeeds
@@ -926,8 +957,9 @@ mod test {
         returns_attributes = ["a", "c"]
         identity_attributes = ["c"]
         "#;
-        let ctoml = parse_toml(tstr);
-        let services = parse_trusted_services(&ctoml);
+        let mut cparser = ConfigParse::new_from_toml_str(tstr).unwrap();
+        let ctx = CompilationCtx::default();
+        let services = cparser.parse_trusted_services(&ctx);
         assert!(services.is_ok());
         let services = services.unwrap();
         assert_eq!(services.len(), 1);
@@ -962,8 +994,9 @@ mod test {
         icmp_type = "request-response"
         icmp_codes = [128, 129]
         "#;
-        let ctoml = parse_toml(tstr);
-        let prots = parse_protocols(&ctoml);
+        let mut cparser = ConfigParse::new_from_toml_str(tstr).unwrap();
+        let ctx = CompilationCtx::default();
+        let prots = cparser.parse_protocols(&ctx);
         assert!(prots.is_ok());
         let prots = prots.unwrap();
         assert_eq!(prots.len(), 2);
@@ -994,8 +1027,9 @@ mod test {
         protocol = "pong"
         provider = [["foo", "bar"]]
         "#;
-        let ctoml = parse_toml(tstr);
-        let services = parse_services(&ctoml);
+        let mut cparser = ConfigParse::new_from_toml_str(tstr).unwrap();
+        let ctx = CompilationCtx::default();
+        let services = cparser.parse_services(&ctx);
         assert!(services.is_ok());
         let services = services.unwrap();
         assert_eq!(services.len(), 2);

--- a/compiler/src/config_api.rs
+++ b/compiler/src/config_api.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use base64::prelude::*;
 
 use crate::config::{self, Config};
+use crate::context::CompilationCtx;
 use crate::crypto::{digest_as_hex, load_asn1data_from_pem};
 use crate::errors::CompilationError;
 use crate::protocols::{IanaProtocol, IcmpFlowType, Protocol};
@@ -215,12 +216,15 @@ impl From<&ConfigItem> for Protocol {
 
 impl ConfigApi {
     /// Create the api from the TOML configuration file.
-    pub fn new_from_toml_file(fname: &Path, verbose: bool) -> Result<ConfigApi, CompilationError> {
-        let config = config::load_config(fname)?;
+    pub fn new_from_toml_file(
+        fname: &Path,
+        ctx: &CompilationCtx,
+    ) -> Result<ConfigApi, CompilationError> {
+        let config = config::load_config(fname, ctx)?;
         let api = ConfigApi {
             config,
             base_path: fname.to_path_buf().parent().unwrap().to_path_buf(),
-            verbose,
+            verbose: ctx.verbose,
         };
         Ok(api)
     }
@@ -231,13 +235,13 @@ impl ConfigApi {
     pub fn new_from_toml_content(
         content: &str,
         base_path: &Path,
-        verbose: bool,
+        ctx: &CompilationCtx,
     ) -> Result<ConfigApi, CompilationError> {
-        let config = config::parse_config(content)?;
+        let config = config::parse_config(content, ctx)?;
         let api = ConfigApi {
             config,
             base_path: PathBuf::from(base_path),
-            verbose,
+            verbose: ctx.verbose,
         };
         Ok(api)
     }
@@ -647,7 +651,8 @@ mod test {
         [services.foo]
         protocol = "bar"
         "#;
-        let api = ConfigApi::new_from_toml_content(cfg, &Path::new(""), true).unwrap();
+        let ctx = CompilationCtx::default();
+        let api = ConfigApi::new_from_toml_content(cfg, &Path::new(""), &ctx).unwrap();
 
         let ver = api.get("zpr/version").unwrap();
         assert_eq!(ver.to_string().len(), 64);

--- a/compiler/src/context.rs
+++ b/compiler/src/context.rs
@@ -1,0 +1,41 @@
+use colored::Colorize;
+
+use crate::errors::CompilationError;
+
+pub struct CompilationCtx {
+    /// True if user requests verbose output
+    pub verbose: bool,
+
+    /// True if warnings should be promoted to errors
+    werror: bool,
+}
+
+impl CompilationCtx {
+    pub fn new(verbose: bool, werror: bool) -> Self {
+        CompilationCtx { verbose, werror }
+    }
+
+    /// Show an informational message.
+    pub fn info(&self, msg: &str) {
+        println!("{} {}", "ℤ".cyan(), msg);
+    }
+
+    /// Show a warning.  May raise an error if warnings are promoted to errors.
+    pub fn warn(&self, msg: &str) -> Result<(), CompilationError> {
+        println!("{}: {}", "warning".yellow().bold(), msg.bold());
+        if self.werror {
+            Err(CompilationError::Warning(msg.to_string()))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Default for CompilationCtx {
+    fn default() -> Self {
+        CompilationCtx {
+            verbose: true,
+            werror: false,
+        }
+    }
+}

--- a/compiler/src/define.rs
+++ b/compiler/src/define.rs
@@ -94,7 +94,7 @@ pub fn parse_define(define_statement: &[Token]) -> Result<Class, CompilationErro
                 tokens.next();
                 parse_attributes(&mut class, &mut tokens)?;
             } else {
-                return Err(CompilationError::ParseError(
+                return Err(CompilationError::DefineStmtParseError(
                     "expected WITH clause".to_string(),
                     tok.line,
                     tok.col,
@@ -130,14 +130,14 @@ where
         match &tok.tt {
             TokenType::Tags => {
                 if tags {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         "multiple TAGS statements".to_string(),
                         tok.line,
                         tok.col,
                     ));
                 }
                 if tag {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         "TAGS following TAG".to_string(),
                         tok.line,
                         tok.col,
@@ -148,7 +148,7 @@ where
             TokenType::Tag => {
                 // tag is the non-greedy version of tags. Next token is the tag name.
                 if tags {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         "TAG following TAGS".to_string(),
                         tok.line,
                         tok.col,
@@ -158,14 +158,14 @@ where
             }
             TokenType::Optional => {
                 if tags || tag {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         "OPTIONAL not allowed after tag/tags".to_string(),
                         tok.line,
                         tok.col,
                     ));
                 }
                 if optional {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         "multiple OPTIONAL statements".to_string(),
                         tok.line,
                         tok.col,
@@ -175,14 +175,14 @@ where
             }
             TokenType::Multiple => {
                 if tags || tag {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         "MULTIPLE not allowed after tag/tags".to_string(),
                         tok.line,
                         tok.col,
                     ));
                 }
                 if multiple {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         "multiple MULTIPLE statements".to_string(),
                         tok.line,
                         tok.col,
@@ -192,14 +192,14 @@ where
             }
             TokenType::And => {
                 if and {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         "multiple AND statements".to_string(),
                         tok.line,
                         tok.col,
                     ));
                 }
                 if tag {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         "TAG requires a tag name, not AND".to_string(),
                         tok.line,
                         tok.col,
@@ -210,7 +210,7 @@ where
             TokenType::With => {
                 // Only valid after an and.
                 if !and {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         "WITH must follow AND".to_string(),
                         tok.line,
                         tok.col,
@@ -226,7 +226,7 @@ where
             TokenType::Comma => {}
             TokenType::Tuple((name, value)) => {
                 if tags || tag {
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         "attributes not allowed in tag/tags".to_string(),
                         tok.line,
                         tok.col,
@@ -257,7 +257,7 @@ where
                 tag = false; // not greedy
             }
             _ => {
-                return Err(CompilationError::ParseError(
+                return Err(CompilationError::DefineStmtParseError(
                     format!("syntax error ({:?})", tok.tt),
                     tok.line,
                     tok.col,
@@ -290,7 +290,7 @@ pub fn resolve_class_flavors(classes: &mut HashMap<String, Class>) -> Result<(),
                 Some(parent) => parent.flavor.clone(),
                 None => {
                     // This is an error, the parent class does not exist.
-                    return Err(CompilationError::ParseError(
+                    return Err(CompilationError::DefineStmtParseError(
                         format!(
                             "parent class {} of {} does not exist",
                             parentless_ref.parent, name
@@ -314,7 +314,7 @@ pub fn resolve_class_flavors(classes: &mut HashMap<String, Class>) -> Result<(),
                     undefined.push(name.clone());
                 }
             }
-            return Err(CompilationError::ParseError(
+            return Err(CompilationError::DefineStmtParseError(
                 format!("could not resolve classes: {:?}", undefined),
                 0,
                 0,
@@ -323,6 +323,9 @@ pub fn resolve_class_flavors(classes: &mut HashMap<String, Class>) -> Result<(),
     }
     Ok(())
 }
+
+
+
 
 #[cfg(test)]
 mod test {

--- a/compiler/src/define.rs
+++ b/compiler/src/define.rs
@@ -324,19 +324,17 @@ pub fn resolve_class_flavors(classes: &mut HashMap<String, Class>) -> Result<(),
     Ok(())
 }
 
-
-
-
 #[cfg(test)]
 mod test {
 
     use super::*;
-    use crate::lex::tokenize_str;
+    use crate::{context::CompilationCtx, lex::tokenize_str};
 
     #[test]
     fn test_required_tag() {
         let statement = "define marketing-emp as a user with tag full-time";
-        let tokens = tokenize_str(statement).unwrap();
+        let tz = tokenize_str(statement, &CompilationCtx::default()).unwrap();
+        let tokens = tz.tokens;
         let class = parse_define(&tokens).unwrap();
         assert_eq!(class.name, "marketing-emp");
     }
@@ -349,8 +347,10 @@ mod test {
             "define marketing-emp as a user with tags multiple foo",
             "define marketing-emp as a user with tag and foo",
         ];
+        let ctx = CompilationCtx::default();
         for statement in invalids {
-            let tokens = tokenize_str(statement).unwrap();
+            let tz = tokenize_str(statement, &ctx).unwrap();
+            let tokens = tz.tokens;
             match parse_define(&tokens) {
                 Ok(_) => panic!("should have failed on: '{}'", statement),
                 Err(_) => {}

--- a/compiler/src/errors.rs
+++ b/compiler/src/errors.rs
@@ -25,11 +25,23 @@ pub enum CompilationError {
     #[error("unexpected keyword at line {1}, column {2}: {0}")]
     UnexpectedKeyword(String, usize, usize),
 
+    #[error("illegal character for unquoted string literal at line {1}, column {2}: {0}")]
+    IllegalStringLiteralChar(char, usize, usize),
+
+    #[error("illegal character for unquoted name literal at line {1}, column {2}: {0}")]
+    IllegalNameLiteralChar(char, usize, usize),
+
     #[error("redefinition of {0} at line {1}, column {2}")]
     Redefinition(String, usize, usize),
 
     #[error("[ line {1}, column {2} ]  {0}")]
     ParseError(String, usize, usize),
+
+    #[error("[ line {1}, column {2} ]  {0}")]
+    AllowStmtParseError(String, usize, usize),
+
+    #[error("[ line {1}, column {2} ]  {0}")]
+    DefineStmtParseError(String, usize, usize),
 
     #[error("[ line {1}, column {2} ]  syntax error in {0}")]
     SyntaxError(String, usize, usize),

--- a/compiler/src/errors.rs
+++ b/compiler/src/errors.rs
@@ -75,4 +75,7 @@ pub enum CompilationError {
 
     #[error("crypto error: {0}")]
     CryptoError(String),
+
+    #[error("warning: {0}")]
+    Warning(String),
 }

--- a/compiler/src/lex.rs
+++ b/compiler/src/lex.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use crate::context::CompilationCtx;
 use crate::errors::CompilationError;
 use crate::zplstr::{ZPLStr, ZPLStrBuilder};
 
@@ -83,14 +84,19 @@ impl Default for Token {
     }
 }
 
-pub fn tokenize(zpl_in: &Path) -> Result<Vec<Token>, CompilationError> {
+#[derive(Debug)]
+pub struct Tokenization {
+    pub tokens: Vec<Token>,
+}
+
+pub fn tokenize(zpl_in: &Path, ctx: &CompilationCtx) -> Result<Tokenization, CompilationError> {
     let zpl = fs::read_to_string(zpl_in).map_err(|e| {
         CompilationError::FileError(format!("failed to read ZPL file {:?}: {}", zpl_in, e))
     })?;
-    tokenize_str(&zpl)
+    tokenize_str(&zpl, ctx)
 }
 
-pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
+pub fn tokenize_str(zpl: &str, ctx: &CompilationCtx) -> Result<Tokenization, CompilationError> {
     let mut tokens = Vec::new();
     let mut line = 1;
     let mut col = 1;
@@ -179,10 +185,10 @@ pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
             }
             '.' => {
                 let followed_by_whitespace = if let Some(&next) = chars.peek() {
-                        next.is_whitespace()
-                    } else {
-                        true // none (end of input)
-                    };
+                    next.is_whitespace()
+                } else {
+                    true // none (end of input)
+                };
                 if current_word.len() > 0 && quoting {
                     current_word.push(c, quoting, line, col)?;
                 } else if current_word.len() > 0 {
@@ -203,8 +209,10 @@ pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
                         // Special case: if we see that there is another period following this one we warn the user.
                         if let Some(&next) = chars.peek() {
                             if next == '.' {
-                                // TODO: Maybe a way to return warnings instead of emitting them directly?
-                                println!("warning: multiple unquoted periods at line {} col {}", line, col);
+                                ctx.warn(&format!(
+                                    "multiple unquoted periods at line: {}, col: {}",
+                                    line, col,
+                                ))?;
                             }
                         }
                     }
@@ -322,17 +330,19 @@ pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
         }
     }
 
-    Ok(tokens)
+    let tz = Tokenization { tokens };
+    Ok(tz)
 }
-
 
 #[cfg(test)]
 mod test {
+    use crate::context::CompilationCtx;
 
     #[test]
     fn test_tuple_literal() {
         let zpl = "define foo as user with color:purple, `role`:`manager`, office:`fris:co`, and tag `foo bar`";
-        let tokens = super::tokenize_str(zpl).unwrap();
+        let tz = super::tokenize_str(zpl, &CompilationCtx::default()).unwrap();
+        let tokens = tz.tokens;
         println!("{:?}", tokens);
         assert_eq!(tokens.len(), 14);
         let colorpurple = &tokens[5];
@@ -346,7 +356,8 @@ mod test {
     #[test]
     fn test_multiple_periods() {
         let zpl = "define alien as user with color green. . . allow aliens to access services";
-        let tokens = super::tokenize_str(zpl).unwrap();
+        let tz = super::tokenize_str(zpl, &CompilationCtx::default()).unwrap();
+        let tokens = tz.tokens;
         println!("{:?}", tokens);
         assert_eq!(tokens.len(), 15);
     }
@@ -356,14 +367,15 @@ mod test {
         {
             // TODO: Should this fail since it does not end in period?
             let zpl = "define alien as user with color:green. allow aliens to access services";
-            let tokens = super::tokenize_str(zpl).unwrap();
+            let tz = super::tokenize_str(zpl, &CompilationCtx::default()).unwrap();
+            let tokens = tz.tokens;
             assert_eq!(tokens.len(), 12);
         }
 
         {
             // This will fail since a period is not allowed on an unquoted string
             let zpl = "define alien as user with color:green.. allow aliens to access services";
-            let res = super::tokenize_str(zpl);
+            let res = super::tokenize_str(zpl, &CompilationCtx::default());
             assert!(res.is_err());
             let err = res.unwrap_err();
             match err {
@@ -378,12 +390,13 @@ mod test {
     #[test]
     fn test_quoted_period_in_attr_value() {
         let zpl = "Define alien as user with color:'green.'.";
-        let tokens = super::tokenize_str(zpl).unwrap();
+        let tz = super::tokenize_str(zpl, &CompilationCtx::default()).unwrap();
+        let tokens = tz.tokens;
         assert_eq!(tokens.len(), 7);
         assert_eq!(tokens[6].tt, super::TokenType::Period);
-        assert_eq!(tokens[5].tt, super::TokenType::Tuple(("color".to_string(), "green.".to_string())));
+        assert_eq!(
+            tokens[5].tt,
+            super::TokenType::Tuple(("color".to_string(), "green.".to_string()))
+        );
     }
-
-
-
 }

--- a/compiler/src/lex.rs
+++ b/compiler/src/lex.rs
@@ -24,6 +24,7 @@ pub enum TokenType {
     Multiple,
     Literal(String),
     Tuple((String, String)),
+    Period,
     EOS, // means "end of statement" but is never actually created
 }
 
@@ -61,6 +62,7 @@ impl Token {
             "tags" => TokenType::Tags,
             "optional" => TokenType::Optional,
             "multiple" => TokenType::Multiple,
+            "." => TokenType::Period,
             _ => TokenType::Literal(s.as_atom()),
         };
         Token::new(tok, line, col)
@@ -97,7 +99,6 @@ pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
     let mut current_word = ZPLStrBuilder::new();
     let mut current_start = (line, col);
     let mut quoting = false;
-    let mut quote_char = ' ';
 
     while let Some(c) = chars.next() {
         match c {
@@ -141,7 +142,7 @@ pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
                 // if we are quoting the literal, keep space, otherwise this is a delimiter
                 if current_word.len() > 0 {
                     if quoting {
-                        current_word.push(c);
+                        current_word.push(c, quoting, line, col)?;
                     } else {
                         if !current_word.is_sugar() {
                             tokens.push(Token::new_from_str(
@@ -159,7 +160,7 @@ pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
                 // if we are quoting the literal, keep comma, otherwise this is new COMMA token (should this be AND?)
                 if current_word.len() > 0 {
                     if quoting {
-                        current_word.push(c);
+                        current_word.push(c, quoting, line, col)?;
                     } else {
                         if !current_word.is_sugar() {
                             tokens.push(Token::new_from_str(
@@ -169,11 +170,50 @@ pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
                             ));
                         }
                         current_word.clear();
-                        col += 1;
                         tokens.push(Token::new(TokenType::Comma, line, col));
-                        col += 1;
                     }
+                } else {
+                    tokens.push(Token::new(TokenType::Comma, line, col));
                 }
+                col += 1;
+            }
+            '.' => {
+                let followed_by_whitespace = if let Some(&next) = chars.peek() {
+                        next.is_whitespace()
+                    } else {
+                        true // none (end of input)
+                    };
+                if current_word.len() > 0 && quoting {
+                    current_word.push(c, quoting, line, col)?;
+                } else if current_word.len() > 0 {
+                    // We have a word going, we are not quoting. A period followed by whitespace ends the statement.
+                    // Otherwise it is assumed to be part of the word.
+                    if followed_by_whitespace {
+                        if !current_word.is_sugar() {
+                            tokens.push(Token::new_from_str(
+                                &current_word.build(),
+                                current_start.0,
+                                current_start.1,
+                            ));
+                        }
+                        current_word.clear();
+                        tokens.push(Token::new(TokenType::Period, line, col));
+                    } else {
+                        current_word.push(c, quoting, line, col)?;
+                        // Special case: if we see that there is another period following this one we warn the user.
+                        if let Some(&next) = chars.peek() {
+                            if next == '.' {
+                                // TODO: Maybe a way to return warnings instead of emitting them directly?
+                                println!("warning: multiple unquoted periods at line {} col {}", line, col);
+                            }
+                        }
+                    }
+                } else if followed_by_whitespace {
+                    tokens.push(Token::new(TokenType::Period, line, col));
+                } else {
+                    current_word.push(c, quoting, line, col)?; // I guess it is allowed to start a "word" with a period?
+                }
+                col += 1;
             }
             ':' => {
                 // If we are quoting, then this is just a normal colon.
@@ -183,7 +223,7 @@ pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
                     return Err(CompilationError::IllegalColon(line, col));
                 }
                 if quoting {
-                    current_word.push(c);
+                    current_word.push(c, quoting, line, col)?;
                 } else if current_word.is_comment_start() {
                     // consume the rest of the line
                     while let Some(c) = chars.next() {
@@ -208,55 +248,50 @@ pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
                 if current_word.len() == 0 {
                     if !quoting {
                         quoting = true;
-                        quote_char = c;
                         current_start = (line, col);
                     } else {
-                        // we are quoting already and word is empty, so only a repeat is allowed.
-                        if c == quote_char {
-                            current_word.push(c);
-                            quoting = false;
-                        } else {
-                            return Err(CompilationError::MismatchedQuote(line, col));
-                        }
+                        // No word in buffer, and now a repeated quote char? Error.
+                        return Err(CompilationError::IllegalQuote(line, col));
                     }
-                    col += 1;
                 } else {
                     // We have a word in buffer
                     if quoting {
-                        if c == quote_char {
-                            // End of the quoted literal. If next char is a colon, then we continue to parse attr value.
-                            if let Some(&next) = chars.peek() {
-                                if next == ':' {
-                                    quoting = false;
-                                    col += 1;
-                                    continue;
-                                }
-                            }
-                            if !current_word.is_sugar() {
-                                tokens.push(Token::new_from_str(
-                                    &current_word.build(),
-                                    current_start.0,
-                                    current_start.1,
-                                ));
-                            }
-                            current_word.clear();
-                            quoting = false;
-                        } else {
-                            current_word.push(c);
-                        }
-                    } else {
-                        // not quoting so this is allowed for escape or for a quoted tuple value.
+                        // We are quoting, if next char is the same quote char, then we are escaping.
+                        // Set flag here which we detect next time.
                         if let Some(&next) = chars.peek() {
                             if next == c {
-                                // this is an escape
-                                current_word.push(c);
+                                current_word.push(c, quoting, line, col)?;
                                 chars.next();
-                                col += 1;
-                            } else if current_word.is_tuple() && current_word.value_len() == 0 {
-                                quoting = true;
-                            } else {
-                                return Err(CompilationError::IllegalQuote(line, col));
+                                col += 2;
+                                continue;
                             }
+                        }
+                        // Else we are at the end of the quoted literal.
+                        // If next char is a colon, then we continue to parse attr value.
+                        if let Some(&next) = chars.peek() {
+                            if next == ':' {
+                                quoting = false;
+                                col += 1;
+                                continue;
+                            }
+                        }
+                        // Otherwise consume the current word.
+                        if !current_word.is_sugar() {
+                            tokens.push(Token::new_from_str(
+                                &current_word.build(),
+                                current_start.0,
+                                current_start.1,
+                            ));
+                        }
+                        current_word.clear();
+                        quoting = false;
+                    } else {
+                        // We have a word in buffer but are not quoting and we just read a quote char?
+                        // Only allowed if this is starting to quote a tuple value.
+                        if current_word.is_tuple() && current_word.value_len() == 0 {
+                            quoting = true; // turn on tuple value quoting
+                        } else {
+                            return Err(CompilationError::IllegalQuote(line, col));
                         }
                     }
                 }
@@ -266,19 +301,8 @@ pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
                 if current_word.len() == 0 && !quoting {
                     current_start = (line, col);
                 }
+                current_word.push(c, quoting, line, col)?;
                 col += 1;
-
-                // Trailing period is discarded
-                if c == '.' {
-                    if let Some(&next) = chars.peek() {
-                        if next.is_whitespace() {
-                            // discard the period
-                            continue;
-                        }
-                    }
-                }
-
-                current_word.push(c);
             }
         }
     }
@@ -301,6 +325,7 @@ pub fn tokenize_str(zpl: &str) -> Result<Vec<Token>, CompilationError> {
     Ok(tokens)
 }
 
+
 #[cfg(test)]
 mod test {
 
@@ -309,12 +334,56 @@ mod test {
         let zpl = "define foo as user with color:purple, `role`:`manager`, office:`fris:co`, and tag `foo bar`";
         let tokens = super::tokenize_str(zpl).unwrap();
         println!("{:?}", tokens);
-        assert_eq!(tokens.len(), 12);
+        assert_eq!(tokens.len(), 14);
         let colorpurple = &tokens[5];
         assert_eq!(colorpurple.tt, super::tuple_from_strs("color", "purple"));
         let rolemanager = &tokens[7];
         assert_eq!(rolemanager.tt, super::tuple_from_strs("role", "manager"));
-        let officefrisco = &tokens[8];
+        let officefrisco = &tokens[9];
         assert_eq!(officefrisco.tt, super::tuple_from_strs("office", "fris:co"));
     }
+
+    #[test]
+    fn test_multiple_periods() {
+        let zpl = "define alien as user with color green. . . allow aliens to access services";
+        let tokens = super::tokenize_str(zpl).unwrap();
+        println!("{:?}", tokens);
+        assert_eq!(tokens.len(), 15);
+    }
+
+    #[test]
+    fn test_successive_periods() {
+        {
+            // TODO: Should this fail since it does not end in period?
+            let zpl = "define alien as user with color:green. allow aliens to access services";
+            let tokens = super::tokenize_str(zpl).unwrap();
+            assert_eq!(tokens.len(), 12);
+        }
+
+        {
+            // This will fail since a period is not allowed on an unquoted string
+            let zpl = "define alien as user with color:green.. allow aliens to access services";
+            let res = super::tokenize_str(zpl);
+            assert!(res.is_err());
+            let err = res.unwrap_err();
+            match err {
+                super::CompilationError::IllegalStringLiteralChar(c, _line, _col) => {
+                    assert_eq!(c, '.');
+                }
+                _ => panic!("unexpected error: {:?}", err),
+            }
+        }
+    }
+
+    #[test]
+    fn test_quoted_period_in_attr_value() {
+        let zpl = "Define alien as user with color:'green.'.";
+        let tokens = super::tokenize_str(zpl).unwrap();
+        assert_eq!(tokens.len(), 7);
+        assert_eq!(tokens[6].tt, super::TokenType::Period);
+        assert_eq!(tokens[5].tt, super::TokenType::Tuple(("color".to_string(), "green.".to_string())));
+    }
+
+
+
 }

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -17,6 +17,7 @@ mod allow;
 pub mod compilation;
 mod config;
 mod config_api;
+mod context;
 mod crypto;
 mod define;
 pub mod errors;

--- a/compiler/src/main.rs
+++ b/compiler/src/main.rs
@@ -92,7 +92,7 @@ fn main() {
         let key = match load_rsa_private_key(&key) {
             Ok(k) => k,
             Err(e) => {
-                eprintln!(
+                println!(
                     "{}{} {}: {}",
                     "error".red().bold(),
                     ":".bold(),
@@ -108,7 +108,7 @@ fn main() {
     match comp.compile() {
         Ok(_) => (),
         Err(e) => {
-            eprintln!("{}{} {}", "error".red().bold(), ":".bold(), e);
+            println!("{}{} {}", "error".red().bold(), ":".bold(), e);
             exit_code = 1;
         }
     }

--- a/compiler/src/main.rs
+++ b/compiler/src/main.rs
@@ -104,7 +104,7 @@ fn main() {
         };
         cb = cb.sign_with_key(key);
     }
-    let mut comp = cb.build();
+    let comp = cb.build();
     match comp.compile() {
         Ok(_) => (),
         Err(e) => {

--- a/compiler/src/main.rs
+++ b/compiler/src/main.rs
@@ -6,6 +6,7 @@ mod allow;
 mod compilation;
 mod config;
 mod config_api;
+mod context;
 mod crypto;
 mod define;
 mod errors;
@@ -22,6 +23,7 @@ mod zpl;
 mod zplstr;
 
 use clap::Parser;
+use colored::Colorize;
 use std::path::PathBuf;
 
 use compilation::Compilation;
@@ -50,6 +52,7 @@ struct Cli {
     /// Write output binary to existing directory DIR instead of default.
     #[arg(short = 'd', long = "outdir", value_name = "DIR")]
     outdir: Option<PathBuf>,
+
     /// Write the binary policy to filed named NAME instead of the default (input file with extension switched to .bin)
     #[arg(short = 'o', long, value_name = "NAME")]
     outfname: Option<String>,
@@ -61,12 +64,18 @@ struct Cli {
     /// Only perform parsing step. Does not produce a binary policy.
     #[arg(short, long)]
     parse_only: bool,
+
+    /// Treat warnings like errors and halt compilation when they occur.
+    #[arg(long = "Werror")]
+    werror: bool,
 }
 
 fn main() {
     let mut exit_code = 0;
     let cli = Cli::parse();
-    let mut cb = Compilation::builder(cli.zpl).verbose(cli.verbose);
+    let mut cb = Compilation::builder(cli.zpl)
+        .verbose(cli.verbose)
+        .werror(cli.werror);
     if cli.parse_only {
         cb = cb.parse_only(true);
     }
@@ -83,17 +92,23 @@ fn main() {
         let key = match load_rsa_private_key(&key) {
             Ok(k) => k,
             Err(e) => {
-                eprintln!("error loading private key: {}", e);
+                eprintln!(
+                    "{}{} {}: {}",
+                    "error".red().bold(),
+                    ":".bold(),
+                    "failed to load private key",
+                    e
+                );
                 std::process::exit(1);
             }
         };
         cb = cb.sign_with_key(key);
     }
-    let comp = cb.build();
+    let mut comp = cb.build();
     match comp.compile() {
-        Ok(_) => println!("ℤ done!"),
+        Ok(_) => (),
         Err(e) => {
-            eprintln!("error: {}", e);
+            eprintln!("{}{} {}", "error".red().bold(), ":".bold(), e);
             exit_code = 1;
         }
     }

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -6,28 +6,51 @@ use crate::errors::CompilationError;
 use crate::lex::{Token, TokenType};
 use crate::ptypes::{Class, Policy};
 
+
 pub fn parse(tokens: Vec<Token>, verbose: bool) -> Result<Policy, CompilationError> {
-    // Convert the tokens into statements, which are just sub-lists of the tokens.
-    // Currently the compiler only accepts ALLOW statements and DEFINE statements.
     let mut statements = Vec::new();
     let mut current_statement = Vec::new();
 
+    // Convert the tokens into statements, which are just sub-lists of the tokens.
+    // Currently the compiler only accepts ALLOW statements and DEFINE statements.
+    // Periods are still optional, but if you use them incorrectly they parser will
+    // complain.
+    let mut in_statement = false;
     for tok in tokens {
         match tok.tt {
+            TokenType::Period => {
+                if !current_statement.is_empty() {
+                    statements.push(current_statement);
+                    current_statement = Vec::new();
+                }
+                in_statement = false;
+            }
             TokenType::Allow | TokenType::Define => {
                 if !current_statement.is_empty() {
                     statements.push(current_statement);
                     current_statement = Vec::new();
                 }
                 current_statement.push(tok);
+                in_statement = true;
+            }
+            _ if in_statement => {
+                current_statement.push(tok);
             }
             _ => {
-                current_statement.push(tok);
+                return Err(CompilationError::ParseError(
+                    "unexpected token".to_string(),
+                    tok.line,
+                    tok.col,
+                ));
             }
         }
     }
     if !current_statement.is_empty() {
         statements.push(current_statement);
+    }
+
+    if statements.is_empty() {
+        println!("warning: empty policy")
     }
 
     let mut policy = Policy::default();
@@ -296,4 +319,49 @@ allow devices with marketing-emps to access role:marketing services
             };
         }
     }
+
+
+    // Test splitting statements with a period. Will work anyway since we
+    // use Allow and Define as our statement delimiters.
+    #[test]
+    fn test_use_periods() {
+        let valids = vec![
+            "Define Alien as a user with color:green. Allow Aliens to access services.",
+            ".",
+        ];
+        for valid in valids {
+            let tokens: Result<Vec<Token>, CompilationError> = tokenize_str(valid).or_else(|e| {
+                panic!("failed to tokenize '{}': {:?}", valid, e);
+            });
+            let _pol = match parse(tokens.unwrap(), true) {
+                Ok(policy) => policy,
+                Err(e) => {
+                    panic!("failed to parse '{}': {:?}", valid, e);
+                }
+            };
+        }
+    }
+
+
+    // Put periods in where they don't belong. Should fail.
+    #[test]
+    fn test_use_periods_in_error() {
+        let invalids = vec![
+            "Define Alien. as a user with color:green. Allow Aliens to. access services",
+            "Define alien as a user. with color:green.",
+        ];
+        for valid in invalids {
+            let tokens: Result<Vec<Token>, CompilationError> = tokenize_str(valid).or_else(|e| {
+                panic!("failed to tokenize '{}': {:?}", valid, e);
+            });
+            let _pol = match parse(tokens.unwrap(), true) {
+                Ok(_policy) => {
+                    panic!("should not have parsed '{}'", valid);
+                }
+                Err(_e) => (),
+            };
+        }
+    }
+
+
 }

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -1,13 +1,19 @@
 use std::collections::HashMap;
 
 use crate::allow::parse_allow;
+use crate::context::CompilationCtx;
 use crate::define::{parse_define, resolve_class_flavors};
 use crate::errors::CompilationError;
 use crate::lex::{Token, TokenType};
 use crate::ptypes::{Class, Policy};
 
+#[derive(Default)]
+pub struct ParsingResult {
+    pub policy: Policy,
+}
 
-pub fn parse(tokens: Vec<Token>, verbose: bool) -> Result<Policy, CompilationError> {
+pub fn parse(tokens: Vec<Token>, ctx: &CompilationCtx) -> Result<ParsingResult, CompilationError> {
+    let mut result = ParsingResult::default();
     let mut statements = Vec::new();
     let mut current_statement = Vec::new();
 
@@ -50,7 +56,7 @@ pub fn parse(tokens: Vec<Token>, verbose: bool) -> Result<Policy, CompilationErr
     }
 
     if statements.is_empty() {
-        println!("warning: empty policy")
+        ctx.warn("empty policy")?;
     }
 
     let mut policy = Policy::default();
@@ -97,14 +103,14 @@ pub fn parse(tokens: Vec<Token>, verbose: bool) -> Result<Policy, CompilationErr
     for (i, statement) in statements.iter().enumerate() {
         if statement[0].tt == TokenType::Allow {
             let allow = parse_allow(statement, i + 1, &class_index, &classes)?;
-            if verbose {
+            if ctx.verbose {
                 println!("{}", allow);
             }
             policy.allows.push(allow);
         }
     }
 
-    if verbose {
+    if ctx.verbose {
         println!()
     }
 
@@ -114,7 +120,7 @@ pub fn parse(tokens: Vec<Token>, verbose: bool) -> Result<Policy, CompilationErr
         if class.is_builtin() {
             continue;
         }
-        if verbose {
+        if ctx.verbose {
             println!("defined class: {} (is a {:?})", class.name, class.flavor);
             for attr in &class.with_attrs {
                 println!("  with: {}", attr);
@@ -123,13 +129,14 @@ pub fn parse(tokens: Vec<Token>, verbose: bool) -> Result<Policy, CompilationErr
         policy.defines.push(class);
     }
 
-    Ok(policy)
+    result.policy = policy;
+    Ok(result)
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::lex::tokenize_str;
+    use crate::lex::{tokenize_str, Tokenization};
     use crate::ptypes::ClassFlavor;
 
     #[test]
@@ -143,11 +150,13 @@ mod test {
             "define gateway as a service with an external-network-connection \n define internet-gateway as a gateway with external-network-connection:public-internet",
             "define peripheral as a user with function \n define mouse AKA mice as a peripheral with function:pointing"
         ];
+        let ctx = CompilationCtx::default();
         for valid in valids {
-            let tokens: Result<Vec<Token>, CompilationError> = tokenize_str(valid).or_else(|e| {
-                panic!("failed to tokenize '{}': {:?}", valid, e);
-            });
-            let _pol = match parse(tokens.unwrap(), true) {
+            let tz: Result<Tokenization, CompilationError> =
+                tokenize_str(valid, &ctx).or_else(|e| {
+                    panic!("failed to tokenize '{}': {:?}", valid, e);
+                });
+            let _pol = match parse(tz.unwrap().tokens, &ctx) {
                 Ok(policy) => policy,
                 Err(e) => {
                     panic!("failed to parse '{}': {:?}", valid, e);
@@ -166,11 +175,12 @@ define marketing-emp as an employee with rule:marketing and tag full-time
 
 allow devices with marketing-emps to access role:marketing services
 "#;
-        let tokens: Result<Vec<Token>, CompilationError> = tokenize_str(pp).or_else(|e| {
+        let ctx = CompilationCtx::default();
+        let tz: Result<Tokenization, CompilationError> = tokenize_str(pp, &ctx).or_else(|e| {
             panic!("failed to tokenize '{}': {:?}", pp, e);
         });
-        let pol = match parse(tokens.unwrap(), true) {
-            Ok(policy) => policy,
+        let pol = match parse(tz.unwrap().tokens, &ctx) {
+            Ok(pr) => pr.policy,
             Err(e) => {
                 panic!("failed to parse '{}': {:?}", pp, e);
             }
@@ -221,13 +231,15 @@ allow devices with marketing-emps to access role:marketing services
     #[test]
     fn test_base_allow() {
         let valids = vec!["allow devices with color:green users to access services"];
+        let ctx = CompilationCtx::default();
         for valid in valids {
-            let tokens: Result<Vec<Token>, CompilationError> = tokenize_str(valid).or_else(|e| {
-                panic!("failed to tokenize '{}': {:?}", valid, e);
-            });
-            let toks = tokens.unwrap();
+            let tokens: Result<Tokenization, CompilationError> =
+                tokenize_str(valid, &ctx).or_else(|e| {
+                    panic!("failed to tokenize '{}': {:?}", valid, e);
+                });
+            let toks = tokens.unwrap().tokens;
             assert_eq!(8, toks.len());
-            let _pol = match parse(toks, true) {
+            let _pol = match parse(toks, &ctx) {
                 Ok(policy) => policy,
                 Err(e) => {
                     panic!("failed to parse '{}': {:?}", valid, e);
@@ -242,12 +254,14 @@ allow devices with marketing-emps to access role:marketing services
             "allow devices with users with loc:italy to access services",
             "allow devices with users to access services with color:green",
         ];
+        let ctx = CompilationCtx::default();
         for valid in valids {
-            let tokens: Result<Vec<Token>, CompilationError> = tokenize_str(valid).or_else(|e| {
-                panic!("failed to tokenize '{}': {:?}", valid, e);
-            });
-            let toks = tokens.unwrap();
-            let _pol = match parse(toks, true) {
+            let tokens: Result<Tokenization, CompilationError> =
+                tokenize_str(valid, &ctx).or_else(|e| {
+                    panic!("failed to tokenize '{}': {:?}", valid, e);
+                });
+            let toks = tokens.unwrap().tokens;
+            let _pol = match parse(toks, &ctx) {
                 Ok(_) => panic!("should not have parsed postfix notation: {}", valid),
                 Err(e) => {
                     assert!(
@@ -268,11 +282,13 @@ allow devices with marketing-emps to access role:marketing services
             "allow color:red users to access services",
             "allow managed, color:red users to access services",
         ];
+        let ctx = CompilationCtx::default();
         for valid in valids {
-            let tokens: Result<Vec<Token>, CompilationError> = tokenize_str(valid).or_else(|e| {
-                panic!("failed to tokenize '{}': {:?}", valid, e);
-            });
-            let _pol = match parse(tokens.unwrap(), true) {
+            let tokens: Result<Tokenization, CompilationError> =
+                tokenize_str(valid, &ctx).or_else(|e| {
+                    panic!("failed to tokenize '{}': {:?}", valid, e);
+                });
+            let _pol = match parse(tokens.unwrap().tokens, &ctx) {
                 Ok(policy) => policy,
                 Err(e) => {
                     panic!("failed to parse '{}': {:?}", valid, e);
@@ -288,11 +304,13 @@ allow devices with marketing-emps to access role:marketing services
             "allow color:red devices to access services",
             "allow managed, color:red devices to access services",
         ];
+        let ctx = CompilationCtx::default();
         for valid in valids {
-            let tokens: Result<Vec<Token>, CompilationError> = tokenize_str(valid).or_else(|e| {
-                panic!("failed to tokenize '{}': {:?}", valid, e);
-            });
-            let _pol = match parse(tokens.unwrap(), true) {
+            let tokens: Result<Tokenization, CompilationError> =
+                tokenize_str(valid, &ctx).or_else(|e| {
+                    panic!("failed to tokenize '{}': {:?}", valid, e);
+                });
+            let _pol = match parse(tokens.unwrap().tokens, &ctx) {
                 Ok(policy) => policy,
                 Err(e) => {
                     panic!("failed to parse '{}': {:?}", valid, e);
@@ -307,11 +325,13 @@ allow devices with marketing-emps to access role:marketing services
             "allow color:green devices with managed, color:red users to access green services",
             "allow color:green devices with color:red, managed users to access color:blue services",
         ];
+        let ctx = CompilationCtx::default();
         for valid in valids {
-            let tokens: Result<Vec<Token>, CompilationError> = tokenize_str(valid).or_else(|e| {
-                panic!("failed to tokenize '{}': {:?}", valid, e);
-            });
-            let _pol = match parse(tokens.unwrap(), true) {
+            let tokens: Result<Tokenization, CompilationError> =
+                tokenize_str(valid, &ctx).or_else(|e| {
+                    panic!("failed to tokenize '{}': {:?}", valid, e);
+                });
+            let _pol = match parse(tokens.unwrap().tokens, &ctx) {
                 Ok(policy) => policy,
                 Err(e) => {
                     panic!("failed to parse '{}': {:?}", valid, e);
@@ -319,7 +339,6 @@ allow devices with marketing-emps to access role:marketing services
             };
         }
     }
-
 
     // Test splitting statements with a period. Will work anyway since we
     // use Allow and Define as our statement delimiters.
@@ -329,11 +348,13 @@ allow devices with marketing-emps to access role:marketing services
             "Define Alien as a user with color:green. Allow Aliens to access services.",
             ".",
         ];
+        let ctx = CompilationCtx::default();
         for valid in valids {
-            let tokens: Result<Vec<Token>, CompilationError> = tokenize_str(valid).or_else(|e| {
-                panic!("failed to tokenize '{}': {:?}", valid, e);
-            });
-            let _pol = match parse(tokens.unwrap(), true) {
+            let tokens: Result<Tokenization, CompilationError> =
+                tokenize_str(valid, &ctx).or_else(|e| {
+                    panic!("failed to tokenize '{}': {:?}", valid, e);
+                });
+            let _pol = match parse(tokens.unwrap().tokens, &ctx) {
                 Ok(policy) => policy,
                 Err(e) => {
                     panic!("failed to parse '{}': {:?}", valid, e);
@@ -342,7 +363,6 @@ allow devices with marketing-emps to access role:marketing services
         }
     }
 
-
     // Put periods in where they don't belong. Should fail.
     #[test]
     fn test_use_periods_in_error() {
@@ -350,11 +370,13 @@ allow devices with marketing-emps to access role:marketing services
             "Define Alien. as a user with color:green. Allow Aliens to. access services",
             "Define alien as a user. with color:green.",
         ];
+        let ctx = CompilationCtx::default();
         for valid in invalids {
-            let tokens: Result<Vec<Token>, CompilationError> = tokenize_str(valid).or_else(|e| {
-                panic!("failed to tokenize '{}': {:?}", valid, e);
-            });
-            let _pol = match parse(tokens.unwrap(), true) {
+            let tokens: Result<Tokenization, CompilationError> =
+                tokenize_str(valid, &ctx).or_else(|e| {
+                    panic!("failed to tokenize '{}': {:?}", valid, e);
+                });
+            let _pol = match parse(tokens.unwrap().tokens, &ctx) {
                 Ok(_policy) => {
                     panic!("should not have parsed '{}'", valid);
                 }
@@ -362,6 +384,4 @@ allow devices with marketing-emps to access role:marketing services
             };
         }
     }
-
-
 }

--- a/compiler/src/policybuilder.rs
+++ b/compiler/src/policybuilder.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::env;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use crate::context::CompilationCtx;
 use crate::errors::CompilationError;
 use crate::fabric::{Fabric, FabricService, ServiceType};
 use crate::polio;
@@ -115,7 +116,11 @@ impl PolicyBuilder {
     ///   - The certificates used for trusted services (TODO) and for the default/internal auth service.
     ///
     /// This does most of the work in building the policy.
-    pub fn with_fabric(&mut self, fabric: &Fabric) -> Result<(), CompilationError> {
+    pub fn with_fabric(
+        &mut self,
+        fabric: &Fabric,
+        ctx: &CompilationCtx,
+    ) -> Result<(), CompilationError> {
         self.policy.policy_revision = fabric.revision.clone();
 
         // The policy refers to attribute keys and values using a lookup table.
@@ -129,7 +134,7 @@ impl PolicyBuilder {
 
         self.set_connects(&fabric)?;
         self.set_policies(&fabric)?;
-        self.set_default_auth(&fabric)?;
+        self.set_default_auth(&fabric, ctx)?;
 
         if self.verbose {
             println!("  {} connect rules", self.policy.connects.len());
@@ -146,9 +151,13 @@ impl PolicyBuilder {
 
     /// Configure the default (internal) authentication service in the policy. This is
     /// essentially just storing a CA certificate along with the expected prefix.
-    fn set_default_auth(&mut self, fabric: &Fabric) -> Result<(), CompilationError> {
+    fn set_default_auth(
+        &mut self,
+        fabric: &Fabric,
+        ctx: &CompilationCtx,
+    ) -> Result<(), CompilationError> {
         if fabric.default_auth_cert_asn.is_empty() {
-            println!("warning: refusing to add empty default certificate to policy");
+            ctx.warn("refusing to add empty default certificate to policy")?;
             return Ok(());
         }
         let pcert = polio::Cert {

--- a/compiler/src/weaver.rs
+++ b/compiler/src/weaver.rs
@@ -6,6 +6,7 @@ use base64::prelude::*;
 
 use crate::compilation::Compilation;
 use crate::config_api::{ConfigApi, ConfigItem};
+use crate::context::CompilationCtx;
 use crate::crypto::{digest_as_hex, sha256_of_bytes};
 use crate::errors::CompilationError;
 use crate::fabric::{Fabric, ServiceType};
@@ -26,6 +27,7 @@ pub fn weave(
     _comp: &Compilation,
     config: &ConfigApi,
     policy: &Policy,
+    ctx: &CompilationCtx,
 ) -> Result<Fabric, CompilationError> {
     let mut weaver = Weaver::new();
 
@@ -67,17 +69,17 @@ pub fn weave(
     // will not be readable by visa service.
     for ts_id in &config.must_get_keys("/trusted_services") {
         if ts_id != zpl::DEFAULT_TRUSTED_SERVICE_ID {
-            println!(
-                "warning: trusted_service '{}': non-default trusted services not supported",
+            ctx.warn(&format!(
+                "trusted_service '{}': non-default trusted services not supported",
                 ts_id
-            );
+            ))?;
         }
     }
 
-    weaver.init_services(&class_idx, policy, config)?;
+    weaver.init_services(&class_idx, policy, config, ctx)?;
     weaver.init_nodes(config)?;
     weaver.add_client_policies(&class_idx, policy, config)?;
-    weaver.add_default_auth(config)?;
+    weaver.add_default_auth(config, ctx)?;
 
     Ok(weaver.fabric)
 }
@@ -110,10 +112,11 @@ impl Weaver {
         class_idx: &HashMap<String, &Class>,
         policy: &Policy,
         config: &ConfigApi,
+        ctx: &CompilationCtx,
     ) -> Result<(), CompilationError> {
         self.defines_to_services(class_idx, policy, config)?;
         self.allow_clauses_to_services(class_idx, policy, config)?;
-        self.visa_services_to_services(config)?;
+        self.visa_services_to_services(config, ctx)?;
 
         Ok(())
     }
@@ -122,7 +125,11 @@ impl Weaver {
     /// Most visa service related functionality is built in. However user can set
     /// the attributes of the administrator who is able to access the visa service
     /// admin HTTPS API.
-    fn visa_services_to_services(&mut self, config: &ConfigApi) -> Result<(), CompilationError> {
+    fn visa_services_to_services(
+        &mut self,
+        config: &ConfigApi,
+        ctx: &CompilationCtx,
+    ) -> Result<(), CompilationError> {
         let vs_protocol = Protocol {
             protocol: IanaProtocol::TCP,
             port: Some(zpl::VISA_SERVICE_PORT.to_string()),
@@ -167,7 +174,7 @@ impl Weaver {
         };
         if admin_access_attrs.is_empty() {
             // TODO: is this an error?
-            println!("warning: no admin attributes set for visa service admin access");
+            ctx.warn("no admin attributes set for visa service admin access")?;
         } else {
             self.fabric
                 .add_condition_to_service(&fab_admin_svc_id, &admin_access_attrs, false)?;
@@ -534,7 +541,11 @@ impl Weaver {
 
     /// For now we only accept the DEFAULT (builtin) trusted service.
     /// And the only thing we care about is the certificate.
-    fn add_default_auth(&mut self, config: &ConfigApi) -> Result<(), CompilationError> {
+    fn add_default_auth(
+        &mut self,
+        config: &ConfigApi,
+        ctx: &CompilationCtx,
+    ) -> Result<(), CompilationError> {
         if config
             .get(&format!(
                 "/trusted_services/{}",
@@ -562,7 +573,7 @@ impl Weaver {
             },
             _ => {
                 // TODO: This should probably be an error, but helps for testing.
-                println!("warning: default trusted service did not return a certificate");
+                ctx.warn("no certificate for default trusted service")?;
                 vec![]
             }
         };
@@ -631,6 +642,8 @@ fn attrs_for_class(class_idx: &HashMap<String, &Class>, class_name: &str) -> Vec
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use crate::context::CompilationCtx;
     use crate::lex::Token;
     use crate::ptypes::{AllowClause, ClassFlavor, Clause, FPos};
     use std::env;
@@ -652,10 +665,11 @@ mod test {
         let mut w = Weaver::new();
         let class_idx = HashMap::new();
         let policy = Policy::default();
-        let config = ConfigApi::new_from_toml_content(&cfg, &env::temp_dir(), true)
-            .expect("failed to parse config");
+        let config =
+            ConfigApi::new_from_toml_content(&cfg, &env::temp_dir(), &CompilationCtx::default())
+                .expect("failed to parse config");
 
-        let res = w.init_services(&class_idx, &policy, &config);
+        let res = w.init_services(&class_idx, &policy, &config, &CompilationCtx::default());
         assert!(res.is_ok());
 
         // Should create two services: visa-service and visa-service-admin
@@ -703,12 +717,13 @@ mod test {
 
         let mut class_idx = HashMap::new();
         let mut policy = Policy::default();
-        let config = ConfigApi::new_from_toml_content(&cfg, &env::temp_dir(), true)
+        let ctx = CompilationCtx::default();
+        let config = ConfigApi::new_from_toml_content(&cfg, &env::temp_dir(), &ctx)
             .expect("failed to parse config");
 
         {
             let mut w = Weaver::new();
-            let res = w.init_services(&class_idx, &policy, &config);
+            let res = w.init_services(&class_idx, &policy, &config, &ctx);
             assert!(res.is_ok(), "init_services failed: {}", res.unwrap_err());
 
             // Should create two services: visa-service and visa-service-admin.
@@ -767,7 +782,7 @@ mod test {
 
         {
             let mut w = Weaver::new();
-            let res = w.init_services(&class_idx, &policy, &config);
+            let res = w.init_services(&class_idx, &policy, &config, &ctx);
             println!("{:?}", res);
             assert!(res.is_ok(), "init_services failed: {}", res.unwrap_err());
             assert_eq!(w.fabric.services.len(), 3);

--- a/compiler/src/zplstr.rs
+++ b/compiler/src/zplstr.rs
@@ -5,6 +5,8 @@
 
 use std::fmt;
 
+use crate::errors::CompilationError;
+
 pub struct ZPLStr {
     name: String,
     value: Option<String>,
@@ -98,12 +100,30 @@ impl ZPLStrBuilder {
         self.name.len() + self.value.len()
     }
 
+    /*
     pub fn push(&mut self, c: char) {
         if self.input_to_value {
             self.value.push(c);
         } else {
             self.name.push(c);
         }
+    }
+    */
+
+    pub fn push(&mut self, c: char, quoted: bool, line: usize, col: usize) -> Result<(), CompilationError> {
+        if self.input_to_value {
+            if !quoted && !c.is_ascii_alphanumeric() && !matches!(c, '-' | '_') {
+                return Err(CompilationError::IllegalStringLiteralChar(c, line, col));
+            }
+            self.value.push(c);
+        } else {
+            // The name part of a tuple is allowed to contain periods wihout needing quotes.
+            if !quoted && !c.is_ascii_alphanumeric() && !matches!(c, '.' | '-' | '_') {
+                return Err(CompilationError::IllegalNameLiteralChar(c, line, col));
+            }
+            self.name.push(c);
+        }
+        Ok(())
     }
 
     /// Switch to value mode ... all further pushes go to the tuple value. Implies that this is a tuple.

--- a/compiler/src/zplstr.rs
+++ b/compiler/src/zplstr.rs
@@ -110,7 +110,13 @@ impl ZPLStrBuilder {
     }
     */
 
-    pub fn push(&mut self, c: char, quoted: bool, line: usize, col: usize) -> Result<(), CompilationError> {
+    pub fn push(
+        &mut self,
+        c: char,
+        quoted: bool,
+        line: usize,
+        col: usize,
+    ) -> Result<(), CompilationError> {
         if self.input_to_value {
             if !quoted && !c.is_ascii_alphanumeric() && !matches!(c, '-' | '_') {
                 return Err(CompilationError::IllegalStringLiteralChar(c, line, col));

--- a/compiler/test-data/rfc15-001.zpl
+++ b/compiler/test-data/rfc15-001.zpl
@@ -1,5 +1,5 @@
-define laptop AKA laptops as device with optional tag managed
+define laptop AKA laptops as device with optional tag managed.
 
 allow managed laptops with cleared government users to access
-classified database services
+classified database services.
 

--- a/compiler/test-data/rfc15-002.zpl
+++ b/compiler/test-data/rfc15-002.zpl
@@ -1,2 +1,2 @@
 allow cleared government users to access classified database 
-services
+services.

--- a/compiler/test-data/rfc15-003.zpl
+++ b/compiler/test-data/rfc15-003.zpl
@@ -1,2 +1,2 @@
 allow devices with cleared government users to access classified database 
-services
+services.

--- a/compiler/test-data/rfc15-004-alt.zpl
+++ b/compiler/test-data/rfc15-004-alt.zpl
@@ -1,2 +1,2 @@
 allow devices with clearance:classified government users to access classified
-services
+services.

--- a/compiler/test-data/rfc15-004.zpl
+++ b/compiler/test-data/rfc15-004.zpl
@@ -1,2 +1,2 @@
 allow clearance:classified government users to access classified
-services
+services.

--- a/compiler/test-data/rfc15-005.zpl
+++ b/compiler/test-data/rfc15-005.zpl
@@ -1,2 +1,2 @@
 allow government, clearance:classified users to access 
-classified services
+classified services.

--- a/compiler/test-data/rfc15-006-todo.zpl
+++ b/compiler/test-data/rfc15-006-todo.zpl
@@ -1,4 +1,4 @@
 Note: Will not work until we support `without`.
 
-Note: allow users without role:intern to access internal services
+Note: allow users without role:intern to access internal services.
 

--- a/compiler/test-data/rfc15-007-alt.zpl
+++ b/compiler/test-data/rfc15-007-alt.zpl
@@ -1,4 +1,4 @@
-define Image-database as a service with svc-id
+define Image-database as a service with svc-id.
 
-allow devices with cleared government users to access Image-database
+allow devices with cleared government users to access Image-database.
 

--- a/compiler/test-data/rfc15-007.zpl
+++ b/compiler/test-data/rfc15-007.zpl
@@ -1,3 +1,3 @@
-define Image-database as a service with svc-id
-allow cleared government users to access Image-database
+define Image-database as a service with svc-id.
+allow cleared government users to access Image-database.
 

--- a/compiler/test-data/rfc15-008-alt.zpl
+++ b/compiler/test-data/rfc15-008-alt.zpl
@@ -1,6 +1,6 @@
-define Image-database as a device with mach-type:idb
+define Image-database as a device with mach-type:idb.
 
-define server as service with machine-id
+define server as service with machine-id.
 
-allow Image-database with users to access service:image-database servers
+allow Image-database with users to access service:image-database servers.
 

--- a/compiler/test-data/rfc15-009.zpl
+++ b/compiler/test-data/rfc15-009.zpl
@@ -1,3 +1,3 @@
 define employee as a user with an ID-number, multiple roles and
-  optional tags full-time, part-time, and intern
+  optional tags full-time, part-time, and intern.
 

--- a/compiler/test-data/rfc15-011.zpl
+++ b/compiler/test-data/rfc15-011.zpl
@@ -1,5 +1,5 @@
-define gateway as a service with an external-network-connection
+define gateway as a service with an external-network-connection.
 
 define internet-gateway as a gateway with
-  external-network-connection:public-internet
+  external-network-connection:public-internet.
 

--- a/compiler/test-data/rfc15-013.zpl
+++ b/compiler/test-data/rfc15-013.zpl
@@ -1,4 +1,4 @@
-define peripheral as a device with function
+define peripheral as a device with function.
 
-define mouse AKA mice as peripheral with function:pointing
+define mouse AKA mice as peripheral with function:pointing.
 

--- a/compiler/test-data/rfc15-014-todo.zpl
+++ b/compiler/test-data/rfc15-014-todo.zpl
@@ -1,4 +1,4 @@
 Note: Requires 'never' support
 
-Note: never allow internet-gateways to access internal services
+Note: never allow internet-gateways to access internal services.
 

--- a/compiler/tests/zpl-test.rs
+++ b/compiler/tests/zpl-test.rs
@@ -86,9 +86,9 @@ fn can_parse_rfc_examples() {
                 .verbose(true)
                 .parse_only(true)
                 .config(&config_file);
-            let comp = cb.build();
+            let mut comp = cb.build();
             match comp.compile() {
-                Ok(_) => println!("{:?}: compiled ok", fent.path()),
+                Ok(_warnings) => println!("{:?}: compiled ok", fent.path()),
                 Err(e) => {
                     println!("error: {}", e);
                     panic!("failed to compile {:?}", fent.path());
@@ -121,9 +121,9 @@ fn can_compile_m3_policies() {
             let cb = CompilationBuilder::new(path)
                 .verbose(true)
                 .output_directory(&temp_dir.path);
-            let comp = cb.build();
+            let mut comp = cb.build();
             match comp.compile() {
-                Ok(_) => println!("{:?}: compiled ok", fent.path()),
+                Ok(_warnings) => println!("{:?}: compiled ok", fent.path()),
                 Err(e) => {
                     println!("error: {}", e);
                     panic!("failed to compile {:?}", fent.path());
@@ -159,9 +159,9 @@ fn can_compile_integtest_policies() {
             let cb = CompilationBuilder::new(path)
                 .verbose(true)
                 .output_directory(&temp_dir.path);
-            let comp = cb.build();
+            let mut comp = cb.build();
             match comp.compile() {
-                Ok(_) => println!("{:?}: compiled ok", fent.path()),
+                Ok(_warnings) => println!("{:?}: compiled ok", fent.path()),
                 Err(e) => {
                     println!("error: {}", e);
                     panic!("failed to compile {:?}", fent.path());

--- a/compiler/tests/zpl-test.rs
+++ b/compiler/tests/zpl-test.rs
@@ -86,7 +86,7 @@ fn can_parse_rfc_examples() {
                 .verbose(true)
                 .parse_only(true)
                 .config(&config_file);
-            let mut comp = cb.build();
+            let comp = cb.build();
             match comp.compile() {
                 Ok(_warnings) => println!("{:?}: compiled ok", fent.path()),
                 Err(e) => {
@@ -121,7 +121,7 @@ fn can_compile_m3_policies() {
             let cb = CompilationBuilder::new(path)
                 .verbose(true)
                 .output_directory(&temp_dir.path);
-            let mut comp = cb.build();
+            let comp = cb.build();
             match comp.compile() {
                 Ok(_warnings) => println!("{:?}: compiled ok", fent.path()),
                 Err(e) => {
@@ -159,7 +159,7 @@ fn can_compile_integtest_policies() {
             let cb = CompilationBuilder::new(path)
                 .verbose(true)
                 .output_directory(&temp_dir.path);
-            let mut comp = cb.build();
+            let comp = cb.build();
             match comp.compile() {
                 Ok(_warnings) => println!("{:?}: compiled ok", fent.path()),
                 Err(e) => {

--- a/examples/milestone3/policies/m3-ping-and-http.zpl
+++ b/examples/milestone3/policies/m3-ping-and-http.zpl
@@ -4,10 +4,10 @@ Note: Since we don't yet authenticate users, this policy is expressed using endp
 
 
 define adapter as a device with cn
-define GoldenClient as an adapter with cn:client.zpr.org
+define GoldenClient as an adapter with cn:'client.zpr.org'
 
-define ZServicePingable as a service with cn:service.zpr.org
-define ZWebService as a service with cn:service.zpr.org
+define ZServicePingable as a service with cn:'service.zpr.org'
+define ZWebService as a service with cn:'service.zpr.org'
 
 allow GoldenClient to access ZServicePingable
 allow GoldenClient to access ZWebService

--- a/examples/milestone3/policies/m3-ping-only.zpl
+++ b/examples/milestone3/policies/m3-ping-only.zpl
@@ -4,8 +4,8 @@ Note: Since we don't yet authenticate users, this policy is expressed using endp
 
 define adapter as a device with cn
 
-define ZServicePingable as a service with cn:service.zpr.org
+define ZServicePingable as a service with cn:'service.zpr.org'
 
-allow cn:client.zpr.org adapter to access ZServicePingable
+allow cn:'client.zpr.org' adapter to access ZServicePingable
 
 

--- a/integration-test/pregen/conform-policy.zpl
+++ b/integration-test/pregen/conform-policy.zpl
@@ -1,14 +1,14 @@
 define adapter as a device with cn
 
 Note: Our node offers PING too
-define PingableNode as a service with cn:node.zpr.org
+define PingableNode as a service with cn:'node.zpr.org'
 
 Note: Three services, all offered by same adapter
-define WebService as a service with cn:service.zpr.org
-define IPerfService as a service with cn:service.zpr.org
-define PingableService as a service with cn:service.zpr.org
+define WebService as a service with cn:'service.zpr.org'
+define IPerfService as a service with cn:'service.zpr.org'
+define PingableService as a service with cn:'service.zpr.org'
 
-define SpecialClient as an adapter with cn:client.zpr.org
+define SpecialClient as an adapter with cn:'client.zpr.org'
 
 Note: the SpecialClient can access three services
 allow SpecialClient to access WebService

--- a/integration-test/pregen/v4-1node-2agent-ping.zpl
+++ b/integration-test/pregen/v4-1node-2agent-ping.zpl
@@ -6,11 +6,11 @@ define adapter as a device with cn
 define A1 as adapter with cn:adapter1
 define A2 as adapter with cn:adapter2
 define Node as adapter with cn:node
-define Vs as adapter with cn:vs.zpr
+define Vs as adapter with cn:'vs.zpr'
 
 define A1Svc as a service with cn:adapter1
 define A2Svc as a service with cn:adapter2
-define PingableVs as a service with cn:vs.zpr
+define PingableVs as a service with cn:'vs.zpr'
 define PingableNode as a service with cn:node
 
 allow A1 to access A2Svc

--- a/integration-test/pregen/v4-1node-3agent-ping.zpl
+++ b/integration-test/pregen/v4-1node-3agent-ping.zpl
@@ -7,12 +7,12 @@ define A1 as adapter with cn:adapter1
 define A2 as adapter with cn:adapter2
 define A3 as adapter with cn:adapter3
 define Node as adapter with cn:node
-define Vs as adapter with cn:vs.zpr
+define Vs as adapter with cn:'vs.zpr'
 
 define A1Svc as a service with cn:adapter1
 define A2Svc as a service with cn:adapter2
 define A3Svc as a service with cn:adapter3
-define PingableVs as a service with cn:vs.zpr
+define PingableVs as a service with cn:'vs.zpr'
 define PingableNode as a service with cn:node
 
 allow A1 to access A2Svc


### PR DESCRIPTION
Period was always allowed, but it was ignored. Now periods are still optional, but if you do happen to use them incorrectly you get an error.

* New `--Werror` flag to halt on any warnings.
* Gratuitous, fancy colored terminal output!

**BREAKING CHANGE** -> Also now correctly enforces the characters allowed in unquoted names and strings.  This means that if you have a period in a tuple value you must quote it.  Eg,

`define FooBoo as service with cn:'hah.ho.hee'`.

_Note the quotes around "hah.ho.hee".  ZPL accepts forward or backward SINGLE quotes (and they don't have to match or anything)_

