### PR TITLE
packet priority flag

### DIFF
--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -14,7 +14,7 @@ use crate::km::Codec;
 use crate::km_noise::NOISE_PADLEN;
 use crate::logging::targets::DATAPATH;
 use crate::net_defs;
-use crate::packet::{Packet, PacketBuffer};
+use crate::packet::{self, Packet, PacketBuffer};
 use crate::queues::{AdapterManager, MgmtDispatch, TryEnqueueError};
 use crate::sys::{TunPi, ZprTun};
 use crate::two_way_queue;
@@ -608,22 +608,46 @@ impl FastpathWorker {
             .expect("unrecoverable I/O error");
 
         // Tally results.
-        let mut dropped = self.substrate_egress_q.len() - n;
-        for res in results {
-            match res {
-                Ok(_) => (),
-                Err(err) if err.kind() == ErrorKind::WouldBlock => dropped += 1,
-                Err(err) => panic!("unrecoverable I/O error: {}", err),
+        let mut dropped = 0;
+        let mut retained = 0;
+
+        for i in 0..self.substrate_egress_q.len() {
+            // Determine whether the packet was in fact sent.
+            // If it was, leave it in place and skip to the next packet.
+            if i < n {
+                match &results[i] {
+                    Ok(_) => continue,
+                    Err(err) if err.kind() == ErrorKind::WouldBlock => (),
+                    Err(err) => panic!("unrecoverable I/O error: {err}"),
+                }
+            }
+
+            // Packet was not sent.
+
+            if self.substrate_egress_q[i].0.metadata().flags & packet::flags::PRIORITY != 0 {
+                // This was a priority packet.  Move it to the front of the queue:
+                // `retained` is the number of packets we've retained so far, so swap
+                // this packet with the one at that index.  We'll later drop all packets
+                // in the range `retained..`.
+                self.substrate_egress_q.swap(i, retained);
+                retained += 1;
+            } else {
+                // This was a normal packet.  Leave it to get dropped.
+                dropped += 1;
             }
         }
+
+        // Now all un-sent priority packets are at the head of the queue.
+
         self.asm.counters[CounterType::OutPacksSent]
-            .increase_by((self.substrate_egress_q.len() - dropped) as u64);
+            .increase_by((self.substrate_egress_q.len() - dropped - retained) as u64);
         self.asm.counters[CounterType::OutPacksDrop].increase_by(dropped as u64);
 
-        // Return buffers to buffer stack.
+        // Return buffers to buffer stack, except for un-sent priority packets (in the range `..retained`),
+        // which are retained for next time.
         self.buffers.extend(
             self.substrate_egress_q
-                .drain(..)
+                .drain(retained..)
                 .map(|(pkt, _)| pkt.destroy()),
         );
     }

--- a/adapter/ph/src/fastpath_worker.rs
+++ b/adapter/ph/src/fastpath_worker.rs
@@ -44,10 +44,9 @@ pub fn launch(
 
 fn fastpath_main(mut worker: FastpathWorker, socket: &UdpSocket, requeue_outq: &UnixDatagram) {
     loop {
-        // output anything we've queued up
+        // try to immediately output anything we've queued up;
+        // if we can't, drop it, unless it's on the substrate and marked PRIORITY
         worker.process_out_queues();
-
-        // WORKING: move return logic into fastpath common
 
         let recv_poll_flags;
         if worker.buffers.is_empty() {
@@ -57,8 +56,15 @@ fn fastpath_main(mut worker: FastpathWorker, socket: &UdpSocket, requeue_outq: &
             recv_poll_flags = poll::PollFlags::POLLIN;
         }
 
+        let send_poll_flags;
+        if worker.substrate_egress_packets_queued() {
+            send_poll_flags = poll::PollFlags::POLLOUT;
+        } else {
+            send_poll_flags = poll::PollFlags::empty();
+        }
+
         let mut poll_fds = enum_map! {
-            PollSlot::Substrate => poll::PollFd::new(socket.as_fd(), recv_poll_flags),
+            PollSlot::Substrate => poll::PollFd::new(socket.as_fd(), recv_poll_flags | send_poll_flags),
             PollSlot::Tun => poll::PollFd::new(worker.agent_input_tun.as_fd(), recv_poll_flags),
             PollSlot::Requeue => poll::PollFd::new(requeue_outq.as_fd(), recv_poll_flags),
             PollSlot::Returns => poll::PollFd::new(worker.return_q.poll_fd(), poll::PollFlags::POLLIN),
@@ -78,6 +84,11 @@ fn fastpath_main(mut worker: FastpathWorker, socket: &UdpSocket, requeue_outq: &
 
         // FIXME: fairness... address this in tandem with batch receive
         // for now, prioritize requeue so it doesn't starve
+
+        if revents[PollSlot::Substrate].contains(poll::PollFlags::POLLOUT) {
+            // try to send queued PRIORITY packets
+            worker.process_substrate_egress_queue();
+        }
 
         if revents[PollSlot::Requeue].contains(poll::PollFlags::POLLIN) {
             // read from requeue

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -167,9 +167,19 @@ pub struct PacketMetadata {
     /// which fastpath lane this packet arrived on
     pub ingress_lane_id: u8,
 
-    _padding: [u8; 1],
+    /// various flags
+    pub flags: PacketFlags,
 
     five_tuple: FiveTuple,
+}
+
+pub type PacketFlags = u8;
+
+pub mod flags {
+    use super::PacketFlags;
+
+    /// Packets marked `PRIORITY` are not dropped on egress queue backpressure.
+    pub const PRIORITY: PacketFlags = 1;
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Adds a notion of "priority" substrate packets to the datapath.  When egressing such a packet, if there is no room in the kernel queue, instead of dropping it, we hang onto it and move it to the front of our own queue.

Will be used by mgmt substrate egress in upcoming review.