### PR TITLE
factor out I/O routines into fastpath_io

### DIFF
--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -5,7 +5,6 @@
 
 use crate::adapter_tables::AltEntry;
 use crate::assembly::{Assembly, PhMode};
-use crate::batch_io::BatchIo;
 use crate::classifier::{self, ClassifierResult};
 use crate::config;
 use crate::counters::CounterType;
@@ -14,18 +13,15 @@ use crate::km::Codec;
 use crate::km_noise::NOISE_PADLEN;
 use crate::logging::targets::DATAPATH;
 use crate::net_defs;
-use crate::packet::{self, Packet, PacketBuffer};
+use crate::packet::{Packet, PacketBuffer};
 use crate::queues::{AdapterManager, MgmtDispatch, TryEnqueueError};
-use crate::sys::{TunPi, ZprTun};
 use crate::two_way_queue;
 use crate::zdp;
 use crate::zdp_ll;
 use crate::{compress, km};
 use blake3;
 use bytes::{Buf, BufMut};
-use std::io::ErrorKind;
-use std::net::{SocketAddr, UdpSocket};
-use std::os::fd::{AsRawFd, BorrowedFd};
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::SystemTime;
 use tracing::*;
@@ -70,20 +66,10 @@ pub struct FastpathWorker {
 
     pub agent_input_q: Vec<Packet>,
     pub substrate_egress_q: Vec<(Packet, std::net::SocketAddr)>,
-
-    pub batch_io: BatchIo,
-    pub agent_input_tun: Arc<ZprTun>,
-    pub substrate_socket: UdpSocket,
 }
 
 impl FastpathWorker {
-    pub fn new(
-        config: FastpathWorkerConfig,
-        worker_index: usize,
-        asm: Arc<Assembly>,
-        substrate_socket: UdpSocket,
-        agent_input_tun: Arc<ZprTun>,
-    ) -> Self {
+    pub fn new(config: FastpathWorkerConfig, worker_index: usize, asm: Arc<Assembly>) -> Self {
         let buffers =
             vec![Box::new([0u8; config::PACKET_BUFFER_SIZE]) as Box<[_]>; config.buffer_count];
 
@@ -103,10 +89,6 @@ impl FastpathWorker {
 
             agent_input_q: Vec::with_capacity(config.buffer_count),
             substrate_egress_q: Vec::with_capacity(config.buffer_count),
-
-            batch_io: BatchIo::new(config.batch_size).unwrap(),
-            agent_input_tun,
-            substrate_socket,
         }
     }
 
@@ -131,7 +113,7 @@ impl FastpathWorker {
         nbufs
     }
 
-    /// Process packets ingressing from the specified address.
+    /// Process packet ingressing from the specified address.
     pub fn substrate_ingress(&mut self, peer_sa: &zpr::SubstrateAddr, mut pkt: Packet) {
         pkt.metadata_mut().ingress_link_id =
             self.asm.peer_table.lookup_peer(peer_sa).unwrap_or_zero();
@@ -526,131 +508,6 @@ impl FastpathWorker {
         self.substrate_egress_q.push((pkt, dest_sa));
     }
 
-    /// Egress any queued packets, or drop if there is no space in the system queues.
-    ///
-    /// After this call, the agent input queue will be empty, and the substrate egress queue
-    /// will contain only PRIORITY packets.
-    pub fn process_out_queues(&mut self) {
-        self.process_agent_input_queue();
-        self.process_substrate_egress_queue();
-    }
-
-    /// Egress queued agent input packets only.
-    pub fn process_agent_input_queue(&mut self) {
-        // temp hack until we move ZprTun to be non-Tokio
-        let tun_fd = unsafe { BorrowedFd::borrow_raw(self.agent_input_tun.as_raw_fd()) };
-
-        // Add TUN PI header.
-        match TunPi::PI_SIZE {
-            0 => (),
-            sz => {
-                for pkt in &mut self.agent_input_q {
-                    let proto = net_defs::ip_ethertype(net_defs::ip_version(pkt.body()));
-                    let mut hdr = pkt.alloc_zeroed_headroom(sz);
-                    TunPi::write_pi(
-                        &mut hdr,
-                        TunPi {
-                            strip: false,
-                            proto,
-                        },
-                    );
-                }
-            }
-        }
-
-        // (Try to) send packets.
-        let mut results = Vec::new(); // TODO: recycle
-        let n = self
-            .batch_io
-            .try_write_batch(
-                &tun_fd,
-                self.agent_input_q.iter().map(|pkt| pkt.body()),
-                &mut results,
-            )
-            .expect("unrecoverable TUN error");
-
-        // Tally results.
-        let mut dropped = self.agent_input_q.len() - n;
-        for res in results {
-            match res {
-                Ok(_) => (),
-                Err(err) if err.kind() == ErrorKind::WouldBlock => dropped += 1,
-                Err(err) => panic!("unrecoverable TUN error: {}", err),
-            }
-        }
-        self.asm.counters[CounterType::InPacksSent]
-            .increase_by((self.agent_input_q.len() - dropped) as u64);
-        self.asm.counters[CounterType::InPacksDrop].increase_by(dropped as u64);
-
-        // Return buffers to buffer stack.
-        self.buffers
-            .extend(self.agent_input_q.drain(..).map(|pkt| pkt.destroy()));
-    }
-
-    /// Egress queued substrate egress packets only.
-    pub fn process_substrate_egress_queue(&mut self) {
-        // (Try to) send packets.
-        let mut results = Vec::new(); // TODO: recycle
-        let n = self
-            .batch_io
-            .try_send_to_batch(
-                &self.substrate_socket,
-                self.substrate_egress_q
-                    .iter()
-                    .map(|(pkt, dest)| (pkt.body(), *dest)),
-                &mut results,
-            )
-            .expect("unrecoverable I/O error");
-
-        // Tally results.
-        let mut dropped = 0;
-        let mut retained = 0;
-
-        for i in 0..self.substrate_egress_q.len() {
-            // Determine whether the packet was in fact sent.
-            // If it was, leave it in place and skip to the next packet.
-            if i < n {
-                match &results[i] {
-                    Ok(_) => continue,
-                    Err(err) if err.kind() == ErrorKind::WouldBlock => (),
-                    // TODO: pending <https://github.com/rust-lang/rust/issues/86442>, provide more info to user
-                    // (or potentially recover from certain errors)
-                    Err(err) => panic!("unrecoverable I/O error: {err}"),
-                }
-            }
-
-            // Packet was not sent.
-
-            if self.substrate_egress_q[i].0.metadata().flags & packet::flags::PRIORITY != 0 {
-                // This was a priority packet.  Move it to the front of the queue:
-                // `retained` is the number of packets we've retained so far, so swap
-                // this packet with the one at that index.  We'll later drop all packets
-                // in the range `retained..`.
-                self.substrate_egress_q.swap(i, retained);
-                retained += 1;
-            } else {
-                // This was a normal packet.  Leave it to get dropped.
-                dropped += 1;
-            }
-        }
-
-        // Now all un-sent priority packets are at the head of the queue.
-
-        self.asm.counters[CounterType::OutPacksSent]
-            .increase_by((self.substrate_egress_q.len() - dropped - retained) as u64);
-        self.asm.counters[CounterType::OutPacksDrop].increase_by(dropped as u64);
-
-        // Return buffers to buffer stack, except for un-sent priority packets (in the range `..retained`),
-        // which are retained for next time.
-        self.buffers.extend(
-            self.substrate_egress_q
-                .drain(retained..)
-                .map(|(pkt, _)| pkt.destroy()),
-        );
-    }
-
-    #[allow(dead_code)]
-    /// Are there any substrate egress packets remaining queued?
     pub fn substrate_egress_packets_queued(&self) -> bool {
         !self.substrate_egress_q.is_empty()
     }

--- a/adapter/ph/src/fastpath_io.rs
+++ b/adapter/ph/src/fastpath_io.rs
@@ -1,0 +1,356 @@
+use crate::batch_io::BatchIo;
+use crate::counters::*;
+use crate::fastpath::{FastpathWorker, FastpathWorkerConfig};
+use crate::net_defs;
+use crate::packet::{self, Packet};
+use crate::sys::{TunPi, ZprTun};
+use crate::zprtun;
+use bytes::Buf;
+use std::io::ErrorKind;
+use std::net::{SocketAddr, UdpSocket};
+use std::os::fd::{AsFd, BorrowedFd};
+use std::os::unix::net::UnixDatagram;
+use std::sync::Arc;
+
+pub struct FastpathIo {
+    batch_io: BatchIo,
+    agent_tun: Arc<ZprTun>,
+    substrate_socket: UdpSocket,
+    pub requeue_outq: UnixDatagram,
+    pub mgmt_substrate_outq: UnixDatagram,
+}
+
+impl FastpathIo {
+    pub fn new(
+        config: FastpathWorkerConfig,
+        substrate_socket: UdpSocket,
+        agent_tun: Arc<ZprTun>,
+        requeue_outq: UnixDatagram,
+        maybe_mgmt_substrate_outq: Option<UnixDatagram>,
+    ) -> Self {
+        // HACK: nix does not support disabling an FD, so instead, make a dummy mgmt_substrate_outq socket
+        // if we weren't given one
+        let mgmt_substrate_outq;
+        match maybe_mgmt_substrate_outq {
+            Some(outq) => mgmt_substrate_outq = outq,
+            None => {
+                let (_, outq) = UnixDatagram::pair().unwrap();
+                mgmt_substrate_outq = outq;
+            }
+        }
+
+        Self {
+            batch_io: BatchIo::new(config.batch_size).unwrap(),
+            agent_tun,
+            substrate_socket,
+            requeue_outq,
+            mgmt_substrate_outq,
+        }
+    }
+
+    /// Substrate socket FD for polling.
+    pub fn substrate_socket_fd(&self) -> BorrowedFd<'_> {
+        self.substrate_socket.as_fd()
+    }
+
+    /// Agent TUN FD for polling.
+    pub fn agent_tun_fd(&self) -> BorrowedFd<'_> {
+        self.agent_tun.as_fd()
+    }
+
+    /// Requeue socket FD for polling.
+    pub fn requeue_fd(&self) -> BorrowedFd<'_> {
+        self.requeue_outq.as_fd()
+    }
+
+    /// Mgmt substrate FD for polling.
+    pub fn mgmt_substrate_fd(&self) -> BorrowedFd<'_> {
+        self.mgmt_substrate_outq.as_fd()
+    }
+
+    /// Process an input-ready notification on the substrate socket (substrate ingress).
+    pub fn process_substrate_socket_in(
+        &mut self,
+        worker: &mut FastpathWorker,
+        pkts: &mut Vec<Packet>,
+    ) {
+        let mut results = Vec::new(); // TODO: recycle
+        let n = self
+            .batch_io
+            .try_recv_buf_from_batch(&self.substrate_socket, pkts.iter_mut(), &mut results)
+            .unwrap();
+
+        // return empty buffers to pool
+        worker
+            .buffers
+            .extend(pkts.drain(n..).rev().map(|pkt| pkt.destroy()));
+
+        // process packets
+        for (pkt, result) in pkts.drain(..).zip(results) {
+            let mut sender = match result {
+                Ok((size, _sender)) if size > pkt.remaining() => {
+                    worker.drop_and_count(pkt, CounterType::DroppedOversize);
+                    continue;
+                }
+
+                Ok((_size, sender)) => {
+                    sender.expect("received from non-IP address, should not happen!")
+                }
+
+                Err(err) => {
+                    match err.kind() {
+                        ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
+                            worker.buffers.push(pkt.destroy());
+                            continue;
+                        }
+
+                        // FIXME: do something with this later...
+                        ErrorKind::ConnectionRefused => {
+                            worker.buffers.push(pkt.destroy());
+                            continue;
+                        }
+
+                        _ => panic!("got socket error {err}"),
+                    }
+                }
+            };
+
+            // SocketAddrV6 distinguishes addresses also by `flowinfo` which
+            // we do not want -- only the 5-tuple.  So clear it.
+            clear_flowinfo(&mut sender);
+
+            worker.asm.counters[CounterType::InPacksRec].increment();
+            worker.substrate_ingress(&sender, pkt);
+        }
+    }
+
+    /// Process an output-ready notification on the substrate socket
+    /// (substrate egress of PRIORITY packets).
+    pub fn process_substrate_socket_out(&mut self, worker: &mut FastpathWorker) {
+        self.process_substrate_egress_queue(worker);
+    }
+
+    /// Process an input-ready notification on the agent TUN (agent output).
+    pub fn process_agent_tun_in(&mut self, worker: &mut FastpathWorker, pkts: &mut Vec<Packet>) {
+        let mut results = Vec::new(); // TODO: recycle
+        let n = self
+            .batch_io
+            .try_read_buf_batch(&self.agent_tun, pkts.iter_mut(), &mut results)
+            .unwrap();
+
+        // return empty buffers to pool
+        worker
+            .buffers
+            .extend(pkts.drain(n..).rev().map(|pkt| pkt.destroy()));
+
+        // process packets
+        for (mut pkt, result) in pkts.drain(..).zip(results) {
+            if let Err(err) = result {
+                match err.kind() {
+                    ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
+                        worker.buffers.push(pkt.destroy());
+                        continue;
+                    }
+
+                    _ => panic!("unrecoverable I/O error {err}"),
+                }
+            }
+
+            if zprtun::TUN_HAS_PI {
+                let pi = TunPi::read_pi(&mut pkt);
+                if pi.strip || !is_ip(pi) {
+                    // packet was too large or non-IP; drop
+                    worker.drop_and_count(pkt, CounterType::OutPacksDrop);
+                    continue;
+                }
+            } else {
+                // No packet info, permit IP and IPv6 only (for now?)
+                if pkt.body()[0] >> 4 != 4 && pkt.body()[0] >> 4 != 6 {
+                    worker.drop_and_count(pkt, CounterType::OutPacksDrop);
+                    continue;
+                }
+            }
+
+            worker.asm.counters[CounterType::OutPacksRec].increment();
+            worker.agent_output(pkt);
+        }
+    }
+
+    /// Process an input-ready notification on the requeue socket.
+    pub fn process_requeue_in(&mut self, worker: &mut FastpathWorker) {
+        // TODO: batch receive
+        while let Some(mut buf) = worker.buffers.pop() {
+            if let Err(err) = self.requeue_outq.recv(buf.as_mut()) {
+                match err.kind() {
+                    ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
+                        worker.buffers.push(buf);
+                        break;
+                    }
+
+                    _ => {
+                        // FIXME: detect packet-too-large
+                        panic!("unrecoverable I/O error {err}");
+                    }
+                }
+            }
+
+            worker.asm.counters[CounterType::RequeuedPacketsReceived].increment();
+            let pkt = Packet::new_with_existing_metadata(buf);
+            worker.agent_output_post_classify(pkt, /* allow_bind_request */ false);
+        }
+    }
+
+    /// Process an input-ready notification on the mgmt substrate socket.
+    pub fn process_mgmt_substrate_in(&mut self, worker: &mut FastpathWorker) {
+        // TODO: batch receive
+        while let Some(mut buf) = worker.buffers.pop() {
+            if let Err(err) = self.mgmt_substrate_outq.recv(buf.as_mut()) {
+                match err.kind() {
+                    ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
+                        worker.buffers.push(buf);
+                        break;
+                    }
+
+                    _ => {
+                        // FIXME: detect packet-too-large
+                        panic!("unrecoverable I/O error {err}");
+                    }
+                }
+            }
+
+            worker.asm.counters[CounterType::MgmtPacketsSent].increment();
+            let pkt = Packet::new_with_existing_metadata(buf);
+            worker.substrate_egress(pkt);
+        }
+    }
+
+    /// Egress any queued packets, or drop if there is no space in the system queues.
+    ///
+    /// After this call, the agent input queue will be empty, and the substrate egress queue
+    /// will contain only PRIORITY packets.
+    pub fn process_out_queues(&mut self, worker: &mut FastpathWorker) {
+        self.process_agent_input_queue(worker);
+        self.process_substrate_egress_queue(worker);
+    }
+
+    /// Egress queued agent input packets only.
+    fn process_agent_input_queue(&mut self, worker: &mut FastpathWorker) {
+        // Add TUN PI header.
+        match TunPi::PI_SIZE {
+            0 => (),
+            sz => {
+                for pkt in &mut worker.agent_input_q {
+                    let proto = net_defs::ip_ethertype(net_defs::ip_version(pkt.body()));
+                    let mut hdr = pkt.alloc_zeroed_headroom(sz);
+                    TunPi::write_pi(
+                        &mut hdr,
+                        TunPi {
+                            strip: false,
+                            proto,
+                        },
+                    );
+                }
+            }
+        }
+
+        // (Try to) send packets.
+        let mut results = Vec::new(); // TODO: recycle
+        let n = self
+            .batch_io
+            .try_write_batch(
+                &self.agent_tun.as_fd(),
+                worker.agent_input_q.iter().map(|pkt| pkt.body()),
+                &mut results,
+            )
+            .expect("unrecoverable TUN error");
+
+        // Tally results.
+        let mut dropped = worker.agent_input_q.len() - n;
+        for res in results {
+            match res {
+                Ok(_) => (),
+                Err(err) if err.kind() == ErrorKind::WouldBlock => dropped += 1,
+                Err(err) => panic!("unrecoverable TUN error: {}", err),
+            }
+        }
+        worker.asm.counters[CounterType::InPacksSent]
+            .increase_by((worker.agent_input_q.len() - dropped) as u64);
+        worker.asm.counters[CounterType::InPacksDrop].increase_by(dropped as u64);
+
+        // Return buffers to buffer stack.
+        worker
+            .buffers
+            .extend(worker.agent_input_q.drain(..).map(|pkt| pkt.destroy()));
+    }
+
+    /// Egress queued substrate egress packets only.
+    fn process_substrate_egress_queue(&mut self, worker: &mut FastpathWorker) {
+        // (Try to) send packets.
+        let mut results = Vec::new(); // TODO: recycle
+        let n = self
+            .batch_io
+            .try_send_to_batch(
+                &self.substrate_socket,
+                worker
+                    .substrate_egress_q
+                    .iter()
+                    .map(|(pkt, dest)| (pkt.body(), *dest)),
+                &mut results,
+            )
+            .expect("unrecoverable I/O error");
+
+        // Tally results.
+        let mut dropped = 0;
+        let mut retained = 0;
+
+        for i in 0..worker.substrate_egress_q.len() {
+            // Determine whether the packet was in fact sent.
+            // If it was, leave it in place and skip to the next packet.
+            if i < n {
+                match &results[i] {
+                    Ok(_) => continue,
+                    Err(err) if err.kind() == ErrorKind::WouldBlock => (),
+                    // TODO: pending <https://github.com/rust-lang/rust/issues/86442>, provide more info to user
+                    // (or potentially recover from certain errors)
+                    Err(err) => panic!("unrecoverable I/O error: {err}"),
+                }
+            }
+
+            // Packet was not sent.
+
+            if worker.substrate_egress_q[i].0.metadata().flags & packet::flags::PRIORITY != 0 {
+                // This was a priority packet.  Move it to the front of the queue.
+                worker.substrate_egress_q.swap(i, retained);
+                retained += 1;
+            } else {
+                // This was a normal packet.  Leave it to get dropped.
+                dropped += 1;
+            }
+        }
+
+        // Now all un-sent priority packets are at the head of the queue.
+
+        worker.asm.counters[CounterType::OutPacksSent]
+            .increase_by((worker.substrate_egress_q.len() - dropped - retained) as u64);
+        worker.asm.counters[CounterType::OutPacksDrop].increase_by(dropped as u64);
+
+        // Return buffers to buffer stack, except for un-sent priority packets, which are retained for next time.
+        worker.buffers.extend(
+            worker
+                .substrate_egress_q
+                .drain(retained..)
+                .map(|(pkt, _)| pkt.destroy()),
+        );
+    }
+}
+
+fn is_ip(pi: TunPi) -> bool {
+    pi.proto == net_defs::ethertype::IP || pi.proto == net_defs::ethertype::IPV6
+}
+
+fn clear_flowinfo(addr: &mut SocketAddr) {
+    match addr {
+        SocketAddr::V4(_) => (),
+        SocketAddr::V6(addr) => addr.set_flowinfo(0),
+    }
+}

