### PR TITLE
Send Init Authentication message

### DIFF
--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -527,6 +527,12 @@ impl LinkStateWrapper {
     /// Update link state based on received register actor address request
     /// Transitions from Registering Actor Address to Active
     /// Does not generate any packets
+    ///
+    /// The "Register Actor Address" is to become the "Acquire ZPR Address"
+    /// message soon.  In that version, the Acquire message will include a
+    /// BLOB showing evidence of authentication which we can evaluate and
+    /// pass to the visa service.  Visa service will grant access and an
+    /// address and call back down here to [process_authorize_response].
     fn process_register_actor_address_request(
         &self,
         asm: &Arc<Assembly>,

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -7,6 +7,7 @@ use crate::counters;
 use crate::defs::*;
 use crate::link_state::LinkEvent;
 use crate::logging::targets::{FLOW_MGMT, REPORTING, ZDP};
+use crate::mgmt::requests::send_init_authentication;
 use crate::net_defs::IpAddress;
 use crate::packet::Packet;
 use crate::zdp;
@@ -88,6 +89,33 @@ pub async fn handle_echo_request(
     Ok(())
 }
 
+/// TODO: Not yet in RFC 6
+///
+/// This is a fire and forget message from the node telling us that authentication
+/// is needed.  Upon receipt, we should take steps to perform authentication with
+/// an authentication service.
+///
+/// If we (the receiver) is configured to perform bootstrap authentication and the
+/// packet includes the necessary bits (nonce, etc) we should do bootstrap authentication
+/// now.
+pub async fn handle_init_authentication(_asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
+    let ingress_link_id = pkt.metadata().ingress_link_id;
+
+    let Ok(payload) = zdp::ZdpInitAuthenticationPayload::read_from_buf(&mut pkt) else {
+        return Err((HandleMgmtError::BadStructure, pkt));
+    };
+
+    if payload.flags & zdp::init_authentication_flags::BOOTSTRAP_SUPPORT != 0 {
+        // bootstrap is supported
+        debug!(target: ZDP, "Received Init Authentication for link {ingress_link_id} with nonce {:x?}", payload.nonce);
+        // TODO: run the self authentication -- if this adapter is configured to do so.
+    } else {
+        debug!(target: ZDP, "Received Init Authentication for link {ingress_link_id} -- bootstrap not supported");
+    }
+
+    Ok(())
+}
+
 /// handle a Terminate Request (RFC 6.5 § 6.3.3)
 pub async fn handle_terminate_request(
     asm: &Arc<Assembly>,
@@ -161,10 +189,11 @@ pub async fn handle_hello_request(
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
     let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpHelloResponseHeader>();
 
-    hdr.status =
+    let send_init: bool;
+    (hdr.status, send_init) =
         match asm.process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloRequest) {
-            Err(_) => zdp::ResponseCode::Other,
-            Ok(()) => zdp::ResponseCode::Success,
+            Err(_) => (zdp::ResponseCode::Other, false),
+            Ok(()) => (zdp::ResponseCode::Success, true),
         };
 
     super::core::send_non_flow_mgmt_response(
@@ -175,6 +204,10 @@ pub async fn handle_hello_request(
         rsp_pkt,
     )
     .await;
+
+    if send_init {
+        send_init_authentication(asm, ingress_link_id).await;
+    }
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -7,9 +7,12 @@ use crate::counters::CounterType;
 use crate::defs::*;
 use crate::logging::targets::ZDP;
 use crate::mgmt::core::SyncReqError;
+use crate::peer_table::AUTH_KEY_SIZE_BYTES;
 use crate::zdp;
 use bytes::{Buf, BufMut};
+use openssl::rand::rand_bytes;
 use std::net::IpAddr;
+use std::time::SystemTime;
 use thiserror::Error;
 use tracing::*;
 use zpr;
@@ -90,6 +93,83 @@ pub async fn send_hello_request(
             Err(())
         }
     }
+}
+
+/// Send Init Authentication (NOT YET IN RFC 6)
+///
+/// This call is not integrated into the link state machine and is called
+/// as a side effect in the Hello Request handler ([handlers::handle_hello_request]).
+///
+/// Message payload is ([zdp::ZdpInitAuthenticationPayload]):
+///
+///     offset  0: flags (1 byte)
+///     offset  1: 8-byte nonce
+///     offset  9: 8-byte (64 bit, big endian) create time (unix seconds)
+///     offset 17: 32-byte blake3 hash
+///
+/// Blake 3 hash is used in keyed-hash mode. The peer_table keeps track of a 256-bit
+/// key on each link.  It in the future it may even change it from time to time.
+/// The nonce and hash are returned in the bootstrap authentication BLOB and
+/// are checked by the node before processing.
+///
+pub async fn send_init_authentication(asm: &Assembly, link_id: zpr::LinkId) {
+    let ctime = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as u64;
+    let be_time = ctime.to_be_bytes();
+
+    let mut nonce = [0u8; 8];
+
+    // TODO: Whether or not we are in bootstrap mode comes from visa service.  For now hardcoded ON.
+    let is_bootstrap = true;
+
+    let payload: zdp::ZdpInitAuthenticationPayload;
+
+    if is_bootstrap {
+        rand_bytes(&mut nonce).expect("failed to generate random bytes for nonce");
+
+        // TODO: Pretty sure I do not need `inspect_sync` below. The key is set at create time and not changed.
+        let key = asm.peer_table.inspect(link_id, {
+            |peer| {
+                let mut key = [0u8; AUTH_KEY_SIZE_BYTES];
+                key[0..AUTH_KEY_SIZE_BYTES].copy_from_slice(&peer.auth_key[0..AUTH_KEY_SIZE_BYTES]);
+                key
+            }
+        });
+
+        match key {
+            Some(key) => {
+                let mut hasher = blake3::Hasher::new_keyed(&key);
+                hasher.update(&nonce);
+                hasher.update(&be_time);
+                let hmac = blake3::keyed_hash(&key, &nonce);
+                payload = zdp::ZdpInitAuthenticationPayload {
+                    flags: zdp::init_authentication_flags::BOOTSTRAP_SUPPORT,
+                    nonce,
+                    ctime: ctime.into(),
+                    hmac: hmac.into(),
+                }
+            }
+            None => {
+                // TODO: Possibly we want to send the Init Authentication message anyway, but
+                //       just not support bootstrap mode.
+                error!(target: ZDP, "unable to send Init Authentication: no auth key found for link {link_id}");
+                return;
+            }
+        }
+    } else {
+        // non-bootstrap mode, just send empty payload.
+        payload = zdp::ZdpInitAuthenticationPayload {
+            flags: 0x0,
+            nonce,
+            ctime: 0.into(),
+            hmac: [0u8; 32],
+        };
+    }
+    let mut pkt = core::new_heap_packet();
+    payload.write_to_buf(&mut pkt).unwrap();
+    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::InitAuthentication, pkt).await;
 }
 
 /// send a Register Actor Address Request (RFC 6.5 § 6.3.10)

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -101,6 +101,10 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
                 handlers::handle_hello_response(asm, seq_num, pkt).await
             }
 
