### PR TITLE
Remove some link-state logic from mgmt::handlers and mgmt::requests

### DIFF
--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -11,7 +11,7 @@ use crate::sample_ring::SampleRing;
 use crate::special_peers;
 use crate::special_peers::SpecialPeerName;
 use crate::visa_mgmt;
-use crate::zdp::{ResponseCode, TerminateReason};
+use crate::zdp::{self, ResponseCode, TerminateReason};
 
 use openssl::x509::X509;
 use std::fmt::{Display, Formatter};
@@ -1057,10 +1057,48 @@ impl LinkStateWrapper {
     /// use for authentication.
     fn send_init_authentication_request(&self, asm: &Arc<Assembly>) {
         let link_id = self.id;
+
+        // TODO: Whether or not we are in bootstrap mode comes from visa service.  For now hardcoded ON.
+        let is_bootstrap = true;
+
+        let payload: auth::ZdpInitAuthenticationPayload;
+        let mut flags = 0u8;
+
+        if is_bootstrap {
+            flags |= zdp::init_authentication_flags::BOOTSTRAP_SUPPORT;
+
+            // TODO: Pretty sure I do not need `inspect_sync` below. The key is set at create time and not changed.
+            let key = asm.peer_table.inspect(link_id, {
+                |peer| {
+                    let mut key = [0u8; auth::AUTH_KEY_SIZE_BYTES];
+                    key[0..auth::AUTH_KEY_SIZE_BYTES]
+                        .copy_from_slice(&peer.auth_key[0..auth::AUTH_KEY_SIZE_BYTES]);
+                    key
+                }
+            });
+            match key {
+                Some(key) => payload = auth::ZdpInitAuthenticationPayload::new(&key),
+                None => {
+                    // TODO: Possibly we want to send the Init Authentication message anyway, but
+                    //       just not support bootstrap mode.
+                    error!(target: LINK_STATE, "unable to send Init Authentication: no auth key found for link {link_id}");
+                    if let Err(e) = asm.process_link_state_event(link_id, LinkEvent::Error) {
+                        error!(target: LINK_STATE, "event handling error: {e}");
+                    }
+                    return;
+                }
+            }
+        } else {
+            payload = auth::ZdpInitAuthenticationPayload::default(); // empty
+        }
+
         let task_asm = asm.clone();
 
         tokio::task::spawn_local(async move {
-            let result = mgmt::requests::send_init_authentication_request(&task_asm, link_id).await;
+            let result = mgmt::requests::send_init_authentication_request(
+                &task_asm, link_id, flags, payload,
+            )
+            .await;
             if result.is_err() {
                 error!(target: LINK_STATE, "Link {link_id} failed to send init-auth request");
                 if let Err(e) = task_asm.process_link_state_event(link_id, LinkEvent::Error) {

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -18,11 +18,13 @@ use tracing::*;
 use zpr;
 use zpr_ext::zerocopy::{FromBytesExt, IntoBytesExt};
 
+/// Indicates whether the mgmt message was handled successfully.
+/// (It may be the case that the mgmt message itself indicates
+/// failure of a remote operation; modulo a parsing issue,
+/// handling such a message would still be considered successful.)
 pub enum HandleMgmtError {
     UnknownType(u8),
     BadStructure,
-    LinkStateError,
-    NonSuccess(zdp::ResponseCode),
 }
 
 impl From<HandleMgmtError> for counters::CounterType {
@@ -30,8 +32,6 @@ impl From<HandleMgmtError> for counters::CounterType {
         match err {
             HandleMgmtError::UnknownType(_type) => Self::UnknownType,
             HandleMgmtError::BadStructure => Self::BadStructure,
-            HandleMgmtError::LinkStateError => Self::OtherError,
-            HandleMgmtError::NonSuccess(_code) => Self::OtherError,
         }
     }
 }
@@ -379,20 +379,28 @@ pub async fn handle_grant_zpr_address_request(
     let mut status_code = zdp::ResponseCode::Other;
 
     match parse_grant_zpr_address_request(&mut pkt) {
-        Ok(actor_addresses) => {
-            info!(target: ZDP,
-                "Received Grant Zpr Address Request for link {} with addresses {:?}", ingress_link_id, actor_addresses);
-            if asm
-                .process_link_state_event(
+        Ok(Ok(actor_addresses)) => {
+            if actor_addresses.is_empty() {
+                error!(target: ZDP, "Received Grant Zpr Address Request with no addresses");
+                let _ = asm.process_link_state_event(
                     ingress_link_id,
-                    LinkEvent::ReceivedGrantZprAddressRequest(Some(actor_addresses)),
-                )
-                .is_ok()
-            {
-                status_code = zdp::ResponseCode::Success;
+                    LinkEvent::ReceivedGrantZprAddressRequest(None),
+                );
+            } else {
+                info!(target: ZDP,
+                    "Received Grant Zpr Address Request for link {} with addresses {:?}", ingress_link_id, actor_addresses);
+                if asm
+                    .process_link_state_event(
+                        ingress_link_id,
+                        LinkEvent::ReceivedGrantZprAddressRequest(Some(actor_addresses)),
+                    )
+                    .is_ok()
+                {
+                    status_code = zdp::ResponseCode::Success;
+                }
             }
         }
-        Err(HandleMgmtError::NonSuccess(c)) => {
+        Ok(Err(c)) => {
             info!(target: ZDP, "Grant request indicates non-success; code: {:?}", c);
             if asm
                 .process_link_state_event(
@@ -516,7 +524,9 @@ fn parse_acquire_zpr_address_request(
 
 /// The grant is a message from a node to an adapter (future: or to a joining node).
 /// In includes the address (or addresses) we have been assigned to use.
-fn parse_grant_zpr_address_request(pkt: &mut Packet) -> Result<Vec<IpAddress>, HandleMgmtError> {
+fn parse_grant_zpr_address_request(
+    pkt: &mut Packet,
+) -> Result<Result<Vec<IpAddress>, zdp::ResponseCode>, HandleMgmtError> {
     let Ok(hdr) = zdp::ZdpGrantZprAddressRequestHeader::read_from_buf(pkt) else {
         return Err(HandleMgmtError::BadStructure);
     };
@@ -527,11 +537,7 @@ fn parse_grant_zpr_address_request(pkt: &mut Packet) -> Result<Vec<IpAddress>, H
 
     if hdr.status_code != zdp::ResponseCode::Success {
         warn!(target: ZDP, "Received Grant Zpr Address Request with non-success status code {:?}", hdr.status_code);
-        return Err(HandleMgmtError::NonSuccess(hdr.status_code));
-    }
-    if hdr.addr_count == 0 {
-        warn!(target: ZDP, "Received Grant Zpr Address Request with no addresses");
-        return Err(HandleMgmtError::LinkStateError);
+        return Ok(Err(hdr.status_code));
     }
 
     let mut actor_addresses = Vec::new();
@@ -568,7 +574,7 @@ fn parse_grant_zpr_address_request(pkt: &mut Packet) -> Result<Vec<IpAddress>, H
         }
         actor_addresses.push(addr);
     }
-    Ok(actor_addresses)
+    Ok(Ok(actor_addresses))
 }
 
 /// handle a Bind Actor Address Request (RFC 6.5 § 6.3.11)

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -1,8 +1,10 @@
 //! Management requests.
+//!
+//! No logic lives in here; this is just a simple API to send ZDP messages.
+
 #![allow(dead_code)]
 
 use super::core;
-use crate::auth::ZdpInitAuthenticationPayload;
 use crate::counters::CounterType;
 use crate::defs::*;
 use crate::logging::targets::ZDP;
@@ -117,37 +119,9 @@ pub async fn send_hello_request(
 pub async fn send_init_authentication_request(
     asm: &Assembly,
     link_id: zpr::LinkId,
+    flags: u8,
+    payload: auth::ZdpInitAuthenticationPayload,
 ) -> Result<zdp::ResponseCode, ()> {
-    // TODO: Whether or not we are in bootstrap mode comes from visa service.  For now hardcoded ON.
-    let is_bootstrap = true;
-
-    let payload: auth::ZdpInitAuthenticationPayload;
-    let mut flags = 0u8;
-
-    if is_bootstrap {
-        flags |= zdp::init_authentication_flags::BOOTSTRAP_SUPPORT;
-
-        // TODO: Pretty sure I do not need `inspect_sync` below. The key is set at create time and not changed.
-        let key = asm.peer_table.inspect(link_id, {
-            |peer| {
-                let mut key = [0u8; auth::AUTH_KEY_SIZE_BYTES];
-                key[0..auth::AUTH_KEY_SIZE_BYTES]
-                    .copy_from_slice(&peer.auth_key[0..auth::AUTH_KEY_SIZE_BYTES]);
-                key
-            }
-        });
-        match key {
-            Some(key) => payload = ZdpInitAuthenticationPayload::new(&key),
-            None => {
-                // TODO: Possibly we want to send the Init Authentication message anyway, but
-                //       just not support bootstrap mode.
-                error!(target: ZDP, "unable to send Init Authentication: no auth key found for link {link_id}");
-                return Err(());
-            }
-        }
-    } else {
-        payload = ZdpInitAuthenticationPayload::default(); // empty
-    }
     debug!(target: ZDP, "Link {link_id}: sending IntitAuthenticationRequest, flags: {flags:x?}");
     let response = core::send_sync_non_flow_req(
         asm,


### PR DESCRIPTION
A few simple cleanups here:

* Removes the logic for deriving a bootstrap key from `mgmt::requests::send_init_authentication_request()` and moves it into the sole caller, `link_state::LinkStateWrapper::send_init_authentication_request()`.  (The intent of `mgmt::requests` is just to be direct wrappers for building & sending ZDP messages; i.e. something which could in theory be autogenerated by an IDL.  Hence any sort of logic should live outside of that module.)
* Removes the `LinkStateError` and `NonSuccess` variants from `MgmtHandlerResult`.  `MgmtHandlerResult` is intended to indicate whether the handler itself was successful, not whether the message received indicated a successful remote operation.  (Such an indication should be passed as an event of some type to the link state machine or wherever.)  These variants were only used by `parse_grant_zpr_address_request()`; now that method instead "successfully" returns the remote end's indication of "success" or "failure" by using a nested `Result`.  The two error cases are now handled in the immediate caller, `handle_grant_zpr_address_request()`.

These changes help simplify forthcoming async messaging changes.