### PR TITLE
fix I/O polling of packet_queue

### DIFF
--- a/adapter/ph/src/fastpath_worker.rs
+++ b/adapter/ph/src/fastpath_worker.rs
@@ -9,7 +9,7 @@ use nix::poll;
 use std::net::UdpSocket;
 use std::sync::Arc;
 
-#[derive(Enum)]
+#[derive(Debug, Enum)]
 enum PollSlot {
     Substrate,
     Tun,

--- a/adapter/ph/src/packet_queue.rs
+++ b/adapter/ph/src/packet_queue.rs
@@ -95,9 +95,26 @@ impl<const BUFSIZE: usize> Receiver<BUFSIZE> {
     }
 
     pub fn try_recv(&mut self, pkt_buf: PacketBuffer) -> Result<Packet, TryRecvError> {
+        if !self.notify.consume() {
+            return Err(TryRecvError::Empty(pkt_buf));
+        }
+
+        let avail = self.recv.len();
+        if avail == 0 {
+            return Err(TryRecvError::Empty(pkt_buf));
+        }
+
         match self.recv.try_recv() {
-            Ok(buf) => Packet::deserialize_into(buf.as_slice(), pkt_buf)
-                .map_err(|pkt_buf| TryRecvError::Oversize(pkt_buf)),
+            Ok(buf) => {
+                if avail > 1 {
+                    // It is likely that we ate the notification of these remaining items.
+                    // Re-post it.  (If we didn't eat it, this is harmless.)
+                    self.notify.post();
+                }
+
+                Packet::deserialize_into(buf.as_slice(), pkt_buf)
+                    .map_err(|pkt_buf| TryRecvError::Oversize(pkt_buf))
+            }
             Err(mpsc::error::TryRecvError::Empty) => Err(TryRecvError::Empty(pkt_buf)),
             Err(mpsc::error::TryRecvError::Disconnected) => {
                 Err(TryRecvError::Disconnected(pkt_buf))

--- a/adapter/ph/src/two_way_queue.rs
+++ b/adapter/ph/src/two_way_queue.rs
@@ -136,7 +136,7 @@ impl<U> ReturnQueue<U> {
 
         self.outstanding.fetch_sub(recvd);
 
-        if recvd > avail {
+        if avail > recvd {
             // It is likely that we ate the notification of these remaining items.
             // Re-post it.  (If we didn't eat it, this is harmless.)
             self.handle.notify.post();


### PR DESCRIPTION
`packet_queue::try_recv()` neglected to clear the notification, thus resulting in endless polling.

Also fixed a notify bug spotted in `two_way_queue`.

I've realized both of these are missing tests.  Will add in a 2nd PR (in the interest of getting this fix out quickly).