### PR TITLE
bare bones TUN interface for macos

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -836,9 +836,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libnode"

--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -144,30 +144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,19 +214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,26 +230,6 @@ name = "bytes"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
-
-[[package]]
-name = "c2rust-bitfields"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367e5d1b30f28be590b6b3868da1578361d29d9bfac516d22f497d28ed7c9055"
-dependencies = [
- "c2rust-bitfields-derive",
-]
-
-[[package]]
-name = "c2rust-bitfields-derive"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a279db9c50c4024eeca1a763b6e0f033848ce74e83e47454bcf8a8a98f7b0b56"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "cbpf-rs"
@@ -393,7 +336,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -407,15 +350,6 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "constant_time_eq"
@@ -521,7 +455,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -544,7 +478,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -555,7 +489,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -606,7 +540,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -627,7 +561,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -635,33 +569,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "event-listener"
-version = "5.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fiat-crypto"
@@ -701,62 +608,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-lite"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1fa2f9765705486b33fd2acf1577f8ec449c2ba1f318ae5447697b7c08d210"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"
@@ -766,7 +621,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -787,13 +642,9 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -953,12 +804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,16 +839,6 @@ name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
-
-[[package]]
-name = "libloading"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
-dependencies = [
- "cfg-if",
- "windows-targets",
-]
 
 [[package]]
 name = "libnode"
@@ -1191,7 +1026,7 @@ checksum = "8d1296fab5231654a5aec8bf9e87ba4e3938c502fc4c3c0425a00084c78944be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1217,7 +1052,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1246,12 +1081,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1314,7 +1143,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "tun",
  "zerocopy 0.8.9",
  "zpr",
  "zpr-ext",
@@ -1331,17 +1159,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkg-config"
@@ -1538,7 +1355,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1651,7 +1468,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1659,17 +1476,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -1699,7 +1505,7 @@ checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1760,7 +1566,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1843,7 +1649,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -1883,27 +1689,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tun"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224cb7686e768be38d03dc660f88947b8976c1d68b8ee731324fe4b761ab80a2"
-dependencies = [
- "bytes",
- "cfg-if",
- "futures",
- "futures-core",
- "ipnet",
- "libc",
- "log",
- "nix",
- "thiserror",
- "tokio",
- "tokio-util",
- "windows-sys 0.59.0",
- "wintun-bindings",
 ]
 
 [[package]]