+            ZdpPacketType::InitAuthentication => {
+                handlers::handle_init_authentication(asm, pkt).await
+            }
+
             ZdpPacketType::RegisterActorAddressRequest => {
                 handlers::handle_register_actor_address_request(asm, seq_num, pkt).await
             }

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -10,6 +10,7 @@ use bytes::Bytes;
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::DashMap;
 use enum_map::EnumMap;
+use openssl::rand::rand_bytes;
 use std::default::Default;
 use std::future::Future;
 use std::num::NonZero;
@@ -25,6 +26,8 @@ use zpr::{self, LinkId, SubstrateAddr, LINK_ID_UNKNOWN};
 
 const PEER_TABLE_SIZE: usize = 1024;
 
+pub const AUTH_KEY_SIZE_BYTES: usize = 32; // blake3 256bit key
+
 pub struct PeerState {
     pub substrate_addr: SubstrateAddr,
     pub link_state_machine: LinkStateWrapper,
@@ -32,6 +35,7 @@ pub struct PeerState {
     pub pft: PeerForwardingTable,
     pub mgmt_processor: queues::MgmtProcessor,
     pub mgmt_processor_worker: task::JoinHandle<()>,
+    pub auth_key: [u8; 32], // set in ::new and never changed.
     km_state: PeerKmState,
 }
 
@@ -79,6 +83,10 @@ impl PeerState {
 
         let mgmt_processor_worker = task::spawn_local(launch_mgmt_processor_worker(mp_outq));
 
+        let mut key = [0u8; AUTH_KEY_SIZE_BYTES];
+        if link_type == LinkType::NodeToAdapter {
+            rand_bytes(&mut key).expect("failed to generate random bytes for peer auth key");
+        }
         Self {
             substrate_addr,
             link_state_machine: LinkStateWrapper::new(link_id.get(), link_type),
@@ -87,6 +95,7 @@ impl PeerState {
             mgmt_processor,
             mgmt_processor_worker,
             km_state: PeerKmState::new(),
+            auth_key: key,
         }
     }
 
@@ -396,6 +405,7 @@ pub mod test {
             mgmt_processor,
             mgmt_processor_worker: task::spawn(async {}),
             km_state: PeerKmState::new(),
+            auth_key: [42u8; AUTH_KEY_SIZE_BYTES],
         }
     }
 }

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -47,6 +47,7 @@ pub enum ZdpPacketType {
     UnregisterActorAddressRequest = 143,
     UnregisterActorAddressResponse = 144,
     Report = 145,
+    InitAuthentication = 146, // TODO: add to RFC 6
 }
 
 pub const ZDP_PACKET_TYPE_NON_FLOW_FLAG: u8 = 0x80;
@@ -136,6 +137,21 @@ pub struct ZdpHelloResponseHeader {
     // Policy ID
     // Version info len
     // Version info
+}
+
+/// Bitflags for the [ZdpInitAuthenticationPayload] flags field.
+pub mod init_authentication_flags {
+    pub const BOOTSTRAP_SUPPORT: u8 = 0x01;
+}
+
+/// Tentative -- pending inclusion into spec.
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(packed)]
+pub struct ZdpInitAuthenticationPayload {
+    pub flags: u8,
+    pub nonce: [u8; 8],
+    pub ctime: U64,
+    pub hmac: [u8; 32],
 }
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]


### PR DESCRIPTION
This adds the "Init Authentication" message immediately after sending a Hello-Response.

A future story will do something useful when this arrives.

I expect that this message payload and maybe semantics will change as it is processed by Frank.