### PR TITLE
switch users to uzers crate to address unaligned access

### DIFF
--- a/adapter/runners/Cargo.lock
+++ b/adapter/runners/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
  "nix",
  "thiserror 2.0.11",
  "toml",
- "users",
+ "uzers",
 ]
 
 [[package]]
@@ -403,20 +403,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uzers"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "windows-sys"

--- a/adapter/runners/Cargo.toml
+++ b/adapter/runners/Cargo.toml
@@ -9,4 +9,4 @@ local-ip-address = "0.6.3"
 nix = { version = "0.29.0", features = ["user", "fs"] }
 thiserror = "2.0.11"
 toml = "0.8.19"
-users = "0.11.0"
+uzers = "0.11.0"

--- a/adapter/runners/src/sys/linux.rs
+++ b/adapter/runners/src/sys/linux.rs
@@ -1,5 +1,5 @@
 use nix::unistd::{self, Gid, Uid};
-use users::get_user_by_name;
+use uzers::get_user_by_name;
 
 use std::net::IpAddr;
 use std::process::Command;

--- a/adapter/runners/src/sys/unix.rs
+++ b/adapter/runners/src/sys/unix.rs
@@ -5,7 +5,7 @@ use nix::unistd::{self, Gid, Uid};
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 
-use users::get_user_by_name;
+use uzers::get_user_by_name;
 
 use crate::sys::PlatformErr;
 


### PR DESCRIPTION
`users` is apparently no longer maintained.  `uzers` is a fork of this, which addresses <https://github.com/org-zpr/zpr-core/security/dependabot/24> in version 0.11.3; see <https://crates.io/crates/uzers> and <https://github.com/rustadopt/uzers-rs/blob/main/CHANGELOG.md>.  (Like for other security updates, I've kept the min-version the same, and just updated the version in the Cargo.lock.)