@@ -1988,7 +1773,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2010,7 +1795,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2086,7 +1871,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2097,7 +1882,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2217,21 +2002,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wintun-bindings"
-version = "0.7.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74675b7fccee92389d38c3d120445864d1085c421ee91c7ed05d66fb9bb76050"
-dependencies = [
- "blocking",
- "c2rust-bitfields",
- "futures",
- "libloading",
- "log",
- "thiserror",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,7 +2028,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]
@@ -2269,7 +2039,7 @@ checksum = "fa732fcc881df7a6fbe8e3ed17baadece53b379ad58fe2633396b1a2b108a7b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn",
 ]
 
 [[package]]

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -43,13 +43,6 @@ zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "zerocopy"] }
 tokio-tun = { version = "0.11.5" }
 io-uring = { version = "0.7.4", optional = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-# This is used for its ability to manage a TUN device on mac.
-# Locked at 0.7.1 just so we are sure to track what is happening
-# in this project. There were some features in v0.6.1 that we
-# may need going forward.
-tun = { version = "=0.7.1", features = ["async"] }
-
 [dev-dependencies]
 rand = "0.8.5"
 

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -19,7 +19,7 @@ dashmap = { version = "6.0.1" }
 enum-map = { version = "2.7.3" }
 enumset = "1.1.5"
 hdrhistogram = { version = "7.5.4" }
-libc = { version = "0.2.155" }
+libc = { version = "0.2.171" }
 libnode = { path = "../../libnode" }
 itertools = "0.14"
 nix = { version = "0.29.0", features = ["ioctl", "net", "poll"] }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -25,7 +25,7 @@ use blake3;
 use bytes::{Buf, BufMut};
 use std::io::ErrorKind;
 use std::net::UdpSocket;
-use std::os::fd::{AsRawFd, BorrowedFd};
+use std::os::fd::AsFd;
 use std::sync::Arc;
 use std::time::SystemTime;
 use tracing::*;
@@ -538,7 +538,8 @@ impl FastpathWorker {
 
     fn process_agent_input_queue(&mut self) {
         // temp hack until we move ZprTun to be non-Tokio
-        let tun_fd = unsafe { BorrowedFd::borrow_raw(self.agent_input_tun.as_raw_fd()) };
+        //let tun_fd = unsafe { BorrowedFd::borrow_raw(self.agent_input_tun.as_raw_fd()) };
+        let tun_fd = self.agent_input_tun.as_fd();
 
         // Add TUN PI header.
         match TunPi::PI_SIZE {

--- a/adapter/ph/src/logging.rs
+++ b/adapter/ph/src/logging.rs
@@ -30,6 +30,7 @@ pub mod targets {
     pub const KEY_MGMT: &str = "key_mgmt";
     pub const LINK_STATE: &str = "link_state";
     pub const MGMT_EVENTS: &str = "mgmt_events";
+    pub const NET_OS: &str = "net_os";
     pub const PEER_MGMT: &str = "peer_mgmt";
     pub const REPORTING: &str = "reporting";
     pub const RPC: &str = "rpc";
@@ -47,6 +48,7 @@ pub mod targets {
         KEY_MGMT,
         LINK_STATE,
         MGMT_EVENTS,
+        NET_OS,
         PEER_MGMT,
         REPORTING,
         RPC,

--- a/adapter/ph/src/sys/linux.rs
+++ b/adapter/ph/src/sys/linux.rs
@@ -1,4 +1,4 @@
 pub mod zprtun;
 pub use zprtun::ZprTun;
 pub mod tun_pi;
-pub use tun_pi::TunPi;
+pub use tun_pi::TunPiImpl;

--- a/adapter/ph/src/sys/linux/tun_pi.rs
+++ b/adapter/ph/src/sys/linux/tun_pi.rs
@@ -1,5 +1,5 @@
-use bytes::buf;
 use crate::sys::TunPi;
+use bytes::buf;
 
 const TUN_PKT_STRIP: u16 = 0x0001;
 
@@ -27,4 +27,3 @@ impl From<TunPi> for TunPiImpl {
         }
     }
 }
-

--- a/adapter/ph/src/sys/linux/tun_pi.rs
+++ b/adapter/ph/src/sys/linux/tun_pi.rs
@@ -1,68 +1,30 @@
 use bytes::buf;
+use crate::sys::TunPi;
 
-/// per-packet packet info
+const TUN_PKT_STRIP: u16 = 0x0001;
+
+#[repr(C)]
 #[derive(Clone, Copy)]
-pub struct TunPi {
-    // the inbound packet was truncated (ignored outbound)
-    pub strip: bool,
-    /// Ethertype of packet
-    pub proto: u16,
+pub struct TunPiImpl {
+    flags: u16,
+    proto: [u8; 2],
 }
 
-impl TunPi {
-    /// The size of a per-packet packet info structure.
-    pub const PI_SIZE: usize = std::mem::size_of::<os::TunPi>();
-
-    /// Read per-packet packet info from a `Buf`.
-    pub fn read_pi<B: buf::Buf>(buf: &mut B) -> TunPi {
-        let mut os_pi = std::mem::MaybeUninit::<os::TunPi>::uninit();
-        let slice = os_pi.as_mut_ptr();
-        buf.copy_to_slice(unsafe {
-            /* SAFETY: we immediately initialize */
-            std::slice::from_raw_parts_mut(slice as *mut u8, TunPi::PI_SIZE)
-        });
-        unsafe {
-            /* SAFETY: was just initialized */
-            os_pi.assume_init()
-        }
-        .into()
-    }
-
-    /// Write per-packet packet info into a `BufMut`.
-    pub fn write_pi<B: buf::BufMut>(buf: &mut B, pi: TunPi) {
-        let os_pi: os::TunPi = pi.into();
-        buf.put(unsafe {
-            /* SAFETY: we are reading exactly the structure */
-            std::slice::from_raw_parts((&os_pi as *const _) as *const u8, TunPi::PI_SIZE)
-        });
-    }
-}
-
-mod os {
-    const TUN_PKT_STRIP: u16 = 0x0001;
-
-    #[repr(C)]
-    #[derive(Clone, Copy)]
-    pub struct TunPi {
-        flags: u16,
-        proto: [u8; 2],
-    }
-
-    impl From<TunPi> for super::TunPi {
-        fn from(pi: TunPi) -> super::TunPi {
-            super::TunPi {
-                strip: pi.flags & TUN_PKT_STRIP != 0,
-                proto: u16::from_be_bytes(pi.proto),
-            }
-        }
-    }
-
-    impl From<super::TunPi> for TunPi {
-        fn from(pi: super::TunPi) -> TunPi {
-            TunPi {
-                flags: 0,
-                proto: pi.proto.to_be_bytes(),
-            }
+impl From<TunPiImpl> for TunPi {
+    fn from(pi: TunPiImpl) -> TunPi {
+        TunPi {
+            strip: pi.flags & TUN_PKT_STRIP != 0,
+            proto: u16::from_be_bytes(pi.proto),
         }
     }
 }
+
+impl From<TunPi> for TunPiImpl {
+    fn from(pi: TunPi) -> TunPiImpl {
+        TunPiImpl {
+            flags: 0,
+            proto: pi.proto.to_be_bytes(),
+        }
+    }
+}
+

--- a/adapter/ph/src/sys/linux/tun_pi.rs
+++ b/adapter/ph/src/sys/linux/tun_pi.rs
@@ -1,5 +1,4 @@
 use crate::sys::TunPi;
-use bytes::buf;
 
 const TUN_PKT_STRIP: u16 = 0x0001;
 

--- a/adapter/ph/src/sys/macos.rs
+++ b/adapter/ph/src/sys/macos.rs
@@ -2,3 +2,5 @@ pub mod zprtun;
 pub use zprtun::ZprTun;
 pub mod tun_pi;
 pub use tun_pi::TunPi;
+
+mod tun;

--- a/adapter/ph/src/sys/macos.rs
+++ b/adapter/ph/src/sys/macos.rs
@@ -1,6 +1,6 @@
 pub mod zprtun;
 pub use zprtun::ZprTun;
 pub mod tun_pi;
-pub use tun_pi::TunPi;
+pub use tun_pi::TunPiImpl;
 
 mod tun;

--- a/adapter/ph/src/sys/macos/tun.rs
+++ b/adapter/ph/src/sys/macos/tun.rs
@@ -1,74 +1,115 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::os::unix::io::{RawFd, AsRawFd};
+use std::os::fd::AsFd;
+use std::os::unix::io::{AsRawFd, OwnedFd, FromRawFd, BorrowedFd};
 use std::mem;
 use std::ptr;
 use std::ffi::CStr;
 use nix::{ioctl_readwrite, ioctl_write_ptr};
 
+use tracing::*;
 use thiserror::Error;
 
-use crate::zprtun::DEFAULT_TUN_MTU;
+use crate::zprtun::{DEFAULT_TUN_MTU, ZPRNET_PREFIX_LEN};
 
 use libc::{
-    self, IFNAMSIZ, PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL, AF_SYSTEM, AF_SYS_CONTROL, AF_INET,
-    UTUN_OPT_IFNAME, c_uint, c_char, socklen_t, sockaddr, c_void, ifreq,
-    sockaddr_in, sockaddr_in6,
+    self, IFNAMSIZ, PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL,
+    AF_SYSTEM, AF_SYS_CONTROL, AF_INET, AF_INET6,
+    UTUN_OPT_IFNAME,
+    c_uint, c_int, c_char, socklen_t, sockaddr, c_void, ifreq,
+    sockaddr_in, sockaddr_in6, ctl_info,
 };
+
+// Not in libc. Copied from netinet6/in6_var.h
+#[allow(non_camel_case_types)]
+#[repr(C)]
+pub struct in6_aliasreq {
+    pub ifra_name: [c_char; IFNAMSIZ],
+    pub ifra_addr: libc::sockaddr_in6,
+    pub ifra_dstaddr: libc::sockaddr_in6,
+    pub ifra_prefixmask: libc::sockaddr_in6,
+    pub ifra_flags: c_int,
+    pub ifra_lifetime: libc::in6_addrlifetime,
+}
+
+// Not in libc. Copied from netinet6/nd6.h
+const ND6_INFINITE_LIFETIME: libc::c_uint = 0xffffffff;
+const IPV6_MMTU: u16 = 1280; // Minimum MTU for IPv6
+const IPV4_MMTU: u16 = 576; // Minimum MTU for IPv4
+
+
 
 /// Special macOS controller name for creating tun devices. (see net/if_utun.h)
 pub const UTUN_CONTROL_NAME: &str = "com.apple.net.utun_control";
 
 /// Size of the ifr_ifru union in the ifreq struct. (see net/if.h)
-const OVERWRITE_SIZE: usize = std::mem::size_of::<libc::__c_anonymous_ifr_ifru>();
+const OVERWRITE_SIZE_IP4: usize = std::mem::size_of::<libc::__c_anonymous_ifr_ifru>();
 
 
 ioctl_readwrite!(ctliocginfo, b'N', 3, ctl_info); // Convert kernel controller name to kernel controller ID
-ioctl_write_ptr!(siocsifaddr, b'i', 12, ifreq); // set ifnet address (XXX is this IPv4 only?)
-// ioctl_write_ptr!(siocsifaddr_in6, b'i', 12, in6_ifreq); // set ifnet address (ipv6)
+ioctl_write_ptr!(siocsifaddr, b'i', 12, ifreq); // set ifnet address (is this IPv4 only?)
+ioctl_write_ptr!(siocaifaddr_in6, b'i', 26, in6_aliasreq); // set ifnet address (ipv6)
 ioctl_write_ptr!(siocsifmtu, b'i', 52, ifreq); // set ifnet MTU
 
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct ctl_info {
-    pub ctl_id: c_uint, // kernel controller ID (filled in on return)
-    pub ctl_name: [c_char; 96], // kernel controller name
-}
 
 
 #[derive(Debug, Error)]
 pub enum TunError {
     #[error("TUN device name is too long")]
     NameTooLong,
+
     #[error("TUN device name is invalid (expect 'utun<N>')")]
     InvalidName,
+
     #[error("Failed to parse TUN interface name: {0}")]
     ParseError(#[from] std::num::ParseIntError),
+
     #[error("I/O Error: {0}")]
     IOError(#[from] std::io::Error),
+
+    #[error("Invalid prefix length (0-128)")]
+    InvalidPrefixLen,
+
+    #[error("Invalid MTU size (must be >= 1280 for IPv6)")]
+    InvalidIpv6Mtu,
+
+    #[error("Invalid MTU size (must be >= 576 for IPv4)")]
+    InvalidIpv4Mtu,
 }
 
-/// TUN device on macOS.
+/// Basic TUN device on macOS.
 pub struct Tun {
-    tun_fd: RawFd,
-    ctl_fd: RawFd,
+    tun_fd: OwnedFd,
+    ctl_fd: OwnedFd,
     name: String,
 }
 
-impl AsRawFd for Tun {
-    fn as_raw_fd(&self) -> RawFd {
-        self.tun_fd
+
+impl AsFd for Tun {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.tun_fd.as_fd()
     }
 }
 
+
 impl Tun {
-    pub fn builder() -> Builder {
-        Builder::default()
+    /// An address is required.
+    pub fn builder(tun_addr: IpAddr) -> Builder {
+        Builder::new(tun_addr)
     }
 
+    /// Create the configure the TUN device.
     pub fn create(config: &Builder) -> Result<Self, TunError> {
         let mtu = config.mtu.unwrap_or(DEFAULT_TUN_MTU);
-
+        let prefix_len = config.prefix_len.unwrap_or(ZPRNET_PREFIX_LEN);
+        if prefix_len > 128 {
+            return Err(TunError::InvalidPrefixLen);
+        }
+        if config.ipv6 && mtu < IPV6_MMTU {
+            return Err(TunError::InvalidIpv6Mtu);
+        }
+        if !config.ipv6 && mtu < IPV4_MMTU {
+            return Err(TunError::InvalidIpv4Mtu);
+        }
         // The id is one plus the number after the "utun" prefix.
         // If we pass the kernel id=0 it will assign the next available id.
         let id = if let Some(tun_name) = config.name.as_ref() {
@@ -98,6 +139,7 @@ impl Tun {
 
             // Obtain a ctl_id for utun controller
             if let Err(err) = ctliocginfo(fd, &mut info as *mut _ as *mut _) {
+                libc::close(fd);
                 return Err(std::io::Error::from(err).into());
             }
 
@@ -110,9 +152,10 @@ impl Tun {
                 sc_reserved: [0; 5],
             };
 
-            // Pretty sure this 'connect' call will create the TUN device
+            // This 'connect' call will request creation of the TUN device
             let address = &addr as *const libc::sockaddr_ctl as *const sockaddr;
             if libc::connect(fd, address, mem::size_of_val(&addr) as socklen_t) < 0 {
+                libc::close(fd);
                 return Err(std::io::Error::last_os_error().into());
             }
 
@@ -122,6 +165,7 @@ impl Tun {
             let optval = &mut tun_name as *mut _ as *mut c_void;
             let optlen = &mut name_len as *mut socklen_t;
             if libc::getsockopt(fd, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, optval, optlen) < 0 {
+                libc::close(fd);
                 return Err(std::io::Error::last_os_error().into());
             }
 
@@ -129,26 +173,37 @@ impl Tun {
                 .to_string_lossy()
                 .into();
 
+            debug!("cerated TUN device with name: {}", tun_name_str);
 
-            let ctl = libc::socket(AF_INET, SOCK_DGRAM, 0);
+            let ctl_sock;
+            if config.ipv6 {
+                ctl_sock = libc::socket(AF_INET6, SOCK_DGRAM, 0);
+            } else {
+                ctl_sock = libc::socket(AF_INET, SOCK_DGRAM, 0);
+            }
+            if ctl_sock < 0 {
+                libc::close(fd);
+                return Err(std::io::Error::last_os_error().into());
+            }
 
             Tun {
-                tun_fd: fd,
-                ctl_fd: ctl,
+                tun_fd: OwnedFd::from_raw_fd(fd),
+                ctl_fd: OwnedFd::from_raw_fd(ctl_sock),
                 name: tun_name_str,
             }
         };
+        info!("TUN device created: {}", tundev.name);
 
-        if config.address.is_some() {
-            tundev.set_address(config.address.unwrap())?;
-        }
+        tundev.set_address(config.address, prefix_len)?;
         tundev.set_mtu(mtu)?;
+
+        // TODO: Set interface UP? Not required? Seems like kernel sets it to UP already.
 
         Ok(tundev)
     }
 
-    /// Prepare a new request for kernel control socket.
-    unsafe fn request(&self) -> Result<libc::ifreq, TunError> {
+    /// Prepare a new `ifreq` request for kernel control socket.  Fills in the name field.
+    unsafe fn request_v4(&self) -> Result<libc::ifreq, TunError> {
         let mut req: libc::ifreq = unsafe { mem::zeroed() };
         unsafe {
             ptr::copy_nonoverlapping(
@@ -160,18 +215,20 @@ impl Tun {
         Ok(req)
     }
 
-    fn set_address(&mut self, addr: IpAddr) -> Result<(), TunError> {
+
+    /// Set the address of the TUN device.  `prefix_len` is the prefix length for IPv6 and is ignored for IPv4.
+    fn set_address(&mut self, addr: IpAddr, prefix_len: usize) -> Result<(), TunError> {
         match addr {
             IpAddr::V4(ipv4) => self.set_address_ipv4(ipv4),
-            IpAddr::V6(ipv6) => self.set_address_ipv6(ipv6),
+            IpAddr::V6(ipv6) => self.set_address_ipv6(ipv6, prefix_len),
         }
     }
 
     fn set_address_ipv4(&mut self, value: Ipv4Addr) -> Result<(), TunError> {
         unsafe {
-            let mut req = self.request()?;
-            ipv4addr_to_sockaddr(value, 0, &mut req.ifr_ifru.ifru_addr, OVERWRITE_SIZE);
-            if let Err(err) = siocsifaddr(self.ctl_fd, &req) {
+            let mut req = self.request_v4()?;
+            ipv4addr_to_sockaddr(value, 0, &mut req.ifr_ifru.ifru_addr, OVERWRITE_SIZE_IP4);
+            if let Err(err) = siocsifaddr(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(std::io::Error::from(err).into());
             }
             // TODO: Update routing?
@@ -179,11 +236,30 @@ impl Tun {
         }
     }
 
-    fn set_address_ipv6(&mut self, value: Ipv6Addr) -> Result<(), TunError> {
+    fn set_address_ipv6(&mut self, value: Ipv6Addr, prefix_len: usize) -> Result<(), TunError> {
+        let mut req: in6_aliasreq = unsafe { mem::zeroed() };
         unsafe {
-            let mut req = self.request()?;
-            ipv6addr_to_sockaddr(value, 0, &mut req.ifr_ifru.ifru_addr, OVERWRITE_SIZE);
-            if let Err(err) = siocsifaddr(self.ctl_fd, &req) {
+            ptr::copy_nonoverlapping(
+                self.name.as_ptr() as *const c_char,
+                req.ifra_name.as_mut_ptr(),
+                self.name.len(),
+            );
+
+            ipv6addr_to_sockaddr(value, 0, &mut req.ifra_addr, mem::size_of::<sockaddr_in6>());
+
+            req.ifra_prefixmask.sin6_family = AF_INET6 as libc::sa_family_t;
+            req.ifra_prefixmask.sin6_len = mem::size_of::<sockaddr_in6>() as u8;
+
+            let mut pfx_mask: u128 = 0;
+            for i in 0..prefix_len {
+                pfx_mask |= 1 << (127 - i);
+            }
+            req.ifra_prefixmask.sin6_addr.s6_addr = pfx_mask.to_be_bytes();
+
+            req.ifra_lifetime.ia6t_vltime = ND6_INFINITE_LIFETIME;
+            req.ifra_lifetime.ia6t_pltime = ND6_INFINITE_LIFETIME;
+
+            if let Err(err) = siocaifaddr_in6(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(std::io::Error::from(err).into());
             }
             // TODO: Update routing?
@@ -194,9 +270,9 @@ impl Tun {
 
     fn set_mtu(&mut self, value: u16) -> Result<(), TunError> {
         unsafe {
-            let mut req = self.request()?;
+            let mut req = self.request_v4()?;
             req.ifr_ifru.ifru_mtu = value as i32;
-            if let Err(err) = siocsifmtu(self.ctl_fd, &req) {
+            if let Err(err) = siocsifmtu(self.ctl_fd.as_raw_fd(), &req) {
                 return Err(std::io::Error::from(err).into());
             }
             Ok(())
@@ -207,17 +283,28 @@ impl Tun {
 
 
 
-#[derive(Default)]
+#[derive(Debug)]
 pub struct Builder {
     name: Option<String>,
     mtu: Option<u16>,
-    address: Option<IpAddr>,
-    // flags: Option<i32>,
-    // queue_count: usize,
+    prefix_len: Option<usize>,
+    address: IpAddr, // required
+    ipv6: bool,
 }
 
 
 impl Builder {
+    /// Create a new builder, which is used to configure the TUN device.
+    pub fn new(tun_addr: IpAddr) -> Builder {
+        Builder {
+            name: None,
+            mtu: None,
+            prefix_len: None,
+            address: tun_addr,
+            ipv6: tun_addr.is_ipv6(),
+        }
+    }
+
     /// Tun name is optional. If provided must be of format "utun<N>" where N is a number.
     #[allow(dead_code)]
     pub fn with_tun_name(&mut self, name: &str) -> &mut Self {
@@ -231,11 +318,13 @@ impl Builder {
         self
     }
 
+    /// Set IPv6 prefix len (0<=prefix_len<=128)
     #[allow(dead_code)]
-    pub fn with_address(&mut self, addr: IpAddr) -> &mut Self {
-        self.address = Some(addr);
+    pub fn with_prefix_len(&mut self, prefix_len: usize) -> &mut Self {
+        self.prefix_len = Some(prefix_len);
         self
     }
+
 }
 
 
@@ -263,10 +352,13 @@ pub unsafe fn ipv4addr_to_sockaddr (
     };
 }
 
+
+/// Fill the `addr` with the address particulars. `size` is the size of the
+/// sockaddr structure to be filled (used as our upper bound for the copy).
 pub unsafe fn ipv6addr_to_sockaddr (
     src_addr: Ipv6Addr,
     src_port: u16,
-    addr: &mut libc::sockaddr,
+    addr: &mut libc::sockaddr_in6,
     size: usize,
 )
 {

--- a/adapter/ph/src/sys/macos/tun.rs
+++ b/adapter/ph/src/sys/macos/tun.rs
@@ -9,6 +9,7 @@ use std::ptr;
 use thiserror::Error;
 use tracing::*;
 
+use crate::logging::targets::NET_OS;
 use crate::zprtun::{DEFAULT_TUN_MTU, ZPRNET_PREFIX_LEN};
 
 use libc::{
@@ -83,25 +84,29 @@ impl AsFd for Tun {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum IPV {
+    V4,
+    V6,
+}
+
+impl From<IpAddr> for IPV {
+    fn from(addr: IpAddr) -> Self {
+        match addr {
+            IpAddr::V4(_) => IPV::V4,
+            IpAddr::V6(_) => IPV::V6,
+        }
+    }
+}
+
 impl Tun {
-    /// An address is required.
-    pub fn builder(tun_addr: IpAddr) -> Builder {
-        Builder::new(tun_addr)
+    /// Create a build to aid in configuring the tun.
+    pub fn builder(ipv: IPV) -> Builder {
+        Builder::new(ipv)
     }
 
     /// Create and configure the TUN device.
     pub fn create(config: &Builder) -> Result<Self, TunError> {
-        let mtu = config.mtu.unwrap_or(DEFAULT_TUN_MTU);
-        let prefix_len = config.prefix_len.unwrap_or(ZPRNET_PREFIX_LEN);
-        if prefix_len > 128 {
-            return Err(TunError::InvalidPrefixLen);
-        }
-        if config.ipv6 && mtu < IPV6_MMTU {
-            return Err(TunError::InvalidIpv6Mtu);
-        }
-        if !config.ipv6 && mtu < IPV4_MMTU {
-            return Err(TunError::InvalidIpv4Mtu);
-        }
         // The id is one plus the number after the "utun" prefix.
         // If we pass the kernel id=0 it will assign the next available id.
         let id = if let Some(tun_name) = config.name.as_ref() {
@@ -117,7 +122,7 @@ impl Tun {
         };
 
         let mut tundev = unsafe {
-            let fd = libc::socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL);
+            let fd = OwnedFd::from_raw_fd(libc::socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL));
             let mut info = ctl_info {
                 ctl_id: 0,
                 ctl_name: {
@@ -130,8 +135,7 @@ impl Tun {
             };
 
             // Obtain a ctl_id for utun controller
-            if let Err(err) = ctliocginfo(fd, &mut info as *mut _ as *mut _) {
-                libc::close(fd);
+            if let Err(err) = ctliocginfo(fd.as_raw_fd(), &mut info as *mut _ as *mut _) {
                 return Err(std::io::Error::from(err).into());
             }
 
@@ -146,8 +150,12 @@ impl Tun {
 
             // This 'connect' call will request creation of the TUN device
             let address = &addr as *const libc::sockaddr_ctl as *const sockaddr;
-            if libc::connect(fd, address, mem::size_of_val(&addr) as socklen_t) < 0 {
-                libc::close(fd);
+            if libc::connect(
+                fd.as_raw_fd(),
+                address,
+                mem::size_of_val(&addr) as socklen_t,
+            ) < 0
+            {
                 return Err(std::io::Error::last_os_error().into());
             }
 
@@ -156,8 +164,14 @@ impl Tun {
             let mut name_len: socklen_t = 64;
             let optval = &mut tun_name as *mut _ as *mut c_void;
             let optlen = &mut name_len as *mut socklen_t;
-            if libc::getsockopt(fd, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, optval, optlen) < 0 {
-                libc::close(fd);
+            if libc::getsockopt(
+                fd.as_raw_fd(),
+                SYSPROTO_CONTROL,
+                UTUN_OPT_IFNAME,
+                optval,
+                optlen,
+            ) < 0
+            {
                 return Err(std::io::Error::last_os_error().into());
             }
 
@@ -165,33 +179,57 @@ impl Tun {
                 .to_string_lossy()
                 .into();
 
-            debug!("cerated TUN device with name: {}", tun_name_str);
-
             let ctl_sock;
-            if config.ipv6 {
+            if config.is_ipv6() {
                 ctl_sock = libc::socket(AF_INET6, SOCK_DGRAM, 0);
             } else {
                 ctl_sock = libc::socket(AF_INET, SOCK_DGRAM, 0);
             }
             if ctl_sock < 0 {
-                libc::close(fd);
                 return Err(std::io::Error::last_os_error().into());
             }
 
             Tun {
-                tun_fd: OwnedFd::from_raw_fd(fd),
+                tun_fd: fd,
                 ctl_fd: OwnedFd::from_raw_fd(ctl_sock),
                 name: tun_name_str,
             }
         };
-        info!("TUN device created: {}", tundev.name);
+        info!(target: NET_OS, "TUN device created: {}", tundev.name);
 
-        tundev.set_address(config.address, prefix_len)?;
-        tundev.set_mtu(mtu)?;
+        tundev.configure(config)?;
 
         // TODO: Set interface UP? Not required? Seems like kernel sets it to UP already.
 
         Ok(tundev)
+    }
+
+    // Post create configuration based on the builder.
+    fn configure(&mut self, config: &Builder) -> Result<(), TunError> {
+        let mtu: Option<u16>;
+        if let Some(addr) = config.address {
+            let prefix_len = config.prefix_len.unwrap_or(ZPRNET_PREFIX_LEN);
+            if prefix_len > 128 {
+                return Err(TunError::InvalidPrefixLen);
+            }
+            self.set_address(addr, prefix_len)?;
+
+            // If address is specified, always also set MTU
+            mtu = Some(config.mtu.unwrap_or(DEFAULT_TUN_MTU));
+        } else {
+            // Address not specied, only set MTU if it (MTU) is specified.
+            mtu = config.mtu;
+        }
+        if let Some(mtu) = mtu {
+            if config.is_ipv6() && mtu < IPV6_MMTU {
+                return Err(TunError::InvalidIpv6Mtu);
+            }
+            if !config.is_ipv6() && mtu < IPV4_MMTU {
+                return Err(TunError::InvalidIpv4Mtu);
+            }
+            self.set_mtu(mtu)?;
+        }
+        Ok(())
     }
 
     /// Prepare a new `ifreq` request for kernel control socket.  Fills in the name field.
@@ -208,7 +246,7 @@ impl Tun {
     }
 
     /// Set the address of the TUN device.  `prefix_len` is the prefix length for IPv6 and is ignored for IPv4.
-    fn set_address(&mut self, addr: IpAddr, prefix_len: usize) -> Result<(), TunError> {
+    pub fn set_address(&mut self, addr: IpAddr, prefix_len: usize) -> Result<(), TunError> {
         match addr {
             IpAddr::V4(ipv4) => self.set_address_ipv4(ipv4),
             IpAddr::V6(ipv6) => self.set_address_ipv6(ipv6, prefix_len),
@@ -258,7 +296,7 @@ impl Tun {
         }
     }
 
-    fn set_mtu(&mut self, value: u16) -> Result<(), TunError> {
+    pub fn set_mtu(&mut self, value: u16) -> Result<(), TunError> {
         unsafe {
             let mut req = self.request_v4()?;
             req.ifr_ifru.ifru_mtu = value as i32;
@@ -275,20 +313,39 @@ pub struct Builder {
     name: Option<String>,
     mtu: Option<u16>,
     prefix_len: Option<usize>,
-    address: IpAddr, // required
-    ipv6: bool,
+    address: Option<IpAddr>,
+    ipv: IPV,
 }
 
 impl Builder {
     /// Create a new builder, which is used to configure the TUN device.
-    pub fn new(tun_addr: IpAddr) -> Builder {
+    /// You must choose either IPv4 or IPv6.
+    fn new(ipv: IPV) -> Builder {
         Builder {
             name: None,
             mtu: None,
             prefix_len: None,
-            address: tun_addr,
-            ipv6: tun_addr.is_ipv6(),
+            address: None,
+            ipv,
         }
+    }
+
+    pub fn is_ipv6(&self) -> bool {
+        self.ipv == IPV::V6
+    }
+
+    /// Set the address of the TUN device.  If you set this in the builder then
+    /// the address will be assigned when you create the TUN device.
+    #[allow(dead_code)]
+    pub fn with_address(&mut self, addr: IpAddr) -> &mut Self {
+        if addr.is_ipv4() && self.is_ipv6() {
+            panic!("Cannot set IPv4 address on IPv6 TUN device");
+        }
+        if addr.is_ipv6() && !self.is_ipv6() {
+            panic!("Cannot set IPv6 address on IPv4 TUN device");
+        }
+        self.address = Some(addr);
+        self
     }
 
     /// Tun name is optional. If provided must be of format "utun<N>" where N is a number.

--- a/adapter/ph/src/sys/macos/tun.rs
+++ b/adapter/ph/src/sys/macos/tun.rs
@@ -1,0 +1,156 @@
+use std::net::IpAddr;
+use std::os::unix::io::{RawFd, AsRawFd};
+use std::mem;
+use nix::{ioctl_readwrite, ioctl_write_ptr};
+
+use thiserror::Error;
+
+use crate::zprtun::DEFAULT_TUN_MTU;
+
+use libc::{
+    self, IFNAMSIZ, PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL, AF_SYSTEM, AF_SYS_CONTROL, AF_INET,
+    UTUN_OPT_IFNAME, c_uint, c_char, socklen_t, sockaddr, c_void,
+};
+
+pub const UTUN_CONTROL_NAME: &str = "com.apple.net.utun_control";
+
+
+
+ioctl_readwrite!(ctliocginfo, b'N', 3, ctl_info); // Convert kernel controller name to kernel controller ID
+
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ctl_info {
+    pub ctl_id: c_uint, // kernel controller ID (filled in on return)
+    pub ctl_name: [c_char; 96], // kernel controller name
+}
+
+
+#[derive(Debug, Error)]
+pub enum TunError {
+    #[error("TUN device name is too long")]
+    NameTooLong,
+    #[error("TUN device name is invalid (expect 'utun<N>')")]
+    InvalidName,
+    #[error("Failed to parse TUN interface name: {0}")]
+    ParseError(#[from] std::num::ParseIntError),
+    #[error("I/O Error: {0}")]
+    IOError(#[from] std::io::Error),
+}
+
+/// TUN device on macOS.
+pub struct Tun {
+    tun_fd: RawFd,
+    ctl_fd: RawFd,
+}
+
+impl AsRawFd for Tun {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tun_fd
+    }
+}
+
+impl Tun {
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+
+    pub fn create(config: &Builder) -> Result<Self, TunError> {
+        let mtu = config.mtu.unwrap_or(DEFAULT_TUN_MTU);
+
+        // The id is one plus the number after the "utun" prefix.
+        // If we pass the kernel id=0 it will assign the next available id.
+        let id = if let Some(tun_name) = config.name.as_ref() {
+            if tun_name.len() > IFNAMSIZ {
+                return Err(TunError::NameTooLong);
+            }
+            if !tun_name.starts_with("utun") {
+                return Err(TunError::InvalidName);
+            }
+            tun_name[4..].parse::<u32>()? + 1_u32
+        } else {
+            0_u32
+        };
+
+        unsafe {
+            let fd = libc::socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL);
+            let mut info = ctl_info {
+                ctl_id: 0,
+                ctl_name: {
+                    let mut buffer = [0; 96];
+                    for (i, o) in UTUN_CONTROL_NAME.as_bytes().iter().zip(buffer.iter_mut()) {
+                        *o = *i as _;
+                    }
+                    buffer
+                },
+            };
+
+            // Obtain a ctl_id for utun controller
+            if let Err(err) = ctliocginfo(fd, &mut info as *mut _ as *mut _) {
+                return Err(std::io::Error::from(err).into());
+            }
+
+            let addr = libc::sockaddr_ctl {
+                sc_id: info.ctl_id,
+                sc_len: mem::size_of::<libc::sockaddr_ctl>() as _,
+                sc_family: AF_SYSTEM as _,
+                ss_sysaddr: AF_SYS_CONTROL as _,
+                sc_unit: id as c_uint,
+                sc_reserved: [0; 5],
+            };
+
+            // Pretty sure this 'connect' call will create the TUN device
+            let address = &addr as *const libc::sockaddr_ctl as *const sockaddr;
+            if libc::connect(fd, address, mem::size_of_val(&addr) as socklen_t) < 0 {
+                return Err(std::io::Error::last_os_error().into());
+            }
+
+            let mut tun_name = [0u8; 64];
+            let mut name_len: socklen_t = 64;
+
+            let optval = &mut tun_name as *mut _ as *mut c_void;
+            let optlen = &mut name_len as *mut socklen_t;
+            if libc::getsockopt(fd, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, optval, optlen) < 0 {
+                return Err(std::io::Error::last_os_error().into());
+            }
+
+            let ctl = libc::socket(AF_INET, SOCK_DGRAM, 0);
+
+
+        }
+
+
+
+        Ok(Tun {})
+    }
+}
+
+
+
+#[derive(Default)]
+pub struct Builder {
+    name: Option<String>,
+    mtu: Option<u16>,
+    address: Option<IpAddr>,
+    // flags: Option<i32>,
+    // queue_count: usize,
+}
+
+
+impl Builder {
+    pub fn set_tun_name(&mut self, name: &str) -> &mut Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    pub fn with_mtu(&mut self, mtu: u16) -> &mut Self {
+        self.mtu = Some(mtu);
+        self
+    }
+
+    pub fn set_address(&mut self, addr: IpAddr) -> &mut Self {
+        self.address = Some(addr);
+        self
+    }
+}

--- a/adapter/ph/src/sys/macos/tun.rs
+++ b/adapter/ph/src/sys/macos/tun.rs
@@ -1,22 +1,20 @@
+use nix::{ioctl_readwrite, ioctl_write_ptr};
+use std::ffi::CStr;
+use std::mem;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::os::fd::AsFd;
-use std::os::unix::io::{AsRawFd, OwnedFd, FromRawFd, BorrowedFd};
-use std::mem;
+use std::os::unix::io::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
 use std::ptr;
-use std::ffi::CStr;
-use nix::{ioctl_readwrite, ioctl_write_ptr};
 
-use tracing::*;
 use thiserror::Error;
+use tracing::*;
 
 use crate::zprtun::{DEFAULT_TUN_MTU, ZPRNET_PREFIX_LEN};
 
 use libc::{
-    self, IFNAMSIZ, PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL,
-    AF_SYSTEM, AF_SYS_CONTROL, AF_INET, AF_INET6,
-    UTUN_OPT_IFNAME,
-    c_uint, c_int, c_char, socklen_t, sockaddr, c_void, ifreq,
-    sockaddr_in, sockaddr_in6, ctl_info,
+    self, c_char, c_int, c_uint, c_void, ctl_info, ifreq, sockaddr, sockaddr_in, sockaddr_in6,
+    socklen_t, AF_INET, AF_INET6, AF_SYSTEM, AF_SYS_CONTROL, IFNAMSIZ, PF_SYSTEM, SOCK_DGRAM,
+    SYSPROTO_CONTROL, UTUN_OPT_IFNAME,
 };
 
 // Not in libc. Copied from netinet6/in6_var.h
@@ -36,21 +34,16 @@ const ND6_INFINITE_LIFETIME: libc::c_uint = 0xffffffff;
 const IPV6_MMTU: u16 = 1280; // Minimum MTU for IPv6
 const IPV4_MMTU: u16 = 576; // Minimum MTU for IPv4
 
-
-
 /// Special macOS controller name for creating tun devices. (see net/if_utun.h)
 pub const UTUN_CONTROL_NAME: &str = "com.apple.net.utun_control";
 
 /// Size of the ifr_ifru union in the ifreq struct. (see net/if.h)
 const OVERWRITE_SIZE_IP4: usize = std::mem::size_of::<libc::__c_anonymous_ifr_ifru>();
 
-
 ioctl_readwrite!(ctliocginfo, b'N', 3, ctl_info); // Convert kernel controller name to kernel controller ID
 ioctl_write_ptr!(siocsifaddr, b'i', 12, ifreq); // set ifnet address (is this IPv4 only?)
 ioctl_write_ptr!(siocaifaddr_in6, b'i', 26, in6_aliasreq); // set ifnet address (ipv6)
 ioctl_write_ptr!(siocsifmtu, b'i', 52, ifreq); // set ifnet MTU
-
-
 
 #[derive(Debug, Error)]
 pub enum TunError {
@@ -83,13 +76,11 @@ pub struct Tun {
     name: String,
 }
 
-
 impl AsFd for Tun {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.tun_fd.as_fd()
     }
 }
-
 
 impl Tun {
     /// An address is required.
@@ -215,7 +206,6 @@ impl Tun {
         Ok(req)
     }
 
-
     /// Set the address of the TUN device.  `prefix_len` is the prefix length for IPv6 and is ignored for IPv4.
     fn set_address(&mut self, addr: IpAddr, prefix_len: usize) -> Result<(), TunError> {
         match addr {
@@ -267,7 +257,6 @@ impl Tun {
         }
     }
 
-
     fn set_mtu(&mut self, value: u16) -> Result<(), TunError> {
         unsafe {
             let mut req = self.request_v4()?;
@@ -278,10 +267,7 @@ impl Tun {
             Ok(())
         }
     }
-
 }
-
-
 
 #[derive(Debug)]
 pub struct Builder {
@@ -291,7 +277,6 @@ pub struct Builder {
     address: IpAddr, // required
     ipv6: bool,
 }
-
 
 impl Builder {
     /// Create a new builder, which is used to configure the TUN device.
@@ -312,32 +297,29 @@ impl Builder {
         self
     }
 
+    /// Will use a default setting if not supplied.
     #[allow(dead_code)]
     pub fn with_mtu(&mut self, mtu: u16) -> &mut Self {
         self.mtu = Some(mtu);
         self
     }
 
-    /// Set IPv6 prefix len (0<=prefix_len<=128)
+    /// Set IPv6 prefix len (0<=prefix_len<=128). Will use a default setting is not supplied.
     #[allow(dead_code)]
     pub fn with_prefix_len(&mut self, prefix_len: usize) -> &mut Self {
         self.prefix_len = Some(prefix_len);
         self
     }
-
 }
-
-
 
 /// Fill the `addr` with the address particulars. `size` is the size of the
 /// sockaddr structure to be filled (used as our upper bound for the copy).
-pub unsafe fn ipv4addr_to_sockaddr (
+pub unsafe fn ipv4addr_to_sockaddr(
     src_addr: Ipv4Addr,
     src_port: u16,
     addr: &mut libc::sockaddr,
     size: usize,
-)
-{
+) {
     let mut s_addr: sockaddr_in = unsafe { std::mem::zeroed() };
     s_addr.sin_len = std::mem::size_of::<libc::sockaddr_in>() as u8;
     s_addr.sin_family = libc::AF_INET as libc::sa_family_t;
@@ -348,20 +330,19 @@ pub unsafe fn ipv4addr_to_sockaddr (
         std::ptr::copy_nonoverlapping(
             &s_addr as *const _ as *const libc::c_void,
             addr as *mut _ as *mut libc::c_void,
-            size.min(std::mem::size_of::<sockaddr_in>()));
+            size.min(std::mem::size_of::<sockaddr_in>()),
+        );
     };
 }
 
-
 /// Fill the `addr` with the address particulars. `size` is the size of the
 /// sockaddr structure to be filled (used as our upper bound for the copy).
-pub unsafe fn ipv6addr_to_sockaddr (
+pub unsafe fn ipv6addr_to_sockaddr(
     src_addr: Ipv6Addr,
     src_port: u16,
     addr: &mut libc::sockaddr_in6,
     size: usize,
-)
-{
+) {
     let mut s_addr: sockaddr_in6 = unsafe { std::mem::zeroed() };
     s_addr.sin6_len = std::mem::size_of::<libc::sockaddr_in6>() as u8;
     s_addr.sin6_family = libc::AF_INET6 as libc::sa_family_t;
@@ -373,9 +354,7 @@ pub unsafe fn ipv6addr_to_sockaddr (
         std::ptr::copy_nonoverlapping(
             &s_addr as *const _ as *const libc::c_void,
             addr as *mut _ as *mut libc::c_void,
-            size.min(std::mem::size_of::<sockaddr_in6>()));
+            size.min(std::mem::size_of::<sockaddr_in6>()),
+        );
     };
 }
-
-
-

--- a/adapter/ph/src/sys/macos/tun.rs
+++ b/adapter/ph/src/sys/macos/tun.rs
@@ -22,15 +22,15 @@ use libc::{
 #[repr(C)]
 pub struct in6_aliasreq {
     pub ifra_name: [c_char; IFNAMSIZ],
-    pub ifra_addr: libc::sockaddr_in6,
-    pub ifra_dstaddr: libc::sockaddr_in6,
-    pub ifra_prefixmask: libc::sockaddr_in6,
+    pub ifra_addr: sockaddr_in6,
+    pub ifra_dstaddr: sockaddr_in6,
+    pub ifra_prefixmask: sockaddr_in6,
     pub ifra_flags: c_int,
     pub ifra_lifetime: libc::in6_addrlifetime,
 }
 
 // Not in libc. Copied from netinet6/nd6.h
-const ND6_INFINITE_LIFETIME: libc::c_uint = 0xffffffff;
+const ND6_INFINITE_LIFETIME: c_uint = 0xffffffff;
 const IPV6_MMTU: u16 = 1280; // Minimum MTU for IPv6
 const IPV4_MMTU: u16 = 576; // Minimum MTU for IPv4
 
@@ -76,6 +76,7 @@ pub struct Tun {
     name: String,
 }
 
+// This is the way ZPR accesses the tun device.
 impl AsFd for Tun {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.tun_fd.as_fd()
@@ -88,7 +89,7 @@ impl Tun {
         Builder::new(tun_addr)
     }
 
-    /// Create the configure the TUN device.
+    /// Create and configure the TUN device.
     pub fn create(config: &Builder) -> Result<Self, TunError> {
         let mtu = config.mtu.unwrap_or(DEFAULT_TUN_MTU);
         let prefix_len = config.prefix_len.unwrap_or(ZPRNET_PREFIX_LEN);

--- a/adapter/ph/src/sys/macos/tun.rs
+++ b/adapter/ph/src/sys/macos/tun.rs
@@ -1,6 +1,8 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::os::unix::io::{RawFd, AsRawFd};
 use std::mem;
+use std::ptr;
+use std::ffi::CStr;
 use nix::{ioctl_readwrite, ioctl_write_ptr};
 
 use thiserror::Error;
@@ -9,14 +11,21 @@ use crate::zprtun::DEFAULT_TUN_MTU;
 
 use libc::{
     self, IFNAMSIZ, PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL, AF_SYSTEM, AF_SYS_CONTROL, AF_INET,
-    UTUN_OPT_IFNAME, c_uint, c_char, socklen_t, sockaddr, c_void,
+    UTUN_OPT_IFNAME, c_uint, c_char, socklen_t, sockaddr, c_void, ifreq,
+    sockaddr_in, sockaddr_in6,
 };
 
+/// Special macOS controller name for creating tun devices. (see net/if_utun.h)
 pub const UTUN_CONTROL_NAME: &str = "com.apple.net.utun_control";
 
+/// Size of the ifr_ifru union in the ifreq struct. (see net/if.h)
+const OVERWRITE_SIZE: usize = std::mem::size_of::<libc::__c_anonymous_ifr_ifru>();
 
 
 ioctl_readwrite!(ctliocginfo, b'N', 3, ctl_info); // Convert kernel controller name to kernel controller ID
+ioctl_write_ptr!(siocsifaddr, b'i', 12, ifreq); // set ifnet address (XXX is this IPv4 only?)
+// ioctl_write_ptr!(siocsifaddr_in6, b'i', 12, in6_ifreq); // set ifnet address (ipv6)
+ioctl_write_ptr!(siocsifmtu, b'i', 52, ifreq); // set ifnet MTU
 
 
 #[repr(C)]
@@ -43,6 +52,7 @@ pub enum TunError {
 pub struct Tun {
     tun_fd: RawFd,
     ctl_fd: RawFd,
+    name: String,
 }
 
 impl AsRawFd for Tun {
@@ -73,7 +83,7 @@ impl Tun {
             0_u32
         };
 
-        unsafe {
+        let mut tundev = unsafe {
             let fd = libc::socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL);
             let mut info = ctl_info {
                 ctl_id: 0,
@@ -106,24 +116,93 @@ impl Tun {
                 return Err(std::io::Error::last_os_error().into());
             }
 
+            // Now query for the name of the TUN device
             let mut tun_name = [0u8; 64];
             let mut name_len: socklen_t = 64;
-
             let optval = &mut tun_name as *mut _ as *mut c_void;
             let optlen = &mut name_len as *mut socklen_t;
             if libc::getsockopt(fd, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, optval, optlen) < 0 {
                 return Err(std::io::Error::last_os_error().into());
             }
 
+            let tun_name_str: String = CStr::from_ptr(tun_name.as_ptr() as *const c_char)
+                .to_string_lossy()
+                .into();
+
+
             let ctl = libc::socket(AF_INET, SOCK_DGRAM, 0);
 
+            Tun {
+                tun_fd: fd,
+                ctl_fd: ctl,
+                name: tun_name_str,
+            }
+        };
 
+        if config.address.is_some() {
+            tundev.set_address(config.address.unwrap())?;
         }
+        tundev.set_mtu(mtu)?;
 
-
-
-        Ok(Tun {})
+        Ok(tundev)
     }
+
+    /// Prepare a new request for kernel control socket.
+    unsafe fn request(&self) -> Result<libc::ifreq, TunError> {
+        let mut req: libc::ifreq = unsafe { mem::zeroed() };
+        unsafe {
+            ptr::copy_nonoverlapping(
+                self.name.as_ptr() as *const c_char,
+                req.ifr_name.as_mut_ptr(),
+                self.name.len(),
+            )
+        };
+        Ok(req)
+    }
+
+    fn set_address(&mut self, addr: IpAddr) -> Result<(), TunError> {
+        match addr {
+            IpAddr::V4(ipv4) => self.set_address_ipv4(ipv4),
+            IpAddr::V6(ipv6) => self.set_address_ipv6(ipv6),
+        }
+    }
+
+    fn set_address_ipv4(&mut self, value: Ipv4Addr) -> Result<(), TunError> {
+        unsafe {
+            let mut req = self.request()?;
+            ipv4addr_to_sockaddr(value, 0, &mut req.ifr_ifru.ifru_addr, OVERWRITE_SIZE);
+            if let Err(err) = siocsifaddr(self.ctl_fd, &req) {
+                return Err(std::io::Error::from(err).into());
+            }
+            // TODO: Update routing?
+            Ok(())
+        }
+    }
+
+    fn set_address_ipv6(&mut self, value: Ipv6Addr) -> Result<(), TunError> {
+        unsafe {
+            let mut req = self.request()?;
+            ipv6addr_to_sockaddr(value, 0, &mut req.ifr_ifru.ifru_addr, OVERWRITE_SIZE);
+            if let Err(err) = siocsifaddr(self.ctl_fd, &req) {
+                return Err(std::io::Error::from(err).into());
+            }
+            // TODO: Update routing?
+            Ok(())
+        }
+    }
+
+
+    fn set_mtu(&mut self, value: u16) -> Result<(), TunError> {
+        unsafe {
+            let mut req = self.request()?;
+            req.ifr_ifru.ifru_mtu = value as i32;
+            if let Err(err) = siocsifmtu(self.ctl_fd, &req) {
+                return Err(std::io::Error::from(err).into());
+            }
+            Ok(())
+        }
+    }
+
 }
 
 
@@ -139,18 +218,72 @@ pub struct Builder {
 
 
 impl Builder {
-    pub fn set_tun_name(&mut self, name: &str) -> &mut Self {
+    /// Tun name is optional. If provided must be of format "utun<N>" where N is a number.
+    #[allow(dead_code)]
+    pub fn with_tun_name(&mut self, name: &str) -> &mut Self {
         self.name = Some(name.into());
         self
     }
 
+    #[allow(dead_code)]
     pub fn with_mtu(&mut self, mtu: u16) -> &mut Self {
         self.mtu = Some(mtu);
         self
     }
 
-    pub fn set_address(&mut self, addr: IpAddr) -> &mut Self {
+    #[allow(dead_code)]
+    pub fn with_address(&mut self, addr: IpAddr) -> &mut Self {
         self.address = Some(addr);
         self
     }
 }
+
+
+
+/// Fill the `addr` with the address particulars. `size` is the size of the
+/// sockaddr structure to be filled (used as our upper bound for the copy).
+pub unsafe fn ipv4addr_to_sockaddr (
+    src_addr: Ipv4Addr,
+    src_port: u16,
+    addr: &mut libc::sockaddr,
+    size: usize,
+)
+{
+    let mut s_addr: sockaddr_in = unsafe { std::mem::zeroed() };
+    s_addr.sin_len = std::mem::size_of::<libc::sockaddr_in>() as u8;
+    s_addr.sin_family = libc::AF_INET as libc::sa_family_t;
+    s_addr.sin_addr.s_addr = u32::from_ne_bytes(src_addr.octets());
+    s_addr.sin_port = src_port.to_be();
+
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            &s_addr as *const _ as *const libc::c_void,
+            addr as *mut _ as *mut libc::c_void,
+            size.min(std::mem::size_of::<sockaddr_in>()));
+    };
+}
+
+pub unsafe fn ipv6addr_to_sockaddr (
+    src_addr: Ipv6Addr,
+    src_port: u16,
+    addr: &mut libc::sockaddr,
+    size: usize,
+)
+{
+    let mut s_addr: sockaddr_in6 = unsafe { std::mem::zeroed() };
+    s_addr.sin6_len = std::mem::size_of::<libc::sockaddr_in6>() as u8;
+    s_addr.sin6_family = libc::AF_INET6 as libc::sa_family_t;
+    s_addr.sin6_port = src_port.to_be();
+    s_addr.sin6_flowinfo = 0;
+    s_addr.sin6_addr.s6_addr = src_addr.octets();
+    s_addr.sin6_scope_id = 0;
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            &s_addr as *const _ as *const libc::c_void,
+            addr as *mut _ as *mut libc::c_void,
+            size.min(std::mem::size_of::<sockaddr_in6>()));
+    };
+}
+
+
+

--- a/adapter/ph/src/sys/macos/tun_pi.rs
+++ b/adapter/ph/src/sys/macos/tun_pi.rs
@@ -1,6 +1,5 @@
-
 use crate::sys::{TunPi, TUN_PI_ETH_P_IP, TUN_PI_ETH_P_IPV6};
-use libc::{AF_INET6, AF_INET};
+use libc::{AF_INET, AF_INET6};
 
 // TODO: I have not confirmed that the packet info FLAGS field is the same as linux.
 // Assuming it is for now.
@@ -9,7 +8,6 @@ const TUN_PKT_STRIP: u16 = 0x0001;
 // 16 bit versions of the libc constants.
 const PI_AF_INET: u16 = AF_INET as u16;
 const PI_AF_INET6: u16 = AF_INET6 as u16;
-
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -47,8 +45,7 @@ impl From<TunPi> for TunPiImpl {
                 PI_AF_INET6.to_be_bytes()
             } else {
                 panic!("PI write expects IPv4 or IPv6 packet");
-            }
+            },
         }
     }
 }
-

--- a/adapter/ph/src/sys/macos/tun_pi.rs
+++ b/adapter/ph/src/sys/macos/tun_pi.rs
@@ -1,3 +1,4 @@
+use crate::net_defs::ethertype;
 use crate::sys::TunPi;
 use libc::{AF_INET, AF_INET6};
 
@@ -8,10 +9,6 @@ const TUN_PKT_STRIP: u16 = 0x0001;
 // 16 bit versions of the libc constants.
 const PI_AF_INET: u16 = AF_INET as u16;
 const PI_AF_INET6: u16 = AF_INET6 as u16;
-
-// The TunPi uses the linux flavor of packet info; the "proto" field is the ethertype.
-const TUN_PI_ETH_P_IP: u16 = 0x0800;
-const TUN_PI_ETH_P_IPV6: u16 = 0x86dd;
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -27,9 +24,9 @@ impl From<TunPiImpl> for TunPi {
             proto: {
                 let plat_pi = u16::from_be_bytes(pi.proto);
                 if plat_pi == PI_AF_INET {
-                    TUN_PI_ETH_P_IP
+                    ethertype::IP
                 } else if plat_pi == PI_AF_INET6 {
-                    TUN_PI_ETH_P_IPV6
+                    ethertype::IPV6
                 } else {
                     // Choosing not to barf here and just let the next layer sort it out.
                     plat_pi
@@ -43,9 +40,9 @@ impl From<TunPi> for TunPiImpl {
     fn from(pi: TunPi) -> TunPiImpl {
         TunPiImpl {
             flags: 0,
-            proto: if pi.proto == TUN_PI_ETH_P_IP {
+            proto: if pi.proto == ethertype::IP {
                 PI_AF_INET.to_be_bytes()
-            } else if pi.proto == TUN_PI_ETH_P_IPV6 {
+            } else if pi.proto == ethertype::IPV6 {
                 PI_AF_INET6.to_be_bytes()
             } else {
                 panic!("PI write expects IPv4 or IPv6 packet");

--- a/adapter/ph/src/sys/macos/tun_pi.rs
+++ b/adapter/ph/src/sys/macos/tun_pi.rs
@@ -1,35 +1,54 @@
-use bytes::buf;
 
-/// per-packet packet info
+use crate::sys::{TunPi, TUN_PI_ETH_P_IP, TUN_PI_ETH_P_IPV6};
+use libc::{AF_INET6, AF_INET};
+
+// TODO: I have not confirmed that the packet info FLAGS field is the same as linux.
+// Assuming it is for now.
+const TUN_PKT_STRIP: u16 = 0x0001;
+
+// 16 bit versions of the libc constants.
+const PI_AF_INET: u16 = AF_INET as u16;
+const PI_AF_INET6: u16 = AF_INET6 as u16;
+
+
+#[repr(C)]
 #[derive(Clone, Copy)]
-pub struct TunPi {
-    /// True if the inbound packet was truncated (ignored outbound)
-    pub strip: bool,
-    /// Ethertype of packet
-    pub proto: u16,
+pub struct TunPiImpl {
+    flags: u16,
+    proto: [u8; 2],
 }
 
-impl TunPi {
-    /// The size of a per-packet packet info structure.
-    /// On macos this is `0` and informs the system that there is no
-    /// PI information on the front of the packet.
-    ///
-    /// TODO: Needs more exploration-- the rust-tun code indiciates that
-    /// there is PI on the mac utun interface, but our tests reading
-    /// packets do not show it. (See #541)
-    ///
-    pub const PI_SIZE: usize = 0;
-
-    /// Since macos does not provide packet info, we just return a
-    /// [TunPi] here with `strip = false` and `proto = 0`.
-    pub fn read_pi<B: buf::Buf>(_buf: &mut B) -> TunPi {
+impl From<TunPiImpl> for TunPi {
+    fn from(pi: TunPiImpl) -> TunPi {
         TunPi {
-            strip: false,
-            proto: 0,
+            strip: pi.flags & TUN_PKT_STRIP != 0,
+            proto: {
+                let plat_pi = u16::from_be_bytes(pi.proto);
+                if plat_pi == PI_AF_INET {
+                    TUN_PI_ETH_P_IP
+                } else if plat_pi == PI_AF_INET6 {
+                    TUN_PI_ETH_P_IPV6
+                } else {
+                    // Choosing not to barf here and just let the next layer sort it out.
+                    plat_pi
+                }
+            },
         }
     }
-
-    /// Write per-packet packet info into a `BufMut`.
-    /// Since macos does not support packet info this does nothing.
-    pub fn write_pi<B: buf::BufMut>(_buf: &mut B, _pi: TunPi) {}
 }
+
+impl From<TunPi> for TunPiImpl {
+    fn from(pi: TunPi) -> TunPiImpl {
+        TunPiImpl {
+            flags: 0,
+            proto: if pi.proto == TUN_PI_ETH_P_IP {
+                PI_AF_INET.to_be_bytes()
+            } else if pi.proto == TUN_PI_ETH_P_IPV6 {
+                PI_AF_INET6.to_be_bytes()
+            } else {
+                panic!("PI write expects IPv4 or IPv6 packet");
+            }
+        }
+    }
+}
+

--- a/adapter/ph/src/sys/macos/tun_pi.rs
+++ b/adapter/ph/src/sys/macos/tun_pi.rs
@@ -1,4 +1,4 @@
-use crate::sys::{TunPi, TUN_PI_ETH_P_IP, TUN_PI_ETH_P_IPV6};
+use crate::sys::TunPi;
 use libc::{AF_INET, AF_INET6};
 
 // TODO: I have not confirmed that the packet info FLAGS field is the same as linux.
@@ -8,6 +8,10 @@ const TUN_PKT_STRIP: u16 = 0x0001;
 // 16 bit versions of the libc constants.
 const PI_AF_INET: u16 = AF_INET as u16;
 const PI_AF_INET6: u16 = AF_INET6 as u16;
+
+// The TunPi uses the linux flavor of packet info; the "proto" field is the ethertype.
+const TUN_PI_ETH_P_IP: u16 = 0x0800;
+const TUN_PI_ETH_P_IPV6: u16 = 0x86dd;
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/adapter/ph/src/sys/macos/zprtun.rs
+++ b/adapter/ph/src/sys/macos/zprtun.rs
@@ -28,8 +28,9 @@ impl ZprTun {
         }
         let addr = address.ok_or_else(|| {
             ZprTunError::PlatformError(String::from("address is required on macos"))
+            // TODO: Temporary
         })?;
-        let mut bldr = tun::Tun::builder(addr);
+        let mut bldr = tun::Tun::builder(addr.into());
         if let Some(name) = ifname {
             bldr.with_tun_name(&name);
         }

--- a/adapter/ph/src/sys/macos/zprtun.rs
+++ b/adapter/ph/src/sys/macos/zprtun.rs
@@ -1,5 +1,5 @@
 use std::net::IpAddr;
-use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
+use std::os::fd::{AsFd, BorrowedFd};
 
 use crate::zprtun::ZprTunError;
 use crate::sys::macos::tun;
@@ -27,12 +27,13 @@ impl ZprTun {
                 "on macos concurrency (queues) must be 1",
             )));
         }
-        let mut bldr = tun::Tun::builder();
+        let addr = address.ok_or_else(|| {
+            ZprTunError::PlatformError(String::from("address is required on macos"))
+        })?;
+
+        let mut bldr = tun::Tun::builder(addr);
         if let Some(name) = ifname {
             bldr.with_tun_name(&name);
-        }
-        if let Some(addr) = address {
-            bldr.with_address(addr);
         }
         let dev = tun::Tun::create(&bldr)?;
         Ok(vec![ZprTun(dev)])
@@ -46,13 +47,7 @@ impl ZprTun {
 
 impl AsFd for ZprTun {
     fn as_fd(&self) -> BorrowedFd<'_> {
-        // SAFETY: we know the FD will be live for the lifetime of the `Device`
-        unsafe { BorrowedFd::borrow_raw(self.0.as_raw_fd()) }
+        self.0.as_fd()
     }
 }
 
-impl AsRawFd for ZprTun {
-    fn as_raw_fd(&self) -> RawFd {
-        self.0.as_raw_fd()
-    }
-}

--- a/adapter/ph/src/sys/macos/zprtun.rs
+++ b/adapter/ph/src/sys/macos/zprtun.rs
@@ -1,11 +1,10 @@
 use std::net::IpAddr;
 use std::os::fd::{AsFd, BorrowedFd};
 
-use crate::zprtun::ZprTunError;
 use crate::sys::macos::tun;
+use crate::zprtun::ZprTunError;
 
 pub struct ZprTun(tun::Tun);
-
 
 impl From<tun::TunError> for ZprTunError {
     fn from(e: tun::TunError) -> Self {
@@ -22,7 +21,7 @@ impl ZprTun {
         concurrency: usize,
         address: Option<IpAddr>,
     ) -> std::result::Result<Vec<Self>, ZprTunError> {
-        if concurrency <= 0 || concurrency > 1 {
+        if concurrency != 1 {
             return Err(ZprTunError::PlatformError(String::from(
                 "on macos concurrency (queues) must be 1",
             )));
@@ -30,7 +29,6 @@ impl ZprTun {
         let addr = address.ok_or_else(|| {
             ZprTunError::PlatformError(String::from("address is required on macos"))
         })?;
-
         let mut bldr = tun::Tun::builder(addr);
         if let Some(name) = ifname {
             bldr.with_tun_name(&name);
@@ -50,4 +48,3 @@ impl AsFd for ZprTun {
         self.0.as_fd()
     }
 }
-

--- a/adapter/ph/src/sys/macos/zprtun.rs
+++ b/adapter/ph/src/sys/macos/zprtun.rs
@@ -1,19 +1,17 @@
 use crate::zprtun::{ZprTunError, DEFAULT_TUN_MTU};
+
 use std::net::IpAddr;
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::result::Result;
-use tun::{AbstractDevice, Device};
+// use tun::{AbstractDevice, Device};
 
-pub struct ZprTun(tun::Device);
+use crate::sys::macos::tun;
 
-impl From<Device> for ZprTun {
-    fn from(tun_device: Device) -> Self {
-        ZprTun(tun_device)
-    }
-}
+pub struct ZprTun(tun::Tun);
 
-impl From<tun::Error> for ZprTunError {
-    fn from(e: tun::Error) -> Self {
+
+impl From<tun::TunError> for ZprTunError {
+    fn from(e: tun::TunError) -> Self {
         ZprTunError::PlatformError(e.to_string())
     }
 }
@@ -27,37 +25,25 @@ impl ZprTun {
         concurrency: usize,
         address: Option<IpAddr>,
     ) -> std::result::Result<Vec<Self>, ZprTunError> {
-        let mut config = tun::Configuration::default();
-        if let Some(name) = ifname {
-            config.tun_name(&name);
-        } else {
-            config.mtu(DEFAULT_TUN_MTU);
-        }
-        if let Some(addr) = address {
-            config.address(addr);
-        }
         if concurrency <= 0 || concurrency > 1 {
             return Err(ZprTunError::PlatformError(String::from(
                 "on macos concurrency (queues) must be 1",
             )));
         }
-
-        let dev = tun::create(&config)?;
-        Ok(vec![ZprTun::from(dev)])
+        let mut bldr = tun::Tun::builder();
+        if let Some(name) = ifname {
+            bldr.set_tun_name(&name);
+        }
+        if let Some(addr) = address {
+            bldr.set_address(addr);
+        }
+        let dev = tun::Tun::create(&bldr)?;
+        Ok(vec![ZprTun(dev)])
     }
 
     /// A NOP on mac.
     pub fn set_carrier(&self, _carrier: bool) -> std::io::Result<()> {
         Ok(())
-    }
-
-    #[allow(dead_code)]
-    pub fn set_address(&mut self, addr: IpAddr) -> Result<(), ZprTunError> {
-        let idev = &mut self.0;
-        match idev.set_address(addr) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(ZprTunError::PlatformError(e.to_string())),
-        }
     }
 }
 

--- a/adapter/ph/src/sys/macos/zprtun.rs
+++ b/adapter/ph/src/sys/macos/zprtun.rs
@@ -1,10 +1,7 @@
-use crate::zprtun::{ZprTunError, DEFAULT_TUN_MTU};
-
 use std::net::IpAddr;
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
-use std::result::Result;
-// use tun::{AbstractDevice, Device};
 
+use crate::zprtun::ZprTunError;
 use crate::sys::macos::tun;
 
 pub struct ZprTun(tun::Tun);
@@ -32,10 +29,10 @@ impl ZprTun {
         }
         let mut bldr = tun::Tun::builder();
         if let Some(name) = ifname {
-            bldr.set_tun_name(&name);
+            bldr.with_tun_name(&name);
         }
         if let Some(addr) = address {
-            bldr.set_address(addr);
+            bldr.with_address(addr);
         }
         let dev = tun::Tun::create(&bldr)?;
         Ok(vec![ZprTun(dev)])

--- a/adapter/ph/src/sys/mod.rs
+++ b/adapter/ph/src/sys/mod.rs
@@ -26,10 +26,6 @@ pub struct TunPi {
     pub proto: u16,
 }
 
-// The TunPi uses the linux flavor of packet info; the "proto" field is the ethertype.
-pub const TUN_PI_ETH_P_IP: u16 = 0x0800;
-pub const TUN_PI_ETH_P_IPV6: u16 = 0x86dd;
-
 impl TunPi {
     /// The size of a per-packet packet info structure.
     pub const PI_SIZE: usize = std::mem::size_of::<TunPiImpl>();

--- a/adapter/ph/src/sys/mod.rs
+++ b/adapter/ph/src/sys/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "linux")]
 pub(crate) mod linux;
 #[cfg(target_os = "linux")]
-pub use self::linux::TunPi;
+pub use self::linux::TunPiImpl;
 #[cfg(target_os = "linux")]
 pub use self::linux::ZprTun;
 

--- a/adapter/ph/src/sys/mod.rs
+++ b/adapter/ph/src/sys/mod.rs
@@ -8,6 +8,50 @@ pub use self::linux::ZprTun;
 #[cfg(target_os = "macos")]
 pub(crate) mod macos;
 #[cfg(target_os = "macos")]
-pub use self::macos::TunPi;
+pub use self::macos::TunPiImpl;
 #[cfg(target_os = "macos")]
 pub use self::macos::ZprTun;
+
+use bytes::buf;
+
+/// per-packet packet info
+#[derive(Clone, Copy)]
+pub struct TunPi {
+    // the inbound packet was truncated (ignored outbound)
+    pub strip: bool,
+    /// Ethertype of packet
+    pub proto: u16,
+}
+
+// The TunPi uses the linux flavor of packet info; the "proto" field is the ethertype.
+pub const TUN_PI_ETH_P_IP: u16 = 0x0800;
+pub const TUN_PI_ETH_P_IPV6: u16 = 0x86dd;
+
+impl TunPi {
+    /// The size of a per-packet packet info structure.
+    pub const PI_SIZE: usize = std::mem::size_of::<TunPiImpl>();
+
+    /// Read per-packet packet info from a `Buf`.
+    pub fn read_pi<B: buf::Buf>(buf: &mut B) -> TunPi {
+        let mut os_pi = std::mem::MaybeUninit::<TunPiImpl>::uninit();
+        let slice = os_pi.as_mut_ptr();
+        buf.copy_to_slice(unsafe {
+            /* SAFETY: we immediately initialize */
+            std::slice::from_raw_parts_mut(slice as *mut u8, TunPi::PI_SIZE)
+        });
+        unsafe {
+            /* SAFETY: was just initialized */
+            os_pi.assume_init()
+        }
+        .into()
+    }
+
+    /// Write per-packet packet info into a `BufMut`.
+    pub fn write_pi<B: buf::BufMut>(buf: &mut B, pi: TunPi) {
+        let os_pi: TunPiImpl = pi.into();
+        buf.put(unsafe {
+            /* SAFETY: we are reading exactly the structure */
+            std::slice::from_raw_parts((&os_pi as *const _) as *const u8, TunPi::PI_SIZE)
+        });
+    }
+}

--- a/adapter/ph/src/sys/mod.rs
+++ b/adapter/ph/src/sys/mod.rs
@@ -12,7 +12,6 @@ pub use self::macos::TunPiImpl;
 #[cfg(target_os = "macos")]
 pub use self::macos::ZprTun;
 
-
 pub(crate) mod posix;
 pub use self::posix::notify;
 

--- a/adapter/ph/src/zprtun.rs
+++ b/adapter/ph/src/zprtun.rs
@@ -10,6 +10,7 @@ use crate::sys::TunPi;
 pub const DEFAULT_TUN_MTU: u16 = 1400;
 
 /// Default prefix len for local tun IPv6 zpr addresses.
+#[allow(dead_code)]
 pub const ZPRNET_PREFIX_LEN: usize = 32;
 
 /// Error type used by some ZprTun functions across platform implementations.

--- a/adapter/ph/src/zprtun.rs
+++ b/adapter/ph/src/zprtun.rs
@@ -9,6 +9,9 @@ use crate::sys::TunPi;
 #[allow(dead_code)]
 pub const DEFAULT_TUN_MTU: u16 = 1400;
 
+/// Default prefix len for local tun IPv6 zpr addresses.
+pub const ZPRNET_PREFIX_LEN: usize = 32;
+
 /// Error type used by some ZprTun functions across platform implementations.
 #[derive(thiserror::Error, Debug)]
 pub enum ZprTunError {


### PR DESCRIPTION
The rust-tun package we were using was not able to handle IPv6 so here is our own tun interface that does.  It also does far less than rust-tun, but should do just enough to cover what we need.

Also includes minor refactoring for linux tun_pi.