### PR TITLE
restructure two_way_queue to allow shared return queue

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "zpr-ext"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bytes",
  "libc",

--- a/adapter/ph/src/agent_output_worker.rs
+++ b/adapter/ph/src/agent_output_worker.rs
@@ -50,16 +50,18 @@ fn agent_output_main(mut worker: FastpathWorker, tun: &ZprTun, requeue_outq: &Un
         // output anything we've queued up
         worker.process_out_queues();
 
+        // WORKING: move return logic into fastpath common
+
         // process the return buffer queue
         if worker.buffers.is_empty() {
             // if we are out of buffers, block
             worker
-                .adapter_manager
-                .recv_return_buffers(&mut worker.buffers, worker.config.buffer_count);
+                .return_q
+                .blocking_recv_many_returns(&mut worker.buffers, worker.config.buffer_count);
         } else {
             worker
-                .adapter_manager
-                .try_recv_return_buffers(&mut worker.buffers, worker.config.buffer_count);
+                .return_q
+                .try_recv_many_returns(&mut worker.buffers, worker.config.buffer_count);
         }
 
         // read & forward packets one at a time

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -82,8 +82,8 @@ pub struct Assembly {
     pub alt: adapter_tables::AgentLookupTable,
     pub dlt: adapter_tables::DockLookupTable,
 
-    pub mgmt_dispatch: MgmtDispatch,
-    pub adapter_manager: AdapterManager,
+    pub mgmt_dispatch_factory: MgmtDispatchFactory,
+    pub adapter_manager_factory: AdapterManagerFactory,
     pub km_state: KmState,
 
     pub self_noise_keypair: Option<NoiseKeypair>,
@@ -343,8 +343,8 @@ pub mod test {
         pub peer_ids: Option<Vec<zpr::LinkId>>,
         pub alt: Option<adapter_tables::AgentLookupTable>,
         pub dlt: Option<adapter_tables::DockLookupTable>,
-        pub mgmt_dispatch: Option<MgmtDispatch>,
-        pub adapter_manager: Option<AdapterManager>,
+        pub mgmt_dispatch_factory: Option<MgmtDispatchFactory>,
+        pub adapter_manager_factory: Option<AdapterManagerFactory>,
         pub km_state: Option<KmState>,
         pub system_start_time: Option<std::time::Instant>,
     }
@@ -404,13 +404,13 @@ pub mod test {
         let dlt = builder
             .dlt
             .unwrap_or_else(|| adapter_tables::DockLookupTable::new());
-        let mgmt_dispatch = builder.mgmt_dispatch.unwrap_or_else(|| {
-            let (md_inq, _md_outq) = two_way_queue::two_way_queue(1);
-            MgmtDispatch::new(md_inq)
+        let mgmt_dispatch_factory = builder.mgmt_dispatch_factory.unwrap_or_else(|| {
+            let (md_inq_factory, _md_outq) = two_way_queue::two_way_queue(1);
+            MgmtDispatchFactory::new(md_inq_factory)
         });
-        let adapter_manager = builder.adapter_manager.unwrap_or_else(|| {
-            let (am_inq, _am_outq) = two_way_queue::two_way_queue(1);
-            AdapterManager::new(am_inq)
+        let adapter_manager_factory = builder.adapter_manager_factory.unwrap_or_else(|| {
+            let (am_inq_factory, _am_outq) = two_way_queue::two_way_queue(1);
+            AdapterManagerFactory::new(am_inq_factory)
         });
         let km_state = builder.km_state.unwrap_or_else(|| {
             let (km_sig_tx, _km_sig_rx) = mpsc::channel(1);
@@ -436,8 +436,8 @@ pub mod test {
             peer_ids,
             alt,
             dlt,
-            mgmt_dispatch,
-            adapter_manager,
+            mgmt_dispatch_factory,
+            adapter_manager_factory,
             km_state,
             self_noise_keypair: None,
             peer_noise_keypair: None,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -17,6 +17,7 @@ use crate::net_defs;
 use crate::packet::{Packet, PacketBuffer};
 use crate::queues::{AdapterManager, MgmtDispatch, TryEnqueueError};
 use crate::sys::{TunPi, ZprTun};
+use crate::two_way_queue;
 use crate::zdp;
 use crate::zdp_ll;
 use crate::{compress, km};
@@ -70,6 +71,8 @@ pub struct FastpathWorker {
     pub worker_index: usize,
     pub asm: Arc<Assembly>,
     pub buffers: Vec<PacketBuffer>,
+
+    pub return_q: two_way_queue::ReturnQueue<PacketBuffer>,
     pub adapter_manager: AdapterManager,
     pub mgmt_dispatch: MgmtDispatch,
 
@@ -86,8 +89,9 @@ impl FastpathWorker {
         let buffers =
             vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]) as Box<[_]>; config.buffer_count];
 
-        let adapter_manager = asm.adapter_manager.clone();
-        let mgmt_dispatch = asm.mgmt_dispatch.clone();
+        let return_q = two_way_queue::ReturnQueue::new();
+        let adapter_manager = asm.adapter_manager_factory.make(&return_q);
+        let mgmt_dispatch = asm.mgmt_dispatch_factory.make(&return_q);
 
         let agent_input_tun = asm.agent_input.tuns[worker_index].clone(); // TEMP HACK
         let substrate_egress_socket = asm.substrate_egress.sockets[worker_index].clone(); // TEMP HACK
@@ -97,6 +101,8 @@ impl FastpathWorker {
             worker_index,
             asm,
             buffers,
+
+            return_q,
             adapter_manager,
             mgmt_dispatch,
 

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -155,8 +155,9 @@ fn main() -> ExitCode {
 
     // TODO: use get/setsockopt(SO_SNDBUF) to ensure we can buffer `capture_queue_size` packets
     let (cap_inq, cap_outq) = std::os::unix::net::UnixDatagram::pair().unwrap();
-    let (md_inq, md_outq) = two_way_queue::two_way_queue(topology_config.mgmt_dispatch_queue_size);
-    let (am_inq, am_outq) =
+    let (md_inq_factory, md_outq) =
+        two_way_queue::two_way_queue(topology_config.mgmt_dispatch_queue_size);
+    let (am_inq_factory, am_outq) =
         two_way_queue::two_way_queue(topology_config.adapter_manager_queue_size);
     let (km_sig_inq, km_sig_outq) = mpsc::channel(topology_config.km_signal_queue_size);
     let (km_inq, km_outq) = mpsc::channel(topology_config.km_message_queue_size);
@@ -331,8 +332,8 @@ fn main() -> ExitCode {
         peer_ids: Default::default(),
         alt: adapter_tables::AgentLookupTable::new(),
         dlt: adapter_tables::DockLookupTable::new(),
-        mgmt_dispatch: MgmtDispatch::new(md_inq),
-        adapter_manager: AdapterManager::new(am_inq),
+        mgmt_dispatch_factory: MgmtDispatchFactory::new(md_inq_factory),
+        adapter_manager_factory: AdapterManagerFactory::new(am_inq_factory),
         km_state: KmState::new(km_inq, km_sig_inq),
         self_noise_keypair,
         peer_noise_keypair,

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -244,16 +244,11 @@ impl two_way_queue::TwoWayReturnable<MgmtDispatchMessage> for PacketBuffer {
     }
 }
 
-#[derive(Clone)]
 pub struct MgmtDispatch {
     sender: two_way_queue::Sender<MgmtDispatchMessage, PacketBuffer>,
 }
 
 impl MgmtDispatch {
-    pub fn new(sender: two_way_queue::Sender<MgmtDispatchMessage, PacketBuffer>) -> Self {
-        Self { sender }
-    }
-
     pub fn try_dispatch_mgmt_packet_with_link(
         &mut self,
         packet: Packet,
@@ -295,17 +290,20 @@ impl MgmtDispatch {
             }
         }
     }
+}
 
-    pub fn recv_return_buffers(&mut self, returns: &mut Vec<PacketBuffer>, limit: usize) -> usize {
-        self.sender.blocking_recv_many_returns(returns, limit)
+/// Factory to build `MgmtDispatch` ingresses for specified two-way-queue return queues.
+pub struct MgmtDispatchFactory(two_way_queue::SenderFactory<MgmtDispatchMessage, PacketBuffer>);
+
+impl MgmtDispatchFactory {
+    pub fn new(fact: two_way_queue::SenderFactory<MgmtDispatchMessage, PacketBuffer>) -> Self {
+        Self(fact)
     }
 
-    pub fn try_recv_return_buffers(
-        &mut self,
-        returns: &mut Vec<PacketBuffer>,
-        limit: usize,
-    ) -> usize {
-        self.sender.try_recv_many_returns(returns, limit)
+    pub fn make(&self, ret_q: &two_way_queue::ReturnQueue<PacketBuffer>) -> MgmtDispatch {
+        MgmtDispatch {
+            sender: self.0.make(ret_q),
+        }
     }
 }
 
@@ -321,16 +319,11 @@ impl two_way_queue::TwoWayReturnable<AdapterManagerMessage> for PacketBuffer {
     }
 }
 
-#[derive(Clone)]
 pub struct AdapterManager {
     sender: two_way_queue::Sender<AdapterManagerMessage, PacketBuffer>,
 }
 
 impl AdapterManager {
-    pub fn new(sender: two_way_queue::Sender<AdapterManagerMessage, PacketBuffer>) -> Self {
-        Self { sender }
-    }
-
     /// Request a tether ID to use for sending packets starting with the
     /// specified packet.
     ///
@@ -358,16 +351,19 @@ impl AdapterManager {
             },
         }
     }
+}
 
-    pub fn recv_return_buffers(&mut self, returns: &mut Vec<PacketBuffer>, limit: usize) -> usize {
-        self.sender.blocking_recv_many_returns(returns, limit)
+/// Factory to build `AdapterManager` ingresses for specified two-way-queue return queues.
+pub struct AdapterManagerFactory(two_way_queue::SenderFactory<AdapterManagerMessage, PacketBuffer>);
+
+impl AdapterManagerFactory {
+    pub fn new(fact: two_way_queue::SenderFactory<AdapterManagerMessage, PacketBuffer>) -> Self {
+        Self(fact)
     }
 
-    pub fn try_recv_return_buffers(
-        &mut self,
-        returns: &mut Vec<PacketBuffer>,
-        limit: usize,
-    ) -> usize {
-        self.sender.try_recv_many_returns(returns, limit)
+    pub fn make(&self, ret_q: &two_way_queue::ReturnQueue<PacketBuffer>) -> AdapterManager {
+        AdapterManager {
+            sender: self.0.make(ret_q),
+        }
     }
 }

--- a/adapter/ph/src/substrate_ingress_worker.rs
+++ b/adapter/ph/src/substrate_ingress_worker.rs
@@ -34,12 +34,12 @@ fn substrate_ingress_main(mut worker: FastpathWorker, socket: &UdpSocket) {
         if worker.buffers.is_empty() {
             // if we are out of buffers, block
             worker
-                .mgmt_dispatch
-                .recv_return_buffers(&mut worker.buffers, worker.config.buffer_count);
+                .return_q
+                .blocking_recv_many_returns(&mut worker.buffers, worker.config.buffer_count);
         } else {
             worker
-                .mgmt_dispatch
-                .try_recv_return_buffers(&mut worker.buffers, worker.config.buffer_count);
+                .return_q
+                .try_recv_many_returns(&mut worker.buffers, worker.config.buffer_count);
         }
 
         let _n = match poll::poll(std::slice::from_mut(&mut poll_fd), poll::PollTimeout::NONE)

--- a/adapter/ph/src/two_way_queue.rs
+++ b/adapter/ph/src/two_way_queue.rs
@@ -14,13 +14,29 @@
 //! differ if `TwoWayReturnable<Forward>` is implemented for the reverse
 //! type.  (This is chosen instead of using `From` so that non-default conversions
 //! can be used.)
+//!
+//! There are three components to any "two-way" queue flow.  Each "service"
+//! to which items are being sent creates a single `Receiver` to receive
+//! tiems on.  Each "client" which is sending items (to any number of
+//! "services") creates a single `ReturnQueue` to receive returned items.
+//! Then, for each client-server pairing, the client creates a `Sender` which
+//! sends items to the given `Receiver`, to be returned on the client's own
+//! `ReturnQueue`.
+//!
+//! The two main entry points to create all these objects are
+//! `ReturnQueue::new()`, and `two_way_queue()`.  The former creates a
+//! single `ReturnQueue`.  The latter creates a pair of a `SenderFactory`
+//! and a `Receiver`.  The `SenderFactory` is then used to create `Sender`
+//! instances linked to the `Receiver` and a supplied `ReturnQueue`.
 
 #![allow(dead_code)]
 
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
 use tokio::sync::mpsc;
+use zpr_ext::std::cell::scalar::UsizeCell;
 
 /// Trait representing a type which can be returned through a `TwoWayQueue`.
 pub trait TwoWayReturnable<T> {
@@ -44,28 +60,21 @@ pub enum TryRecvReturnError {
     Disconnected,
 }
 
-/// The producer half of a two-way queue.
-pub struct Sender<T, U> {
-    outgoing_q: mpsc::Sender<(T, mpsc::UnboundedSender<U>)>,
-    outgoing_return_q: mpsc::UnboundedSender<U>,
+/// The return path of a two-way queue.
+pub struct ReturnQueue<U> {
     incoming_return_q: mpsc::UnboundedReceiver<U>,
-    outstanding: usize,
+    outgoing_return_q: mpsc::UnboundedSender<U>,
+    outstanding: Rc<UsizeCell>,
 }
 
-impl<T, U> Sender<T, U> {
-    /// Try to send an item.  Note that it is possible for the queue
-    /// to appear full for the reason that there are outstanding returns.
-    pub fn try_send(&mut self, item: T) -> Result<(), TrySendError<T>> {
-        match self
-            .outgoing_q
-            .try_send((item, self.outgoing_return_q.clone()))
-        {
-            Ok(()) => {
-                self.outstanding += 1;
-                Ok(())
-            }
-            Err(mpsc::error::TrySendError::Full((item, _))) => Err(TrySendError::Full(item)),
-            Err(mpsc::error::TrySendError::Closed((item, _))) => Err(TrySendError::Closed(item)),
+impl<U> ReturnQueue<U> {
+    /// Construct a new return queue.
+    pub fn new() -> Self {
+        let (outgoing_return_q, incoming_return_q) = mpsc::unbounded_channel();
+        Self {
+            incoming_return_q,
+            outgoing_return_q,
+            outstanding: Rc::new(UsizeCell::new(0)),
         }
     }
 
@@ -73,9 +82,9 @@ impl<T, U> Sender<T, U> {
     ///
     /// Panics if called when no items are outstanding.
     pub fn blocking_recv_return(&mut self) -> U {
-        assert!(self.outstanding > 0);
+        assert!(self.outstanding.load() > 0);
         let ret = self.incoming_return_q.blocking_recv().unwrap();
-        self.outstanding -= 1;
+        self.outstanding.fetch_sub(1);
         return ret;
     }
 
@@ -85,9 +94,9 @@ impl<T, U> Sender<T, U> {
     ///
     /// Panics if called when no items are outstanding.
     pub fn blocking_recv_many_returns(&mut self, returns: &mut Vec<U>, limit: usize) -> usize {
-        assert!(self.outstanding > 0 || limit == 0);
+        assert!(self.outstanding.load() > 0 || limit == 0);
         let ret = self.incoming_return_q.blocking_recv_many(returns, limit);
-        self.outstanding -= ret;
+        self.outstanding.fetch_sub(ret);
         return ret;
     }
 
@@ -97,7 +106,7 @@ impl<T, U> Sender<T, U> {
     pub fn try_recv_return(&mut self) -> Option<U> {
         let ret = self.incoming_return_q.try_recv().ok();
         if ret.is_some() {
-            self.outstanding -= 1;
+            self.outstanding.fetch_sub(1);
         }
         return ret;
     }
@@ -110,39 +119,73 @@ impl<T, U> Sender<T, U> {
             match self.incoming_return_q.try_recv() {
                 Ok(item) => returns.push(item),
                 Err(_) => {
-                    self.outstanding -= i;
+                    self.outstanding.fetch_sub(i);
                     return i;
                 }
             }
         }
 
-        self.outstanding -= limit;
+        self.outstanding.fetch_sub(limit);
         return limit;
     }
 
     /// Async version of `blocking_recv_return()`.
     pub async fn recv_return(&mut self) -> U {
+        assert!(self.outstanding.load() > 0);
         let ret = self.incoming_return_q.recv().await.unwrap();
-        self.outstanding -= 1;
+        self.outstanding.fetch_sub(1);
         return ret;
     }
 
     /// Async version of `blocking_recv_many_returns()`.
     pub async fn recv_many_returns(&mut self, returns: &mut Vec<U>, limit: usize) -> usize {
+        assert!(self.outstanding.load() > 0 || limit == 0);
         let ret = self.incoming_return_q.recv_many(returns, limit).await;
-        self.outstanding -= ret;
+        self.outstanding.fetch_sub(ret);
         return ret;
     }
 }
 
-impl<T, U> Clone for Sender<T, U> {
-    fn clone(&self) -> Self {
-        let (outgoing_return_q, incoming_return_q) = mpsc::unbounded_channel();
-        Self {
+/// The producer half of a two-way queue.
+pub struct Sender<T, U> {
+    outgoing_q: mpsc::Sender<(T, mpsc::UnboundedSender<U>)>,
+    outgoing_return_q: mpsc::UnboundedSender<U>,
+    outstanding: Rc<UsizeCell>,
+}
+
+impl<T, U> Sender<T, U> {
+    /// Try to send an item.  Note that it is possible for the queue
+    /// to appear full for the reason that there are outstanding returns.
+    pub fn try_send(&mut self, item: T) -> Result<(), TrySendError<T>> {
+        match self
+            .outgoing_q
+            .try_send((item, self.outgoing_return_q.clone()))
+        {
+            Ok(()) => {
+                self.outstanding.fetch_add(1);
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Full((item, _))) => Err(TrySendError::Full(item)),
+            Err(mpsc::error::TrySendError::Closed((item, _))) => Err(TrySendError::Closed(item)),
+        }
+    }
+}
+
+/// `SenderFactory` is used to create `Sender` instances which send to the
+/// associated `Receiver` and return items along the specified
+/// `ReturnQueue`.
+#[derive(Clone)]
+pub struct SenderFactory<T, U> {
+    outgoing_q: mpsc::Sender<(T, mpsc::UnboundedSender<U>)>,
+}
+
+impl<T, U> SenderFactory<T, U> {
+    /// Construct a sender for the factory's associated receiver which returns items on the given return queue.
+    pub fn make(&self, ret_q: &ReturnQueue<U>) -> Sender<T, U> {
+        Sender {
             outgoing_q: self.outgoing_q.clone(),
-            outgoing_return_q,
-            incoming_return_q,
-            outstanding: 0,
+            outgoing_return_q: ret_q.outgoing_return_q.clone(),
+            outstanding: ret_q.outstanding.clone(),
         }
     }
 }
@@ -206,17 +249,11 @@ impl<T, U: TwoWayReturnable<T>> Drop for ItemGuard<'_, T, U> {
     }
 }
 
-/// Construct a send-receive pair for a two-way queue.
-pub fn two_way_queue<T, U>(buffer: usize) -> (Sender<T, U>, Receiver<T, U>) {
+/// Construct a receive queue of the specified size.
+///
+/// Also returns a `SenderFactory`, which can be used to create one or more
+/// `Sender` instances associated with specified `ReturnQueue`s.
+pub fn two_way_queue<T, U>(buffer: usize) -> (SenderFactory<T, U>, Receiver<T, U>) {
     let (outgoing_q, incoming_q) = mpsc::channel(buffer);
-    let (outgoing_return_q, incoming_return_q) = mpsc::unbounded_channel();
-    (
-        Sender {
-            outgoing_q,
-            outgoing_return_q,
-            incoming_return_q,
-            outstanding: 0,
-        },
-        Receiver { incoming_q },
-    )
+    (SenderFactory { outgoing_q }, Receiver { incoming_q })
 }

--- a/zpr-ext/Cargo.lock
+++ b/zpr-ext/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "zpr-ext"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bytes",
  "libc",

--- a/zpr-ext/Cargo.toml
+++ b/zpr-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zpr-ext"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 [dependencies]

--- a/zpr-ext/src/std.rs
+++ b/zpr-ext/src/std.rs
@@ -1,3 +1,4 @@
+pub mod cell;
 pub mod mem;
 pub mod net;
 pub mod num;

--- a/zpr-ext/src/std/cell.rs
+++ b/zpr-ext/src/std/cell.rs
@@ -1,0 +1,62 @@
+pub mod scalar {
+    //! Types in this module are "single-threaded atomics".
+    //!
+    //! Like other cell types, they provide dynamic enforcement of Rust's
+    //! ownership rules, within a single thread.
+    //!
+    //! Unlike other cell types, they are limited to fixed operations on
+    //! integral types, but have practically no overhead.
+    //!
+    //! Like atomic types, they provide mutable access via a shared reference.
+    //!
+    //! Unlike atomic types, they are not `Sync`, but have less overhead and
+    //! a simpler API.
+
+    use std::cell::RefCell;
+    use std::marker::PhantomData;
+    use std::sync::atomic::*;
+
+    pub struct UsizeCell(AtomicUsize, PhantomData<RefCell<usize>>);
+
+    impl UsizeCell {
+        pub const fn new(val: usize) -> Self {
+            Self(AtomicUsize::new(val), PhantomData)
+        }
+
+        pub const fn into_inner(self) -> usize {
+            self.0.into_inner()
+        }
+
+        pub fn load(&self) -> usize {
+            self.0.load(Ordering::Relaxed)
+        }
+
+        pub fn store(&self, val: usize) {
+            self.0.store(val, Ordering::Relaxed)
+        }
+
+        pub fn fetch_add(&self, val: usize) -> usize {
+            let old = self.load();
+            self.store(old.wrapping_add(val));
+            old
+        }
+
+        pub fn fetch_sub(&self, val: usize) -> usize {
+            let old = self.load();
+            self.store(old.wrapping_sub(val));
+            old
+        }
+
+        pub fn fetch_add_nowrap(&self, val: usize) -> usize {
+            let old = self.load();
+            self.store(old + val);
+            old
+        }
+
+        pub fn fetch_sub_nowrap(&self, val: usize) -> usize {
+            let old = self.load();
+            self.store(old - val);
+            old
+        }
+    }
+}


### PR DESCRIPTION
Prerequisite to unifying the fastpath workers.  Closes #717.