### PR TITLE
integrate two-way queue returns with poll

### DIFF
--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -22,7 +22,7 @@ hdrhistogram = { version = "7.5.4" }
 libc = { version = "0.2.155" }
 libnode = { path = "../../libnode" }
 itertools = "0.14"
-nix = { version = "0.29.0", features = ["ioctl", "net", "poll"] }
+nix = { version = "0.29.0", features = ["fs", "ioctl", "net", "poll"] }
 open-enum = { version = "0.5.1" }
 openssl = { version = "0.10.70" }
 openssl-sys = { version = "0.9.102" }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -531,12 +531,17 @@ impl FastpathWorker {
         self.substrate_egress_q.push((pkt, dest_sa));
     }
 
+    /// Egress any queued packets, or drop if there is no space in the system queues.
+    ///
+    /// After this call, the agent input queue will be empty, and the substrate egress queue
+    /// will contain only PRIORITY packets.
     pub fn process_out_queues(&mut self) {
         self.process_agent_input_queue();
         self.process_substrate_egress_queue();
     }
 
-    fn process_agent_input_queue(&mut self) {
+    /// Egress queued agent input packets only.
+    pub fn process_agent_input_queue(&mut self) {
         // temp hack until we move ZprTun to be non-Tokio
         let tun_fd = unsafe { BorrowedFd::borrow_raw(self.agent_input_tun.as_raw_fd()) };
 
@@ -587,7 +592,8 @@ impl FastpathWorker {
             .extend(self.agent_input_q.drain(..).map(|pkt| pkt.destroy()));
     }
 
-    fn process_substrate_egress_queue(&mut self) {
+    /// Egress queued substrate egress packets only.
+    pub fn process_substrate_egress_queue(&mut self) {
         // (Try to) send packets.
         let mut results = Vec::new(); // TODO: recycle
         let n = self
@@ -620,6 +626,12 @@ impl FastpathWorker {
                 .drain(..)
                 .map(|(pkt, _)| pkt.destroy()),
         );
+    }
+
+    #[allow(dead_code)]
+    /// Are there any substrate egress packets remaining queued?
+    pub fn substrate_egress_packets_queued(&self) -> bool {
+        !self.substrate_egress_q.is_empty()
     }
 }
 

--- a/adapter/ph/src/fastpath_worker.rs
+++ b/adapter/ph/src/fastpath_worker.rs
@@ -25,6 +25,7 @@ enum PollSlot {
     Substrate,
     Tun,
     Requeue,
+    Returns,
 }
 
 pub fn launch(
@@ -48,25 +49,21 @@ fn fastpath_main(mut worker: FastpathWorker, socket: &UdpSocket, requeue_outq: &
 
         // WORKING: move return logic into fastpath common
 
-        // process the return buffer queue
+        let recv_poll_flags;
         if worker.buffers.is_empty() {
-            // if we are out of buffers, block
-            worker
-                .return_q
-                .blocking_recv_many_returns(&mut worker.buffers, worker.config.buffer_count);
+            // If we have no buffers, let's not get woken up to receive packets.
+            recv_poll_flags = poll::PollFlags::empty();
         } else {
-            worker
-                .return_q
-                .try_recv_many_returns(&mut worker.buffers, worker.config.buffer_count);
+            recv_poll_flags = poll::PollFlags::POLLIN;
         }
 
         let mut poll_fds = enum_map! {
-            PollSlot::Substrate => poll::PollFd::new(socket.as_fd(), poll::PollFlags::POLLIN),
-            PollSlot::Tun => poll::PollFd::new(worker.agent_input_tun.as_fd(), poll::PollFlags::POLLIN),
-            PollSlot::Requeue => poll::PollFd::new(requeue_outq.as_fd(), poll::PollFlags::POLLIN),
+            PollSlot::Substrate => poll::PollFd::new(socket.as_fd(), recv_poll_flags),
+            PollSlot::Tun => poll::PollFd::new(worker.agent_input_tun.as_fd(), recv_poll_flags),
+            PollSlot::Requeue => poll::PollFd::new(requeue_outq.as_fd(), recv_poll_flags),
+            PollSlot::Returns => poll::PollFd::new(worker.return_q.poll_fd(), poll::PollFlags::POLLIN),
         };
 
-        // read & forward packets one at a time
         let _n = match poll::poll(poll_fds.as_mut_slice(), poll::PollTimeout::NONE)
             .map_err(|err| std::io::Error::from_raw_os_error(err as i32))
         {
@@ -206,6 +203,13 @@ fn fastpath_main(mut worker: FastpathWorker, socket: &UdpSocket, requeue_outq: &
                 worker.asm.counters[CounterType::OutPacksRec].increment();
                 worker.agent_output(pkt);
             }
+        }
+
+        if revents[PollSlot::Returns].contains(poll::PollFlags::POLLIN) {
+            // process the return buffer queue
+            worker
+                .return_q
+                .try_recv_many_returns(&mut worker.buffers, worker.config.buffer_count);
         }
     }
 }

--- a/adapter/ph/src/sys/mod.rs
+++ b/adapter/ph/src/sys/mod.rs
@@ -11,3 +11,6 @@ pub(crate) mod macos;
 pub use self::macos::TunPi;
 #[cfg(target_os = "macos")]
 pub use self::macos::ZprTun;
+
+pub(crate) mod posix;
+pub use self::posix::notify;

--- a/adapter/ph/src/sys/posix.rs
+++ b/adapter/ph/src/sys/posix.rs
@@ -1,0 +1,1 @@
+pub mod notify;

--- a/adapter/ph/src/sys/posix/notify.rs
+++ b/adapter/ph/src/sys/posix/notify.rs
@@ -1,0 +1,213 @@
+//! Notification of events via a file descriptor.
+//!
+//! Useful to signal events to a thread which is using `poll(2)`.
+
+use nix::{errno, fcntl, ioctl_read_bad, libc, poll, unistd};
+use std::io::Result;
+use std::mem::MaybeUninit;
+use std::os::fd::*;
+
+ioctl_read_bad!(ioctl_fionread, libc::FIONREAD, libc::c_int);
+
+/// A synchronization object used to post notifications.
+///
+/// A `Notify` object either has an notification, or does not.
+/// Posting a notification causes the `Notify` to have a notification.
+/// Consuming the notification causes the `Notify` to have no notification.
+///
+/// The primary benefit of a `Notify` (over e.g. an `AtomicBool`) is that
+/// the presence of notifications can be monitored via a file descriptor.
+pub struct Notify {
+    reader: OwnedFd,
+    writer: OwnedFd,
+}
+
+fn map_nix_err(errno: errno::Errno) -> std::io::Error {
+    std::io::Error::from_raw_os_error(errno as i32)
+}
+
+fn set_nonblocking(fd: impl AsFd) -> Result<()> {
+    let _ = fcntl::fcntl(
+        fd.as_fd().as_raw_fd(),
+        fcntl::FcntlArg::F_SETFL(fcntl::OFlag::O_NONBLOCK),
+    )
+    .map_err(map_nix_err)?;
+    Ok(())
+}
+
+fn fionread(fd: impl AsFd) -> Result<usize> {
+    let mut n = MaybeUninit::uninit();
+    // SAFETY: we've declared `ioctl_fionread` correctly.  The pointer is an output parameter.
+    unsafe { ioctl_fionread(fd.as_fd().as_raw_fd(), n.as_mut_ptr()) }.map_err(map_nix_err)?;
+    // SAFETY: a successful return above indicates that `n` is now filled in.
+    Ok(unsafe { n.assume_init() } as usize)
+}
+
+impl Notify {
+    pub fn new() -> Result<Self> {
+        let (reader, writer) = unistd::pipe().map_err(map_nix_err)?;
+
+        set_nonblocking(&reader)?;
+        set_nonblocking(&writer)?;
+
+        Ok(Self { reader, writer })
+    }
+
+    /// Returns a reference to an FD which can be used to poll for events (using POLLIN).
+    ///
+    /// If an event is reported, `consume()` must be used to check for and consume
+    /// notifications.  (Else the notifications will stay put and re-trigger the poll event.)
+    pub fn poll_fd(&self) -> BorrowedFd<'_> {
+        self.reader.as_fd()
+    }
+
+    /// Post a notification.
+    ///
+    /// This is a memory synchronization operation.
+    pub fn post(&self) {
+        let buf = [0u8; 1];
+
+        match unistd::write(&self.writer, &buf) {
+            Ok(_) => (),
+            // this is fine; means there's already a notification!
+            Err(errno::Errno::EAGAIN) => (),
+            Err(err) => panic!("Unexpected error: {err}"),
+        }
+    }
+
+    /// Consume any outstanding notification.
+    ///
+    /// This is a memory synchronization operation.
+    ///
+    /// Returns `true` if there was a notification, `false` otherwise.
+    pub fn consume(&self) -> bool {
+        let mut buf = [0u8; 4096];
+
+        match unistd::read(self.reader.as_raw_fd(), &mut buf) {
+            Ok(0) => panic!("Unexpected end of file"),
+            Ok(n) if n < buf.len() => return true,
+            Ok(_) => (),
+            Err(errno::Errno::EAGAIN) => return false,
+            Err(err) => panic!("Unexpected error: {err}"),
+        }
+
+        // At this point, we know we've read a full buffer's worth
+        // of notifications, but there might be more.
+        // We want to both (a) ensure we've read all notifications posted
+        // prior to this function being called, but also (b) ensure
+        // that we terminate, in the event that someone is concurrently
+        // posting notifications faster than we can retrieve them.
+        // So, use `ioctl(FIONREAD)` to see how many are still outstanding,
+        // and read at least that many, then return.  It's possible also
+        // we find fewer notifications because someone else raced us;
+        // that's OK.
+
+        let mut remaining = fionread(&self.reader).unwrap() as isize;
+
+        while remaining > 0 {
+            match unistd::read(self.reader.as_raw_fd(), &mut buf) {
+                Ok(0) => panic!("Unexpected end of file"),
+                Ok(n) if n < buf.len() => break,
+                Ok(n) => remaining -= n as isize,
+                Err(errno::Errno::EAGAIN) => break,
+                Err(err) => panic!("Unexpected error: {err}"),
+            }
+        }
+
+        true
+    }
+
+    /// Wait for a notification to be present, and consume it.
+    pub fn wait_and_consume(&self) {
+        let mut pollfd = poll::PollFd::new(self.poll_fd(), poll::PollFlags::POLLIN);
+
+        loop {
+            match poll::poll(std::slice::from_mut(&mut pollfd), poll::PollTimeout::NONE) {
+                Ok(_) => {
+                    if pollfd.any().unwrap() && self.consume() {
+                        break;
+                    }
+                }
+
+                Err(errno::Errno::EINTR) => (),
+
+                Err(err) => panic!("Unexpected error: {err}"),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nix::poll;
+    use std::sync::Arc;
+
+    #[test]
+    fn basic_test() {
+        let notify = Notify::new().unwrap();
+
+        assert!(!notify.consume());
+
+        notify.post();
+        assert!(notify.consume());
+        assert!(!notify.consume());
+
+        notify.post();
+        assert!(notify.consume());
+        assert!(!notify.consume());
+
+        notify.post();
+        notify.post();
+        assert!(notify.consume());
+        assert!(!notify.consume());
+        assert!(!notify.consume());
+    }
+
+    #[test]
+    fn poll_test() {
+        let notify1 = Arc::new(Notify::new().unwrap());
+        let notify2 = Arc::new(Notify::new().unwrap());
+
+        let th_notify1 = notify1.clone();
+        let th_notify2 = notify2.clone();
+
+        let th = std::thread::spawn(move || {
+            th_notify1.wait_and_consume();
+            th_notify2.post();
+        });
+
+        notify1.post();
+
+        let mut pollfd2 = poll::PollFd::new(notify2.poll_fd(), poll::PollFlags::POLLIN);
+        assert_eq!(
+            poll::poll(std::slice::from_mut(&mut pollfd2), 5000u16).unwrap(),
+            1
+        );
+
+        assert!(pollfd2.any().unwrap());
+        assert!(notify2.consume());
+        assert!(!notify2.consume());
+
+        assert_eq!(
+            poll::poll(std::slice::from_mut(&mut pollfd2), 0u16).unwrap(),
+            0
+        );
+
+        th.join().unwrap();
+    }
+
+    #[test]
+    fn multi_read_test() {
+        let notify = Notify::new().unwrap();
+
+        // 10000 is greater than twice the implementation's read buffer size
+        // (forces 2 extra reads)
+        for _ in 0..10000 {
+            notify.post();
+        }
+
+        assert!(notify.consume());
+        assert!(!notify.consume());
+    }
+}

--- a/adapter/ph/src/sys/posix/notify.rs
+++ b/adapter/ph/src/sys/posix/notify.rs
@@ -118,6 +118,7 @@ impl Notify {
     }
 
     /// Wait for a notification to be present, and consume it.
+    #[allow(dead_code)]
     pub fn wait_and_consume(&self) {
         let mut pollfd = poll::PollFd::new(self.poll_fd(), poll::PollFlags::POLLIN);
 

--- a/adapter/ph/src/two_way_queue.rs
+++ b/adapter/ph/src/two_way_queue.rs
@@ -31,10 +31,13 @@
 
 #![allow(dead_code)]
 
+use crate::sys::notify::Notify;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
+use std::os::fd::BorrowedFd;
 use std::rc::Rc;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use zpr_ext::std::cell::scalar::UsizeCell;
 
@@ -64,6 +67,7 @@ pub enum TryRecvReturnError {
 pub struct ReturnQueue<U> {
     incoming_return_q: mpsc::UnboundedReceiver<U>,
     outgoing_return_q: mpsc::UnboundedSender<U>,
+    return_notify: Arc<Notify>,
     outstanding: Rc<UsizeCell>,
 }
 
@@ -74,6 +78,7 @@ impl<U> ReturnQueue<U> {
         Self {
             incoming_return_q,
             outgoing_return_q,
+            return_notify: Arc::new(Notify::new().unwrap()),
             outstanding: Rc::new(UsizeCell::new(0)),
         }
     }
@@ -83,9 +88,8 @@ impl<U> ReturnQueue<U> {
     /// Panics if called when no items are outstanding.
     pub fn blocking_recv_return(&mut self) -> U {
         assert!(self.outstanding.load() > 0);
-        let ret = self.incoming_return_q.blocking_recv().unwrap();
-        self.outstanding.fetch_sub(1);
-        return ret;
+        self.return_notify.wait_and_consume();
+        self.try_recv_return().unwrap()
     }
 
     /// Receive up to `limit` returned items.  Blocks until at least one item can be returned.
@@ -95,9 +99,8 @@ impl<U> ReturnQueue<U> {
     /// Panics if called when no items are outstanding.
     pub fn blocking_recv_many_returns(&mut self, returns: &mut Vec<U>, limit: usize) -> usize {
         assert!(self.outstanding.load() > 0 || limit == 0);
-        let ret = self.incoming_return_q.blocking_recv_many(returns, limit);
-        self.outstanding.fetch_sub(ret);
-        return ret;
+        self.return_notify.wait_and_consume();
+        self.try_recv_many_returns(returns, limit)
     }
 
     /// Try to receive a single returned item.  Does not block, returning
@@ -108,6 +111,13 @@ impl<U> ReturnQueue<U> {
         if ret.is_some() {
             self.outstanding.fetch_sub(1);
         }
+
+        if !self.incoming_return_q.is_empty() {
+            // It is possible the caller ate the notification of this remaining item.
+            // Re-post it.  (If we didn't eat it, this is harmless.)
+            self.return_notify.post();
+        }
+
         return ret;
     }
 
@@ -115,41 +125,40 @@ impl<U> ReturnQueue<U> {
     /// returning 0 if no items are immediately available (possibly because
     /// none are outstanding).
     pub fn try_recv_many_returns(&mut self, returns: &mut Vec<U>, limit: usize) -> usize {
-        for i in 0..limit {
+        let mut recvd = 0;
+
+        while recvd < limit {
             match self.incoming_return_q.try_recv() {
-                Ok(item) => returns.push(item),
-                Err(_) => {
-                    self.outstanding.fetch_sub(i);
-                    return i;
+                Ok(item) => {
+                    recvd += 1;
+                    returns.push(item);
                 }
+
+                Err(_) => break,
             }
         }
 
-        self.outstanding.fetch_sub(limit);
-        return limit;
+        self.outstanding.fetch_sub(recvd);
+
+        if !self.incoming_return_q.is_empty() {
+            // It is possible the caller ate the notification of this remaining item.
+            // Re-post it.  (If we didn't eat it, this is harmless.)
+            self.return_notify.post();
+        }
+
+        return recvd;
     }
 
-    /// Async version of `blocking_recv_return()`.
-    pub async fn recv_return(&mut self) -> U {
-        assert!(self.outstanding.load() > 0);
-        let ret = self.incoming_return_q.recv().await.unwrap();
-        self.outstanding.fetch_sub(1);
-        return ret;
-    }
-
-    /// Async version of `blocking_recv_many_returns()`.
-    pub async fn recv_many_returns(&mut self, returns: &mut Vec<U>, limit: usize) -> usize {
-        assert!(self.outstanding.load() > 0 || limit == 0);
-        let ret = self.incoming_return_q.recv_many(returns, limit).await;
-        self.outstanding.fetch_sub(ret);
-        return ret;
+    pub fn poll_fd(&self) -> BorrowedFd<'_> {
+        self.return_notify.poll_fd()
     }
 }
 
 /// The producer half of a two-way queue.
 pub struct Sender<T, U> {
-    outgoing_q: mpsc::Sender<(T, mpsc::UnboundedSender<U>)>,
+    outgoing_q: mpsc::Sender<(T, mpsc::UnboundedSender<U>, Arc<Notify>)>,
     outgoing_return_q: mpsc::UnboundedSender<U>,
+    return_notify: Arc<Notify>,
     outstanding: Rc<UsizeCell>,
 }
 
@@ -157,16 +166,17 @@ impl<T, U> Sender<T, U> {
     /// Try to send an item.  Note that it is possible for the queue
     /// to appear full for the reason that there are outstanding returns.
     pub fn try_send(&mut self, item: T) -> Result<(), TrySendError<T>> {
-        match self
-            .outgoing_q
-            .try_send((item, self.outgoing_return_q.clone()))
-        {
+        match self.outgoing_q.try_send((
+            item,
+            self.outgoing_return_q.clone(),
+            self.return_notify.clone(),
+        )) {
             Ok(()) => {
                 self.outstanding.fetch_add(1);
                 Ok(())
             }
-            Err(mpsc::error::TrySendError::Full((item, _))) => Err(TrySendError::Full(item)),
-            Err(mpsc::error::TrySendError::Closed((item, _))) => Err(TrySendError::Closed(item)),
+            Err(mpsc::error::TrySendError::Full((item, _, _))) => Err(TrySendError::Full(item)),
+            Err(mpsc::error::TrySendError::Closed((item, _, _))) => Err(TrySendError::Closed(item)),
         }
     }
 }
@@ -176,7 +186,7 @@ impl<T, U> Sender<T, U> {
 /// `ReturnQueue`.
 #[derive(Clone)]
 pub struct SenderFactory<T, U> {
-    outgoing_q: mpsc::Sender<(T, mpsc::UnboundedSender<U>)>,
+    outgoing_q: mpsc::Sender<(T, mpsc::UnboundedSender<U>, Arc<Notify>)>,
 }
 
 impl<T, U> SenderFactory<T, U> {
@@ -185,6 +195,7 @@ impl<T, U> SenderFactory<T, U> {
         Sender {
             outgoing_q: self.outgoing_q.clone(),
             outgoing_return_q: ret_q.outgoing_return_q.clone(),
+            return_notify: ret_q.return_notify.clone(),
             outstanding: ret_q.outstanding.clone(),
         }
     }
@@ -192,7 +203,7 @@ impl<T, U> SenderFactory<T, U> {
 
 /// The consumer half of a two-way queue.
 pub struct Receiver<T, U> {
-    incoming_q: mpsc::Receiver<(T, mpsc::UnboundedSender<U>)>,
+    incoming_q: mpsc::Receiver<(T, mpsc::UnboundedSender<U>, Arc<Notify>)>,
 }
 
 impl<T, U> Receiver<T, U>
@@ -210,10 +221,11 @@ where
     /// transformed using `TwoWayReturnable::convert()` on its way back to
     /// the producer.
     pub async fn recv(&mut self) -> Option<ItemGuard<'_, T, U>> {
-        let (item, outgoing_return_q) = self.incoming_q.recv().await?;
+        let (item, outgoing_return_q, return_notify) = self.incoming_q.recv().await?;
         Some(ItemGuard {
             item: ManuallyDrop::new(item),
             outgoing_return_q,
+            return_notify,
             receiver: PhantomData,
         })
     }
@@ -223,6 +235,7 @@ where
 pub struct ItemGuard<'a, T, U: TwoWayReturnable<T>> {
     item: ManuallyDrop<T>,
     outgoing_return_q: mpsc::UnboundedSender<U>,
+    return_notify: Arc<Notify>,
     receiver: PhantomData<&'a Receiver<T, U>>,
 }
 
@@ -246,6 +259,8 @@ impl<T, U: TwoWayReturnable<T>> Drop for ItemGuard<'_, T, U> {
         let _ = self
             .outgoing_return_q
             .send(U::convert(unsafe { ManuallyDrop::take(&mut self.item) }));
+
+        self.return_notify.post();
     }
 }
 

--- a/adapter/ph/src/two_way_queue.rs
+++ b/adapter/ph/src/two_way_queue.rs
@@ -83,39 +83,25 @@ impl<U> ReturnQueue<U> {
         }
     }
 
-    /// Receive a single returned item.  Blocks until there is such an item.
-    ///
-    /// Panics if called when no items are outstanding.
-    pub fn blocking_recv_return(&mut self) -> U {
-        assert!(self.outstanding.load() > 0);
-        self.return_notify.wait_and_consume();
-        self.try_recv_return().unwrap()
-    }
-
-    /// Receive up to `limit` returned items.  Blocks until at least one item can be returned.
-    ///
-    /// Immediately returns 0 if-and-only-if `limit` is 0.
-    ///
-    /// Panics if called when no items are outstanding.
-    pub fn blocking_recv_many_returns(&mut self, returns: &mut Vec<U>, limit: usize) -> usize {
-        assert!(self.outstanding.load() > 0 || limit == 0);
-        self.return_notify.wait_and_consume();
-        self.try_recv_many_returns(returns, limit)
-    }
-
     /// Try to receive a single returned item.  Does not block, returning
     /// `None` if no items are immediately available (possibly because none
     /// are outstanding).
     pub fn try_recv_return(&mut self) -> Option<U> {
+        if !self.return_notify.consume() {
+            return None;
+        }
+
+        let avail = self.incoming_return_q.len();
+
         let ret = self.incoming_return_q.try_recv().ok();
         if ret.is_some() {
             self.outstanding.fetch_sub(1);
-        }
 
-        if !self.incoming_return_q.is_empty() {
-            // It is possible the caller ate the notification of this remaining item.
-            // Re-post it.  (If we didn't eat it, this is harmless.)
-            self.return_notify.post();
+            if avail > 1 {
+                // It is likely that we ate the notification of these remaining items.
+                // Re-post it.  (If we didn't eat it, this is harmless.)
+                self.return_notify.post();
+            }
         }
 
         return ret;
@@ -125,6 +111,12 @@ impl<U> ReturnQueue<U> {
     /// returning 0 if no items are immediately available (possibly because
     /// none are outstanding).
     pub fn try_recv_many_returns(&mut self, returns: &mut Vec<U>, limit: usize) -> usize {
+        if !self.return_notify.consume() {
+            return 0;
+        }
+
+        let avail = self.incoming_return_q.len();
+
         let mut recvd = 0;
 
         while recvd < limit {
@@ -140,8 +132,8 @@ impl<U> ReturnQueue<U> {
 
         self.outstanding.fetch_sub(recvd);
 
-        if !self.incoming_return_q.is_empty() {
-            // It is possible the caller ate the notification of this remaining item.
+        if recvd > avail {
+            // It is likely that we ate the notification of these remaining items.
             // Re-post it.  (If we didn't eat it, this is harmless.)
             self.return_notify.post();
         }


### PR DESCRIPTION
In support of a forthcoming change in the datapath, we can no longer simply block when we're out of packet buffers; we need to be able to poll on them.  This means we need a file descriptor which signals readiness when returned packet buffers are available.

This PR (1) adds a `Notify` struct, which provides a means of FD-based notifications; (2) uses `Notify` in `two_way_queue` to provide FD-based notifications of returned items; and (3) uses this mechanism in the datapath to integrate buffer return processing into `poll`.