### PR TITLE
Initial async rework

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -1191,6 +1191,7 @@ dependencies = [
  "serial_test",
  "snow",
  "socket2",
+ "strum 0.27.1",
  "thiserror",
  "tokio",
  "tokio-tun",
@@ -1568,7 +1569,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -1576,6 +1586,19 @@ name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2166,7 +2189,7 @@ name = "zpr"
 version = "0.1.1"
 dependencies = [
  "open-enum",
- "strum",
+ "strum 0.26.3",
  "zerocopy 0.8.9",
 ]
 

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -29,6 +29,7 @@ openssl-sys = { version = "0.9.102" }
 serde = { version = "1.0.214", features = ["derive"] }
 snow = "0.9.6"
 socket2 = { version = "0.5.7" }
+strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "1.0.65"
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-util = { version = "0.7.11", features = ["rt"] }

--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -37,7 +37,7 @@ pub const BLOB_TYPE_AC: &str = "AC";
 pub const MAX_BLOB_AGE_SECONDS: u64 = 120; // 2 minutes
 
 /// This is the data payload in a [zdp::PacketType::InitAuthenticationRequest] packet.
-#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned, Debug, Default)]
+#[derive(Clone, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned, Debug, Default)]
 #[repr(packed)]
 pub struct ZdpInitAuthenticationPayload {
     /// 8 bytes random data

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -163,7 +163,7 @@ pub enum LinkEvent {
 #[derive(Error, Debug)]
 pub enum LinkStateError {
     #[error("Got unexpected event {1} on state {0:?}")]
-    UnexpectedTransition(LinkState, String),
+    UnexpectedTransition(LinkState, &'static str),
     #[error("Invalid operation: {0}")]
     InvalidOperation(String),
     #[error("Link {0} does not exist in peer table")]
@@ -339,7 +339,7 @@ impl LinkStateWrapper {
         if locked_fsm.state != LinkState::Inactive {
             return Err(LinkStateError::UnexpectedTransition(
                 locked_fsm.state,
-                "start".to_string(),
+                "Start",
             ));
         }
 
@@ -393,7 +393,7 @@ impl LinkStateWrapper {
         if locked_fsm.state != LinkState::Keying {
             return Err(LinkStateError::UnexpectedTransition(
                 locked_fsm.state,
-                "keying done".to_string(),
+                "KeyingDone",
             ));
         }
 
@@ -404,7 +404,7 @@ impl LinkStateWrapper {
         let Some(sa) = peer_state.get_established_transport_association() else {
             return Err(LinkStateError::UnexpectedTransition(
                 locked_fsm.state,
-                "keying done when SA not established".to_owned(),
+                "KeyingDone when SA not established",
             ));
         };
 
@@ -481,7 +481,7 @@ impl LinkStateWrapper {
             }
             (_, _) => Err(LinkStateError::UnexpectedTransition(
                 locked_fsm.state,
-                "process hello request".to_string(),
+                "ReceivedHelloRequest",
             )),
         }
     }
@@ -529,7 +529,7 @@ impl LinkStateWrapper {
             }
             (_, _) => Err(LinkStateError::UnexpectedTransition(
                 locked_fsm.state,
-                "process hello response".to_string(),
+                "ReceivedHelloRespone",
             )),
         }
     }
@@ -860,7 +860,7 @@ impl LinkStateWrapper {
             (_, _) => {
                 return Err(LinkStateError::UnexpectedTransition(
                     locked_fsm.state,
-                    "Discard unexpected init authentication".to_string(),
+                    "ReceivedInitAuth",
                 ));
             }
         }
@@ -980,7 +980,7 @@ impl LinkStateWrapper {
         if locked_fsm.state == LinkState::Inactive {
             Err(LinkStateError::UnexpectedTransition(
                 locked_fsm.state,
-                "terminate".to_string(),
+                "ReceivedTerminateRequest",
             ))
         } else {
             locked_fsm.set_state(LinkState::Closing);
@@ -1105,7 +1105,7 @@ impl LinkStateWrapper {
             }
             _ => Err(LinkStateError::UnexpectedTransition(
                 state,
-                "terminate response".to_string(),
+                "ReceivedTerminateResponse",
             )),
         }
     }

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -19,6 +19,7 @@ use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use thiserror::Error;
+use tokio::sync::broadcast;
 use tokio::time::MissedTickBehavior;
 use tracing::*;
 use zpr::LinkId;
@@ -134,7 +135,7 @@ pub enum LinkState {
 }
 
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Clone, Debug, strum::IntoStaticStr)]
 pub enum LinkEvent {
     Start,
     KeyingDone,
@@ -149,6 +150,7 @@ pub enum LinkEvent {
     ReceivedGrantZprAddressRequest(Option<Vec<IpAddress>>), // granted_addrs, None means failure.
     ReceivedGrantResponse(ResponseCode),
 
+    ReceivedEchoResponse { sequence_number: u16 },
     ReceivedAuthorizeResponse, // from visa service
     ReceivedKeepAliveResponse,
     ReceivedTerminateRequest(TerminateReason),
@@ -237,10 +239,13 @@ impl LinkStateMachine {
     }
 }
 
+const LINK_STATE_EVENT_QUEUE_SIZE: usize = 16;
+
 pub struct LinkStateWrapper {
     id: LinkId, // set at constructor, never changes.
     link_type: LinkType,
     locked_fsm: Mutex<LinkStateMachine>,
+    events: broadcast::Sender<LinkEvent>,
     pub locked_data: Mutex<LinkData>,
 }
 
@@ -250,6 +255,7 @@ impl LinkStateWrapper {
             id: new_id,
             link_type: new_link_type,
             locked_fsm: Mutex::new(LinkStateMachine::new(new_id)),
+            events: broadcast::Sender::new(LINK_STATE_EVENT_QUEUE_SIZE),
             locked_data: Mutex::new(LinkData::new()),
         }
     }
@@ -294,6 +300,19 @@ impl LinkStateWrapper {
         event: LinkEvent,
     ) -> Result<(), LinkStateError> {
         debug!(target: LINK_STATE, "Link {}: *EVENT* {event:?}", self.id);
+
+        // Enqueue a copy of this event with any concurrent listening state machines.
+        // If there are none, avoid trying to do so we don't make a needless copy.
+        let listened_for;
+        if self.events.receiver_count() > 0 {
+            match self.events.send(event.clone()) {
+                Ok(n) => listened_for = n > 0,
+                Err(_) => listened_for = false,
+            }
+        } else {
+            listened_for = false;
+        }
+
         match event {
             LinkEvent::Start => self.start(asm),
             LinkEvent::KeyingDone => self.keying_done(asm),
@@ -326,6 +345,17 @@ impl LinkStateWrapper {
             LinkEvent::Close(code) => self.initiate_close(asm, code),
             LinkEvent::CloseDone => Ok(self.complete_close(asm)),
             LinkEvent::Error => self.process_error_response(asm),
+
+            ev => {
+                if listened_for {
+                    Ok(())
+                } else {
+                    Err(LinkStateError::UnexpectedTransition(
+                        self.locked_fsm.lock().unwrap().state,
+                        ev.into(),
+                    ))
+                }
+            }
         }
     }
 

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -65,21 +65,14 @@ impl ZdpPacketType {
         // so this logic becomes a simple range check
 
         match self {
-            Self::VisaHeraldResponse
-            | Self::VisaUpdateResponse
-            | Self::VisaRetractResponse
-            | Self::VisaDeacceptAcknowledgement
-            | Self::BindActorAddressResponse
-            | Self::UnbindActorAddressResponse
+            Self::BindActorAddressResponse
             | Self::AuthenticationResponse
             | Self::EchoResponse
             | Self::TerminateLinkResponse
             | Self::HelloResponse
-            | Self::ConfigurationResponse
             | Self::AcquireZprAddressResponse
             | Self::InitAuthenticationResponse
-            | Self::GrantZprAddressResponse
-            | Self::UnregisterActorAddressResponse => true,
+            | Self::GrantZprAddressResponse => true,
             _ => false,
         }
     }


### PR DESCRIPTION
Some prep work for reworking sync requests as async messages.

* removes currently-unused messages from the response-matching function
* adds a pub/sub channel to the link state machine, used to communicate link events to other concurrent state machines (e.g. the echo state machine)
* adds a `ReceivedEchoResponse` event as a placeholder (used to subsequent PR)
* slightly restructures state names in errors to permit easy generation of these error messages