### PR TITLE
Rework echo requests as async

### DIFF
--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -22,7 +22,7 @@ pub const PACKET_BUFFER_SIZE: usize = 4096 * 3;
 pub const DEFAULT_MESSAGE_HEADROOM: usize = 256;
 
 pub const DEFAULT_REQUEST_RETRY_COUNT: usize = 3;
-pub const DEFAULT_REQUEST_RETRY_TIMER: usize = 1;
+pub const DEFAULT_REQUEST_RETRY_TIMER: std::time::Duration = std::time::Duration::from_secs(1);
 
 pub const ANCILLARY_BUFFER_SIZE: usize = 128;
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -6,7 +6,6 @@ use crate::km::ZPIPair;
 use crate::km_multiplexor;
 use crate::logging::targets::LINK_STATE;
 use crate::mgmt;
-use crate::mgmt::core::SyncReqError;
 use crate::net_defs::IpAddress;
 use crate::sample_ring::SampleRing;
 use crate::special_peers;
@@ -191,7 +190,6 @@ pub enum LinkStatus {
 pub struct LinkData {
     echo_success: u64, // Echo requests received response
     echo_timeout: u64, // Echo requests timed out
-    echo_failure: u64, // Echo requests failed for other reasons
     // TODO: configurable keep-alive period
     // For now, keep-alives are attempted every 3 seconds
     // Assuming no loss, 100 samples will store 5 minutes of latency data
@@ -203,7 +201,6 @@ impl LinkData {
         Self {
             echo_success: 0,
             echo_timeout: 0,
-            echo_failure: 0,
             latency_data: SampleRing::new(Duration::ZERO),
         }
     }
@@ -1160,6 +1157,7 @@ impl LinkStateWrapper {
     pub fn run_active(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
         let link_id = self.id;
         let task_asm = asm.clone();
+        let task_events = self.events.clone();
         asm.counters[CounterType::PeerHandshakeSuccess].increment();
         debug!(target: LINK_STATE, "Link {link_id} entering active state");
         tokio::task::spawn_local(async move {
@@ -1175,33 +1173,54 @@ impl LinkStateWrapper {
                 if peer.link_state_machine.locked_fsm.lock().unwrap().state != LinkState::Active {
                     return;
                 }
-                let response = mgmt::requests::send_echo_request(&task_asm, link_id).await;
-                match response {
-                    Ok(()) => {
-                        let mut link_data = peer.link_state_machine.locked_data.lock().unwrap();
-                        link_data.echo_success += 1;
-                        link_data
-                            .latency_data
-                            .add(Instant::now().duration_since(start_time));
-                        consecutive_misses = 0;
-                    }
-                    Err(SyncReqError::Timeout) => {
-                        peer.link_state_machine
-                            .locked_data
-                            .lock()
-                            .unwrap()
-                            .echo_timeout += 1;
-                        consecutive_misses += 1;
-                    }
-                    Err(_) => {
-                        peer.link_state_machine
-                            .locked_data
-                            .lock()
-                            .unwrap()
-                            .echo_failure += 1;
-                        consecutive_misses += 1;
-                    }
+
+                let mut recv = task_events.subscribe();
+
+                let sent_seq_num = mgmt::requests::send_echo_request(&task_asm, link_id).await;
+                let expected_seq_num = (sent_seq_num & 0xffff) as u16;
+
+                let got_response =
+                    tokio::time::timeout(config::DEFAULT_REQUEST_RETRY_TIMER,
+                        async {
+                            loop {
+                                match recv.recv().await {
+                                    Ok(LinkEvent::ReceivedEchoResponse { sequence_number: recvd_seq_num }) => {
+                                        if recvd_seq_num == expected_seq_num {
+                                            break true;
+                                        } else {
+                                            debug!(target: LINK_STATE, "Link {link_id} saw echo response {recvd_seq_num} while waiting for {expected_seq_num}");
+                                        }
+                                    }
+
+                                    Ok(_) => (),
+
+                                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                                        debug!(target: LINK_STATE, "Link {link_id} lagged waiting for echo response (unexpected)");
+                                    }
+
+                                    Err(broadcast::error::RecvError::Closed) => {
+                                        break false;  // we'll exit next time through the loop
+                                    }
+                                }
+                            }
+                        }).await.unwrap_or(false);
+
+                drop(recv);
+
+                let mut link_data = peer.link_state_machine.locked_data.lock().unwrap();
+
+                if got_response {
+                    link_data.echo_success += 1;
+                    link_data
+                        .latency_data
+                        .add(Instant::now().duration_since(start_time));
+                    consecutive_misses = 0;
+                } else {
+                    link_data.echo_timeout += 1;
+                    consecutive_misses += 1;
                 }
+
+                drop(link_data);
 
                 if consecutive_misses >= config::DEFAULT_KEEP_ALIVE_RETRIES {
                     if task_asm
@@ -1289,7 +1308,6 @@ impl Display for LinkData {
         write!(f, "  Echo stats:\n")?;
         write!(f, "    Successes: {}\n", self.echo_success)?;
         write!(f, "    Timeouts: {}\n", self.echo_timeout)?;
-        write!(f, "    Other failures: {}\n", self.echo_failure)?;
         write!(
             f,
             "    Latency: Min {:?}, Max {:?}, Avg {average:?}\n",

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -8,7 +8,6 @@ use crate::config;
 use crate::counters::CounterType;
 use crate::packet::Packet;
 use crate::zdp;
-use std::time::Duration;
 use thiserror::Error;
 use tokio::time::sleep;
 use tracing::*;
@@ -39,8 +38,10 @@ pub async fn send_non_flow_mgmt(
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
     packet: Packet,
-) {
-    send_mgmt_helper(asm, link_id, packet_type, None, None, packet).await
+) -> zpr::SeqNum {
+    let seq_num = 0; // TODO, zpr-core/839
+    send_mgmt_helper(asm, link_id, packet_type, None, None, packet).await;
+    seq_num
 }
 
 /// Send a unidirectional per-flow management message on the given link.
@@ -227,7 +228,7 @@ async fn send_sync_req_helper(
                 drop(permit);
                 return match_received(asm, response.ok(), SyncReqError::LinkClosed, zdp_response_type);
             }
-            _ = sleep(Duration::from_secs(config::DEFAULT_REQUEST_RETRY_TIMER as u64)) => ()
+            _ = sleep(config::DEFAULT_REQUEST_RETRY_TIMER) => ()
         }
     }
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -77,16 +77,31 @@ pub async fn handle_echo_request(
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-    let _hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpEchoHeader>();
+    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpEchoHeader>();
+    hdr.sequence_number = ((seq_num & 0xffff) as u16).into();
 
-    super::core::send_non_flow_mgmt_response(
+    super::core::send_non_flow_mgmt(
         asm,
         ingress_link_id,
         zdp::ZdpPacketType::EchoResponse,
-        seq_num,
         rsp_pkt,
     )
     .await;
+
+    Ok(())
+}
+
+pub async fn handle_echo_response(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
+    let Ok(hdr) = zdp::ZdpEchoHeader::read_from_buf(&mut pkt) else {
+        return Err((HandleMgmtError::BadStructure, pkt));
+    };
+
+    let _ = asm.process_link_state_event(
+        pkt.metadata().ingress_link_id,
+        LinkEvent::ReceivedEchoResponse {
+            sequence_number: hdr.sequence_number.into(),
+        },
+    );
 
     Ok(())
 }

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -6,7 +6,6 @@ use crate::auth::ZdpInitAuthenticationPayload;
 use crate::counters::CounterType;
 use crate::defs::*;
 use crate::logging::targets::ZDP;
-use crate::mgmt::core::SyncReqError;
 use crate::zdp;
 use crate::{assembly::Assembly, auth};
 
@@ -37,28 +36,16 @@ pub async fn send_key_management(
 
 #[allow(dead_code)]
 /// send a Discard message (RFC 6.5 § 6.3.1)
-pub async fn send_discard(asm: &Assembly, link_id: zpr::LinkId) {
+pub async fn send_discard(asm: &Assembly, link_id: zpr::LinkId) -> zpr::SeqNum {
     let pkt = core::new_heap_packet();
-    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::Discard, pkt).await;
+    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::Discard, pkt).await
 }
 
-/// send an Echo Request and wait for the Response (RFC 6.5 § 6.3.2)
-pub async fn send_echo_request(asm: &Assembly, link_id: zpr::LinkId) -> Result<(), SyncReqError> {
-    let mut echo = core::send_sync_non_flow_req(
-        asm,
-        link_id,
-        zdp::ZdpPacketType::EchoRequest,
-        zdp::ZdpPacketType::EchoResponse,
-        move |_packet| {},
-    )
-    .await?;
-
-    // TODO: Break these apart
-    let Ok(_) = zdp::ZdpEchoHeader::read_from_buf(&mut echo) else {
-        core::count_event(asm, &mut echo, CounterType::BadStructure);
-        return Err(SyncReqError::ProtocolError);
-    };
-    Ok(())
+/// send an Echo Request (RFC 6.5 § 6.3.2)
+pub async fn send_echo_request(asm: &Assembly, link_id: zpr::LinkId) -> zpr::SeqNum {
+    let mut pkt = core::new_heap_packet();
+    pkt.alloc_zeroed_header::<zdp::ZdpEchoHeader>();
+    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::EchoRequest, pkt).await
 }
 
 /// send a Hello Request and wait for the Response (RFC 6.5 § 6.3.4)

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -83,6 +83,8 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
 
             ZdpPacketType::EchoRequest => handlers::handle_echo_request(asm, seq_num, pkt).await,
 
+            ZdpPacketType::EchoResponse => handlers::handle_echo_response(asm, pkt).await,
+
             ZdpPacketType::KeyManagement => {
                 panic!("unexpected Key Management message in mgmt processor")
             }

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -67,7 +67,6 @@ impl ZdpPacketType {
         match self {
             Self::BindActorAddressResponse
             | Self::AuthenticationResponse
-            | Self::EchoResponse
             | Self::TerminateLinkResponse
             | Self::HelloResponse
             | Self::AcquireZprAddressResponse

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -115,7 +115,6 @@ pub struct ZdpPerFlowHeader {
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpEchoHeader {
-    pub base_header: ZdpBaseHeader,
     pub sequence_number: U16, // Only used for the response
     pub additional_length: U16,
 }


### PR DESCRIPTION
Echo requests + replies are now two independent messages.

I tried to change the functionality as little as possible but here are some things which did change.

* We now no longer automatically retry echos using the sync request framework.  Instead we rely on the echo state machine logic.
* We now explicitly check sequence numbers in the echo state machine.  (However the sequence numbers are currently always 0.  I opened #839 to address this more generally.)
* Echo failures are no longer a thing.  (The only two error types were "link closed", which now just exits the loop, and "protocol error", which is now caught before dispatching the event.)