### PR TITLE
fastpath I/O fairness

### DIFF
--- a/adapter/ph/src/fastpath_io.rs
+++ b/adapter/ph/src/fastpath_io.rs
@@ -69,11 +69,13 @@ impl FastpathIo {
     }
 
     /// Process an input-ready notification on the substrate socket (substrate ingress).
-    pub fn process_substrate_socket_in(
-        &mut self,
-        worker: &mut FastpathWorker,
-        pkts: &mut Vec<Packet>,
-    ) {
+    pub fn process_substrate_socket_in(&mut self, worker: &mut FastpathWorker) {
+        let mut pkts = Vec::new(); // TODO: recycle
+        let nbufs = worker.get_fresh_packets(worker.config.batch_size, &mut pkts);
+        if nbufs == 0 {
+            return;
+        }
+
         let mut results = Vec::new(); // TODO: recycle
         let n = self
             .batch_io
@@ -131,7 +133,13 @@ impl FastpathIo {
     }
 
     /// Process an input-ready notification on the agent TUN (agent output).
-    pub fn process_agent_tun_in(&mut self, worker: &mut FastpathWorker, pkts: &mut Vec<Packet>) {
+    pub fn process_agent_tun_in(&mut self, worker: &mut FastpathWorker) {
+        let mut pkts = Vec::new(); // TODO: recycle
+        let nbufs = worker.get_fresh_packets(worker.config.batch_size, &mut pkts);
+        if nbufs == 0 {
+            return;
+        }
+
         let mut results = Vec::new(); // TODO: recycle
         let n = self
             .batch_io
@@ -178,7 +186,6 @@ impl FastpathIo {
 
     /// Process an input-ready notification on the requeue socket.
     pub fn process_requeue_in(&mut self, worker: &mut FastpathWorker) {
-        // TODO: batch receive
         while let Some(mut buf) = worker.buffers.pop() {
             if let Err(err) = self.requeue_outq.recv(buf.as_mut()) {
                 match err.kind() {
@@ -202,7 +209,6 @@ impl FastpathIo {
 
     /// Process an input-ready notification on the mgmt substrate socket.
     pub fn process_mgmt_substrate_in(&mut self, worker: &mut FastpathWorker) {
-        // TODO: batch receive
         while let Some(mut buf) = worker.buffers.pop() {
             if let Err(err) = self.mgmt_substrate_outq.recv(buf.as_mut()) {
                 match err.kind() {

--- a/adapter/ph/src/fastpath_worker.rs
+++ b/adapter/ph/src/fastpath_worker.rs
@@ -2,6 +2,7 @@ use crate::assembly::Assembly;
 use crate::fastpath::{FastpathWorker, FastpathWorkerConfig};
 use crate::fastpath_io::FastpathIo;
 use crate::sys::ZprTun;
+use crate::util::fair;
 use enum_map::{enum_map, Enum};
 use nix::poll;
 use std::net::UdpSocket;
@@ -40,6 +41,8 @@ pub fn launch(
 }
 
 fn fastpath_main(mut worker: FastpathWorker, mut io: FastpathIo) {
+    let mut fair = 0usize; // counter used to ensure fairness, below
+
     loop {
         // try to immediately output anything we've queued up;
         // if we can't, drop it, unless it's on the substrate and marked PRIORITY
@@ -80,44 +83,15 @@ fn fastpath_main(mut worker: FastpathWorker, mut io: FastpathIo) {
         // references to things in `worker`, which we need `&mut` access to later.
         let revents = poll_fds.map(|_, pfd| pfd.revents().unwrap());
 
-        // FIXME: fairness... address this in tandem with batch receive
-        // for now, prioritize requeue so it doesn't starve
+        // First, process I/O events which involve releasing packet buffers.
+        // These do not compete with each other and thus can be run in any order
+        // without affecting fairness guarantees.
+        // We run them first so that any released buffers are immediately available
+        // for use for packet receive below.
 
         if revents[PollSlot::Substrate].contains(poll::PollFlags::POLLOUT) {
             // try to send queued PRIORITY packets
             io.process_substrate_socket_out(&mut worker);
-        }
-
-        if revents[PollSlot::Requeue].contains(poll::PollFlags::POLLIN) {
-            // read from requeue
-            io.process_requeue_in(&mut worker);
-        }
-
-        if revents[PollSlot::MgmtSubstrate].contains(poll::PollFlags::POLLIN) {
-            // read from mgmt_substrate
-            io.process_mgmt_substrate_in(&mut worker);
-        }
-
-        if revents[PollSlot::Substrate].contains(poll::PollFlags::POLLIN) {
-            // read from socket
-            let mut pkts = Vec::new(); // TODO: recycle
-            let nbufs = worker.get_fresh_packets(worker.config.batch_size, &mut pkts);
-            if nbufs == 0 {
-                continue;
-            }
-
-            io.process_substrate_socket_in(&mut worker, &mut pkts);
-        }
-
-        if revents[PollSlot::Tun].contains(poll::PollFlags::POLLIN) {
-            // read from TUN device
-            let mut pkts = Vec::new(); // TODO: recycle
-            let nbufs = worker.get_fresh_packets(worker.config.batch_size, &mut pkts);
-            if nbufs == 0 {
-                continue;
-            }
-
-            io.process_agent_tun_in(&mut worker, &mut pkts);
         }
 
         if revents[PollSlot::Returns].contains(poll::PollFlags::POLLIN) {
@@ -126,5 +100,34 @@ fn fastpath_main(mut worker: FastpathWorker, mut io: FastpathIo) {
                 .return_q
                 .try_recv_many_returns(&mut worker.buffers, worker.config.buffer_count);
         }
+
+        // Now, process I/O events which involve consuming packet buffers.
+        // Since these compete with each other, we want to ensure some fairness among them.
+
+        fair!(
+            fair,
+            {
+                if revents[PollSlot::Requeue].contains(poll::PollFlags::POLLIN) {
+                    io.process_requeue_in(&mut worker);
+                }
+            },
+            {
+                if revents[PollSlot::MgmtSubstrate].contains(poll::PollFlags::POLLIN) {
+                    io.process_mgmt_substrate_in(&mut worker);
+                }
+            },
+            {
+                if revents[PollSlot::Substrate].contains(poll::PollFlags::POLLIN) {
+                    io.process_substrate_socket_in(&mut worker);
+                }
+            },
+            {
+                if revents[PollSlot::Tun].contains(poll::PollFlags::POLLIN) {
+                    io.process_agent_tun_in(&mut worker);
+                }
+            },
+        );
+
+        fair = fair.wrapping_add(1);
     }
 }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -57,6 +57,7 @@ mod sys;
 mod test_packet;
 mod tun_ctl;
 mod two_way_queue;
+mod util;
 mod visa_mgmt;
 mod visa_table;
 mod vs_worker;

--- a/adapter/ph/src/util.rs
+++ b/adapter/ph/src/util.rs
@@ -1,0 +1,123 @@
+//! Miscellaneous utility items.
+
+/// Utility macro to count the number of items in the body.
+macro_rules! count {
+    {} => (0usize);
+    { $b:block $($bs:tt)* } => (1usize + $crate::util::count!($($bs)*));
+}
+
+pub(crate) use count;
+
+/// Round-robin-based fairness.
+///
+/// The first argument is a "fairness counter".  The remaining arguments
+/// are code blocks which will all be executed once, but in varying order.
+///
+/// The order of execution of the code blocks is determined by the fairness
+/// counter, such that differing values of the counter result in different
+/// orders of execution.  The invoker must increment or randomly generate
+/// the fairness counter for each invocation.
+macro_rules! fair {
+    ( $counter:expr, $($branch:block),+ $(,)? ) => {
+        let cohort = $crate::util::count!($({$branch})*);
+
+        for round in 0..2 {
+            let mut index = 0;
+
+            $(
+                if ((($counter % cohort) <= index) as usize ^ round) != 0 {
+                    $branch
+                }
+
+                index += 1;
+            )+
+
+            let _ = index;
+        }
+    }
+}
+
+pub(crate) use fair;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn single_branch() {
+        // Confirm that a single branch always gets executed.
+
+        for i in 0..4 {
+            let mut foo = 0;
+            fair!(i, { foo += 1 });
+            assert_eq!(foo, 1);
+        }
+    }
+
+    #[test]
+    fn multiple_branches() {
+        // Confirm that multiple branches always get executed.
+
+        for i in 0..16 {
+            let mut foo = 0;
+            let mut bar = 0;
+            let mut baz = 0;
+            let mut quux = 0;
+
+            fair!(i, { foo += 1 }, { bar += 1 }, { baz += 1 }, { quux += 1 },);
+
+            assert_eq!(foo, 1);
+            assert_eq!(bar, 1);
+            assert_eq!(baz, 1);
+            assert_eq!(quux, 1);
+        }
+    }
+
+    #[test]
+    fn fairness() {
+        // Confirm that each of several branches regularly gets to go first.
+        // (This is a very simplistic and strict check but it captures our current behavior.)
+
+        let mut foo = 0;
+        let mut bar = 0;
+        let mut baz = 0;
+        let mut quux = 0;
+
+        for i in 0..16 {
+            let mut token = true;
+
+            fair!(
+                i,
+                {
+                    if token {
+                        foo += 1;
+                        token = false;
+                    }
+                },
+                {
+                    if token {
+                        bar += 1;
+                        token = false;
+                    }
+                },
+                {
+                    if token {
+                        baz += 1;
+                        token = false;
+                    }
+                },
+                {
+                    if token {
+                        quux += 1;
+                        token = false;
+                    }
+                },
+            );
+
+            assert_eq!(token, false);
+        }
+
+        assert_eq!(foo, 4);
+        assert_eq!(bar, 4);
+        assert_eq!(baz, 4);
+        assert_eq!(quux, 4);
+    }
+}


### PR DESCRIPTION
Introduces a macro, `fair!()`, to help with writing code whose order of execution is varied to ensure fairness.

Uses said macro to ensure fairness among the fastpath I/O operations which consume buffers, to ensure that when under buffer pressure, all input sources get a chance to be processed.