### PR TITLE
Tie links to a specific local address

### DIFF
--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -22,7 +22,7 @@ hdrhistogram = { version = "7.5.4" }
 libc = { version = "0.2.171" }
 libnode = { path = "../../libnode" }
 itertools = "0.14"
-nix = { version = "0.29.0", features = ["fs", "ioctl", "net", "poll"] }
+nix = { version = "0.29.0", features = ["fs", "ioctl", "net", "poll", "uio"] }
 open-enum = { version = "0.5.1" }
 openssl = { version = "0.10.70" }
 openssl-sys = { version = "0.9.102" }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -13,7 +13,7 @@ use crate::link_state::{LinkEvent, LinkStateError, LinkType};
 use crate::logging::targets::PEER_MGMT;
 use crate::mgmt;
 use crate::mgmt_processor_worker;
-use crate::net_defs::IpAddress;
+use crate::net_defs::{self, IpAddress, ScopedIpAddr};
 use crate::peer_table;
 use crate::peer_table::PeerInsertError;
 use crate::queues::*;
@@ -161,6 +161,7 @@ impl Assembly {
             entry.key(),
             LinkType::Internal,
             std::net::SocketAddrV6::new(std::net::Ipv6Addr::from_bits(0), 0, 0, 0).into(),
+            net_defs::ScopedIpv6Addr::new(std::net::Ipv6Addr::from_bits(0), 0).into(),
             |_| std::future::pending(),
         );
 
@@ -171,6 +172,7 @@ impl Assembly {
         self: &Arc<Self>,
         link_type: LinkType,
         peer_addr: &SubstrateAddr,
+        interface_addr: &ScopedIpAddr,
     ) -> Result<NonZero<LinkId>, PeerInsertError> {
         let entry = self.peer_table.vacant_entry()?;
 
@@ -178,9 +180,10 @@ impl Assembly {
             link_id: entry.key(),
         };
 
-        let peer_state = peer_table::PeerState::new(entry.key(), link_type, *peer_addr, |q| {
-            mgmt_processor_worker::launch(worker_config, self.clone(), q)
-        });
+        let peer_state =
+            peer_table::PeerState::new(entry.key(), link_type, *peer_addr, *interface_addr, |q| {
+                mgmt_processor_worker::launch(worker_config, self.clone(), q)
+            });
 
         Ok(entry.insert(peer_state))
     }
