### PR TITLE
Replace Unix-domain datagram queues with homegrown queues

### DIFF
--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -330,6 +330,7 @@ pub mod test {
 
     use super::*;
     use crate::config::TopologyConfig;
+    use crate::packet_queue;
     use crate::two_way_queue;
     use std::net::Ipv4Addr;
     use tokio::sync::mpsc;
@@ -379,9 +380,9 @@ pub mod test {
         let local_zpr_addresses = builder
             .local_zpr_addresses
             .unwrap_or(Vec::from([IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]));
-        let mgmt_substrate_egress = builder.mgmt_substrate_egress.unwrap_or_else(|| {
-            MgmtSubstrateEgress::new(tokio::net::UnixDatagram::pair().unwrap().0)
-        });
+        let mgmt_substrate_egress = builder
+            .mgmt_substrate_egress
+            .unwrap_or_else(|| MgmtSubstrateEgress::new(packet_queue::packet_queue(1).0));
         let actor_output_requeue = builder
             .actor_output_requeue
             .unwrap_or_else(|| ActorOutputRequeue::new(Vec::new()));

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -441,8 +441,8 @@ pub struct TopologyConfig {
     pub fastpath_batch_size: usize,
     pub capture_batch_size: usize,
 
-    #[allow(dead_code)] // see TODO in main
     pub capture_queue_size: usize,
+    pub mgmt_datapath_queue_size: usize,
     pub mgmt_dispatch_queue_size: usize,
     pub adapter_manager_queue_size: usize,
     pub km_signal_queue_size: usize,
@@ -464,6 +464,7 @@ impl Default for TopologyConfig {
             capture_batch_size: DEFAULT_BATCH_SIZE,
 
             capture_queue_size: DEFAULT_DATAPATH_QUEUE_SIZE,
+            mgmt_datapath_queue_size: DEFAULT_MGMT_QUEUE_SIZE,
             mgmt_dispatch_queue_size: DEFAULT_MGMT_QUEUE_SIZE,
             adapter_manager_queue_size: DEFAULT_MGMT_QUEUE_SIZE,
             km_signal_queue_size: DEFAULT_MGMT_QUEUE_SIZE,

--- a/adapter/ph/src/fastpath_io.rs
+++ b/adapter/ph/src/fastpath_io.rs
@@ -179,44 +179,18 @@ impl FastpathIo {
 
     /// Process an input-ready notification on the requeue socket.
     pub fn process_requeue_in(&mut self, worker: &mut FastpathWorker) {
-        while let Some(buf) = worker.buffers.pop() {
-            match self.requeue_outq.try_recv(buf) {
-                Ok(pkt) => {
-                    worker.asm.counters[CounterType::RequeuedPacketsReceived].increment();
-                    worker.actor_output_post_classify(pkt, /* allow_bind_request */ false);
-                }
-
-                Err(packet_queue::TryRecvError::Empty(buf)) => {
-                    worker.buffers.push(buf);
-                    break;
-                }
-
-                Err(err) => {
-                    panic!("unrecoverable I/O error {err:?}");
-                }
-            }
-        }
+        batch_process_packet_queue(worker, &mut self.requeue_outq, |worker, pkt| {
+            worker.asm.counters[CounterType::RequeuedPacketsReceived].increment();
+            worker.actor_output_post_classify(pkt, /* allow_bind_request */ false);
+        });
     }
 
     /// Process an input-ready notification on the mgmt substrate socket.
     pub fn process_mgmt_substrate_in(&mut self, worker: &mut FastpathWorker) {
-        while let Some(buf) = worker.buffers.pop() {
-            match self.mgmt_substrate_outq.try_recv(buf) {
-                Ok(pkt) => {
-                    worker.asm.counters[CounterType::MgmtPacketsSent].increment();
-                    worker.substrate_egress(pkt);
-                }
-
-                Err(packet_queue::TryRecvError::Empty(buf)) => {
-                    worker.buffers.push(buf);
-                    break;
-                }
-
-                Err(err) => {
-                    panic!("unrecoverable I/O error {err:?}");
-                }
-            }
-        }
+        batch_process_packet_queue(worker, &mut self.mgmt_substrate_outq, |worker, pkt| {
+            worker.asm.counters[CounterType::MgmtPacketsSent].increment();
+            worker.substrate_egress(pkt);
+        });
     }
 
     /// Egress any queued packets, or drop if there is no space in the system queues.
@@ -347,5 +321,28 @@ fn clear_flowinfo(addr: &mut SocketAddr) {
     match addr {
         SocketAddr::V4(_) => (),
         SocketAddr::V6(addr) => addr.set_flowinfo(0),
+    }
+}
+
+fn batch_process_packet_queue(
+    worker: &mut FastpathWorker,
+    queue: &mut packet_queue::Receiver<{ config::PACKET_BUFFER_SIZE }>,
+    mut process_fn: impl FnMut(&mut FastpathWorker, Packet),
+) {
+    while let Some(buf) = worker.buffers.pop() {
+        match queue.try_recv(buf) {
+            Ok(pkt) => {
+                process_fn(worker, pkt);
+            }
+
+            Err(packet_queue::TryRecvError::Empty(buf)) => {
+                worker.buffers.push(buf);
+                break;
+            }
+
+            Err(err) => {
+                panic!("unrecoverable I/O error {err:?}");
+            }
+        }
     }
 }

--- a/adapter/ph/src/fastpath_io.rs
+++ b/adapter/ph/src/fastpath_io.rs
@@ -11,14 +11,13 @@ use bytes::Buf;
 use std::io::ErrorKind;
 use std::net::{SocketAddr, UdpSocket};
 use std::os::fd::{AsFd, BorrowedFd};
-use std::os::unix::net::UnixDatagram;
 use std::sync::Arc;
 
 pub struct FastpathIo {
     batch_io: BatchIo,
     actor_tun: Arc<ZprTun>,
     substrate_socket: UdpSocket,
-    pub requeue_outq: UnixDatagram,
+    pub requeue_outq: packet_queue::Receiver<{ config::PACKET_BUFFER_SIZE }>,
     pub mgmt_substrate_outq: packet_queue::Receiver<{ config::PACKET_BUFFER_SIZE }>,
 }
 
@@ -27,7 +26,7 @@ impl FastpathIo {
         config: FastpathWorkerConfig,
         substrate_socket: UdpSocket,
         actor_tun: Arc<ZprTun>,
-        requeue_outq: UnixDatagram,
+        requeue_outq: packet_queue::Receiver<{ config::PACKET_BUFFER_SIZE }>,
         maybe_mgmt_substrate_outq: Option<packet_queue::Receiver<{ config::PACKET_BUFFER_SIZE }>>,
     ) -> Self {
         // HACK: nix does not support disabling an FD, so instead, make a dummy mgmt_substrate_outq socket
@@ -62,7 +61,7 @@ impl FastpathIo {
 
     /// Requeue socket FD for polling.
     pub fn requeue_fd(&self) -> BorrowedFd<'_> {
-        self.requeue_outq.as_fd()
+        self.requeue_outq.poll_fd()
     }
 
     /// Mgmt substrate FD for polling.
@@ -180,31 +179,27 @@ impl FastpathIo {
 
     /// Process an input-ready notification on the requeue socket.
     pub fn process_requeue_in(&mut self, worker: &mut FastpathWorker) {
-        // TODO: batch receive
-        while let Some(mut buf) = worker.buffers.pop() {
-            if let Err(err) = self.requeue_outq.recv(buf.as_mut()) {
-                match err.kind() {
-                    ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
-                        worker.buffers.push(buf);
-                        break;
-                    }
+        while let Some(buf) = worker.buffers.pop() {
+            match self.requeue_outq.try_recv(buf) {
+                Ok(pkt) => {
+                    worker.asm.counters[CounterType::RequeuedPacketsReceived].increment();
+                    worker.actor_output_post_classify(pkt, /* allow_bind_request */ false);
+                }
 
-                    _ => {
-                        // FIXME: detect packet-too-large
-                        panic!("unrecoverable I/O error {err}");
-                    }
+                Err(packet_queue::TryRecvError::Empty(buf)) => {
+                    worker.buffers.push(buf);
+                    break;
+                }
+
+                Err(err) => {
+                    panic!("unrecoverable I/O error {err:?}");
                 }
             }
-
-            worker.asm.counters[CounterType::RequeuedPacketsReceived].increment();
-            let pkt = Packet::new_with_existing_metadata(buf);
-            worker.actor_output_post_classify(pkt, /* allow_bind_request */ false);
         }
     }
 
     /// Process an input-ready notification on the mgmt substrate socket.
     pub fn process_mgmt_substrate_in(&mut self, worker: &mut FastpathWorker) {
-        // TODO: batch receive
         while let Some(buf) = worker.buffers.pop() {
             match self.mgmt_substrate_outq.try_recv(buf) {
                 Ok(pkt) => {

--- a/adapter/ph/src/fastpath_io.rs
+++ b/adapter/ph/src/fastpath_io.rs
@@ -1,8 +1,10 @@
 use crate::batch_io::BatchIo;
+use crate::config;
 use crate::counters::*;
 use crate::fastpath::{FastpathWorker, FastpathWorkerConfig};
 use crate::net_defs;
 use crate::packet::{self, Packet};
+use crate::packet_queue;
 use crate::sys::{TunPi, ZprTun};
 use crate::zprtun;
 use bytes::Buf;
@@ -17,7 +19,7 @@ pub struct FastpathIo {
     actor_tun: Arc<ZprTun>,
     substrate_socket: UdpSocket,
     pub requeue_outq: UnixDatagram,
-    pub mgmt_substrate_outq: UnixDatagram,
+    pub mgmt_substrate_outq: packet_queue::Receiver<{ config::PACKET_BUFFER_SIZE }>,
 }
 
 impl FastpathIo {
@@ -26,7 +28,7 @@ impl FastpathIo {
         substrate_socket: UdpSocket,
         actor_tun: Arc<ZprTun>,
         requeue_outq: UnixDatagram,
-        maybe_mgmt_substrate_outq: Option<UnixDatagram>,
+        maybe_mgmt_substrate_outq: Option<packet_queue::Receiver<{ config::PACKET_BUFFER_SIZE }>>,
     ) -> Self {
         // HACK: nix does not support disabling an FD, so instead, make a dummy mgmt_substrate_outq socket
         // if we weren't given one
@@ -34,7 +36,7 @@ impl FastpathIo {
         match maybe_mgmt_substrate_outq {
             Some(outq) => mgmt_substrate_outq = outq,
             None => {
-                let (_, outq) = UnixDatagram::pair().unwrap();
+                let (_, outq) = packet_queue::packet_queue(1);
                 mgmt_substrate_outq = outq;
             }
         }
@@ -65,7 +67,7 @@ impl FastpathIo {
 
     /// Mgmt substrate FD for polling.
     pub fn mgmt_substrate_fd(&self) -> BorrowedFd<'_> {
-        self.mgmt_substrate_outq.as_fd()
+        self.mgmt_substrate_outq.poll_fd()
     }
 
     /// Process an input-ready notification on the substrate socket (substrate ingress).
@@ -203,24 +205,22 @@ impl FastpathIo {
     /// Process an input-ready notification on the mgmt substrate socket.
     pub fn process_mgmt_substrate_in(&mut self, worker: &mut FastpathWorker) {
         // TODO: batch receive
-        while let Some(mut buf) = worker.buffers.pop() {
-            if let Err(err) = self.mgmt_substrate_outq.recv(buf.as_mut()) {
-                match err.kind() {
-                    ErrorKind::WouldBlock | ErrorKind::ResourceBusy => {
-                        worker.buffers.push(buf);
-                        break;
-                    }
+        while let Some(buf) = worker.buffers.pop() {
+            match self.mgmt_substrate_outq.try_recv(buf) {
+                Ok(pkt) => {
+                    worker.asm.counters[CounterType::MgmtPacketsSent].increment();
+                    worker.substrate_egress(pkt);
+                }
 
-                    _ => {
-                        // FIXME: detect packet-too-large
-                        panic!("unrecoverable I/O error {err}");
-                    }
+                Err(packet_queue::TryRecvError::Empty(buf)) => {
+                    worker.buffers.push(buf);
+                    break;
+                }
+
+                Err(err) => {
+                    panic!("unrecoverable I/O error {err:?}");
                 }
             }
-
-            worker.asm.counters[CounterType::MgmtPacketsSent].increment();
-            let pkt = Packet::new_with_existing_metadata(buf);
-            worker.substrate_egress(pkt);
         }
     }
 

--- a/adapter/ph/src/fastpath_io.rs
+++ b/adapter/ph/src/fastpath_io.rs
@@ -329,7 +329,16 @@ fn batch_process_packet_queue(
     queue: &mut packet_queue::Receiver<{ config::PACKET_BUFFER_SIZE }>,
     mut process_fn: impl FnMut(&mut FastpathWorker, Packet),
 ) {
-    while let Some(buf) = worker.buffers.pop() {
+    // Do not receive more than is currently in the queue;
+    // avoids racing with a fast sender and getting stuck here
+    // indefinitely.
+    let limit = queue.len();
+
+    for _i in 0..limit {
+        let Some(buf) = worker.buffers.pop() else {
+            break;
+        };
+
         match queue.try_recv(buf) {
             Ok(pkt) => {
                 process_fn(worker, pkt);

--- a/adapter/ph/src/fastpath_worker.rs
+++ b/adapter/ph/src/fastpath_worker.rs
@@ -1,6 +1,8 @@
 use crate::assembly::Assembly;
+use crate::config;
 use crate::fastpath::{FastpathWorker, FastpathWorkerConfig};
 use crate::fastpath_io::FastpathIo;
+use crate::packet_queue;
 use crate::sys::ZprTun;
 use enum_map::{enum_map, Enum};
 use nix::poll;
@@ -24,7 +26,7 @@ pub fn launch(
     substrate_socket: UdpSocket,
     actor_input_tun: Arc<ZprTun>,
     requeue_outq: UnixDatagram,
-    mgmt_substrate_outq: Option<UnixDatagram>,
+    mgmt_substrate_outq: Option<packet_queue::Receiver<{ config::PACKET_BUFFER_SIZE }>>,
 ) -> impl FnOnce() {
     move || {
         let worker = FastpathWorker::new(config, worker_index, asm.clone());

--- a/adapter/ph/src/fastpath_worker.rs
+++ b/adapter/ph/src/fastpath_worker.rs
@@ -7,7 +7,6 @@ use crate::sys::ZprTun;
 use enum_map::{enum_map, Enum};
 use nix::poll;
 use std::net::UdpSocket;
-use std::os::unix::net::UnixDatagram;
 use std::sync::Arc;
 
 #[derive(Enum)]
@@ -25,7 +24,7 @@ pub fn launch(
     asm: Arc<Assembly>,
     substrate_socket: UdpSocket,
     actor_input_tun: Arc<ZprTun>,
-    requeue_outq: UnixDatagram,
+    requeue_outq: packet_queue::Receiver<{ config::PACKET_BUFFER_SIZE }>,
     mgmt_substrate_outq: Option<packet_queue::Receiver<{ config::PACKET_BUFFER_SIZE }>>,
 ) -> impl FnOnce() {
     move || {

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -277,8 +277,7 @@ fn main() -> ExitCode {
     }
 
     let (mgmt_substrate_inq, mgmt_substrate_outq) =
-        packet_buffer_socket_pair(topology_config.mgmt_datapath_queue_size).unwrap();
-    let mgmt_substrate_inq = tokio::net::UnixDatagram::from_std(mgmt_substrate_inq).unwrap();
+        packet_queue::packet_queue(topology_config.mgmt_datapath_queue_size);
 
     //
     // configure packet steering for better load balancing

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -241,9 +241,8 @@ fn main() -> ExitCode {
     let mut actor_requeue_inqs = Vec::new();
     let mut actor_requeue_outqs = Vec::new();
     for _i in 0..topology_config.fastpath_concurrency {
-        let (inq, outq) =
-            packet_buffer_socket_pair(topology_config.mgmt_datapath_queue_size).unwrap();
-        actor_requeue_inqs.push(tokio::net::UnixDatagram::from_std(inq).unwrap());
+        let (inq, outq) = packet_queue::packet_queue(topology_config.mgmt_datapath_queue_size);
+        actor_requeue_inqs.push(inq);
         actor_requeue_outqs.push(outq);
     }
 

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -44,6 +44,7 @@ mod mgmt_dispatch_worker;
 mod mgmt_processor_worker;
 mod net_defs;
 mod packet;
+mod packet_queue;
 mod packet_steering;
 mod pcap_writer;
 mod peer_table;

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -81,7 +81,9 @@ use tun_ctl::TunCtl;
 
 /// Creates a nonblocking local socket pair suitable for transferring
 /// PACKET_BUFFER_SIZE-sized messages.
-fn packet_buffer_socket_pair() -> std::io::Result<(
+fn packet_buffer_socket_pair(
+    queue_size: usize,
+) -> std::io::Result<(
     std::os::unix::net::UnixDatagram,
     std::os::unix::net::UnixDatagram,
 )> {
@@ -89,8 +91,10 @@ fn packet_buffer_socket_pair() -> std::io::Result<(
     // isn't supported on macOS, and Linux provides reliable delivery
     // with SOCK_DGRAM.
     let (a, b) = socket2::Socket::pair(socket2::Domain::UNIX, socket2::Type::DGRAM, None)?;
-    a.set_send_buffer_size(config::PACKET_BUFFER_SIZE)?;
-    b.set_send_buffer_size(config::PACKET_BUFFER_SIZE)?;
+    a.set_send_buffer_size(queue_size * config::PACKET_BUFFER_SIZE)?;
+    a.set_recv_buffer_size(queue_size * config::PACKET_BUFFER_SIZE)?;
+    b.set_send_buffer_size(queue_size * config::PACKET_BUFFER_SIZE)?;
+    b.set_recv_buffer_size(queue_size * config::PACKET_BUFFER_SIZE)?;
     a.set_nonblocking(true)?;
     b.set_nonblocking(true)?;
     Ok((a.into(), b.into()))
@@ -171,8 +175,8 @@ fn main() -> ExitCode {
 
     let topology_config = config::TopologyConfig::default();
 
-    // TODO: use get/setsockopt(SO_SNDBUF) to ensure we can buffer `capture_queue_size` packets
-    let (cap_inq, cap_outq) = packet_buffer_socket_pair().unwrap();
+    let (cap_inq, cap_outq) =
+        packet_buffer_socket_pair(topology_config.capture_queue_size).unwrap();
     let (md_inq_factory, md_outq) =
         two_way_queue::two_way_queue(topology_config.mgmt_dispatch_queue_size);
     let (am_inq_factory, am_outq) =
@@ -236,7 +240,8 @@ fn main() -> ExitCode {
     let mut actor_requeue_inqs = Vec::new();
     let mut actor_requeue_outqs = Vec::new();
     for _i in 0..topology_config.fastpath_concurrency {
-        let (inq, outq) = packet_buffer_socket_pair().unwrap();
+        let (inq, outq) =
+            packet_buffer_socket_pair(topology_config.mgmt_datapath_queue_size).unwrap();
         actor_requeue_inqs.push(tokio::net::UnixDatagram::from_std(inq).unwrap());
         actor_requeue_outqs.push(outq);
     }
@@ -270,7 +275,8 @@ fn main() -> ExitCode {
         substrate_sockets.push(socket.into());
     }
 
-    let (mgmt_substrate_inq, mgmt_substrate_outq) = packet_buffer_socket_pair().unwrap();
+    let (mgmt_substrate_inq, mgmt_substrate_outq) =
+        packet_buffer_socket_pair(topology_config.mgmt_datapath_queue_size).unwrap();
     let mgmt_substrate_inq = tokio::net::UnixDatagram::from_std(mgmt_substrate_inq).unwrap();
 
     //

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -301,14 +301,63 @@ impl Packet {
         pkt
     }
 
+    fn metadata_is_valid(&self) -> bool {
+        let md = self.metadata();
+        md.offset >= Self::MIN_BODY_OFFSET && md.len <= self.buf.len()
+            || md.offset <= self.buf.len() - md.len
+    }
+
     /// Initialize a buffer with existing packet data and metadata as a packet buffer.
-    pub fn new_with_existing_metadata(buf: PacketBuffer) -> Self {
+    /// Returns an error if packet body metadata is invalid.
+    pub fn try_new_with_existing_metadata(buf: PacketBuffer) -> Result<Self, PacketBuffer> {
         let pkt = Packet { buf };
-        let md = pkt.metadata();
-        assert!(md.offset >= Self::MIN_BODY_OFFSET);
-        assert!(md.len <= pkt.buf.len());
-        assert!(md.offset <= pkt.buf.len() - md.len);
-        pkt
+        if !pkt.metadata_is_valid() {
+            return Err(pkt.destroy());
+        }
+        Ok(pkt)
+    }
+
+    /// Initialize a buffer with existing packet data and metadata as a packet buffer.
+    /// Panics if packet body metadata is invalid.
+    pub fn new_with_existing_metadata(buf: PacketBuffer) -> Self {
+        Self::try_new_with_existing_metadata(buf).unwrap()
+    }
+
+    /// Copy the backing buffer's data to a destination buffer in a compact form.
+    /// (Specifically, only the metadata and packet body are copied.)
+    pub fn serialize(&self, mut buf: impl buf::BufMut) -> Result<(), ()> {
+        if size_of::<PacketMetadata>() + self.metadata().len > buf.remaining_mut() {
+            return Err(());
+        }
+
+        buf.put(self.metadata().as_bytes());
+        buf.put(self.body());
+
+        Ok(())
+    }
+
+    /// Reconstitute a packet from its serialized form.
+    /// The reconstituted packet will have the same amount of headroom and tailroom
+    /// as the original packet, so long as the given packet buffer is of the same size.
+    /// If the given packet buffer cannot hold the deserialized packet, we return an error.
+    pub fn deserialize_into(
+        mut src: impl buf::Buf,
+        mut buf: PacketBuffer,
+    ) -> Result<Packet, PacketBuffer> {
+        if src.remaining() < size_of::<PacketMetadata>() {
+            return Err(buf);
+        }
+
+        src.copy_to_slice(&mut buf[..size_of::<PacketMetadata>()]);
+        let mut pkt = Self::try_new_with_existing_metadata(buf)?;
+
+        if src.remaining() < pkt.metadata().len {
+            return Err(pkt.destroy());
+        }
+
+        src.copy_to_slice(pkt.body_mut());
+
+        Ok(pkt)
     }
 
     /// Copy this packet's metadata, data and layout into a new buffer, returning a handle for it.
@@ -370,6 +419,11 @@ impl Packet {
         let offset = self.metadata().offset;
         let len = self.metadata().len;
         &self.buf[offset..offset + len]
+    }
+
+    /// Length of packet body.
+    pub fn len(&self) -> usize {
+        self.metadata().len
     }
 
     /// Returns a mutable reference to the packet body.
@@ -475,7 +529,7 @@ impl buf::Buf for Packet {
 
     /// This is simply the packet size.
     fn remaining(&self) -> usize {
-        self.metadata().len
+        self.len()
     }
 
     /// Provides a reference to a portion of the remaining packet.
@@ -634,6 +688,25 @@ mod tests {
         pkt.metadata_mut().ingress_stream_id = 100;
         let buf2 = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
         let pkt2 = pkt.clone_into_with_headroom(buf2, 456);
+        assert_eq!(
+            pkt.metadata().ingress_stream_id,
+            pkt2.metadata().ingress_stream_id
+        );
+        assert_eq!(*pkt.body(), *pkt2.body());
+    }
+
+    #[test]
+    fn serialize_deserialize_test() {
+        let mut buf = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let offset = Packet::MIN_BODY_OFFSET + 123;
+        let data = [1, 2, 3, 4, 5, 6, 7, 8].as_slice();
+        buf[offset..offset + 8].copy_from_slice(data);
+        let mut pkt = Packet::new_with_existing_data(buf, Packet::MIN_BODY_OFFSET + 123, 8);
+        pkt.metadata_mut().ingress_stream_id = 100;
+        let mut buf_temp = [0u8; config::PACKET_BUFFER_SIZE];
+        pkt.serialize(buf_temp.as_mut_slice()).unwrap();
+        let buf2 = Box::new([0u8; config::PACKET_BUFFER_SIZE]);
+        let pkt2 = Packet::deserialize_into(buf_temp.as_slice(), buf2).unwrap();
         assert_eq!(
             pkt.metadata().ingress_stream_id,
             pkt2.metadata().ingress_stream_id

--- a/adapter/ph/src/packet_queue.rs
+++ b/adapter/ph/src/packet_queue.rs
@@ -6,11 +6,24 @@
 //! * async mgmt (send) side
 //! * bounded queue
 
-use crate::packet::Packet;
+use crate::packet::{Packet, PacketBuffer};
 use crate::sys::notify;
 use std::os::fd::BorrowedFd;
 use std::sync::Arc;
 use tokio::sync::mpsc;
+
+#[derive(Debug)]
+pub enum SendError {
+    Closed,
+    Oversize,
+}
+
+#[derive(Debug)]
+pub enum TrySendError {
+    Full,
+    Closed,
+    Oversize,
+}
 
 #[derive(Clone)]
 pub struct Sender<const BUFSIZE: usize> {
@@ -19,18 +32,51 @@ pub struct Sender<const BUFSIZE: usize> {
 }
 
 impl<const BUFSIZE: usize> Sender<BUFSIZE> {
-    pub async fn send(&self, packet: &Packet) -> Result<(), ()> {
+    pub async fn send(&self, packet: &Packet) -> Result<(), SendError> {
         let mut buf = [0u8; BUFSIZE];
-        packet.serialize(&mut buf[..]).unwrap();
-        self.send.send(buf).await.map_err(|_| ())?;
+        packet
+            .serialize(&mut buf[..])
+            .map_err(|_| SendError::Oversize)?;
+        self.send.send(buf).await.map_err(|_| SendError::Closed)?;
+        self.notify.post();
+        Ok(())
+    }
+
+    pub fn try_send(&self, packet: &Packet) -> Result<(), TrySendError> {
+        let mut buf = [0u8; BUFSIZE];
+        packet
+            .serialize(&mut buf[..])
+            .map_err(|_| TrySendError::Oversize)?;
+        match self.send.try_send(buf) {
+            Ok(()) => (),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                return Err(TrySendError::Full);
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                return Err(TrySendError::Closed);
+            }
+        }
         self.notify.post();
         Ok(())
     }
 }
 
+#[derive(Debug)]
 pub enum TryRecvError {
-    Empty,
-    Disconnected,
+    Empty(PacketBuffer),
+    Disconnected(PacketBuffer),
+    Oversize(PacketBuffer),
+}
+
+impl TryRecvError {
+    #[allow(dead_code)]
+    pub fn into_inner(self) -> PacketBuffer {
+        match self {
+            Self::Empty(buf) => buf,
+            Self::Disconnected(buf) => buf,
+            Self::Oversize(buf) => buf,
+        }
+    }
 }
 
 pub struct Receiver<const BUFSIZE: usize> {
@@ -43,11 +89,18 @@ impl<const BUFSIZE: usize> Receiver<BUFSIZE> {
         self.notify.poll_fd()
     }
 
-    pub fn try_recv(&mut self, packet: &mut Packet) -> Result<(), TryRecvError> {
+    pub fn len(&self) -> usize {
+        self.recv.len()
+    }
+
+    pub fn try_recv(&mut self, pkt_buf: PacketBuffer) -> Result<Packet, TryRecvError> {
         match self.recv.try_recv() {
-            Ok(buf) => Ok(packet.deserialize_from(&buf[..]).unwrap()),
-            Err(mpsc::error::TryRecvError::Empty) => Err(TryRecvError::Empty),
-            Err(mpsc::error::TryRecvError::Disconnected) => Err(TryRecvError::Disconnected),
+            Ok(buf) => Packet::deserialize_into(buf.as_slice(), pkt_buf)
+                .map_err(|pkt_buf| TryRecvError::Oversize(pkt_buf)),
+            Err(mpsc::error::TryRecvError::Empty) => Err(TryRecvError::Empty(pkt_buf)),
+            Err(mpsc::error::TryRecvError::Disconnected) => {
+                Err(TryRecvError::Disconnected(pkt_buf))
+            }
         }
     }
 }
@@ -56,5 +109,14 @@ pub fn packet_queue<const BUFSIZE: usize>(depth: usize) -> (Sender<BUFSIZE>, Rec
     let (send, recv) = mpsc::channel(depth);
     let notify_send = Arc::new(notify::Notify::new().unwrap());
     let notify_recv = notify_send.clone();
-    (Sender { send, notify: notify_send }, Receiver { recv, notify: notify_recv })
+    (
+        Sender {
+            send,
+            notify: notify_send,
+        },
+        Receiver {
+            recv,
+            notify: notify_recv,
+        },
+    )
 }

--- a/adapter/ph/src/packet_queue.rs
+++ b/adapter/ph/src/packet_queue.rs
@@ -1,0 +1,60 @@
+//! Queue used to transfer packet from mgmt to datapath.
+//!
+//! Some properties:
+//! * no allocations/deallocations on datapath (receive) side
+//! * datapath (receive) notifications provided via file descriptor
+//! * async mgmt (send) side
+//! * bounded queue
+
+use crate::packet::Packet;
+use crate::sys::notify;
+use std::os::fd::BorrowedFd;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+#[derive(Clone)]
+pub struct Sender<const BUFSIZE: usize> {
+    send: mpsc::Sender<[u8; BUFSIZE]>,
+    notify: Arc<notify::Notify>,
+}
+
+impl<const BUFSIZE: usize> Sender<BUFSIZE> {
+    pub async fn send(&self, packet: &Packet) -> Result<(), ()> {
+        let mut buf = [0u8; BUFSIZE];
+        packet.serialize(&mut buf[..]).unwrap();
+        self.send.send(buf).await.map_err(|_| ())?;
+        self.notify.post();
+        Ok(())
+    }
+}
+
+pub enum TryRecvError {
+    Empty,
+    Disconnected,
+}
+
+pub struct Receiver<const BUFSIZE: usize> {
+    recv: mpsc::Receiver<[u8; BUFSIZE]>,
+    notify: Arc<notify::Notify>,
+}
+
+impl<const BUFSIZE: usize> Receiver<BUFSIZE> {
+    pub fn poll_fd(&self) -> BorrowedFd<'_> {
+        self.notify.poll_fd()
+    }
+
+    pub fn try_recv(&mut self, packet: &mut Packet) -> Result<(), TryRecvError> {
+        match self.recv.try_recv() {
+            Ok(buf) => Ok(packet.deserialize_from(&buf[..]).unwrap()),
+            Err(mpsc::error::TryRecvError::Empty) => Err(TryRecvError::Empty),
+            Err(mpsc::error::TryRecvError::Disconnected) => Err(TryRecvError::Disconnected),
+        }
+    }
+}
+
+pub fn packet_queue<const BUFSIZE: usize>(depth: usize) -> (Sender<BUFSIZE>, Receiver<BUFSIZE>) {
+    let (send, recv) = mpsc::channel(depth);
+    let notify_send = Arc::new(notify::Notify::new().unwrap());
+    let notify_recv = notify_send.clone();
+    (Sender { send, notify: notify_send }, Receiver { recv, notify: notify_recv })
+}

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -7,10 +7,9 @@ use crate::test_packet::*;
 use crate::two_way_queue;
 use bytes::Buf;
 use std::io::ErrorKind;
-use std::os::unix::net::UnixDatagram as StdUnixDatagram;
+use std::os::unix::net::UnixDatagram;
 use std::result::Result;
 use std::time::SystemTime;
-use tokio::net::UnixDatagram as TokioUnixDatagram;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::oneshot::error::RecvError;
@@ -71,12 +70,14 @@ impl MgmtProcessor {
 }
 
 /// MgmtSubstrateEgress allows mgmt to inject ZDP packets into the substrate egress fastpath.
-pub struct MgmtSubstrateEgress(packet_queue::Sender<{ config::PACKET_BUFFER_SIZE }>);
+pub struct MgmtSubstrateEgress {
+    queue: packet_queue::Sender<{ config::PACKET_BUFFER_SIZE }>,
+}
 
 impl MgmtSubstrateEgress {
     /// Sockets must be marked non-blocking by caller.
     pub fn new(queue: packet_queue::Sender<{ config::PACKET_BUFFER_SIZE }>) -> Self {
-        Self(queue)
+        Self { queue }
     }
 
     /// Enqueue the given packet to be egressed on the substrate.
@@ -86,7 +87,10 @@ impl MgmtSubstrateEgress {
     pub async fn enqueue_packet(&self, link_id: zpr::LinkId, mut packet: Packet) {
         packet.metadata_mut().egress_link_id = link_id;
         packet.metadata_mut().flags |= packet::flags::PRIORITY;
-        self.0.send(&packet).await.expect("unrecoverable I/O error");
+        self.queue
+            .send(&packet)
+            .await
+            .expect("unrecoverable I/O error");
     }
 
     /// Try to enqueue the given packet to be egressed on the substrate.
@@ -95,7 +99,7 @@ impl MgmtSubstrateEgress {
     #[allow(dead_code)]
     pub fn try_enqueue_packet(&self, link_id: zpr::LinkId, mut packet: Packet) -> bool {
         packet.metadata_mut().egress_link_id = link_id;
-        match self.0.try_send(&packet) {
+        match self.queue.try_send(&packet) {
             Ok(()) => true,
             Err(packet_queue::TrySendError::Full) => false,
             Err(err) => panic!("unrecoverable I/O error: {err:?}"),
@@ -105,42 +109,48 @@ impl MgmtSubstrateEgress {
 
 /// Used for requeueing actor output packets from mgmt.
 pub struct ActorOutputRequeue {
-    sockets: Box<[TokioUnixDatagram]>,
+    queues: Box<[packet_queue::Sender<{ config::PACKET_BUFFER_SIZE }>]>,
 }
 
 impl ActorOutputRequeue {
-    pub fn new(sockets: impl IntoIterator<Item = TokioUnixDatagram>) -> Self {
+    pub fn new(
+        queues: impl IntoIterator<Item = packet_queue::Sender<{ config::PACKET_BUFFER_SIZE }>>,
+    ) -> Self {
         Self {
-            sockets: sockets.into_iter().collect(),
+            queues: queues.into_iter().collect(),
         }
     }
 
     pub fn try_enqueue_packet(&self, packet: Packet) -> Result<(), TryEnqueueError<Packet>> {
-        let socket = self.select_socket(&packet);
+        let queue = self.select_queue(&packet);
 
-        match socket.try_send(packet.buffer()) {
-            Ok(_) => Ok(()),
+        match queue.try_send(&packet) {
+            Ok(()) => {
+                drop(packet);
+                Ok(())
+            }
 
-            Err(err) => match err.kind() {
-                ErrorKind::WouldBlock => Err(TryEnqueueError::Full(packet)),
-                _ => panic!("unrecoverable I/O error: {}", err),
-            },
+            Err(packet_queue::TrySendError::Full) => Err(TryEnqueueError::Full(packet)),
+            Err(err) => panic!("unrecoverable I/O error: {err:?}"),
         }
     }
 
-    fn select_socket(&self, packet: &Packet) -> &TokioUnixDatagram {
-        &self.sockets[packet.metadata().ingress_lane_id as usize]
+    fn select_queue(
+        &self,
+        packet: &Packet,
+    ) -> &packet_queue::Sender<{ config::PACKET_BUFFER_SIZE }> {
+        &self.queues[packet.metadata().ingress_lane_id as usize]
     }
 }
 
 /// Capture will intercept packets in the PH and dump them into a file for debugging purposes
 pub struct Capture {
-    sender: StdUnixDatagram,
+    sender: UnixDatagram,
 }
 
 impl Capture {
     /// `sender` must be set nonblocking
-    pub fn new(sender: StdUnixDatagram) -> Self {
+    pub fn new(sender: UnixDatagram) -> Self {
         Self { sender }
     }
 

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -6,6 +6,7 @@ use crate::packet_queue;
 use crate::test_packet::*;
 use crate::two_way_queue;
 use bytes::Buf;
+use libc;
 use std::io::ErrorKind;
 use std::os::unix::net::UnixDatagram;
 use std::result::Result;
@@ -194,7 +195,10 @@ impl Capture {
                 ErrorKind::ConnectionRefused | ErrorKind::BrokenPipe => {
                     panic!("capture channel closed")
                 }
-                _ => panic!("unrecoverable I/O error: {}", err),
+                _ => match err.raw_os_error() {
+                    Some(libc::ENOBUFS) => Err(TryEnqueueError::Full(())),
+                    _ => panic!("unrecoverable I/O error: {}", err),
+                },
             },
         }
     }

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -1,6 +1,8 @@
 //! Queues (i.e., frontend interface) for each stage of the system.
 
+use crate::config;
 use crate::packet::{self, Packet, PacketBuffer};
+use crate::packet_queue;
 use crate::test_packet::*;
 use crate::two_way_queue;
 use bytes::Buf;
@@ -69,27 +71,35 @@ impl MgmtProcessor {
 }
 
 /// MgmtSubstrateEgress allows mgmt to inject ZDP packets into the substrate egress fastpath.
-pub struct MgmtSubstrateEgress {
-    socket: TokioUnixDatagram,
-}
+pub struct MgmtSubstrateEgress(packet_queue::Sender<{ config::PACKET_BUFFER_SIZE }>);
 
 impl MgmtSubstrateEgress {
     /// Sockets must be marked non-blocking by caller.
-    pub fn new(socket: TokioUnixDatagram) -> Self {
-        Self { socket }
+    pub fn new(queue: packet_queue::Sender<{ config::PACKET_BUFFER_SIZE }>) -> Self {
+        Self(queue)
     }
 
-    // Enqueue the given packet to be egressed on the substrate.
-    // Blocks until the packet is in the hands of the fastpath.
-    // The packet is marked PRIORITY, which instructs the fastpath to
-    // ensure it eventually gets queued with the OS.
+    /// Enqueue the given packet to be egressed on the substrate.
+    /// Blocks until the packet is in the hands of the fastpath.
+    /// The packet is marked PRIORITY, which instructs the fastpath to
+    /// ensure it eventually gets queued with the OS.
     pub async fn enqueue_packet(&self, link_id: zpr::LinkId, mut packet: Packet) {
         packet.metadata_mut().egress_link_id = link_id;
         packet.metadata_mut().flags |= packet::flags::PRIORITY;
-        self.socket
-            .send(packet.buffer())
-            .await
-            .expect("unrecoverable I/O error");
+        self.0.send(&packet).await.expect("unrecoverable I/O error");
+    }
+
+    /// Try to enqueue the given packet to be egressed on the substrate.
+    /// Returns said packet if there is no room in the queue.
+    /// Unlike `enqueue_packet()`, the packet is not marked for any special processing.
+    #[allow(dead_code)]
+    pub fn try_enqueue_packet(&self, link_id: zpr::LinkId, mut packet: Packet) -> bool {
+        packet.metadata_mut().egress_link_id = link_id;
+        match self.0.try_send(&packet) {
+            Ok(()) => true,
+            Err(packet_queue::TrySendError::Full) => false,
+            Err(err) => panic!("unrecoverable I/O error: {err:?}"),
+        }
     }
 }
 

--- a/adapter/ph/src/two_way_queue.rs
+++ b/adapter/ph/src/two_way_queue.rs
@@ -63,11 +63,17 @@ pub enum TryRecvReturnError {
     Disconnected,
 }
 
+struct ReturnQueueHandleInner<U> {
+    outgoing_return_q: mpsc::UnboundedSender<U>,
+    notify: Notify,
+}
+
+type ReturnQueueHandle<U> = Arc<ReturnQueueHandleInner<U>>;
+
 /// The return path of a two-way queue.
 pub struct ReturnQueue<U> {
     incoming_return_q: mpsc::UnboundedReceiver<U>,
-    outgoing_return_q: mpsc::UnboundedSender<U>,
-    return_notify: Arc<Notify>,
+    handle: ReturnQueueHandle<U>,
     outstanding: Rc<UsizeCell>,
 }
 
@@ -75,10 +81,15 @@ impl<U> ReturnQueue<U> {
     /// Construct a new return queue.
     pub fn new() -> Self {
         let (outgoing_return_q, incoming_return_q) = mpsc::unbounded_channel();
+
+        let handle = ReturnQueueHandleInner {
+            outgoing_return_q,
+            notify: Notify::new().unwrap(),
+        };
+
         Self {
             incoming_return_q,
-            outgoing_return_q,
-            return_notify: Arc::new(Notify::new().unwrap()),
+            handle: Arc::new(handle),
             outstanding: Rc::new(UsizeCell::new(0)),
         }
     }
@@ -87,7 +98,7 @@ impl<U> ReturnQueue<U> {
     /// `None` if no items are immediately available (possibly because none
     /// are outstanding).
     pub fn try_recv_return(&mut self) -> Option<U> {
-        if !self.return_notify.consume() {
+        if !self.handle.notify.consume() {
             return None;
         }
 
@@ -100,7 +111,7 @@ impl<U> ReturnQueue<U> {
             if avail > 1 {
                 // It is likely that we ate the notification of these remaining items.
                 // Re-post it.  (If we didn't eat it, this is harmless.)
-                self.return_notify.post();
+                self.handle.notify.post();
             }
         }
 
@@ -111,46 +122,38 @@ impl<U> ReturnQueue<U> {
     /// returning 0 if no items are immediately available (possibly because
     /// none are outstanding).
     pub fn try_recv_many_returns(&mut self, returns: &mut Vec<U>, limit: usize) -> usize {
-        if !self.return_notify.consume() {
+        if !self.handle.notify.consume() {
             return 0;
         }
 
         let avail = self.incoming_return_q.len();
-
-        let mut recvd = 0;
-
-        while recvd < limit {
-            match self.incoming_return_q.try_recv() {
-                Ok(item) => {
-                    recvd += 1;
-                    returns.push(item);
-                }
-
-                Err(_) => break,
-            }
+        if avail == 0 {
+            return 0;
         }
+
+        // Will not block, as we know something is there to receive.
+        let recvd = self.incoming_return_q.blocking_recv_many(returns, limit);
 
         self.outstanding.fetch_sub(recvd);
 
         if recvd > avail {
             // It is likely that we ate the notification of these remaining items.
             // Re-post it.  (If we didn't eat it, this is harmless.)
-            self.return_notify.post();
+            self.handle.notify.post();
         }
 
         return recvd;
     }
 
     pub fn poll_fd(&self) -> BorrowedFd<'_> {
-        self.return_notify.poll_fd()
+        self.handle.notify.poll_fd()
     }
 }
 
 /// The producer half of a two-way queue.
 pub struct Sender<T, U> {
-    outgoing_q: mpsc::Sender<(T, mpsc::UnboundedSender<U>, Arc<Notify>)>,
-    outgoing_return_q: mpsc::UnboundedSender<U>,
-    return_notify: Arc<Notify>,
+    outgoing_q: mpsc::Sender<(T, ReturnQueueHandle<U>)>,
+    return_q_handle: ReturnQueueHandle<U>,
     outstanding: Rc<UsizeCell>,
 }
 
@@ -158,17 +161,16 @@ impl<T, U> Sender<T, U> {
     /// Try to send an item.  Note that it is possible for the queue
     /// to appear full for the reason that there are outstanding returns.
     pub fn try_send(&mut self, item: T) -> Result<(), TrySendError<T>> {
-        match self.outgoing_q.try_send((
-            item,
-            self.outgoing_return_q.clone(),
-            self.return_notify.clone(),
-        )) {
+        match self
+            .outgoing_q
+            .try_send((item, self.return_q_handle.clone()))
+        {
             Ok(()) => {
                 self.outstanding.fetch_add(1);
                 Ok(())
             }
-            Err(mpsc::error::TrySendError::Full((item, _, _))) => Err(TrySendError::Full(item)),
-            Err(mpsc::error::TrySendError::Closed((item, _, _))) => Err(TrySendError::Closed(item)),
+            Err(mpsc::error::TrySendError::Full((item, _))) => Err(TrySendError::Full(item)),
+            Err(mpsc::error::TrySendError::Closed((item, _))) => Err(TrySendError::Closed(item)),
         }
     }
 }
@@ -178,7 +180,7 @@ impl<T, U> Sender<T, U> {
 /// `ReturnQueue`.
 #[derive(Clone)]
 pub struct SenderFactory<T, U> {
-    outgoing_q: mpsc::Sender<(T, mpsc::UnboundedSender<U>, Arc<Notify>)>,
+    outgoing_q: mpsc::Sender<(T, ReturnQueueHandle<U>)>,
 }
 
 impl<T, U> SenderFactory<T, U> {
@@ -186,8 +188,7 @@ impl<T, U> SenderFactory<T, U> {
     pub fn make(&self, ret_q: &ReturnQueue<U>) -> Sender<T, U> {
         Sender {
             outgoing_q: self.outgoing_q.clone(),
-            outgoing_return_q: ret_q.outgoing_return_q.clone(),
-            return_notify: ret_q.return_notify.clone(),
+            return_q_handle: ret_q.handle.clone(),
             outstanding: ret_q.outstanding.clone(),
         }
     }
@@ -195,7 +196,7 @@ impl<T, U> SenderFactory<T, U> {
 
 /// The consumer half of a two-way queue.
 pub struct Receiver<T, U> {
-    incoming_q: mpsc::Receiver<(T, mpsc::UnboundedSender<U>, Arc<Notify>)>,
+    incoming_q: mpsc::Receiver<(T, ReturnQueueHandle<U>)>,
 }
 
 impl<T, U> Receiver<T, U>
@@ -213,11 +214,10 @@ where
     /// transformed using `TwoWayReturnable::convert()` on its way back to
     /// the producer.
     pub async fn recv(&mut self) -> Option<ItemGuard<'_, T, U>> {
-        let (item, outgoing_return_q, return_notify) = self.incoming_q.recv().await?;
+        let (item, return_q_handle) = self.incoming_q.recv().await?;
         Some(ItemGuard {
             item: ManuallyDrop::new(item),
-            outgoing_return_q,
-            return_notify,
+            return_q_handle,
             receiver: PhantomData,
         })
     }
@@ -226,8 +226,7 @@ where
 /// Guard for an item received from a two-way queue.
 pub struct ItemGuard<'a, T, U: TwoWayReturnable<T>> {
     item: ManuallyDrop<T>,
-    outgoing_return_q: mpsc::UnboundedSender<U>,
-    return_notify: Arc<Notify>,
+    return_q_handle: ReturnQueueHandle<U>,
     receiver: PhantomData<&'a Receiver<T, U>>,
 }
 
@@ -249,10 +248,11 @@ impl<T, U: TwoWayReturnable<T>> Drop for ItemGuard<'_, T, U> {
     fn drop(&mut self) {
         // SAFETY: because we are in the destructor, `take()` can never be called again
         let _ = self
+            .return_q_handle
             .outgoing_return_q
             .send(U::convert(unsafe { ManuallyDrop::take(&mut self.item) }));
 
-        self.return_notify.post();
+        self.return_q_handle.notify.post();
     }
 }
 


### PR DESCRIPTION
This PR does two main things: introduce `packet_queue`, which gives us the properties we want for a mgmt->datapath queue without relying on Unix-domain datagram queues (which don't quite work correctly under macOS), and add an API to `Packet` which allows serializing/deserializing without copying the entire (12 KiB) buffer.

Also, for now we address the same issue in capture queue by sizing the socket buffers correctly and correctly handling ENOBUFS.  We don't need blocking from it so that was an easier fix there.