### PR TITLE
check that addr on tun interface is not misconfigured

### DIFF
--- a/adapter/runners/Cargo.lock
+++ b/adapter/runners/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,7 +107,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -115,6 +121,12 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -157,6 +169,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "local-ip-address"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3669cf5561f8d27e8fc84cc15e58350e70f557d4d65f70e3154e54cd2f8e1782"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror 1.0.69",
+ "windows-sys",
+]
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +191,31 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "neli"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93062a0dce6da2517ea35f301dfc88184ce18d3601ec786a727a87bf535deca9"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8034b7fbb6f9455b2a96c19e6edf8dc9fc34c70449938d8ee3b4df363f61fe"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "nix"
@@ -209,8 +258,9 @@ name = "runners"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "local-ip-address",
  "nix",
- "thiserror",
+ "thiserror 2.0.11",
  "toml",
  "users",
 ]
@@ -232,7 +282,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -252,6 +302,17 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
@@ -263,11 +324,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.11",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -278,7 +359,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/adapter/runners/Cargo.toml
+++ b/adapter/runners/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
+local-ip-address = "0.6.3"
 nix = { version = "0.29.0", features = ["user", "fs"] }
 thiserror = "2.0.11"
 toml = "0.8.19"

--- a/adapter/runners/src/env.rs
+++ b/adapter/runners/src/env.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 
+use local_ip_address::list_afinet_netifas;
+
 use crate::config::{ConfigRdr, PCErr};
 use crate::errors::LaunchErr;
 use crate::sys;
@@ -42,6 +44,10 @@ pub fn configure_env(config: &Path, dry_run: bool) -> Result<(), LaunchErr> {
         None => sys::get_platform().get_tun_ifname().to_string(),
     };
 
+    if !tun_name.is_empty() {
+        check_tun_interface_addr_matches(&tun_name, tun_addr)?;
+    }
+
     #[cfg(target_os = "macos")]
     {
         if !tun_name.is_empty() {
@@ -64,7 +70,7 @@ pub fn configure_env(config: &Path, dry_run: bool) -> Result<(), LaunchErr> {
 
     // If TUN already exists we could check to see if it has correct address etc.
     // But for now just notify.
-    if sys::get_platform().is_tun_exist(&tun_name) {
+    if tun_if_exists(&tun_name)? {
         println!(
             "TUN interface {} already exists, skipping TUN configuration",
             tun_name
@@ -141,4 +147,43 @@ pub fn configure_env(config: &Path, dry_run: bool) -> Result<(), LaunchErr> {
     }
 
     Ok(())
+}
+
+/// Check that if the interface `tun_name` exists, and it has an address, then the address
+/// (or one of its addresses) is `tun_addr`.
+fn check_tun_interface_addr_matches(tun_name: &str, tun_addr: IpAddr) -> Result<(), LaunchErr> {
+    // Get all the addresses set on the `tun_name` interface.
+    let addrs = list_afinet_netifas()
+        .or(Err(LaunchErr::EnvironmentErr(format!(
+            "unable to list addresses for interface {}",
+            tun_name
+        ))))?
+        .into_iter()
+        .filter(|(name, _)| name == tun_name)
+        .map(|(_, addr)| addr)
+        .collect::<Vec<_>>();
+    if addrs.is_empty() {
+        return Ok(());
+    }
+    for addr in addrs {
+        if addr == tun_addr {
+            return Ok(());
+        }
+    }
+    Err(LaunchErr::EnvironmentErr(format!(
+        "interface {} already has addresses set, but none match the configured address {}",
+        tun_name, tun_addr
+    )))
+}
+
+/// Return true if there is an interface with name `tun_name`.
+fn tun_if_exists(tun_name: &str) -> Result<bool, LaunchErr> {
+    let ifa = list_afinet_netifas()
+        .or(Err(LaunchErr::EnvironmentErr(
+            "unable to list interfaces".into(),
+        )))?
+        .into_iter()
+        .find(|(name, _)| name == tun_name);
+
+    Ok(ifa.is_some())
 }

--- a/adapter/runners/src/errors.rs
+++ b/adapter/runners/src/errors.rs
@@ -16,4 +16,7 @@ pub enum LaunchErr {
 
     #[error("file error: {0}")]
     FileError(String),
+
+    #[error("environment error: {0}")]
+    EnvironmentErr(String),
 }

--- a/adapter/runners/src/sys/linux.rs
+++ b/adapter/runners/src/sys/linux.rs
@@ -65,16 +65,6 @@ impl Platform for LinuxPlatform {
         Ok(())
     }
 
-    fn is_tun_exist(&self, tun_name: &str) -> bool {
-        Command::new("ip")
-            .arg("link")
-            .arg("show")
-            .arg(tun_name)
-            .status()
-            .unwrap()
-            .success()
-    }
-
     fn create_tun(
         &self,
         tun_name: &str,

--- a/adapter/runners/src/sys/macos.rs
+++ b/adapter/runners/src/sys/macos.rs
@@ -16,14 +16,6 @@ impl Platform for MacosPlatform {
         return String::new();
     }
 
-    fn is_tun_exist(&self, tun_name: &str) -> bool {
-        Command::new("ifconfig")
-            .arg(tun_name)
-            .status()
-            .unwrap()
-            .success()
-    }
-
     fn set_control_dir_owner_and_perms(
         &self,
         ctrl_path: &std::path::PathBuf,

--- a/adapter/runners/src/sys/mod.rs
+++ b/adapter/runners/src/sys/mod.rs
@@ -33,9 +33,6 @@ pub trait Platform {
     /// Return the default TUN interface name for this platform.
     fn get_tun_ifname(&self) -> String;
 
-    /// Check if a TUN interface with the given name exists.
-    fn is_tun_exist(&self, tun_name: &str) -> bool;
-
     /// The control directory holds the control socket for the ph.
     /// This function sets the owner and permissions on the control directory.
     fn set_control_dir_owner_and_perms(


### PR DESCRIPTION
Decided to implement this in the runner to avoid adding additional temporary dependency to ph.  Eventually the addrs will all come from the ZPRnet.  This patch prevents a mismatch between zpr address set in config and zpr address set on tun.

Fix for #725  