@@ -202,11 +205,12 @@ impl Assembly {
     pub fn start_tether(
         self: &Arc<Self>,
         adapter_addr: &SubstrateAddr,
+        interface_addr: &ScopedIpAddr,
         link_type: LinkType,
     ) -> Result<NonZero<LinkId>, PeerInsertError> {
         assert!(link_type != LinkType::NodeToNode);
-        debug!(target: PEER_MGMT, "Starting tether with {adapter_addr}");
-        let peer_id = self.add_peer(link_type, adapter_addr)?;
+        debug!(target: PEER_MGMT, "Starting tether with {adapter_addr} connected to {interface_addr}");
+        let peer_id = self.add_peer(link_type, adapter_addr, interface_addr)?;
         self.peer_ids.lock().unwrap().push(peer_id.get());
 
         let Some(peer) = self.peer_table.get(peer_id.get()) else {

--- a/adapter/ph/src/batch_io.rs
+++ b/adapter/ph/src/batch_io.rs
@@ -5,8 +5,80 @@
 //! All these operations assume a file descriptor which has been set
 //! non-blocking, and they perform non-blocking I/O operations.
 
-use nix::sys::socket::{AddressFamily, SockaddrLike, SockaddrStorage};
-use std::net::SocketAddr;
+use crate::net_defs::{ScopedIpAddr, ScopedIpv6Addr};
+use nix::sys::socket::{self, AddressFamily, ControlMessageOwned, SockaddrLike, SockaddrStorage};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::os::fd::{AsFd, AsRawFd};
+
+macro_rules! scoped_ip_addr_to_cmsg (
+    ($cmsg_id:ident : $addr:expr) => {
+        let in_pktinfo;
+        let in6_pktinfo;
+        let $cmsg_id;
+        match $addr {
+            $crate::net_defs::ScopedIpAddr::V4(addr) => {
+                in_pktinfo = libc::in_pktinfo {
+                        ipi_ifindex: 0,
+                        ipi_spec_dst: libc::in_addr { s_addr: addr.to_bits().to_be() },
+                        ipi_addr: libc::in_addr { s_addr: 0 },
+                    };
+
+                $cmsg_id = nix::sys::socket::ControlMessage::Ipv4PacketInfo(&in_pktinfo);
+            },
+
+            $crate::net_defs::ScopedIpAddr::V6(addr) => {
+                in6_pktinfo = libc::in6_pktinfo {
+                        ipi6_addr: libc::in6_addr { s6_addr: addr.ip().octets() },
+                        ipi6_ifindex: addr.scope_id(),
+                    };
+
+                $cmsg_id = nix::sys::socket::ControlMessage::Ipv6PacketInfo(&in6_pktinfo);
+            },
+        }
+    }
+);
+
+fn cmsg_to_scoped_ip_addr(cmsg: ControlMessageOwned) -> Option<ScopedIpAddr> {
+    match cmsg {
+        ControlMessageOwned::Ipv4PacketInfo(info) => Some(ScopedIpAddr::V4(Ipv4Addr::from(
+            u32::from_be(info.ipi_addr.s_addr),
+        ))),
+
+        ControlMessageOwned::Ipv6PacketInfo(info) => Some(ScopedIpAddr::V6(ScopedIpv6Addr::new(
+            Ipv6Addr::from(info.ipi6_addr.s6_addr),
+            info.ipi6_ifindex,
+        ))),
+
+        _ => None,
+    }
+}
+
+fn sockaddr_to_socket_addr(sa: SockaddrStorage) -> Option<SocketAddr> {
+    match sa.family()? {
+        AddressFamily::Inet => Some(SocketAddr::V4((*sa.as_sockaddr_in().unwrap()).into())),
+        AddressFamily::Inet6 => Some(SocketAddr::V6((*sa.as_sockaddr_in6().unwrap()).into())),
+        _ => None,
+    }
+}
+
+fn errno_to_error(errno: nix::errno::Errno) -> std::io::Error {
+    std::io::Error::from_raw_os_error(errno as i32)
+}
+
+/// Enable the reception of packet info on a socket.  Required for
+/// `try_recv_buf_from_to_batch()` to return the destination address.
+pub fn set_recv_packet_info(fd: &impl AsFd, enable: bool) -> std::io::Result<()> {
+    match socket::getsockname::<SockaddrStorage>(fd.as_fd().as_raw_fd())?.family() {
+        Some(AddressFamily::Inet) => {
+            socket::setsockopt(fd, socket::sockopt::Ipv4PacketInfo, &enable).map_err(errno_to_error)
+        }
+        Some(AddressFamily::Inet6) => {
+            socket::setsockopt(fd, socket::sockopt::Ipv6RecvPacketInfo, &enable)
+                .map_err(errno_to_error)
+        }
+        _ => Ok(()),
+    }
+}
 
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
 mod io_uring {
@@ -408,8 +480,7 @@ mod io_uring {
         where
             B: BufMut + 'a,
         {
-            let foo = TryRecvBufFromBatchOp::new();
-            self.do_batch_op(foo, fd, bufs, results)
+            self.do_batch_op(TryRecvBufFromBatchOp::new(), fd, bufs, results)
         }
     }
 
@@ -429,15 +500,18 @@ mod io_uring {
     }
 }
 
-#[cfg(not(all(target_os = "linux", feature = "io-uring")))]
+//#[cfg(not(all(target_os = "linux", feature = "io-uring")))]
 mod posix_unbatched {
     //! Unbatched implementation using POSIX primitives.
 
-    use super::sockaddr_to_socket_addr;
+    use super::*;
+    use crate::net_defs::ScopedIpAddr;
     use bytes::BufMut;
-    use nix::sys::socket::{self, MsgFlags, SockaddrStorage};
+    use libc;
+    use nix::cmsg_space;
+    use nix::sys::socket::{self, sockaddr_storage, MsgFlags, SockaddrStorage};
     use nix::unistd;
-    use std::io::{Error, Result};
+    use std::io::{IoSlice, IoSliceMut, Result};
     use std::net::SocketAddr;
     use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
     use zpr_ext::std::mem::slice_assume_init_mut;
@@ -445,20 +519,19 @@ mod posix_unbatched {
     #[allow(dead_code)]
     pub const MAX_ENTRIES: usize = 1024;
 
-    pub struct BatchIo {}
-
-    fn errno_to_error(errno: nix::errno::Errno) -> Error {
-        Error::from_raw_os_error(errno as i32)
+    pub struct BatchIo {
+        cmsg_buffer: Vec<u8>,
     }
 
     impl BatchIo {
         pub fn new(_entries: usize) -> Result<Self> {
-            Ok(Self {})
+            Ok(Self {
+                cmsg_buffer: cmsg_space!(sockaddr_storage),
+            })
         }
 
         fn do_batch_op<'a, Item, Res>(
-            &mut self,
-            op: impl Fn(BorrowedFd<'a>, Item) -> Result<Res>,
+            mut op: impl FnMut(BorrowedFd<'a>, Item) -> Result<Res>,
             fd: &'a impl AsFd,
             items: impl IntoIterator<Item = Item>,
             results: &'a mut Vec<Result<Res>>,
@@ -487,7 +560,7 @@ mod posix_unbatched {
             bufs: impl IntoIterator<Item = &'a [u8]>,
             results: &'a mut Vec<Result<usize>>,
         ) -> Result<usize> {
-            self.do_batch_op(
+            Self::do_batch_op(
                 |fd, buf| unistd::write(fd, buf).map_err(errno_to_error),
                 fd,
                 bufs,
@@ -504,7 +577,7 @@ mod posix_unbatched {
         where
             B: BufMut + 'a,
         {
-            self.do_batch_op(
+            Self::do_batch_op(
                 |fd, buf| {
                     // SAFETY: We will only be writing to the chunk.
                     let chunk =
@@ -526,7 +599,7 @@ mod posix_unbatched {
             bufs: impl IntoIterator<Item = (&'a [u8], SocketAddr)>,
             results: &'a mut Vec<Result<usize>>,
         ) -> Result<usize> {
-            self.do_batch_op(
+            Self::do_batch_op(
                 |fd, (buf, addr)| {
                     socket::sendto(
                         fd.as_raw_fd(),
@@ -535,6 +608,40 @@ mod posix_unbatched {
                         MsgFlags::empty(),
                     )
                     .map_err(errno_to_error)
+                },
+                fd,
+                bufs,
+                results,
+            )
+        }
+
+        pub fn try_send_to_from_batch<'a>(
+            &'a mut self,
+            fd: &'a impl AsFd,
+            bufs: impl IntoIterator<Item = (&'a [u8], SocketAddr, Option<ScopedIpAddr>)>,
+            results: &'a mut Vec<Result<usize>>,
+        ) -> Result<usize> {
+            Self::do_batch_op(
+                |fd, (buf, dst, src)| match src {
+                    Some(src) => {
+                        scoped_ip_addr_to_cmsg!(cmsg: &src);
+                        socket::sendmsg(
+                            fd.as_raw_fd(),
+                            &[IoSlice::new(buf)],
+                            &[cmsg],
+                            MsgFlags::empty(),
+                            Some(&SockaddrStorage::from(dst)),
+                        )
+                        .map_err(errno_to_error)
+                    }
+
+                    None => socket::sendto(
+                        fd.as_raw_fd(),
+                        buf,
+                        &SockaddrStorage::from(dst),
+                        MsgFlags::empty(),
+                    )
+                    .map_err(errno_to_error),
                 },
                 fd,
                 bufs,
@@ -551,16 +658,55 @@ mod posix_unbatched {
         where
             B: BufMut + 'a,
         {
-            self.do_batch_op(
+            Self::do_batch_op(
                 |fd, buf| {
                     // SAFETY: We will only be writing to the chunk.
                     let chunk =
                         unsafe { slice_assume_init_mut(buf.chunk_mut().as_uninit_slice_mut()) };
+                    // FIXME: use MSG_TRUNC
                     let (amt, addr) =
                         socket::recvfrom(fd.as_raw_fd(), chunk).map_err(errno_to_error)?;
                     // SAFETY: We know we've written the given number of bytes in the BufMut.
-                    unsafe { buf.advance_mut(amt as usize) };
+                    unsafe { buf.advance_mut(amt) };
                     Ok((amt, addr.and_then(sockaddr_to_socket_addr)))
+                },
+                fd,
+                bufs,
+                results,
+            )
+        }
+
+        pub fn try_recv_buf_from_to_batch<'a, B>(
+            &'a mut self,
+            fd: &'a impl AsFd,
+            bufs: impl IntoIterator<Item = &'a mut B>,
+            results: &'a mut Vec<Result<(usize, Option<SocketAddr>, Option<ScopedIpAddr>)>>,
+        ) -> Result<usize>
+        where
+            B: BufMut + 'a,
+        {
+            Self::do_batch_op(
+                |fd, buf| {
+                    // SAFETY: We will only be writing to the chunk.
+                    let chunk =
+                        unsafe { slice_assume_init_mut(buf.chunk_mut().as_uninit_slice_mut()) };
+                    let mut io_slice = IoSliceMut::new(chunk);
+                    let recvmsg = socket::recvmsg(
+                        fd.as_raw_fd(),
+                        std::slice::from_mut(&mut io_slice),
+                        Some(&mut self.cmsg_buffer),
+                        MsgFlags::MSG_TRUNC,
+                    )
+                    .map_err(errno_to_error)?;
+                    let amt = recvmsg.bytes;
+                    let from_addr = recvmsg.address.and_then(sockaddr_to_socket_addr);
+                    let to_addr = recvmsg
+                        .cmsgs()
+                        .expect("cmsgs sizing error")
+                        .find_map(cmsg_to_scoped_ip_addr);
+                    // SAFETY: We know we've written the given number of bytes in the BufMut.
+                    unsafe { buf.advance_mut(std::cmp::min(amt, buf.remaining_mut())) };
+                    Ok((amt, from_addr, to_addr))
                 },
                 fd,
                 bufs,
@@ -570,28 +716,21 @@ mod posix_unbatched {
     }
 }
 
-#[cfg(all(target_os = "linux", feature = "io-uring"))]
+/*#[cfg(all(target_os = "linux", feature = "io-uring"))]
 pub use io_uring::*;
-#[cfg(not(all(target_os = "linux", feature = "io-uring")))]
+#[cfg(not(all(target_os = "linux", feature = "io-uring")))]*/
 pub use posix_unbatched::*;
-
-fn sockaddr_to_socket_addr(sa: SockaddrStorage) -> Option<SocketAddr> {
-    match sa.family() {
-        Some(AddressFamily::Inet) => Some(SocketAddr::V4((*sa.as_sockaddr_in().unwrap()).into())),
-        Some(AddressFamily::Inet6) => Some(SocketAddr::V6((*sa.as_sockaddr_in6().unwrap()).into())),
-        _ => None,
-    }
-}
 
 #[cfg(test)]
 mod tests {
-    use super::BatchIo;
+    use super::*;
+    use bytes::BufMut;
     use std::io::Result;
     use std::net::UdpSocket;
     use std::os::unix::net::UnixDatagram;
 
     #[test]
-    fn write_test() {
+    fn test_write() {
         // FIXME: we need to test EAGAIN behavior... possibly by first filling queue, then draining a few
 
         let (inq, outq) = UnixDatagram::pair().unwrap();
@@ -625,7 +764,7 @@ mod tests {
     }
 
     #[test]
-    fn read_test() {
+    fn test_read() {
         let (inq, outq) = UnixDatagram::pair().unwrap();
         inq.set_nonblocking(true).unwrap();
         outq.set_nonblocking(true).unwrap();
@@ -657,7 +796,7 @@ mod tests {
     }
 
     #[test]
-    fn send_test() {
+    fn test_send() {
         // FIXME: we need to test EAGAIN behavior... possibly by first filling queue, then draining a few
 
         let inq = udp_socket().unwrap();
@@ -698,7 +837,7 @@ mod tests {
     }
 
     #[test]
-    fn recv_test() {
+    fn test_recv() {
         let inq = udp_socket().unwrap();
         let outq = udp_socket().unwrap();
         inq.set_nonblocking(true).unwrap();
@@ -734,6 +873,66 @@ mod tests {
             assert_eq!(bufs[i].as_slice(), msgs[i].as_bytes());
         }
     }
+
+    #[test]
+    fn test_recv_to() {
+        let inq = udp_socket().unwrap();
+        let outq = udp_socket().unwrap();
+        inq.set_nonblocking(true).unwrap();
+        outq.set_nonblocking(true).unwrap();
+        set_recv_packet_info(&outq, true).unwrap();
+        inq.connect(outq.local_addr().unwrap()).unwrap();
+
+        let mut bio = BatchIo::new(1).unwrap();
+
+        let msg = "Hello".as_bytes();
+
+        let _ = inq.send(msg).unwrap();
+
+        let mut buf = Vec::with_capacity(64);
+        let mut results = Vec::new();
+
+        let n = bio.try_recv_buf_from_to_batch(&outq, std::iter::once(&mut buf), &mut results);
+        assert!(n.unwrap() == 1);
+
+        let res = results[0].as_ref().unwrap();
+        assert_eq!(res.0, msg.len());
+        assert_eq!(res.1, Some(inq.local_addr().unwrap()));
+        // NOTE: we don't have any way of testing the scope ID functionality as a unit test
+        assert_eq!(
+            res.2.map(|sa| sa.ip()),
+            Some(outq.local_addr().unwrap().ip())
+        );
+        assert_eq!(buf.as_slice(), msg);
+    }
+
+    #[test]
+    fn test_oversize_recv_to() {
+        let inq = udp_socket().unwrap();
+        let outq = udp_socket().unwrap();
+        inq.set_nonblocking(true).unwrap();
+        outq.set_nonblocking(true).unwrap();
+        inq.connect(outq.local_addr().unwrap()).unwrap();
+
+        let mut bio = BatchIo::new(1).unwrap();
+
+        let msg = [123u8; 128];
+
+        let _ = inq.send(&[123u8; 128]).unwrap();
+
+        let limit = 64;
+        let mut buf = Vec::with_capacity(64).limit(limit);
+        let mut results = Vec::new();
+
+        let n = bio.try_recv_buf_from_to_batch(&outq, std::iter::once(&mut buf), &mut results);
+        assert!(n.unwrap() == 1);
+
+        assert_eq!(results[0].as_ref().unwrap().0, msg.len());
+        assert_eq!(buf.get_ref().len(), limit);
+        assert_eq!(buf.get_ref().as_slice(), &msg[..limit]);
+    }
+
+    // NOTE: we don't have any way of really testing the "send_from" functionality as a unit test
 
     fn udp_socket() -> Result<UdpSocket> {
         UdpSocket::bind(std::net::SocketAddrV6::new(

--- a/adapter/ph/src/batch_io.rs
+++ b/adapter/ph/src/batch_io.rs
@@ -5,53 +5,11 @@
 //! All these operations assume a file descriptor which has been set
 //! non-blocking, and they perform non-blocking I/O operations.
 
-use crate::net_defs::{ScopedIpAddr, ScopedIpv6Addr};
-use nix::sys::socket::{self, AddressFamily, ControlMessageOwned, SockaddrLike, SockaddrStorage};
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use crate::net_defs::ScopedIpv6Addr;
+use libc;
+use nix::sys::socket::{self, AddressFamily, SockaddrLike, SockaddrStorage};
+use std::net::{Ipv4Addr, SocketAddr};
 use std::os::fd::{AsFd, AsRawFd};
-
-macro_rules! scoped_ip_addr_to_cmsg (
-    ($cmsg_id:ident : $addr:expr) => {
-        let in_pktinfo;
-        let in6_pktinfo;
-        let $cmsg_id;
-        match $addr {
-            $crate::net_defs::ScopedIpAddr::V4(addr) => {
-                in_pktinfo = libc::in_pktinfo {
-                        ipi_ifindex: 0,
-                        ipi_spec_dst: libc::in_addr { s_addr: addr.to_bits().to_be() },
-                        ipi_addr: libc::in_addr { s_addr: 0 },
-                    };
-
-                $cmsg_id = nix::sys::socket::ControlMessage::Ipv4PacketInfo(&in_pktinfo);
-            },
-
-            $crate::net_defs::ScopedIpAddr::V6(addr) => {
-                in6_pktinfo = libc::in6_pktinfo {
-                        ipi6_addr: libc::in6_addr { s6_addr: addr.ip().octets() },
-                        ipi6_ifindex: addr.scope_id(),
-                    };
-
-                $cmsg_id = nix::sys::socket::ControlMessage::Ipv6PacketInfo(&in6_pktinfo);
-            },
-        }
-    }
-);
-
-fn cmsg_to_scoped_ip_addr(cmsg: ControlMessageOwned) -> Option<ScopedIpAddr> {
-    match cmsg {
-        ControlMessageOwned::Ipv4PacketInfo(info) => Some(ScopedIpAddr::V4(Ipv4Addr::from(
-            u32::from_be(info.ipi_addr.s_addr),
-        ))),
-
-        ControlMessageOwned::Ipv6PacketInfo(info) => Some(ScopedIpAddr::V6(ScopedIpv6Addr::new(
-            Ipv6Addr::from(info.ipi6_addr.s6_addr),
-            info.ipi6_ifindex,
-        ))),
-
-        _ => None,
-    }
-}
 
 fn sockaddr_to_socket_addr(sa: SockaddrStorage) -> Option<SocketAddr> {
     match sa.family()? {
@@ -63,6 +21,25 @@ fn sockaddr_to_socket_addr(sa: SockaddrStorage) -> Option<SocketAddr> {
 
 fn errno_to_error(errno: nix::errno::Errno) -> std::io::Error {
     std::io::Error::from_raw_os_error(errno as i32)
+}
+
+fn pktinfo_from_ipv4addr(addr: &Ipv4Addr) -> libc::in_pktinfo {
+    libc::in_pktinfo {
+        ipi_ifindex: 0,
+        ipi_spec_dst: libc::in_addr {
+            s_addr: addr.to_bits().to_be(),
+        },
+        ipi_addr: libc::in_addr { s_addr: 0 },
+    }
+}
+
+fn pktinfo_from_scoped_ipv6addr(addr: &ScopedIpv6Addr) -> libc::in6_pktinfo {
+    libc::in6_pktinfo {
+        ipi6_addr: libc::in6_addr {
+            s6_addr: addr.ip().octets(),
+        },
+        ipi6_ifindex: addr.scope_id(),
+    }
 }
 
 /// Enable the reception of packet info on a socket.  Required for
@@ -85,14 +62,16 @@ mod io_uring {
     //! io_uring(7)-based implementation.  Only available for Linux.
 
     use super::sockaddr_to_socket_addr;
+    use crate::net_defs::{ScopedIpAddr, ScopedIpv6Addr};
     use bytes::BufMut;
     use io_uring::{cqueue, opcode, squeue, types, IoUring};
     use libc;
     use nix::sys::socket::{SockaddrLike, SockaddrStorage};
     use std::io::Result;
     use std::mem::MaybeUninit;
-    use std::net::SocketAddr;
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
     use std::os::fd::{AsFd, AsRawFd};
+    use std::ptr::NonNull;
 
     pub const MAX_ENTRIES: usize = 1024;
 
@@ -110,7 +89,6 @@ mod io_uring {
             }
         }
 
-        #[allow(dead_code)]
         fn get(&self, idx: usize) -> &T {
             assert!(idx < self.allocated);
             // SAFETY: we've written to all entries which have been allocated
@@ -147,6 +125,21 @@ mod io_uring {
         fn build_op(&mut self, fd: types::Fd, item: Item, idx: usize) -> (squeue::Entry, State);
         fn process_result(&self, idx: usize, state: State, amt: usize) -> Res;
     }
+
+    // std::cmp::max() is not const
+    const fn const_u32_max(x: u32, y: u32) -> u32 {
+        if x > y {
+            x
+        } else {
+            y
+        }
+    }
+
+    const PKTINFO_CMSG_SPACE_NEEDED: usize = const_u32_max(
+        // SAFETY: these const functions are erroneously marked unsafe
+        unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::in_pktinfo>() as u32) },
+        unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::in6_pktinfo>() as u32) },
+    ) as usize;
 
     struct TryWriteBatchOp {}
 
@@ -239,6 +232,67 @@ mod io_uring {
         }
     }
 
+    struct TrySendToFromBatchOp {
+        iovec_slab: Slab<libc::iovec>,
+        sockaddr_slab: Slab<SockaddrStorage>,
+        cmsg_slab: Slab<[u8; PKTINFO_CMSG_SPACE_NEEDED]>,
+        msghdr_slab: Slab<libc::msghdr>,
+    }
+
+    impl BatchOp<(&[u8], SocketAddr, Option<ScopedIpAddr>), (), usize> for TrySendToFromBatchOp {
+        fn new() -> Self {
+            Self {
+                iovec_slab: Slab::new(),
+                sockaddr_slab: Slab::new(),
+                cmsg_slab: Slab::new(),
+                msghdr_slab: Slab::new(),
+            }
+        }
+
+        fn build_op(
+            &mut self,
+            fd: types::Fd,
+            (buf, dst_addr, src_addr): (&[u8], SocketAddr, Option<ScopedIpAddr>),
+            _idx: usize,
+        ) -> (squeue::Entry, ()) {
+            let iovec_ref = self.iovec_slab.push(slice_as_iovec(buf));
+            let sockaddr_ref = self.sockaddr_slab.push(SockaddrStorage::from(dst_addr));
+
+            let cmsg_ref = self.cmsg_slab.push([0u8; PKTINFO_CMSG_SPACE_NEEDED]);
+
+            let msghdr_ref = self.msghdr_slab.push(libc::msghdr {
+                msg_name: sockaddr_ref as *mut _ as *mut libc::c_void,
+                msg_namelen: sockaddr_ref.len(),
+                msg_iov: iovec_ref,
+                msg_iovlen: 1,
+                msg_control: cmsg_ref as *mut _ as *mut libc::c_void,
+                msg_controllen: std::mem::size_of_val(cmsg_ref),
+                msg_flags: 0,
+            });
+
+            match src_addr {
+                None => {
+                    msghdr_ref.msg_controllen = 0;
+                }
+
+                Some(src_addr) => {
+                    // SAFETY: we have enough space in cmsg_ref for a cmsg header
+                    let cmsg_ptr =
+                        unsafe { NonNull::new(libc::CMSG_FIRSTHDR(msghdr_ref)).unwrap_unchecked() };
+                    // SAFETY: we have enough space in cmsg_ref for our cmsg
+                    let cmsg_len = unsafe { scoped_ip_addr_to_cmsg(cmsg_ptr, src_addr) };
+                    msghdr_ref.msg_controllen = cmsg_len;
+                }
+            }
+
+            (opcode::SendMsg::new(fd, msghdr_ref as *const _).build(), ())
+        }
+
+        fn process_result(&self, _idx: usize, (): (), amt: usize) -> usize {
+            amt
+        }
+    }
+
     struct TryRecvBufFromBatchOp<'a, B> {
         iovec_slab: Slab<libc::iovec>,
         sockaddr_slab: [MaybeUninit<SockaddrStorage>; MAX_ENTRIES],
@@ -283,13 +337,95 @@ mod io_uring {
             &self,
             idx: usize,
             buf: &'a mut B,
-            amt: usize,
+            mut amt: usize,
         ) -> (usize, Option<SocketAddr>) {
+            if (self.msghdr_slab.get(idx).msg_flags & libc::MSG_TRUNC) != 0 {
+                // HACK: Linux bug maybe? despite MSG_TRUNC being set on entry,
+                // we don't get the actual size back here.  But we *do* at least get
+                // a MSG_TRUNC on output, so for now we fake a "too large" size.
+                amt = unsafe { self.msghdr_slab.get(idx).msg_iov.as_ref() }
+                    .unwrap()
+                    .iov_len
+                    + 1;
+            }
+
             // SAFETY: We know we've written the given number of bytes in the BufMut.
-            unsafe { buf.advance_mut(amt) };
+            unsafe { buf.advance_mut(std::cmp::min(amt, buf.remaining_mut())) };
             // SAFETY: We know the sockaddr is now filled.
             let addr = sockaddr_to_socket_addr(unsafe { self.sockaddr_slab[idx].assume_init() });
             (amt, addr)
+        }
+    }
+
+    struct TryRecvBufFromToBatchOp<'a, B> {
+        iovec_slab: Slab<libc::iovec>,
+        sockaddr_slab: [MaybeUninit<SockaddrStorage>; MAX_ENTRIES],
+        cmsg_slab: [[u8; PKTINFO_CMSG_SPACE_NEEDED]; MAX_ENTRIES],
+        msghdr_slab: Slab<libc::msghdr>,
+        phantom: std::marker::PhantomData<&'a B>,
+    }
+
+    impl<'a, B: BufMut>
+        BatchOp<&'a mut B, &'a mut B, (usize, Option<SocketAddr>, Option<ScopedIpAddr>)>
+        for TryRecvBufFromToBatchOp<'a, B>
+    {
+        fn new() -> Self {
+            Self {
+                iovec_slab: Slab::new(),
+                sockaddr_slab: [MaybeUninit::uninit(); MAX_ENTRIES],
+                cmsg_slab: [[0u8; PKTINFO_CMSG_SPACE_NEEDED]; MAX_ENTRIES],
+                msghdr_slab: Slab::new(),
+                phantom: std::marker::PhantomData,
+            }
+        }
+
+        fn build_op(
+            &mut self,
+            fd: types::Fd,
+            buf: &'a mut B,
+            idx: usize,
+        ) -> (squeue::Entry, &'a mut B) {
+            let iovec_ref = self.iovec_slab.push(buf_mut_as_iovec(buf));
+            let sockaddr_ref = &mut self.sockaddr_slab[idx];
+            let cmsg_ref = &mut self.cmsg_slab[idx];
+            let msghdr_ref = self.msghdr_slab.push(libc::msghdr {
+                msg_name: sockaddr_ref.as_mut_ptr() as *mut libc::c_void,
+                msg_namelen: std::mem::size_of_val(sockaddr_ref) as u32,
+                msg_iov: iovec_ref,
+                msg_iovlen: 1,
+                msg_control: cmsg_ref.as_mut_ptr() as *mut libc::c_void,
+                msg_controllen: std::mem::size_of_val(cmsg_ref),
+                msg_flags: libc::MSG_TRUNC,
+            });
+
+            (opcode::RecvMsg::new(fd, msghdr_ref as *mut _).build(), buf)
+        }
+
+        fn process_result(
+            &self,
+            idx: usize,
+            buf: &'a mut B,
+            mut amt: usize,
+        ) -> (usize, Option<SocketAddr>, Option<ScopedIpAddr>) {
+            if (self.msghdr_slab.get(idx).msg_flags & libc::MSG_TRUNC) != 0 {
+                // HACK: Linux bug maybe? despite MSG_TRUNC being set on entry,
+                // we don't get the actual size back here.  But we *do* at least get
+                // a MSG_TRUNC on output, so for now we fake a "too large" size.
+                amt = unsafe { self.msghdr_slab.get(idx).msg_iov.as_ref() }
+                    .unwrap()
+                    .iov_len
+                    + 1;
+            }
+
+            // SAFETY: We know we've written the given number of bytes in the BufMut.
+            unsafe { buf.advance_mut(std::cmp::min(amt, buf.remaining_mut())) };
+            // SAFETY: We know the sockaddr is now filled.
+            let from_addr =
+                sockaddr_to_socket_addr(unsafe { self.sockaddr_slab[idx].assume_init() });
+            // SAFETY: We know the cmsgs are valid.
+            let to_addr = unsafe { cmsg_iter(self.msghdr_slab.get(idx)) }
+                .find_map(|cmsg| unsafe { cmsg_to_scoped_ip_addr(cmsg.as_ptr()) });
+            (amt, from_addr, to_addr)
         }
     }
 
@@ -462,6 +598,7 @@ mod io_uring {
             self.do_batch_op(TryReadBufBatchOp::new(), fd, bufs, results)
         }
 
+        #[allow(dead_code)]
         pub fn try_send_to_batch<'a>(
             &mut self,
             fd: &impl AsFd,
@@ -471,6 +608,16 @@ mod io_uring {
             self.do_batch_op(TrySendToBatchOp::new(), fd, bufs, results)
         }
 
+        pub fn try_send_to_from_batch<'a>(
+            &mut self,
+            fd: &impl AsFd,
+            bufs: impl IntoIterator<Item = (&'a [u8], SocketAddr, Option<ScopedIpAddr>)>,
+            results: &mut Vec<Result<usize>>,
+        ) -> Result<usize> {
+            self.do_batch_op(TrySendToFromBatchOp::new(), fd, bufs, results)
+        }
+
+        #[allow(dead_code)]
         pub fn try_recv_buf_from_batch<'a, B>(
             &mut self,
             fd: &impl AsFd,
@@ -481,6 +628,18 @@ mod io_uring {
             B: BufMut + 'a,
         {
             self.do_batch_op(TryRecvBufFromBatchOp::new(), fd, bufs, results)
+        }
+
+        pub fn try_recv_buf_from_to_batch<'a, B>(
+            &mut self,
+            fd: &impl AsFd,
+            bufs: impl IntoIterator<Item = &'a mut B>,
+            results: &mut Vec<Result<(usize, Option<SocketAddr>, Option<ScopedIpAddr>)>>,
+        ) -> Result<usize>
+        where
+            B: BufMut + 'a,
+        {
+            self.do_batch_op(TryRecvBufFromToBatchOp::new(), fd, bufs, results)
         }
     }
 
@@ -498,21 +657,115 @@ mod io_uring {
             iov_len: chunk.len(),
         }
     }
+
+    /// SAFETY: `msg` be initialized, and its cmsgs must outlive the returned iterator
+    unsafe fn cmsg_iter(msg: &libc::msghdr) -> CmsgIterator<'_> {
+        CmsgIterator(msg, std::ptr::null())
+    }
+
+    struct CmsgIterator<'a>(&'a libc::msghdr, *const libc::cmsghdr);
+
+    impl Iterator for CmsgIterator<'_> {
+        type Item = NonNull<libc::cmsghdr>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            let next;
+            if self.1.is_null() {
+                // SAFETY: we were constructed with a valid `msghdr`
+                next = unsafe { libc::CMSG_FIRSTHDR(self.0) };
+            } else {
+                // SAFETY: we were constructed with a valid `msghdr`, and the `cmsghdr` is nonnull and came from a previous call
+                next = unsafe { libc::CMSG_NXTHDR(self.0, self.1) };
+            }
+
+            self.1 = next;
+
+            NonNull::new(next)
+        }
+    }
+
+    /// SAFETY: `cmsg` has enough space for an `in_pktinfo` or `in6_pktinfo` message
+    unsafe fn scoped_ip_addr_to_cmsg(cmsg: NonNull<libc::cmsghdr>, addr: ScopedIpAddr) -> usize {
+        let in_pktinfo;
+        let in6_pktinfo;
+        let pktinfo_ptr;
+        let pktinfo_len;
+
+        match &addr {
+            ScopedIpAddr::V4(addr) => {
+                in_pktinfo = super::pktinfo_from_ipv4addr(addr);
+                pktinfo_ptr = &in_pktinfo as *const _ as *const u8;
+                pktinfo_len = std::mem::size_of_val(&in_pktinfo);
+            }
+
+            ScopedIpAddr::V6(addr) => {
+                in6_pktinfo = super::pktinfo_from_scoped_ipv6addr(addr);
+                pktinfo_ptr = &in6_pktinfo as *const _ as *const u8;
+                pktinfo_len = std::mem::size_of_val(&in6_pktinfo);
+            }
+        }
+
+        // SAFETY: we were called with a valid `cmsg` with enough space
+        unsafe {
+            cmsg.write(libc::cmsghdr {
+                cmsg_len: libc::CMSG_LEN(pktinfo_len as u32) as usize,
+                cmsg_level: libc::IPPROTO_IP,
+                cmsg_type: libc::IP_PKTINFO,
+            });
+            libc::CMSG_DATA(cmsg.as_ptr()).copy_from(pktinfo_ptr, pktinfo_len); // note unaligned (*u8) copy!
+            return libc::CMSG_SPACE(pktinfo_len as u32) as usize;
+        }
+    }
+
+    /// SAFETY: `cmsg` must point to a valid `cmsghdr`
+    unsafe fn cmsg_to_scoped_ip_addr(cmsg: *const libc::cmsghdr) -> Option<ScopedIpAddr> {
+        // SAFETY: `cmsg` points to a valid cmsg
+        let cmsg_ref = unsafe { cmsg.as_ref()? };
+        match (cmsg_ref.cmsg_level, cmsg_ref.cmsg_type) {
+            (libc::IPPROTO_IP, libc::IP_PKTINFO) => {
+                // SAFETY: we know the pointed-to cmsg is valid and of the correct type
+                let info = unsafe {
+                    (libc::CMSG_DATA(cmsg) as *const libc::in_pktinfo)
+                        .as_ref()
+                        .unwrap_unchecked()
+                };
+                Some(ScopedIpAddr::V4(Ipv4Addr::from(u32::from_be(
+                    info.ipi_addr.s_addr,
+                ))))
+            }
+
+            (libc::IPPROTO_IPV6, libc::IPV6_PKTINFO) => {
+                // SAFETY: we know the pointed-to cmsg is valid and of the correct type
+                let info = unsafe {
+                    (libc::CMSG_DATA(cmsg) as *const libc::in6_pktinfo)
+                        .as_ref()
+                        .unwrap_unchecked()
+                };
+                Some(ScopedIpAddr::V6(ScopedIpv6Addr::new(
+                    Ipv6Addr::from(info.ipi6_addr.s6_addr),
+                    info.ipi6_ifindex,
+                )))
+            }
+
+            _ => None,
+        }
+    }
 }
 
-//#[cfg(not(all(target_os = "linux", feature = "io-uring")))]
+#[cfg(not(all(target_os = "linux", feature = "io-uring")))]
 mod posix_unbatched {
     //! Unbatched implementation using POSIX primitives.
 
     use super::*;
-    use crate::net_defs::ScopedIpAddr;
+    use crate::net_defs::{ScopedIpAddr, ScopedIpv6Addr};
     use bytes::BufMut;
-    use libc;
     use nix::cmsg_space;
-    use nix::sys::socket::{self, sockaddr_storage, MsgFlags, SockaddrStorage};
+    use nix::sys::socket::{
+        self, sockaddr_storage, ControlMessageOwned, MsgFlags, SockaddrStorage,
+    };
     use nix::unistd;
     use std::io::{IoSlice, IoSliceMut, Result};
-    use std::net::SocketAddr;
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
     use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
     use zpr_ext::std::mem::slice_assume_init_mut;
 
@@ -522,6 +775,25 @@ mod posix_unbatched {
     pub struct BatchIo {
         cmsg_buffer: Vec<u8>,
     }
+
+    macro_rules! scoped_ip_addr_to_cmsg (
+        ($cmsg_id:ident : $addr:expr) => {
+            let in_pktinfo;
+            let in6_pktinfo;
+            let $cmsg_id;
+            match $addr {
+                $crate::net_defs::ScopedIpAddr::V4(addr) => {
+                    in_pktinfo = super::pktinfo_from_ipv4addr(addr);
+                    $cmsg_id = nix::sys::socket::ControlMessage::Ipv4PacketInfo(&in_pktinfo);
+                },
+
+                $crate::net_defs::ScopedIpAddr::V6(addr) => {
+                    in6_pktinfo = super::pktinfo_from_scoped_ipv6addr(addr);
+                    $cmsg_id = nix::sys::socket::ControlMessage::Ipv6PacketInfo(&in6_pktinfo);
+                },
+            }
+        }
+    );
 
     impl BatchIo {
         pub fn new(_entries: usize) -> Result<Self> {
@@ -593,6 +865,7 @@ mod posix_unbatched {
             )
         }
 
+        #[allow(dead_code)]
         pub fn try_send_to_batch<'a>(
             &'a mut self,
             fd: &'a impl AsFd,
@@ -649,6 +922,7 @@ mod posix_unbatched {
             )
         }
 
+        #[allow(dead_code)]
         pub fn try_recv_buf_from_batch<'a, B>(
             &'a mut self,
             fd: &'a impl AsFd,
@@ -723,11 +997,25 @@ mod posix_unbatched {
             )
         }
     }
+
+    fn cmsg_to_scoped_ip_addr(cmsg: ControlMessageOwned) -> Option<ScopedIpAddr> {
+        match cmsg {
+            ControlMessageOwned::Ipv4PacketInfo(info) => Some(ScopedIpAddr::V4(Ipv4Addr::from(
+                u32::from_be(info.ipi_addr.s_addr),
+            ))),
+
+            ControlMessageOwned::Ipv6PacketInfo(info) => Some(ScopedIpAddr::V6(
+                ScopedIpv6Addr::new(Ipv6Addr::from(info.ipi6_addr.s6_addr), info.ipi6_ifindex),
+            )),
+
+            _ => None,
+        }
+    }
 }
 
-/*#[cfg(all(target_os = "linux", feature = "io-uring"))]
+#[cfg(all(target_os = "linux", feature = "io-uring"))]
 pub use io_uring::*;
-#[cfg(not(all(target_os = "linux", feature = "io-uring")))]*/
+#[cfg(not(all(target_os = "linux", feature = "io-uring")))]
 pub use posix_unbatched::*;
 
 #[cfg(test)]
@@ -904,7 +1192,7 @@ mod tests {
         let n = bio.try_recv_buf_from_batch(&outq, std::iter::once(&mut buf), &mut results);
         assert!(n.unwrap() == 1);
 
-        assert_eq!(results[0].as_ref().unwrap().0, msg.len());
+        assert!(results[0].as_ref().unwrap().0 > limit); // HACK: see discussion on potential Linux bug in io_uring above
         assert_eq!(buf.get_ref().len(), limit);
         assert_eq!(buf.get_ref().as_slice(), &msg[..limit]);
     }
@@ -962,7 +1250,8 @@ mod tests {
         let n = bio.try_recv_buf_from_to_batch(&outq, std::iter::once(&mut buf), &mut results);
         assert!(n.unwrap() == 1);
 
-        assert_eq!(results[0].as_ref().unwrap().0, msg.len());
+        //assert_eq!(results[0].as_ref().unwrap().0, msg.len());
+        assert!(results[0].as_ref().unwrap().0 > limit); // HACK: see discussion on potential Linux bug in io_uring above
         assert_eq!(buf.get_ref().len(), limit);
         assert_eq!(buf.get_ref().as_slice(), &msg[..limit]);
     }

--- a/adapter/ph/src/batch_io.rs
+++ b/adapter/ph/src/batch_io.rs
@@ -663,12 +663,21 @@ mod posix_unbatched {
                     // SAFETY: We will only be writing to the chunk.
                     let chunk =
                         unsafe { slice_assume_init_mut(buf.chunk_mut().as_uninit_slice_mut()) };
-                    // FIXME: use MSG_TRUNC
-                    let (amt, addr) =
-                        socket::recvfrom(fd.as_raw_fd(), chunk).map_err(errno_to_error)?;
+                    let mut io_slice = IoSliceMut::new(chunk);
+                    // NOTE: nix's `recvfrom` weirdly is missing the `flags` argument,
+                    // so we're forced to use `recvmsg` here
+                    let recvmsg = socket::recvmsg(
+                        fd.as_raw_fd(),
+                        std::slice::from_mut(&mut io_slice),
+                        None,
+                        MsgFlags::MSG_TRUNC,
+                    )
+                    .map_err(errno_to_error)?;
+                    let amt = recvmsg.bytes;
+                    let from_addr = recvmsg.address.and_then(sockaddr_to_socket_addr);
                     // SAFETY: We know we've written the given number of bytes in the BufMut.
-                    unsafe { buf.advance_mut(amt) };
-                    Ok((amt, addr.and_then(sockaddr_to_socket_addr)))
+                    unsafe { buf.advance_mut(std::cmp::min(amt, buf.remaining_mut())) };
+                    Ok((amt, from_addr))
                 },
                 fd,
                 bufs,
@@ -872,6 +881,32 @@ mod tests {
             assert_eq!(res.1, Some(sender));
             assert_eq!(bufs[i].as_slice(), msgs[i].as_bytes());
         }
+    }
+
+    #[test]
+    fn test_oversize_recv() {
+        let inq = udp_socket().unwrap();
+        let outq = udp_socket().unwrap();
+        inq.set_nonblocking(true).unwrap();
+        outq.set_nonblocking(true).unwrap();
+        inq.connect(outq.local_addr().unwrap()).unwrap();
+
+        let mut bio = BatchIo::new(1).unwrap();
+
+        let msg = [123u8; 128];
+
+        let _ = inq.send(&[123u8; 128]).unwrap();
+
+        let limit = 64;
+        let mut buf = Vec::with_capacity(64).limit(limit);
+        let mut results = Vec::new();
+
+        let n = bio.try_recv_buf_from_batch(&outq, std::iter::once(&mut buf), &mut results);
+        assert!(n.unwrap() == 1);
+
+        assert_eq!(results[0].as_ref().unwrap().0, msg.len());
+        assert_eq!(buf.get_ref().len(), limit);
+        assert_eq!(buf.get_ref().as_slice(), &msg[..limit]);
     }
 
     #[test]

--- a/adapter/ph/src/batch_io.rs
+++ b/adapter/ph/src/batch_io.rs
@@ -1021,7 +1021,6 @@ pub use posix_unbatched::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::BufMut;
     use std::io::Result;
     use std::net::UdpSocket;
     use std::os::unix::net::UnixDatagram;
@@ -1172,32 +1171,6 @@ mod tests {
     }
 
     #[test]
-    fn test_oversize_recv() {
-        let inq = udp_socket().unwrap();
-        let outq = udp_socket().unwrap();
-        inq.set_nonblocking(true).unwrap();
-        outq.set_nonblocking(true).unwrap();
-        inq.connect(outq.local_addr().unwrap()).unwrap();
-
-        let mut bio = BatchIo::new(1).unwrap();
-
-        let msg = [123u8; 128];
-
-        let _ = inq.send(&[123u8; 128]).unwrap();
-
-        let limit = 64;
-        let mut buf = Vec::with_capacity(64).limit(limit);
-        let mut results = Vec::new();
-
-        let n = bio.try_recv_buf_from_batch(&outq, std::iter::once(&mut buf), &mut results);
-        assert!(n.unwrap() == 1);
-
-        assert!(results[0].as_ref().unwrap().0 > limit); // HACK: see discussion on potential Linux bug in io_uring above
-        assert_eq!(buf.get_ref().len(), limit);
-        assert_eq!(buf.get_ref().as_slice(), &msg[..limit]);
-    }
-
-    #[test]
     fn test_recv_to() {
         let inq = udp_socket().unwrap();
         let outq = udp_socket().unwrap();
@@ -1227,33 +1200,6 @@ mod tests {
             Some(outq.local_addr().unwrap().ip())
         );
         assert_eq!(buf.as_slice(), msg);
-    }
-
-    #[test]
-    fn test_oversize_recv_to() {
-        let inq = udp_socket().unwrap();
-        let outq = udp_socket().unwrap();
-        inq.set_nonblocking(true).unwrap();
-        outq.set_nonblocking(true).unwrap();
-        inq.connect(outq.local_addr().unwrap()).unwrap();
-
-        let mut bio = BatchIo::new(1).unwrap();
-
-        let msg = [123u8; 128];
-
-        let _ = inq.send(&[123u8; 128]).unwrap();
-
-        let limit = 64;
-        let mut buf = Vec::with_capacity(64).limit(limit);
-        let mut results = Vec::new();
-
-        let n = bio.try_recv_buf_from_to_batch(&outq, std::iter::once(&mut buf), &mut results);
-        assert!(n.unwrap() == 1);
-
-        //assert_eq!(results[0].as_ref().unwrap().0, msg.len());
-        assert!(results[0].as_ref().unwrap().0 > limit); // HACK: see discussion on potential Linux bug in io_uring above
-        assert_eq!(buf.get_ref().len(), limit);
-        assert_eq!(buf.get_ref().as_slice(), &msg[..limit]);
     }
 
     // NOTE: we don't have any way of really testing the "send_from" functionality as a unit test

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -54,6 +54,12 @@ pub struct FastpathWorkerConfig {
     pub batch_size: usize,
 }
 
+pub struct QueuedEgressPacket {
+    pub pkt: Packet,
+    pub dst: std::net::SocketAddr,
+    pub src: net_defs::ScopedIpAddr,
+}
+
 pub struct FastpathWorker {
     pub config: FastpathWorkerConfig,
     pub worker_index: usize,
@@ -65,7 +71,7 @@ pub struct FastpathWorker {
     pub mgmt_dispatch: MgmtDispatch,
 
     pub actor_input_q: Vec<Packet>,
-    pub substrate_egress_q: Vec<(Packet, std::net::SocketAddr)>,
+    pub substrate_egress_q: Vec<QueuedEgressPacket>,
 }
 
 impl FastpathWorker {
@@ -114,9 +120,18 @@ impl FastpathWorker {
     }
 
     /// Process packet ingressing from the specified address.
-    pub fn substrate_ingress(&mut self, peer_sa: &zpr::SubstrateAddr, mut pkt: Packet) {
-        pkt.metadata_mut().ingress_link_id =
-            self.asm.peer_table.lookup_peer(peer_sa).unwrap_or_zero();
+    pub fn substrate_ingress(
+        &mut self,
+        peer_sa: &zpr::SubstrateAddr,
+        interface_addr: &net_defs::ScopedIpAddr,
+        mut pkt: Packet,
+    ) {
+        // Lookup peer by its substrate address.
+        pkt.metadata_mut().ingress_link_id = self
+            .asm
+            .peer_table
+            .lookup_peer(peer_sa, interface_addr)
+            .unwrap_or_zero();
 
         // Read, but do not remove the ZPI header
         let Ok((zpi_hdr, _)) = zdp::ZdpZpiHeader::read_from_prefix(&pkt.body()) else {
@@ -142,10 +157,11 @@ impl FastpathWorker {
         // If we weren't able to match this packet to an existing link,
         // send it off to be processed as a potential new link.
         if pkt.metadata().ingress_link_id == zpr::LINK_ID_UNKNOWN {
-            match self
-                .mgmt_dispatch
-                .try_dispatch_mgmt_packet_with_addr(peer_sa, pkt)
-            {
+            match self.mgmt_dispatch.try_dispatch_mgmt_packet_with_addr(
+                peer_sa,
+                interface_addr,
+                pkt,
+            ) {
                 Ok(()) => self.asm.counters[CounterType::DispatchedToMgmt].increment(),
                 Err(TryEnqueueError::Full(pkt)) => {
                     self.drop_and_count(pkt, CounterType::QueueBackpressure)
@@ -417,8 +433,8 @@ impl FastpathWorker {
     pub fn substrate_egress(&mut self, mut pkt: Packet) {
         let link_id = pkt.metadata().egress_link_id;
 
-        let dest_sa = match substrate_egress_common(&self.asm, link_id, &mut pkt) {
-            Ok(Some(dest_sa)) => dest_sa,
+        let (dest_sa, src_intf) = match substrate_egress_common(&self.asm, link_id, &mut pkt) {
+            Ok(Some((dest_sa, src_intf))) => (dest_sa, src_intf),
             Ok(None) => {
                 self.drop_and_count(pkt, CounterType::PeerRemoved);
                 return;
@@ -431,7 +447,11 @@ impl FastpathWorker {
         };
 
         // queue packet for send via substrate
-        self.substrate_egress_q.push((pkt, dest_sa));
+        self.substrate_egress_q.push(QueuedEgressPacket {
+            pkt,
+            dst: dest_sa,
+            src: src_intf,
+        });
     }
 
     pub fn substrate_egress_packets_queued(&self) -> bool {
@@ -724,7 +744,7 @@ fn substrate_egress_common(
     asm: &Assembly,
     link_id: zpr::LinkId,
     pkt: &mut Packet,
-) -> Result<Option<zpr::SubstrateAddr>, km::EncryptionError> {
+) -> Result<Option<(zpr::SubstrateAddr, net_defs::ScopedIpAddr)>, km::EncryptionError> {
     // TODO: should we add ZDP header here also??
 
     let zdp_hdr = match zdp::ZdpBaseHeader::ref_from_prefix(&pkt.body()) {
@@ -797,7 +817,7 @@ fn substrate_egress_common(
     // Set substrate flowinfo from our flowhash.
     set_flowinfo(&mut dest_sa, pkt.flowhash());
 
-    Ok(Some(dest_sa))
+    Ok(Some((dest_sa, peer_state.interface_addr)))
 }
 
 /// If substrate supports flow info, set it to the specified value.

--- a/adapter/ph/src/fastpath_io.rs
+++ b/adapter/ph/src/fastpath_io.rs
@@ -25,7 +25,7 @@ pub struct FastpathIo {
     /// temporary read result storage during I/O batch operations
     io_results: Vec<Result<usize>>,
     /// temporary recv result storage during I/O batch operations
-    recv_results: Vec<Result<(usize, Option<SocketAddr>)>>,
+    recv_results: Vec<Result<(usize, Option<SocketAddr>, Option<net_defs::ScopedIpAddr>)>>,
 }
 
 impl FastpathIo {
@@ -86,7 +86,7 @@ impl FastpathIo {
         self.io_results.clear();
         let n = self
             .batch_io
-            .try_recv_buf_from_batch(
+            .try_recv_buf_from_to_batch(
                 &self.substrate_socket,
                 self.packets.iter_mut(),
                 &mut self.recv_results,
@@ -100,15 +100,16 @@ impl FastpathIo {
 
         // process packets
         for (pkt, result) in self.packets.drain(..).zip(self.recv_results.drain(..)) {
-            let mut sender = match result {
-                Ok((size, _sender)) if size > pkt.remaining() => {
+            let (mut sender, dest) = match result {
+                Ok((size, _sender, _dest)) if size > pkt.remaining() => {
                     worker.drop_and_count(pkt, CounterType::DroppedOversize);
                     continue;
                 }
 
-                Ok((_size, sender)) => {
-                    sender.expect("received from non-IP address, should not happen!")
-                }
+                Ok((_size, sender, dest)) => (
+                    sender.expect("received from non-IP address, should not happen!"),
+                    dest.expect("unknown recipient, should not happen!"),
+                ),
 
                 Err(err) => {
                     match err.kind() {
@@ -133,7 +134,7 @@ impl FastpathIo {
             clear_flowinfo(&mut sender);
 
             worker.asm.counters[CounterType::InPacksRec].increment();
-            worker.substrate_ingress(&sender, pkt);
+            worker.substrate_ingress(&sender, &dest, pkt);
         }
     }
 
@@ -286,12 +287,12 @@ impl FastpathIo {
         self.io_results.clear();
         let n = self
             .batch_io
-            .try_send_to_batch(
+            .try_send_to_from_batch(
                 &self.substrate_socket,
                 worker
                     .substrate_egress_q
                     .iter()
-                    .map(|(pkt, dest)| (pkt.body(), *dest)),
+                    .map(|pkt| (pkt.pkt.body(), pkt.dst, Some(pkt.src))),
                 &mut self.io_results,
             )
             .expect("unrecoverable I/O error");
@@ -315,7 +316,7 @@ impl FastpathIo {
 
             // Packet was not sent.
 
-            if worker.substrate_egress_q[i].0.metadata().flags & packet::flags::PRIORITY != 0 {
+            if worker.substrate_egress_q[i].pkt.metadata().flags & packet::flags::PRIORITY != 0 {
                 // This was a priority packet.  Move it to the front of the queue.
                 worker.substrate_egress_q.swap(i, retained);
                 retained += 1;
@@ -337,7 +338,7 @@ impl FastpathIo {
             worker
                 .substrate_egress_q
                 .drain(retained..)
-                .map(|(pkt, _)| pkt.destroy()),
+                .map(|pkt| pkt.pkt.destroy()),
         );
     }
 }

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -5,6 +5,7 @@ use crate::km_noise::{KmNoise, NoiseKeypair};
 use crate::link_state::LinkEvent;
 use crate::logging::targets::{KEY_MGMT, LINK_STATE};
 use crate::mgmt::requests;
+use crate::net_defs;
 use crate::peer_table::KmHandle;
 use bytes::Bytes;
 use std::collections::HashMap;
@@ -398,10 +399,13 @@ mod test {
                     let fake_sa =
                         zpr::SubstrateAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9000);
 
+                    let fake_intf_addr = net_defs::ScopedIpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
+
                     let peer_state = peer_table::PeerState::new(
                         entry.key(),
                         LinkType::NodeToAdapter,
                         fake_sa,
+                        fake_intf_addr,
                         |q| mgmt_processor_worker::launch(worker_config, asm.clone(), q),
                     );
 

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -5,7 +5,6 @@ use crate::km_noise::{KmNoise, NoiseKeypair};
 use crate::link_state::LinkEvent;
 use crate::logging::targets::{KEY_MGMT, LINK_STATE};
 use crate::mgmt::requests;
-use crate::net_defs;
 use crate::peer_table::KmHandle;
 use bytes::Bytes;
 use std::collections::HashMap;
@@ -342,6 +341,7 @@ mod test {
     use crate::km_testdata::test::*;
     use crate::link_state::LinkType;
     use crate::mgmt_processor_worker;
+    use crate::net_defs;
     use crate::peer_table;
     use base64::prelude::*;
     use std::net::{IpAddr, Ipv4Addr};

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -252,6 +252,13 @@ fn main() -> ExitCode {
     // open substrate sockets and mgmt substrate injection socket
     //
 
+    if ph_mode == PhMode::Node {
+        if config.self_addr.port() == 0 {
+            // TODO: Should we force setting a port when configuring a node?
+            warn!(target: STARTUP, "self_addr port is 0 which means dock listening port will be chosen by OS");
+        }
+    }
+
     let mut substrate_sockets: Vec<std::net::UdpSocket> = Vec::new();
 
     for _i in 0..topology_config.fastpath_concurrency {
@@ -275,6 +282,14 @@ fn main() -> ExitCode {
             info!(target: STARTUP, "assigned substrate UDP port {port}");
         }
         substrate_sockets.push(socket.into());
+    }
+
+    if ph_mode == PhMode::Node {
+        info!(
+            target: STARTUP,
+            "dock listening on {}",
+            substrate_sockets[0].local_addr().unwrap()
+        );
     }
 
     let (mgmt_substrate_inq, mgmt_substrate_outq) =
@@ -408,18 +423,6 @@ fn main() -> ExitCode {
     //
     // start data path workers
     //
-
-    if ph_mode == PhMode::Node {
-        if config.self_addr.port() == 0 {
-            // TODO: Should we force setting a port when configuring a node?
-            warn!(target: STARTUP, "self_addr port is 0 which means dock listening port will be randomly assigned");
-        }
-        info!(
-            target: STARTUP,
-            "dock listening on {}",
-            substrate_sockets[0].local_addr().unwrap()
-        );
-    }
 
     let mut fastpath_threads = Vec::new();
 

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -78,6 +78,7 @@ use flow_control::FlowControl;
 use km_multiplexor::KmState;
 use km_noise::NoiseKeypair;
 use logging::targets::STARTUP;
+use net_defs::SocketAddrExt;
 use pki::load_noise_public_key;
 use queues::*;
 use sys::ZprTun;
@@ -269,6 +270,7 @@ fn main() -> ExitCode {
         )
         .unwrap();
         socket.set_nonblocking(true).unwrap();
+        batch_io::set_recv_packet_info(&socket, true).unwrap();
         socket.set_reuse_port(true).unwrap();
         socket
             .bind(&socket2::SockAddr::from(config.self_addr))
@@ -397,6 +399,7 @@ fn main() -> ExitCode {
         let dsid = asm
             .start_tether(
                 config.node_addr.as_ref().unwrap(),
+                &config.self_addr.scoped_ip(),
                 link_state::LinkType::AdapterToNode,
             )
             .unwrap();

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -6,6 +6,7 @@ use crate::counters::CounterType;
 use crate::km_multiplexor;
 use crate::link_state::LinkType;
 use crate::logging::targets::{KEY_MGMT, ZDP};
+use crate::net_defs;
 use crate::packet::Packet;
 use crate::queues;
 use crate::zdp;
@@ -23,6 +24,7 @@ use zpr_ext::zerocopy::FromBytesExt;
 pub fn dispatch_mgmt_packet_with_addr(
     asm: &Arc<Assembly>,
     peer_sa: zpr::SubstrateAddr,
+    interface_addr: net_defs::ScopedIpAddr,
     pkt: &mut Packet,
 ) {
     match zdp::ZdpBaseHeader::ref_from_prefix(pkt.body()) {
@@ -31,7 +33,9 @@ pub fn dispatch_mgmt_packet_with_addr(
 
             // TODO: once we have multi-node, how do we know whether this is a link or a
             // tether?
-            let Some(ingress_link_id) = asm.start_tether(&peer_sa, LinkType::NodeToAdapter).ok()
+            let Some(ingress_link_id) = asm
+                .start_tether(&peer_sa, &interface_addr, LinkType::NodeToAdapter)
+                .ok()
             else {
                 core::count_event(asm, pkt, CounterType::UnknownPeer);
                 return;

--- a/adapter/ph/src/mgmt_dispatch_worker.rs
+++ b/adapter/ph/src/mgmt_dispatch_worker.rs
@@ -16,8 +16,12 @@ pub async fn launch(
             MgmtDispatchMessage::WithLink(pkt) => {
                 dispatch::dispatch_mgmt_packet_with_link(&asm, pkt);
             }
-            MgmtDispatchMessage::WithAddr(peer_sa, pkt) => {
-                dispatch::dispatch_mgmt_packet_with_addr(&asm, *peer_sa, pkt);
+            MgmtDispatchMessage::WithAddr {
+                peer_sa,
+                interface_addr,
+                packet,
+            } => {
+                dispatch::dispatch_mgmt_packet_with_addr(&asm, *peer_sa, *interface_addr, packet);
             }
         }
     }

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -183,6 +183,7 @@ pub enum ScopedIpAddr {
 }
 
 impl ScopedIpAddr {
+    #[allow(dead_code)]
     pub fn ip(&self) -> IpAddr {
         match self {
             ScopedIpAddr::V4(v4) => IpAddr::V4(*v4),
@@ -246,10 +247,12 @@ impl ScopedIpv6Addr {
         self.scope_id
     }
 
+    #[allow(dead_code)]
     pub fn set_ip(&mut self, new_ip: Ipv6Addr) {
         self.ip = new_ip
     }
 
+    #[allow(dead_code)]
     pub fn set_scope_id(&mut self, new_scope_id: u32) {
         self.scope_id = new_scope_id
     }

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -12,6 +12,8 @@ pub mod ethertype {
 
 pub const IPV6_ADDRESS_SIZE: usize = 16;
 
+/// "Flat" (non-enum) representation of an IPv4 or IPv6 address, used
+/// internally to represent ZPR addresses.
 #[derive(
     FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Hash, Debug, PartialEq, Eq,
 )]
@@ -167,6 +169,111 @@ impl From<&IpAddress> for IpAddr {
 impl std::fmt::Display for IpAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         Ipv6Addr::from(*self).fmt(f)
+    }
+}
+
+/// Like `std::net::IpAddr`, but includes IPv6 scope ID field, needed to
+/// distinguish link-local addresses from one another.  Used to represent
+/// the portion of a substrate address (i.e. `std::net::SocketAddr`) needed
+/// for routing.
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum ScopedIpAddr {
+    V4(Ipv4Addr),
+    V6(ScopedIpv6Addr),
+}
+
+impl std::fmt::Display for ScopedIpAddr {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScopedIpAddr::V4(v4) => v4.fmt(fmt),
+            ScopedIpAddr::V6(v6) => v6.fmt(fmt),
+        }
+    }
+}
+
+impl From<IpAddr> for ScopedIpAddr {
+    fn from(addr: IpAddr) -> Self {
+        match addr {
+            IpAddr::V4(v4) => ScopedIpAddr::V4(v4),
+            IpAddr::V6(v6) => ScopedIpAddr::V6(v6.into()),
+        }
+    }
+}
+
+impl From<Ipv4Addr> for ScopedIpAddr {
+    fn from(addr: Ipv4Addr) -> Self {
+        ScopedIpAddr::V4(addr)
+    }
+}
+
+impl From<ScopedIpv6Addr> for ScopedIpAddr {
+    fn from(addr: ScopedIpv6Addr) -> Self {
+        ScopedIpAddr::V6(addr)
+    }
+}
+
+impl From<Ipv6Addr> for ScopedIpAddr {
+    fn from(addr: Ipv6Addr) -> Self {
+        ScopedIpAddr::V6(addr.into())
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ScopedIpv6Addr {
+    ip: Ipv6Addr,
+    scope_id: u32,
+}
+
+impl ScopedIpv6Addr {
+    pub fn new(ip: Ipv6Addr, scope_id: u32) -> Self {
+        Self { ip, scope_id }
+    }
+
+    pub fn ip(&self) -> &Ipv6Addr {
+        &self.ip
+    }
+
+    pub fn scope_id(&self) -> u32 {
+        self.scope_id
+    }
+
+    pub fn set_ip(&mut self, new_ip: Ipv6Addr) {
+        self.ip = new_ip
+    }
+
+    pub fn set_scope_id(&mut self, new_scope_id: u32) {
+        self.scope_id = new_scope_id
+    }
+}
+
+impl std::fmt::Display for ScopedIpv6Addr {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.ip.fmt(fmt)?;
+        if self.scope_id != 0 {
+            write!(fmt, "%{}", self.scope_id)?;
+        }
+        Ok(())
+    }
+}
+
+impl From<Ipv6Addr> for ScopedIpv6Addr {
+    fn from(ip: Ipv6Addr) -> Self {
+        Self { ip, scope_id: 0 }
+    }
+}
+
+pub trait SocketAddrExt {
+    fn scoped_ip(&self) -> ScopedIpAddr;
+}
+
+impl SocketAddrExt for std::net::SocketAddr {
+    fn scoped_ip(&self) -> ScopedIpAddr {
+        match self {
+            std::net::SocketAddr::V4(v4) => ScopedIpAddr::V4(*v4.ip()),
+            std::net::SocketAddr::V6(v6) => {
+                ScopedIpAddr::V6(ScopedIpv6Addr::new(*v6.ip(), v6.scope_id()))
+            }
+        }
     }
 }
 

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -182,6 +182,15 @@ pub enum ScopedIpAddr {
     V6(ScopedIpv6Addr),
 }
 
+impl ScopedIpAddr {
+    pub fn ip(&self) -> IpAddr {
+        match self {
+            ScopedIpAddr::V4(v4) => IpAddr::V4(*v4),
+            ScopedIpAddr::V6(v6) => IpAddr::V6(v6.ip),
+        }
+    }
+}
+
 impl std::fmt::Display for ScopedIpAddr {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -3,6 +3,7 @@ use crate::auth::AUTH_KEY_SIZE_BYTES;
 use crate::forwarding_tables::PeerForwardingTable;
 use crate::km::{KeyManager, KmTransportSA};
 use crate::link_state::{LinkStateWrapper, LinkType};
+use crate::net_defs::ScopedIpAddr;
 use crate::queues;
 use crate::rcu::{RcuBox, RcuCslabEntryGuard, RcuOptionGuard};
 use crate::special_peers::*;
@@ -29,6 +30,7 @@ const PEER_TABLE_SIZE: usize = 1024;
 
 pub struct PeerState {
     pub substrate_addr: SubstrateAddr,
+    pub interface_addr: ScopedIpAddr,
     pub link_state_machine: LinkStateWrapper,
     pub sync_req_state: sync_req::SyncReqState,
     pub pft: PeerForwardingTable,
@@ -70,6 +72,7 @@ impl PeerState {
         link_id: NonZero<LinkId>,
         link_type: LinkType,
         substrate_addr: SubstrateAddr,
+        interface_addr: ScopedIpAddr,
         launch_mgmt_processor_worker: impl FnOnce(
             mpsc::Receiver<queues::MgmtProcessorMessage>,
         ) -> Worker,
@@ -88,6 +91,7 @@ impl PeerState {
         }
         Self {
             substrate_addr,
+            interface_addr,
             link_state_machine: LinkStateWrapper::new(link_id.get(), link_type),
             pft: PeerForwardingTable::new(),
             sync_req_state: sync_req::SyncReqState::new(),
@@ -112,7 +116,7 @@ const _: () = assert!(std::mem::size_of::<AtomicLinkId>() == std::mem::size_of::
 pub struct PeerTable {
     peer_slab: Mutex<RcuCslab<PeerState>>,
     peer_slab_reader: RcuBox<RcuCslabReader<PeerState>>,
-    sa_to_link: DashMap<SubstrateAddr, NonZero<LinkId>>,
+    sa_to_link: DashMap<(SubstrateAddr, ScopedIpAddr), NonZero<LinkId>>,
     // TODO: it would be nice if this lived in the same RCU as peer_slab_reader
     special_peers: RcuBox<EnumMap<SpecialPeerName, LinkId>>,
 }
@@ -166,7 +170,8 @@ impl PeerTable {
         let Some(peer_state) = peer_slab.get((link_id as usize).wrapping_sub(1)) else {
             return;
         };
-        self.sa_to_link.remove(&peer_state.substrate_addr);
+        self.sa_to_link
+            .remove(&(peer_state.substrate_addr, peer_state.interface_addr));
 
         self.special_peers
             .update(|sp_ref| {
@@ -197,8 +202,15 @@ impl PeerTable {
             .map(inspector)
     }
 
-    pub fn lookup_peer(&self, substrate_addr: &SubstrateAddr) -> Option<NonZero<LinkId>> {
-        let id = self.sa_to_link.get(substrate_addr).map(|id| *id);
+    pub fn lookup_peer(
+        &self,
+        substrate_addr: &SubstrateAddr,
+        interface_addr: &ScopedIpAddr,
+    ) -> Option<NonZero<LinkId>> {
+        let id = self
+            .sa_to_link
+            .get(&(*substrate_addr, *interface_addr))
+            .map(|id| *id);
 
         // synchronizes with the Release in VacantPeerTableEntry::insert();
         // ensures anyone who reads from the slab following this sees the peer
@@ -349,7 +361,7 @@ impl PeerTable {
 
 pub struct VacantPeerTableEntry<'a> {
     peer_slab_guard: MutexGuard<'a, RcuCslab<PeerState>>,
-    sa_to_link_ref: &'a DashMap<SubstrateAddr, NonZero<LinkId>>,
+    sa_to_link_ref: &'a DashMap<(SubstrateAddr, ScopedIpAddr), NonZero<LinkId>>,
 }
 
 impl VacantPeerTableEntry<'_> {
@@ -368,13 +380,13 @@ impl VacantPeerTableEntry<'_> {
         // the "reverse" table with Acquire ordering
         atomic::fence(Ordering::Release);
 
-        if let Some(other) = self
-            .sa_to_link_ref
-            .insert(peer_state_ref.substrate_addr, link_id)
-        {
+        if let Some(other) = self.sa_to_link_ref.insert(
+            (peer_state_ref.substrate_addr, peer_state_ref.interface_addr),
+            link_id,
+        ) {
             panic!(
-                "duplicate peer substrate address: {link_id} and {other} share {}",
-                peer_state_ref.substrate_addr
+                "duplicate peer substrate address: {link_id} and {other} share {} on dock {}",
+                peer_state_ref.substrate_addr, peer_state_ref.interface_addr,
             );
         }
 
@@ -392,12 +404,14 @@ pub mod test {
         link_id: NonZero<LinkId>,
         link_type: LinkType,
         substrate_addr: SubstrateAddr,
+        interface_addr: ScopedIpAddr,
     ) -> PeerState {
         let (mp_inq, _mp_outq) = mpsc::channel(MGMT_PROCESSOR_QUEUE_SIZE);
         let mgmt_processor = queues::MgmtProcessor::new(mp_inq);
 
         PeerState {
             substrate_addr,
+            interface_addr,
             link_state_machine: LinkStateWrapper::new(link_id.get(), link_type),
             pft: PeerForwardingTable::new(),
             sync_req_state: sync_req::SyncReqState::new(),

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -1,6 +1,7 @@
 //! Queues (i.e., frontend interface) for each stage of the system.
 
 use crate::config;
+use crate::net_defs;
 use crate::packet::{self, Packet, PacketBuffer};
 use crate::packet_queue;
 use crate::test_packet::*;
@@ -206,14 +207,18 @@ impl Capture {
 
 pub enum MgmtDispatchMessage {
     WithLink(Packet), // Link ID stored in packet metadata
-    WithAddr(zpr::SubstrateAddr, Packet),
+    WithAddr {
+        peer_sa: zpr::SubstrateAddr,
+        interface_addr: net_defs::ScopedIpAddr,
+        packet: Packet,
+    },
 }
 
 impl two_way_queue::TwoWayReturnable<MgmtDispatchMessage> for PacketBuffer {
     fn convert(value: MgmtDispatchMessage) -> Self {
         match value {
             MgmtDispatchMessage::WithLink(pkt) => pkt.destroy(),
-            MgmtDispatchMessage::WithAddr(_, pkt) => pkt.destroy(),
+            MgmtDispatchMessage::WithAddr { packet, .. } => packet.destroy(),
         }
     }
 }
@@ -245,22 +250,24 @@ impl MgmtDispatch {
     pub fn try_dispatch_mgmt_packet_with_addr(
         &mut self,
         peer_sa: &zpr::SubstrateAddr,
+        interface_addr: &net_defs::ScopedIpAddr,
         packet: Packet,
     ) -> Result<(), TryEnqueueError<Packet>> {
         debug_assert_eq!(packet.metadata().ingress_link_id, 0);
-        match self
-            .sender
-            .try_send(MgmtDispatchMessage::WithAddr(*peer_sa, packet))
-        {
+        match self.sender.try_send(MgmtDispatchMessage::WithAddr {
+            peer_sa: *peer_sa,
+            interface_addr: *interface_addr,
+            packet,
+        }) {
             Ok(()) => Ok(()),
 
             Err(two_way_queue::TrySendError::Closed(_)) => panic!("mgmt dispatch channel closed"),
 
             Err(two_way_queue::TrySendError::Full(msg)) => {
-                let MgmtDispatchMessage::WithAddr(_, pkt) = msg else {
+                let MgmtDispatchMessage::WithAddr { packet, .. } = msg else {
                     unreachable!()
                 };
-                Err(TryEnqueueError::Full(pkt))
+                Err(TryEnqueueError::Full(packet))
             }
         }
     }

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -187,6 +187,7 @@ mod tests {
     use crate::assembly::test::{create_assembly, TestAssemblyBuilder};
     use crate::forwarding_tables::PftPep;
     use crate::link_state::LinkType;
+    use crate::net_defs;
     use crate::peer_table::test::create_dummy_peer_state;
     use std::net::{IpAddr, Ipv4Addr};
     use std::num::NonZero;
@@ -251,6 +252,7 @@ mod tests {
                 NonZero::new(zpr::LOCAL_ACTOR_LINK_ID).unwrap(),
                 LinkType::Internal,
                 zpr::SubstrateAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 443),
+                net_defs::ScopedIpAddr::V4(Ipv4Addr::new(1, 2, 3, 5)),
             ))
             .unwrap()
             .get();

--- a/integration-test/common_funcs.sh
+++ b/integration-test/common_funcs.sh
@@ -68,7 +68,9 @@ function create_network() {
   sudo ip -n zpr-node addr add "$NODE_SUBSTRATE_ADDR_A" peer "$A_SUBSTRATE_ADDR" dev veth-zpr-a
   sudo ip -n zpr-node addr add "$NODE_SUBSTRATE_ADDR_B" peer "$B_SUBSTRATE_ADDR" dev veth-zpr-b
   sudo ip -n zpr-node addr add "$NODE_SUBSTRATE_ADDR_C/24" dev veth-zpr-c
-  sudo ip -n zpr-node addr add "$NODE_SUBSTRATE_ADDR_C_ALT/24" dev veth-zpr-c  # Used for testing routing.
+  if [ -n "${NODE_SUBSTRATE_ADDR_C_ALT-}" ]
+  then sudo ip -n zpr-node addr add "$NODE_SUBSTRATE_ADDR_C_ALT/24" dev veth-zpr-c  # Used for testing routing.
+  fi
   sudo ip -n zpr-vs addr add "$VS_SUBSTRATE_ADDR" peer "$NODE_SUBSTRATE_ADDR_VS" dev veth0
   sudo ip -n zpr-a addr add "$A_SUBSTRATE_ADDR" peer "$NODE_SUBSTRATE_ADDR_A" dev veth0
   sudo ip -n zpr-b addr add "$B_SUBSTRATE_ADDR" peer "$NODE_SUBSTRATE_ADDR_B" dev veth0

--- a/integration-test/common_funcs.sh
+++ b/integration-test/common_funcs.sh
@@ -67,11 +67,12 @@ function create_network() {
   sudo ip -n zpr-node addr add "$NODE_SUBSTRATE_ADDR_VS" peer "$VS_SUBSTRATE_ADDR" dev veth-zpr-vs
   sudo ip -n zpr-node addr add "$NODE_SUBSTRATE_ADDR_A" peer "$A_SUBSTRATE_ADDR" dev veth-zpr-a
   sudo ip -n zpr-node addr add "$NODE_SUBSTRATE_ADDR_B" peer "$B_SUBSTRATE_ADDR" dev veth-zpr-b
-  sudo ip -n zpr-node addr add "$NODE_SUBSTRATE_ADDR_C" peer "$C_SUBSTRATE_ADDR" dev veth-zpr-c
+  sudo ip -n zpr-node addr add "$NODE_SUBSTRATE_ADDR_C/24" dev veth-zpr-c
+  sudo ip -n zpr-node addr add "$NODE_SUBSTRATE_ADDR_C_ALT/24" dev veth-zpr-c  # Used for testing routing.
   sudo ip -n zpr-vs addr add "$VS_SUBSTRATE_ADDR" peer "$NODE_SUBSTRATE_ADDR_VS" dev veth0
   sudo ip -n zpr-a addr add "$A_SUBSTRATE_ADDR" peer "$NODE_SUBSTRATE_ADDR_A" dev veth0
   sudo ip -n zpr-b addr add "$B_SUBSTRATE_ADDR" peer "$NODE_SUBSTRATE_ADDR_B" dev veth0
-  sudo ip -n zpr-c addr add "$C_SUBSTRATE_ADDR" peer "$NODE_SUBSTRATE_ADDR_C" dev veth0
+  sudo ip -n zpr-c addr add "$C_SUBSTRATE_ADDR/24" dev veth0
 
   sudo ip -n zpr-node link set veth-zpr-vs up
   sudo ip -n zpr-node link set veth-zpr-a up

--- a/integration-test/one-node-test.sh
+++ b/integration-test/one-node-test.sh
@@ -18,6 +18,7 @@ NODE_SUBSTRATE_ADDR_VS=10.0.0.1
 NODE_SUBSTRATE_ADDR_A=10.0.1.1
 NODE_SUBSTRATE_ADDR_B=10.0.2.1
 NODE_SUBSTRATE_ADDR_C=10.0.3.1
+NODE_SUBSTRATE_ADDR_C_ALT=10.0.3.129  # Used for testing routing when a dock has multiple addresses.
 VS_SUBSTRATE_ADDR=10.0.0.2
 A_SUBSTRATE_ADDR=10.0.1.2
 B_SUBSTRATE_ADDR=10.0.2.2
@@ -146,6 +147,8 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --zpr-addr "$B_ZPR_ADDR" 2>&1 | tee adapter2.log | prefix_log zpr-b &
 
 if [[ "$NUM_ACTORS" -ge 3 ]]; then
+  # Note, this adapter we connect to the "alternative" dock address
+  # on this interface, to test that replies are still routed correctly.
   sudo -E ip netns exec zpr-c sudo -E -u "$ZPR_USER" "$PH_BIN" \
     adapter \
     --control-path "$ADAPTER3_SOCK" \
@@ -154,7 +157,7 @@ if [[ "$NUM_ACTORS" -ge 3 ]]; then
     --certificate-file adapter3.crt \
     --private-key-file adapter3.key \
     --tun-if tun0 \
-    --node-addr "$NODE_SUBSTRATE_ADDR_C":12345 \
+    --node-addr "$NODE_SUBSTRATE_ADDR_C_ALT":12345 \
     --node-public-key-file node.pubkey \
     --zpr-addr "$C_ZPR_ADDR" 2>&1 | tee adapter3.log | prefix_log zpr-c &
 fi


### PR DESCRIPTION
When the local substrate address is set to 0.0.0.0, the kernel chooses for each packet which source IP to use for it.  This means that outbound packets on a link can originate from a different IP than the peer is sending packets to, and this address can change if the host's IP addresses are changed.  I think it's fair to consider this a bug.

The solution is to imbue link/peer state with a notion of "local IP", which is the local IP address which the peer initiated the link with.  This "local IP" is used both for setting the source (local) IP of outbound packets, as well as matching inbound packets based on their destination (local) IP in addition to the source (remote) IP.

The "local IP" is necessarily not just an IP address but actually IP + interface index (a.k.a. "scope ID"), which is used to disambiguate IPv6 link-local addresses (which are valid and useful substrate addresses).  Although this is captured in Rust's `SocketAddrV6` type, `Ipv6Addr` does not capture it, so I was forced to introduce a new type, `ScopedIpv6Addr` (and also `ScopedIpAddr` which is an enum of `Ipv4Addr` and `ScopedIpv6Addr`).

Unlike remote addresses, we do not retain the port in local addresses.  This is because POSIX, and by extension the PH, only supports listening on a single port, even when listening on 0.0.0.0.  In fact there is no way to set a source port on a per-packet basis.

What this PR does not provide is any means to either (a) listen on multiple _specified_ IP addresses or interfaces; (b) listen on multiple ports; or (c) listen on different ports for each IP or interface.  Any of these would (due to the above-mentioned limitations of the POSIX interface) require using multiple substrate sockets for each worker.  This might be desirable in the future, but (to me) falls into the category of "new feature".

In addition to the primary change of using the local IP to additionally identify a link:
* add support in `batch_io` for per-packet local IPs
* slightly modify the integration test to place one adapter on a "secondary" IP of its interface
* ~fix a couple bugs in `batch_io` relating to detecting oversize messages~  macOS and io_uring both apparently don't support this; removed these tests for now and opened #826 to address this properly
* fix a minor bug whereby specifying port "0" wasn't displaying the warning we intended