--- a/adapter/ph/src/fastpath_worker.rs
+++ b/adapter/ph/src/fastpath_worker.rs
@@ -1,24 +1,12 @@
 use crate::assembly::Assembly;
-use crate::counters::*;
 use crate::fastpath::{FastpathWorker, FastpathWorkerConfig};
-use crate::net_defs;
-use crate::packet::Packet;
-use crate::sys::TunPi;
+use crate::fastpath_io::FastpathIo;
 use crate::sys::ZprTun;
-use crate::zprtun;
-use bytes::Buf;
 use enum_map::{enum_map, Enum};
 use nix::poll;
-use std::io::ErrorKind;
-use std::net::SocketAddr;
 use std::net::UdpSocket;
-use std::os::fd::AsFd;
 use std::os::unix::net::UnixDatagram;
 use std::sync::Arc;
-
-fn is_ip(pi: TunPi) -> bool {
-    pi.proto == net_defs::ethertype::IP || pi.proto == net_defs::ethertype::IPV6
-}
 
 #[derive(Enum)]
 enum PollSlot {
@@ -39,39 +27,23 @@ pub fn launch(
     mgmt_substrate_outq: Option<UnixDatagram>,
 ) -> impl FnOnce() {
     move || {
-        let worker = FastpathWorker::new(
+        let worker = FastpathWorker::new(config, worker_index, asm.clone());
+        let io = FastpathIo::new(
             config,
-            worker_index,
-            asm.clone(),
             substrate_socket,
             agent_input_tun,
+            requeue_outq,
+            mgmt_substrate_outq,
         );
-        fastpath_main(worker, &requeue_outq, mgmt_substrate_outq.as_ref());
+        fastpath_main(worker, io);
     }
 }
 
-fn fastpath_main(
-    mut worker: FastpathWorker,
-    requeue_outq: &UnixDatagram,
-    maybe_mgmt_substrate_outq: Option<&UnixDatagram>,
-) {
-    // HACK: nix does not support disabling an FD, so instead, make a dummy mgmt_substrate_outq socket
-    // if we weren't given one
-    let mgmt_substrate_outq;
-    let fake_mgmt_substrate_outq;
-    match maybe_mgmt_substrate_outq {
-        Some(outq) => mgmt_substrate_outq = outq,
-        None => {
-            let (_, outq) = UnixDatagram::pair().unwrap();
-            fake_mgmt_substrate_outq = Some(outq);
-            mgmt_substrate_outq = fake_mgmt_substrate_outq.as_ref().unwrap();
-        }
-    }
-
+fn fastpath_main(mut worker: FastpathWorker, mut io: FastpathIo) {
     loop {
         // try to immediately output anything we've queued up;
         // if we can't, drop it, unless it's on the substrate and marked PRIORITY
-        worker.process_out_queues();
+        io.process_out_queues(&mut worker);
 
         let recv_poll_flags;
         if worker.buffers.is_empty() {
@@ -89,10 +61,10 @@ fn fastpath_main(
         }
 
         let mut poll_fds = enum_map! {
-            PollSlot::Substrate => poll::PollFd::new(worker.substrate_socket.as_fd(), recv_poll_flags | send_poll_flags),
-            PollSlot::Tun => poll::PollFd::new(worker.agent_input_tun.as_fd(), recv_poll_flags),
-            PollSlot::Requeue => poll::PollFd::new(requeue_outq.as_fd(), recv_poll_flags),
-            PollSlot::MgmtSubstrate => poll::PollFd::new(mgmt_substrate_outq.as_fd(), recv_poll_flags),
+            PollSlot::Substrate => poll::PollFd::new(io.substrate_socket_fd(), recv_poll_flags | send_poll_flags),
+            PollSlot::Tun => poll::PollFd::new(io.agent_tun_fd(), recv_poll_flags),
+            PollSlot::Requeue => poll::PollFd::new(io.requeue_fd(), recv_poll_flags),
+            PollSlot::MgmtSubstrate => poll::PollFd::new(io.mgmt_substrate_fd(), recv_poll_flags),
             PollSlot::Returns => poll::PollFd::new(worker.return_q.poll_fd(), poll::PollFlags::POLLIN),
         };
 
@@ -113,55 +85,17 @@ fn fastpath_main(
 
         if revents[PollSlot::Substrate].contains(poll::PollFlags::POLLOUT) {
             // try to send queued PRIORITY packets
-            worker.process_substrate_egress_queue();
+            io.process_substrate_socket_out(&mut worker);
         }
 
         if revents[PollSlot::Requeue].contains(poll::PollFlags::POLLIN) {
             // read from requeue
-            // TODO: batch receive
-            while let Some(mut buf) = worker.buffers.pop() {
-                if let Err(err) = requeue_outq.recv(buf.as_mut()) {
-                    match err.kind() {
-                        ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
-                            worker.buffers.push(buf);
-                            break;
-                        }
-
-                        _ => {
-                            // FIXME: detect packet-too-large
-                            panic!("unrecoverable I/O error {err}");
-                        }
-                    }
-                }
-
-                worker.asm.counters[CounterType::RequeuedPacketsReceived].increment();
-                let pkt = Packet::new_with_existing_metadata(buf);
-                worker.agent_output_post_classify(pkt, /* allow_bind_request */ false);
-            }
+            io.process_requeue_in(&mut worker);
         }
 
         if revents[PollSlot::MgmtSubstrate].contains(poll::PollFlags::POLLIN) {
             // read from mgmt_substrate
-            // TODO: batch receive
-            while let Some(mut buf) = worker.buffers.pop() {
-                if let Err(err) = mgmt_substrate_outq.recv(buf.as_mut()) {
-                    match err.kind() {
-                        ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
-                            worker.buffers.push(buf);
-                            break;
-                        }
-
-                        _ => {
-                            // FIXME: detect packet-too-large
-                            panic!("unrecoverable I/O error {err}");
-                        }
-                    }
-                }
-
-                worker.asm.counters[CounterType::MgmtPacketsSent].increment();
-                let pkt = Packet::new_with_existing_metadata(buf);
-                worker.substrate_egress(pkt);
-            }
+            io.process_mgmt_substrate_in(&mut worker);
         }
 
         if revents[PollSlot::Substrate].contains(poll::PollFlags::POLLIN) {
@@ -172,54 +106,7 @@ fn fastpath_main(
                 continue;
             }
 
-            let mut results = Vec::new(); // TODO: recycle
-            let n = worker
-                .batch_io
-                .try_recv_buf_from_batch(&worker.substrate_socket, pkts.iter_mut(), &mut results)
-                .unwrap();
-
-            // return empty buffers to pool
-            worker
-                .buffers
-                .extend(pkts.drain(n..).rev().map(|pkt| pkt.destroy()));
-
-            // process packets
-            for (pkt, result) in pkts.into_iter().zip(results) {
-                let mut sender = match result {
-                    Ok((size, _sender)) if size > pkt.remaining() => {
-                        worker.drop_and_count(pkt, CounterType::DroppedOversize);
-                        continue;
-                    }
-
-                    Ok((_size, sender)) => {
-                        sender.expect("received from non-IP address, should not happen!")
-                    }
-
-                    Err(err) => {
-                        match err.kind() {
-                            ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
-                                worker.buffers.push(pkt.destroy());
-                                continue;
-                            }
-
-                            // FIXME: do something with this later...
-                            ErrorKind::ConnectionRefused => {
-                                worker.buffers.push(pkt.destroy());
-                                continue;
-                            }
-
-                            _ => panic!("got socket error {err}"),
-                        }
-                    }
-                };
-
-                // SocketAddrV6 distinguishes addresses also by `flowinfo` which
-                // we do not want -- only the 5-tuple.  So clear it.
-                clear_flowinfo(&mut sender);
-
-                worker.asm.counters[CounterType::InPacksRec].increment();
-                worker.substrate_ingress(&sender, pkt);
-            }
+            io.process_substrate_socket_in(&mut worker, &mut pkts);
         }
 
         if revents[PollSlot::Tun].contains(poll::PollFlags::POLLIN) {
@@ -230,48 +117,7 @@ fn fastpath_main(
                 continue;
             }
 
-            let mut results = Vec::new(); // TODO: recycle
-            let n = worker
-                .batch_io
-                .try_read_buf_batch(&worker.agent_input_tun, pkts.iter_mut(), &mut results)
-                .unwrap();
-
-            // return empty buffers to pool
-            worker
-                .buffers
-                .extend(pkts.drain(n..).rev().map(|pkt| pkt.destroy()));
-
-            // process packets
-            for (mut pkt, result) in pkts.into_iter().zip(results) {
-                if let Err(err) = result {
-                    match err.kind() {
-                        ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
-                            worker.buffers.push(pkt.destroy());
-                            continue;
-                        }
-
-                        _ => panic!("unrecoverable I/O error {err}"),
-                    }
-                }
-
-                if zprtun::TUN_HAS_PI {
-                    let pi = TunPi::read_pi(&mut pkt);
-                    if pi.strip || !is_ip(pi) {
-                        // packet was too large or non-IP; drop
-                        worker.drop_and_count(pkt, CounterType::OutPacksDrop);
-                        continue;
-                    }
-                } else {
-                    // No packet info, permit IP and IPv6 only (for now?)
-                    if pkt.body()[0] >> 4 != 4 && pkt.body()[0] >> 4 != 6 {
-                        worker.drop_and_count(pkt, CounterType::OutPacksDrop);
-                        continue;
-                    }
-                }
-
-                worker.asm.counters[CounterType::OutPacksRec].increment();
-                worker.agent_output(pkt);
-            }
+            io.process_agent_tun_in(&mut worker, &mut pkts);
         }
 
         if revents[PollSlot::Returns].contains(poll::PollFlags::POLLIN) {
@@ -280,12 +126,5 @@ fn fastpath_main(
                 .return_q
                 .try_recv_many_returns(&mut worker.buffers, worker.config.buffer_count);
         }
-    }
-}
-
-fn clear_flowinfo(addr: &mut SocketAddr) {
-    match addr {
-        SocketAddr::V4(_) => (),
-        SocketAddr::V6(addr) => addr.set_flowinfo(0),
     }
 }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -27,6 +27,7 @@ mod config;
 mod counters;
 mod defs;
 mod fastpath;
+mod fastpath_io;
 mod fastpath_worker;
 mod flow_control;
 mod forwarding_tables;


### PR DESCRIPTION
No code changes.  This just factors out all I/O operations (reads and writes) from `fastpath_worker` and `fastpath` into a new `fastpath_io` module.  So `fastpath_worker` is left to handle I/O multiplexing (i.e. poll), and `fastpath` is left to do actual packet processing (i.e. no I/O performed).

These modules could probably be renamed/moved but I'm gonna punt on that for now.  (Notably `fastpath` state is kept in a struct named `FastpathWorker`.)  The purpose of this PR is so that my next one (which implements fairness) is legible.