### PR TITLE
Mk/832 on 790ah rebased

### DIFF
--- a/visaservice/core/pkg/actor/keys.go
+++ b/visaservice/core/pkg/actor/keys.go
@@ -15,3 +15,37 @@ const (
 const (
 	KAttrActorAuthority = "authority" // Actor requested authority
 )
+
+type Namespace int
+
+const (
+	NsUser Namespace = iota + 1
+	NsDevice
+	NsService
+)
+
+func (n Namespace) String() string {
+	switch n {
+	case NsUser:
+		return "user"
+	case NsDevice:
+		return "device"
+	case NsService:
+		return "service"
+	default:
+		return "unknown"
+	}
+}
+
+func ParseNamespace(s string) (Namespace, bool) {
+	switch s {
+	case "user":
+		return NsUser, true
+	case "device":
+		return NsDevice, true
+	case "service":
+		return NsService, true
+	default:
+		return 0, false
+	}
+}

--- a/visaservice/core/pkg/vservice/auth/authenticator.go
+++ b/visaservice/core/pkg/vservice/auth/authenticator.go
@@ -194,6 +194,8 @@ func (a *Authenticator) AddDatasourceProvider(service string, contactAddr netip.
 	urlp.Path = "/token"
 	fixedValidateUri := urlp.String()
 
+	nsMap := a.createNamespaceMap(service, psvc.GetAttrs(), psvc.GetIdAttrs())
+
 	// TODO: Update this when we implement Query
 
 	features := DSFeatures{
@@ -202,6 +204,7 @@ func (a *Authenticator) AddDatasourceProvider(service string, contactAddr netip.
 		ValidationUri:     fixedValidateUri,
 		QueryUri:          psvc.QueryUri,
 		TLSDomain:         psvc.Domain,
+		NsMap:             nsMap,
 	}
 
 	// TODO: Needs thought
@@ -211,6 +214,52 @@ func (a *Authenticator) AddDatasourceProvider(service string, contactAddr netip.
 		contactAddr,
 		&features,
 		configID)
+}
+
+// createNamespaceMap creates a map of attribute keys to their namespaces and identity status based
+// on information held in policy for the trusted service.
+func (a *Authenticator) createNamespaceMap(service string, attrs []string, idAttrs []string) map[string]AttrInfo {
+	nsMap := make(map[string]AttrInfo)
+	for _, attrWithPfx := range attrs {
+		key, ns, ok := a.keyAndNsForAttr(attrWithPfx)
+		if !ok {
+			a.log.Warn("failed to parse prefix from attribute in policy", "attr", attrWithPfx, "service", service)
+			continue
+		}
+		nsMap[key] = AttrInfo{
+			namespace: ns,
+			identity:  false,
+		}
+	}
+	for _, attrWithPfx := range idAttrs {
+		key, ns, ok := a.keyAndNsForAttr(attrWithPfx)
+		if !ok {
+			a.log.Warn("failed to parse prefix from identity attribute in policy", "attr", attrWithPfx, "service", service)
+			continue
+		}
+		if ai, found := nsMap[key]; found {
+			// If we already have this key, just set the identity flag.
+			ai.identity = true
+			nsMap[key] = ai
+		} else {
+			nsMap[key] = AttrInfo{
+				namespace: ns,
+				identity:  true,
+			}
+		}
+	}
+	return nsMap
+}
+
+func (a *Authenticator) keyAndNsForAttr(attr string) (string, actor.Namespace, bool) {
+	pfxstr, rest, ok := strings.Cut(attr, ".")
+	if !ok {
+		return "", 0, false // no prefix
+	}
+	if pfx, ok := actor.ParseNamespace(pfxstr); ok {
+		return rest, pfx, true
+	}
+	return "", 0, false
 }
 
 // Authenticate - perform authentication at the node.

--- a/visaservice/core/pkg/vservice/auth/directory.go
+++ b/visaservice/core/pkg/vservice/auth/directory.go
@@ -37,7 +37,8 @@ type DSFeatures struct {
 	ValidationUri     string
 	SupportQuery      bool
 	QueryUri          string
-	TLSDomain         string // optional TLS domain name
+	TLSDomain         string              // optional TLS domain name
+	NsMap             map[string]AttrInfo // Namespace map for attributes
 }
 
 type OAuthValidateResponse struct {
@@ -59,6 +60,11 @@ func (f *DSFeatures) ShortStr() string {
 	}
 }
 
+type AttrInfo struct {
+	namespace actor.Namespace
+	identity  bool
+}
+
 // VLoc is a "Validation service LOCation"
 type VLoc struct {
 	configID      uint64 // Config ID when actor connected and was permitted to add itself
@@ -70,6 +76,7 @@ type VLoc struct {
 	allowValidate bool
 	queryUri      string
 	validationUri string
+	nsMap         map[string]AttrInfo // Namespace map for attributes
 }
 
 // Directory manages a collection of (external) validators (ie, simplev)
@@ -173,7 +180,24 @@ func (vs *Directory) Validate(dsPrefix string, msg *ZdpAuthCodeBlob, revokes []*
 	}
 
 	// ZPR allows setting attributes in tokens using claims with "zpra/"
-	claims := vs.parseZPRClaimsFromJWT(resp.AccessToken, expiration)
+	rawClaims := vs.parseZPRClaimsFromJWT(resp.AccessToken, expiration)
+
+	// The attribute from the service are mapped into namespaces using the
+	// attribute (returns & identity) information from the policy.  The claims
+	// returned above are raw, eg if the policy says the service returns "user.id"
+	// then the claim will have an "id" value in it (no namespace).
+	claims := make(map[string]*actor.ClaimV)
+	for attrName, cv := range rawClaims {
+		if info, found := v.nsMap[attrName]; found {
+			newName := fmt.Sprintf("%s.%s", info.namespace, attrName)
+			// TODO: For now ignoring identity bit
+			claims[newName] = cv
+		} else {
+			// Attribute from service not listed in policy, warn.
+			vs.log.Warn("attribute from trusted service not listed in policy",
+				"prefix", dsPrefix, "attr", fmt.Sprintf("%s:%s", attrName, cv.V))
+		}
+	}
 
 	vres := &ValidateResult{
 		Prefix:     dsPrefix,
@@ -260,10 +284,12 @@ func (vs *Directory) AddService(prefix string, contactAddr netip.Addr, features 
 	if !contactAddr.IsValid() || contactAddr.IsUnspecified() {
 		return errInvalidAddress
 	}
+	if features.NsMap == nil {
+		return fmt.Errorf("features.nsMap is nil for prefix %s", prefix)
+	}
 	vs.log.Debug("AddService", "prefix", prefix)
 	vs.mtx.Lock()
 	defer vs.mtx.Unlock()
-
 	vs.log.Info("adding validations service",
 		"prefix", prefix, "support", features.ShortStr(), "addr", contactAddr,
 		"configID", configID)
@@ -277,6 +303,7 @@ func (vs *Directory) AddService(prefix string, contactAddr netip.Addr, features 
 		queryUri:      features.QueryUri,
 		validationUri: features.ValidationUri,
 		Domain:        features.TLSDomain,
+		nsMap:         features.NsMap,
 	}
 	return nil
 }

--- a/visaservice/core/pkg/vservice/auth/directory_test.go
+++ b/visaservice/core/pkg/vservice/auth/directory_test.go
@@ -25,6 +25,7 @@ func TestAddRemoveService(t *testing.T) {
 		SupportQuery:      false,
 		QueryUri:          "",
 		ValidationUri:     "zpr-validation2://[::1]:5001",
+		NsMap:             make(map[string]auth.AttrInfo),
 	}
 	err := dir.AddService("svcpfx", svcAddr, &feats, 1)
 	require.Nil(t, err)
@@ -100,6 +101,7 @@ func TestRemoveServiceByContactAddr(t *testing.T) {
 		SupportQuery:      false,
 		QueryUri:          "",
 		ValidationUri:     "zpr-validation2://[::1]:5001",
+		NsMap:             make(map[string]auth.AttrInfo),
 	}
 
 	for n := 0; n < 3; n++ {

--- a/visaservice/mods/polio/policy.pb.go
+++ b/visaservice/mods/polio/policy.pb.go
@@ -794,6 +794,8 @@ type Service struct {
 	Domain        string                 `protobuf:"bytes,4,opt,name=domain,proto3" json:"domain,omitempty"`                              // TLS domain
 	QueryUri      string                 `protobuf:"bytes,5,opt,name=query_uri,json=queryUri,proto3" json:"query_uri,omitempty"`          // Empty, or needs an l7 protocol name and port.
 	ValidateUri   string                 `protobuf:"bytes,6,opt,name=validate_uri,json=validateUri,proto3" json:"validate_uri,omitempty"` // Empty, or needs an l7 protocol name and port.
+	Attrs         []string               `protobuf:"bytes,7,rep,name=attrs,proto3" json:"attrs,omitempty"`                                // Returns attribute keys (with domains)
+	IdAttrs       []string               `protobuf:"bytes,8,rep,name=id_attrs,json=idAttrs,proto3" json:"id_attrs,omitempty"`             // Identity attribute keys (with domains)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -868,6 +870,20 @@ func (x *Service) GetValidateUri() string {
 		return x.ValidateUri
 	}
 	return ""
+}
+
+func (x *Service) GetAttrs() []string {
+	if x != nil {
+		return x.Attrs
+	}
+	return nil
+}
+
+func (x *Service) GetIdAttrs() []string {
+	if x != nil {
+		return x.IdAttrs
+	}
+	return nil
 }
 
 type Condition struct {
@@ -2175,14 +2191,16 @@ const file_policy_proto_rawDesc = "" +
 	"\n" +
 	"conditions\x18\x04 \x03(\v2\x10.polio.ConditionR\n" +
 	"conditions\x123\n" +
-	"\vconstraints\x18\x05 \x03(\v2\x11.polio.ConstraintR\vconstraints\"\xae\x01\n" +
+	"\vconstraints\x18\x05 \x03(\v2\x11.polio.ConstraintR\vconstraints\"\xdf\x01\n" +
 	"\aService\x12\x1f\n" +
 	"\x04type\x18\x01 \x01(\x0e2\v.polio.SvcTR\x04type\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x16\n" +
 	"\x06prefix\x18\x03 \x01(\tR\x06prefix\x12\x16\n" +
 	"\x06domain\x18\x04 \x01(\tR\x06domain\x12\x1b\n" +
 	"\tquery_uri\x18\x05 \x01(\tR\bqueryUri\x12!\n" +
-	"\fvalidate_uri\x18\x06 \x01(\tR\vvalidateUri\"J\n" +
+	"\fvalidate_uri\x18\x06 \x01(\tR\vvalidateUri\x12\x14\n" +
+	"\x05attrs\x18\a \x03(\tR\x05attrs\x12\x19\n" +
+	"\bid_attrs\x18\b \x03(\tR\aidAttrs\"J\n" +
 	"\tCondition\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12-\n" +
 	"\tattrExprs\x18\x02 \x03(\v2\x0f.polio.AttrExprR\tattrExprs\"\xa9\x01\n" +

--- a/visaservice/mods/polio/policy.proto
+++ b/visaservice/mods/polio/policy.proto
@@ -83,6 +83,8 @@ message Service {
     string domain               = 4; // TLS domain
     string query_uri            = 5; // Empty, or needs an l7 protocol name and port.
     string validate_uri         = 6; // Empty, or needs an l7 protocol name and port.
+    repeated string attrs       = 7; // Returns attribute keys (with domains)
+    repeated string id_attrs    = 8; // Identity attribute keys (with domains)
 }
 
 message Condition {


### PR DESCRIPTION
Adds logic to visa service to read the attribute lists stored in the binary policy ( see https://github.com/org-zpr/zpr-policy/pull/6 ) and save them along with the other trusted service details.

Also implements the mapping of trusted service attributes into the correct namespace.

Note we have copied the latest policy.proto file from the policy repo since the visa service is no using that yet.