### PR TITLE
prettier counter output

### DIFF
--- a/adapter/ph/src/signal_worker.rs
+++ b/adapter/ph/src/signal_worker.rs
@@ -46,11 +46,11 @@ pub async fn launch(asm: Arc<Assembly>) {
 }
 
 fn emit_counts(counters: &Counters, uptime: std::time::Duration) {
-    println!("\n*** Counters ***");
+    println!("{:>42}\n", "*** Counters ***");
+    println!("{:>34}: {:?}", "Uptime", uptime);
     for (key, ref value) in counters {
-        println!("{}: {}", key, value.get_count());
+        println!("{:>34}: {}", key.name(), value.get_count());
     }
-    println!("Uptime: {uptime:?}");
 }
 
 async fn do_clean_shutdown(asm: Arc<Assembly>) -> ! {


### PR DESCRIPTION
Nicer format of the counters.

New format:
```
                          *** Counters ***

                            Uptime: 3.133912977s
          Inbound Packets Received: 4
           Inbound Packets Dropped: 0
              Inbound Packets Sent: 0
         Outbound Packets Received: 0
         Requeued Packets Received: 0
          Outbound Packets Dropped: 0
             Outbound Packets Sent: 6
       Outbound Packet Send Errors: 0
   Inbound Capture Packets Written: 0
  Outbound Capture Packets Written: 0
   Inbound Capture Packets Dropped: 0
  Outbound Capture Packets Dropped: 0
  Inbound Capture Packets Filtered: 0
 Outbound Capture Packets Filtered: 0
                 QueueBackpressure: 0
             Dropped Awaiting Bind: 0
              Dropped No Operation: 0
                 Dropped Duplicate: 0
   Dropped No Security Association: 0
            Internal Routing Error: 0
          Dispatched to Management: 4
                    Agent Slowpath: 0
           Bad Management Response: 0
    Unexpected Management Response: 0
                      Unknown Peer: 0
                      Peer Removed: 0
            Peer Handshake Success: 1
            Peer Handshake Failure: 0
                       Unknown ZPI: 0
                    Sequence Error: 0
                      MICV Failure: 0
                      Bad Checksum: 0
                Decryption Failure: 0
                Encryption Failure: 0
                      Unknown Type: 0
                 Unknown Stream ID: 0
                     Bad Structure: 0
                       Other Error: 0
                    Visa Requested: 0
              Visa Request Success: 0
               Visa Request Denied: 0
                Visa Request Error: 0
        Agent Packets Out-Of-Order: 0
```