### PR TITLE
Add configuration to force correct dependency behavior on private repo

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[net]
+git-fetch-with-cli = true
+


### PR DESCRIPTION
@vvisigoth observed build failures when trying to pull in a dependency from a private github repo. The addition of the `net.git-fetch-with-cli` to the config file fixed this behavior. This fix should make the build system more robust to automation.

NB other users (@mkolehmainen ) haven't run into this problem.