### PR TITLE
Remove tokio from zprtun

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -584,6 +584,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "enum-map"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +965,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1296,7 @@ dependencies = [
  "enumset",
  "hdrhistogram",
  "io-uring",
+ "itertools",
  "libc",
  "libnode",
  "nix",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -21,6 +21,7 @@ enumset = "1.1.5"
 hdrhistogram = { version = "7.5.4" }
 libc = { version = "0.2.155" }
 libnode = { path = "../../libnode" }
+itertools = "0.14"
 nix = { version = "0.29.0", features = ["ioctl", "net", "poll"] }
 open-enum = { version = "0.5.1" }
 openssl = { version = "0.10.70" }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -58,7 +58,6 @@ pub struct Assembly {
     // Shared resources.  These may be accessed by any part of the system.
     pub agent_addresses: Vec<IpAddr>,
 
-    pub agent_input: AgentInput,
     pub substrate_egress: SubstrateEgress,
     pub agent_output_requeue: AgentOutputRequeue,
 
@@ -336,7 +335,6 @@ pub mod test {
         pub ph_mode: Option<PhMode>,
         pub topology_config: Option<TopologyConfig>,
         pub agent_addresses: Option<Vec<IpAddr>>,
-        pub agent_input: Option<AgentInput>,
         pub substrate_egress: Option<SubstrateEgress>,
         pub agent_output_requeue: Option<AgentOutputRequeue>,
         pub vsconn: Option<Option<libnode::vsconn::VSConnHandle>>,
@@ -376,9 +374,6 @@ pub mod test {
         let agent_addresses = builder
             .agent_addresses
             .unwrap_or(Vec::from([IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]));
-        let agent_input = builder
-            .agent_input
-            .unwrap_or_else(|| AgentInput::new(Vec::new()));
         let substrate_egress = builder
             .substrate_egress
             .unwrap_or_else(|| SubstrateEgress::new(Vec::new()));
@@ -429,7 +424,6 @@ pub mod test {
             ph_mode,
             topology_config,
             agent_addresses,
-            agent_input,
             substrate_egress,
             agent_output_requeue,
             vsconn,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -85,7 +85,12 @@ pub struct FastpathWorker {
 }
 
 impl FastpathWorker {
-    pub fn new(config: FastpathWorkerConfig, worker_index: usize, asm: Arc<Assembly>) -> Self {
+    pub fn new(
+        config: FastpathWorkerConfig,
+        worker_index: usize,
+        asm: Arc<Assembly>,
+        agent_input_tun: Arc<ZprTun>,
+    ) -> Self {
         let buffers =
             vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]) as Box<[_]>; config.buffer_count];
 
@@ -93,7 +98,6 @@ impl FastpathWorker {
         let adapter_manager = asm.adapter_manager_factory.make(&return_q);
         let mgmt_dispatch = asm.mgmt_dispatch_factory.make(&return_q);
 
-        let agent_input_tun = asm.agent_input.tuns[worker_index].clone(); // TEMP HACK
         let substrate_egress_socket = asm.substrate_egress.sockets[worker_index].clone(); // TEMP HACK
 
         Self {

--- a/adapter/ph/src/fastpath_worker.rs
+++ b/adapter/ph/src/fastpath_worker.rs
@@ -32,23 +32,18 @@ pub fn launch(
     worker_index: usize,
     asm: Arc<Assembly>,
     socket: Arc<UdpSocket>,
-    tun: Arc<ZprTun>,
+    agent_input_tun: Arc<ZprTun>,
     requeue_outq: UnixDatagram,
 ) -> impl FnOnce() {
     move || {
-        let worker = FastpathWorker::new(config, worker_index, asm.clone());
-        fastpath_main(worker, &socket, &tun, &requeue_outq);
+        let worker = FastpathWorker::new(config, worker_index, asm.clone(), agent_input_tun);
+        fastpath_main(worker, &socket, &requeue_outq);
     }
 }
 
-fn fastpath_main(
-    mut worker: FastpathWorker,
-    socket: &UdpSocket,
-    tun: &ZprTun,
-    requeue_outq: &UnixDatagram,
-) {
+fn fastpath_main(mut worker: FastpathWorker, socket: &UdpSocket, requeue_outq: &UnixDatagram) {
     // temp hack until we move ZprTun to be non-Tokio
-    let tun_fd = unsafe { BorrowedFd::borrow_raw(tun.as_raw_fd()) };
+    let tun_fd = unsafe { BorrowedFd::borrow_raw(worker.agent_input_tun.as_raw_fd()) };
 
     loop {
         // output anything we've queued up

--- a/adapter/ph/src/fastpath_worker.rs
+++ b/adapter/ph/src/fastpath_worker.rs
@@ -12,7 +12,7 @@ use nix::poll;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::net::UdpSocket;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
+use std::os::fd::AsFd;
 use std::os::unix::net::UnixDatagram;
 use std::sync::Arc;
 
@@ -42,9 +42,6 @@ pub fn launch(
 }
 
 fn fastpath_main(mut worker: FastpathWorker, socket: &UdpSocket, requeue_outq: &UnixDatagram) {
-    // temp hack until we move ZprTun to be non-Tokio
-    let tun_fd = unsafe { BorrowedFd::borrow_raw(worker.agent_input_tun.as_raw_fd()) };
-
     loop {
         // output anything we've queued up
         worker.process_out_queues();
@@ -65,7 +62,7 @@ fn fastpath_main(mut worker: FastpathWorker, socket: &UdpSocket, requeue_outq: &
 
         let mut poll_fds = enum_map! {
             PollSlot::Substrate => poll::PollFd::new(socket.as_fd(), poll::PollFlags::POLLIN),
-            PollSlot::Tun => poll::PollFd::new(tun_fd, poll::PollFlags::POLLIN),
+            PollSlot::Tun => poll::PollFd::new(worker.agent_input_tun.as_fd(), poll::PollFlags::POLLIN),
             PollSlot::Requeue => poll::PollFd::new(requeue_outq.as_fd(), poll::PollFlags::POLLIN),
         };
 
@@ -170,7 +167,7 @@ fn fastpath_main(mut worker: FastpathWorker, socket: &UdpSocket, requeue_outq: &
             let mut results = Vec::new(); // TODO: recycle
             let n = worker
                 .batch_io
-                .try_read_buf_batch(&tun_fd, pkts.iter_mut(), &mut results)
+                .try_read_buf_batch(&worker.agent_input_tun, pkts.iter_mut(), &mut results)
                 .unwrap();
 
             // return empty buffers to pool

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(feature = "ci", deny(warnings))]
 
+use itertools::izip;
 use km_cert_exchange::KmCertExchange;
 use std::default::Default;
 use std::fs;
@@ -317,7 +318,6 @@ fn main() -> ExitCode {
         ph_mode,
         topology_config,
         agent_addresses: config.agent_addr,
-        agent_input: AgentInput::new(tun_devs.clone()),
         substrate_egress: SubstrateEgress::new(substrate_sockets.iter().cloned()),
         agent_output_requeue: AgentOutputRequeue::new(agent_requeue_inqs),
         vsconn: vsconn.as_ref().map(|c| c.handle()),
@@ -408,12 +408,13 @@ fn main() -> ExitCode {
         buffer_count: asm.topology_config.buffer_count,
         batch_size: asm.topology_config.fastpath_batch_size,
     };
-    for (worker_index, ((socket, tun_dev), requeue)) in substrate_sockets
-        .into_iter()
-        .zip(tun_devs.into_iter())
-        .zip(agent_requeue_outqs)
-        .enumerate()
-    {
+
+    for (worker_index, socket, tun_dev, requeue) in izip!(
+        0..asm.topology_config.fastpath_concurrency,
+        substrate_sockets,
+        tun_devs,
+        agent_requeue_outqs
+    ) {
         let builder = std::thread::Builder::new().name(format!("fastpath {worker_index}"));
         fastpath_threads.push(
             builder

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -1,7 +1,6 @@
 //! Queues (i.e., frontend interface) for each stage of the system.
 
 use crate::packet::{Packet, PacketBuffer};
-use crate::sys::ZprTun;
 use crate::test_packet::*;
 use crate::two_way_queue;
 use bytes::Buf;
@@ -68,22 +67,6 @@ impl MgmtProcessor {
             .unwrap();
 
         Ok(test_tuple.1.await?)
-    }
-}
-
-/// AgentInput is responsible for emitting decapsulated agent packets on the
-/// host's TUN interface.
-pub struct AgentInput {
-    pub tuns: Box<[Arc<ZprTun>]>,
-}
-
-impl AgentInput {
-    // We necessarily have multiple queues, corresponding to the multiple
-    // FDs of a multiqueue-enabled TUN interface.
-    pub fn new(tuns: impl IntoIterator<Item = Arc<ZprTun>>) -> Self {
-        Self {
-            tuns: tuns.into_iter().collect(),
-        }
     }
 }
 

--- a/adapter/ph/src/sys/linux/zprtun.rs
+++ b/adapter/ph/src/sys/linux/zprtun.rs
@@ -1,20 +1,23 @@
 use crate::zprtun::ZprTunError;
-use bytes::buf;
 use nix::ioctl_write_ptr;
 use std::io::Result;
 use std::net::IpAddr;
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 use tokio_tun::{Tun, TunBuilder};
-use zpr_ext::std::mem::slice_assume_init_mut;
 
 // from /usr/include/linux/if_tun.h
 ioctl_write_ptr!(tun_set_carrier, b'T', 226, libc::c_int);
 
-pub struct ZprTun(Tun);
+pub struct ZprTun(OwnedFd);
 
 impl From<Tun> for ZprTun {
     fn from(tun: Tun) -> Self {
-        ZprTun(tun)
+        // SAFETY: the FD is live until we exit this function
+        ZprTun(
+            (unsafe { BorrowedFd::borrow_raw(tun.as_raw_fd()) })
+                .try_clone_to_owned()
+                .unwrap(),
+        )
     }
 }
 
@@ -43,20 +46,7 @@ impl ZprTun {
             .try_build_mq(concurrency)
             .or_else(|e| Err(ZprTunError::PlatformError(e.to_string())))?;
 
-        Ok(tok_tun_devs.into_iter().map(ZprTun).collect())
-    }
-
-    #[allow(dead_code)]
-    pub fn try_recv_buf<B: buf::BufMut>(&self, buf: &mut B) -> Result<usize> {
-        let uninit_slice = buf.chunk_mut();
-        // SAFETY: we are only writing to this uninitialized slice
-        let slice = unsafe { slice_assume_init_mut(uninit_slice.as_uninit_slice_mut()) };
-        let size = self.0.try_recv(slice)?;
-        // SAFETY: we've now initialized this much of the slice
-        unsafe {
-            buf.advance_mut(size);
-        }
-        Ok(size)
+        Ok(tok_tun_devs.into_iter().map(ZprTun::from).collect())
     }
 
     pub fn set_carrier(&self, carrier: bool) -> Result<()> {
@@ -71,6 +61,12 @@ impl ZprTun {
         Err(ZprTunError::PlatformError(
             "cannot set TUN address after creation".to_string(),
         ))
+    }
+}
+
+impl AsFd for ZprTun {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_fd()
     }
 }
 

--- a/adapter/ph/src/sys/macos/zprtun.rs
+++ b/adapter/ph/src/sys/macos/zprtun.rs
@@ -1,13 +1,13 @@
 use crate::zprtun::{ZprTunError, DEFAULT_TUN_MTU};
 use std::net::IpAddr;
-use std::os::fd::{AsRawFd, RawFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::result::Result;
-use tun::{AbstractDevice, AsyncDevice};
+use tun::{AbstractDevice, Device};
 
-pub struct ZprTun(tun::AsyncDevice);
+pub struct ZprTun(tun::Device);
 
-impl From<AsyncDevice> for ZprTun {
-    fn from(tun_device: AsyncDevice) -> Self {
+impl From<Device> for ZprTun {
+    fn from(tun_device: Device) -> Self {
         ZprTun(tun_device)
     }
 }
@@ -42,7 +42,7 @@ impl ZprTun {
             )));
         }
 
-        let dev = tun::create_as_async(&config)?;
+        let dev = tun::create(&config)?;
         Ok(vec![ZprTun::from(dev)])
     }
 
@@ -58,6 +58,13 @@ impl ZprTun {
             Ok(_) => Ok(()),
             Err(e) => Err(ZprTunError::PlatformError(e.to_string())),
         }
+    }
+}
+
+impl AsFd for ZprTun {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        // SAFETY: we know the FD will be live for the lifetime of the `Device`
+        unsafe { BorrowedFd::borrow_raw(self.0.as_raw_fd()) }
     }
 }
 


### PR DESCRIPTION
We no longer need tokio support in zprtun, since we are now using dedicated OS threads, `poll`, and `batch_io`.