### PR TITLE
update crossbeam-channel to 0.5.15 to address double-free

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Addresses <https://github.com/org-zpr/zpr-core/security/dependabot/41>.