### PR TITLE
ph-debug link show command can list all (non-internal) links

### DIFF
--- a/adapter/ph-debug/src/main.rs
+++ b/adapter/ph-debug/src/main.rs
@@ -126,7 +126,7 @@ struct LinkArgs {
 #[derive(Debug, Subcommand)]
 enum LinkCommands {
     /// Show a link's status
-    Show { id: u32 },
+    Show { id: Option<u32> },
     /// Configure a link
     Configure { id: u32 },
     /// Start a link
@@ -411,7 +411,8 @@ fn handle_set_capture_program(program: Option<String>, socket: &str) -> std::io:
 
 fn handle_link_command(link_args: LinkArgs, socket: &str) -> std::io::Result<()> {
     match link_args.command {
-        LinkCommands::Show { id } => basic_command!(RpcCommands::ShowLink, socket, id)?,
+        LinkCommands::Show { id: None } => basic_command!(RpcCommands::ShowLink, socket)?,
+        LinkCommands::Show { id: Some(id) } => basic_command!(RpcCommands::ShowLink, socket, id)?,
         LinkCommands::Configure { id } => basic_command!(RpcCommands::ConfigureLink, socket, id)?,
         LinkCommands::Start { id } => basic_command!(RpcCommands::StartLink, socket, id)?,
         LinkCommands::Stop { id } => basic_command!(RpcCommands::StopLink, socket, id)?,

--- a/adapter/ph/src/admin_worker.rs
+++ b/adapter/ph/src/admin_worker.rs
@@ -157,6 +157,12 @@ async fn handle_connection(asm: Arc<Assembly>, mut stream: UnixStream) -> std::i
                 buf_writer.write_all("OK\n".as_bytes()).await?
             }
             Ok(RpcCommands::ShowLink) => match vec_message.len() {
+                1 => {
+                    buf_writer
+                        .write_all(show_link_summary(&asm.clone()).as_bytes())
+                        .await?;
+                    buf_writer.write_all("OK\n".as_bytes()).await?
+                }
                 2 => match vec_message[1].parse::<u32>() {
                     Ok(link_id) => {
                         buf_writer
@@ -466,6 +472,28 @@ fn delete_capture_program(asm: &Assembly) -> String {
     asm.flow_control.delete_program();
 
     String::from("Program deleted\n")
+}
+
+fn get_link_summary(asm: &Arc<Assembly>, link_id: LinkId) -> String {
+    match asm.peer_table.get(link_id) {
+        Some(peer) => format!(
+            "{} ({:?})",
+            peer.substrate_addr,
+            peer.link_state_machine.get_state()
+        ),
+        None => format!("Unconfigured"),
+    }
+}
+
+fn show_link_summary(asm: &Arc<Assembly>) -> String {
+    let mut links: String = String::new();
+    let _ = write!(&mut links, "Link summary:\n");
+
+    for id in asm.peer_ids.lock().unwrap().clone() {
+        let _ = write!(&mut links, "  {id}: {}\n", get_link_summary(asm, id));
+    }
+
+    links
 }
 
 fn show_link(asm: &Arc<Assembly>, link_id: LinkId) -> String {


### PR DESCRIPTION
When you don't give a link ID to the link show command, it now prints a brief summary:
```
> link show
Message Received
Link summary:
  2: 10.0.0.2:53100 (Active)
  3: 10.0.2.2:39619 (Active)
  4: 10.0.1.2:57783 (Active)
  5: 10.0.3.2:59093 (Active)
OK
```