### PR TITLE
visa service must register its admin service endpoint

### DIFF
--- a/visaservice/core/pkg/vservice/vsinst.go
+++ b/visaservice/core/pkg/vservice/vsinst.go
@@ -188,6 +188,7 @@ func NewVSInst(vcf *VSIConfig) (*VSInst, error) {
 		visaServiceAgent.SetProvides([]string{
 			polio.VisaServiceName,
 			fmt.Sprintf("/zpr/%s", polio.VisaServiceName),
+			fmt.Sprintf("/zpr/%s/admin", polio.VisaServiceName),
 		})
 		authedClaims := make(map[string]*agent.ClaimV)
 		authedClaims[agent.KAttrVisaServiceAdapter] = &agent.ClaimV{


### PR DESCRIPTION
Oops ... The visa service was not registering it's own admin endpoint.

This is still a hack since the visa service is just self-registering it's own adapter.  We will eventually need the node to perform some sort of auth on the vs adapter (as is case for all adapters).