### PR TITLE
Make authentication messages asynchronous

### DIFF
--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1203,36 +1203,21 @@ impl LinkStateWrapper {
         Ok(())
     }
 
-    /// Send Acquire message, and if all goes well fire off a ReceivedAcquireResponse event.
+    /// Send Acquire message
     fn send_acquire_zpr_address_request(&self, asm: &Arc<Assembly>, blob: &str) {
         let link_id = self.id;
         let task_asm = asm.clone();
 
-        let blob_opt = Some(blob.as_bytes().to_vec());
+        let blob_opt = Some(blob.as_bytes().to_owned());
 
         tokio::task::spawn_local(async move {
-            let result = mgmt::requests::send_acquire_zpr_address_request(
+            mgmt::requests::send_acquire_zpr_address_request(
                 &task_asm,
                 link_id,
                 &task_asm.local_zpr_addresses,
-                blob_opt,
+                blob_opt.as_deref(),
             )
-            .await;
-
-            if result.is_err() {
-                error!(target: LINK_STATE, "Link {link_id} failed to send acquire zpr address");
-                if let Err(e) = task_asm.process_link_state_event(link_id, LinkEvent::Error) {
-                    error!(target: LINK_STATE, "event handlinhg error {e}");
-                }
-            } else {
-                // Did send and got response.
-                if let Err(e) = task_asm.process_link_state_event(
-                    link_id,
-                    LinkEvent::ReceivedAcquireResponse(result.unwrap()),
-                ) {
-                    error!(target: LINK_STATE, "event handling error {e}");
-                }
-            }
+            .await
         });
     }
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -623,7 +623,6 @@ impl LinkStateWrapper {
                 Ok(())
             }
             (LinkType::NodeToAdapter, LinkState::Helloing) => {
-                // Note that the node goes into RegisterAA while the adapter will go into WaitForInitAuth.
                 // Node is really waiting now for an Acquire Call.
                 locked_fsm.actor_addresses.push(peer_zpr_addr);
                 debug!(
@@ -631,7 +630,7 @@ impl LinkStateWrapper {
                     "Link {link_id} peer is using ZPR addr {}",
                     peer_zpr_addr
                 );
-                locked_fsm.set_state(LinkState::RegisterAA);
+                locked_fsm.set_state(LinkState::WaitForInitAuth);
                 debug!(
                     target: LINK_STATE,
                     "Link {link_id} finished helloing.  Waiting for other side to respond to init-auth"
@@ -717,7 +716,7 @@ impl LinkStateWrapper {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
 
         match (self.link_type, locked_fsm.state) {
-            (LinkType::NodeToAdapter, LinkState::RegisterAA) => {}
+            (LinkType::NodeToAdapter, LinkState::WaitForInitAuth) => {}
 
             (_, _) => {
                 return Err(LinkStateError::InvalidOperation(
@@ -768,6 +767,8 @@ impl LinkStateWrapper {
                 }
             }
         }
+
+        locked_fsm.set_state(LinkState::RegisterAA);
 
         // Now we have verified our part of the blob, we can send to the visa service for checking the signature.
         match visa_mgmt::build_connect_request(asm, link_id, requested_addr, &blob) {

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -467,7 +467,7 @@ impl LinkStateWrapper {
                 self.process_authentication_success(asm, blob)
             }
 
-            LinkEvent::ReceivedAuthorizeResponse => self.process_authorize_repsonse(asm),
+            LinkEvent::ReceivedAuthorizeResponse => self.process_authorize_response(asm),
 
             LinkEvent::ReceivedTerminateRequest(code) => self.process_terminate_request(asm, code),
             LinkEvent::ReceivedTerminateResponse(_) => self.process_terminate_response(asm),
@@ -644,8 +644,8 @@ impl LinkStateWrapper {
                     target: LINK_STATE,
                     "Link {link_id} finished helloing.  Waiting for other side to respond to init-auth"
                 );
-                drop(locked_fsm);
                 self.send_init_authentication_request(asm);
+                self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_RETRY_TIMER);
                 Ok(())
             }
             (LinkType::AdapterToNode, _) => {
@@ -709,7 +709,7 @@ impl LinkStateWrapper {
         }
     }
 
-    /// The ZprAddressRequest is from adapter to node (furute: joining node to node).
+    /// The ZprAddressRequest is from adapter to node (future: joining node to node).
     /// Includes authentication blob from sender, as well as the requested addresses.
     /// Inclusion of requested addresses is temporary.
     ///
@@ -954,7 +954,7 @@ impl LinkStateWrapper {
     /// TODO: At some point this will need the ZPR address returned to it also.  For now we
     /// use the address we saved in our state (from the original request).
     ///
-    fn process_authorize_repsonse(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
+    fn process_authorize_response(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
 
         match (self.link_type, locked_fsm.state) {
@@ -1105,16 +1105,8 @@ impl LinkStateWrapper {
         let task_asm = asm.clone();
 
         tokio::task::spawn_local(async move {
-            let result = mgmt::requests::send_init_authentication_request(
-                &task_asm, link_id, flags, payload,
-            )
-            .await;
-            if result.is_err() {
-                error!(target: LINK_STATE, "Link {link_id} failed to send init-auth request");
-                if let Err(e) = task_asm.process_link_state_event(link_id, LinkEvent::Error) {
-                    error!(target: LINK_STATE, "event handling error: {e}");
-                }
-            }
+            mgmt::requests::send_init_authentication_request(&task_asm, link_id, flags, payload)
+                .await
         });
     }
 
@@ -1294,6 +1286,7 @@ impl LinkStateWrapper {
 
             (LinkType::NodeToAdapter, LinkState::RegisterAA) => {
                 self.send_grant_zpr_address_request(asm, &locked_fsm.actor_addresses)
+                //self.send_init_authentication_request(asm)  // FIXME
             }
 
             (LinkType::NodeToAdapter, LinkState::WaitForInitAuth) => {

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1267,9 +1267,10 @@ impl LinkStateWrapper {
                 Ok(())
             }
 
-            (_, _) => Err(LinkStateError::InvalidOperation(
-                "Ignoring unexpected timeout".to_owned(),
-            )),
+            (_, _) => Err(LinkStateError::InvalidOperation(format!(
+                "Ignoring unexpected timeout in state {:?}",
+                locked_fsm.state
+            ))),
         }
     }
 
@@ -1286,7 +1287,6 @@ impl LinkStateWrapper {
 
             (LinkType::NodeToAdapter, LinkState::RegisterAA) => {
                 self.send_grant_zpr_address_request(asm, &locked_fsm.actor_addresses)
-                //self.send_init_authentication_request(asm)  // FIXME
             }
 
             (LinkType::NodeToAdapter, LinkState::WaitForInitAuth) => {

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1105,7 +1105,7 @@ impl LinkStateWrapper {
         });
     }
 
-    /// Send the Grant message, if all goes well then fire off a ReceivedGrantResponse event.
+    /// Send the Grant message
     fn send_grant_zpr_address_request(&self, asm: &Arc<Assembly>, addrs: Vec<IpAddress>) {
         let link_id = self.id;
         let task_asm = asm.clone();
@@ -1117,28 +1117,13 @@ impl LinkStateWrapper {
             .collect::<Vec<_>>();
 
         tokio::task::spawn_local(async move {
-            let result = mgmt::requests::send_grant_zpr_address_request(
+            mgmt::requests::send_grant_zpr_address_request(
                 &task_asm,
                 link_id,
                 ResponseCode::Success,
                 &ipaddrs,
             )
-            .await;
-
-            if result.is_err() {
-                error!(target: LINK_STATE, "Link {link_id} failed to send grant zpr address");
-                if let Err(e) = task_asm.process_link_state_event(link_id, LinkEvent::Error) {
-                    error!(target: LINK_STATE, "event handling error: {e}");
-                }
-            } else {
-                // Did send and got response.
-                if let Err(e) = task_asm.process_link_state_event(
-                    link_id,
-                    LinkEvent::ReceivedGrantResponse(result.unwrap()),
-                ) {
-                    error!(target: LINK_STATE, "event handling error: {e}");
-                }
-            }
+            .await
         });
     }
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -259,6 +259,11 @@ pub struct LinkStateMachine {
     /// used to prevent A/B/A errors with timeouts
     logical_clock: u64,
     timeout_handle: Option<tokio::task::AbortHandle>,
+    /// Counter available for use by states which wish to count timeouts.
+    /// Reset to 0 on any state transition.
+    timeout_count: usize,
+    /// present only while in RegisterAA state; used for retransmits
+    auth_blob: Option<String>,
 }
 
 impl LinkStateMachine {
@@ -272,6 +277,8 @@ impl LinkStateMachine {
             last_state_change: std::time::Instant::now(),
             logical_clock: 0,
             timeout_handle: None,
+            timeout_count: 0,
+            auth_blob: None,
         }
     }
 
@@ -282,6 +289,8 @@ impl LinkStateMachine {
         self.state = new_state;
         self.last_state_change = std::time::Instant::now();
         self.cancel_timeout();
+        self.timeout_count = 0;
+        self.auth_blob = None;
     }
 
     /// Schedule the given callback to be invoked asynchronously after the
@@ -373,7 +382,7 @@ impl LinkStateWrapper {
     fn set_timeout(
         &self,
         asm: &Arc<Assembly>,
-        locked_fsm: &mut tokio::sync::MutexGuard<'_, LinkStateMachine>,
+        locked_fsm: &mut std::sync::MutexGuard<'_, LinkStateMachine>,
         duration: std::time::Duration,
     ) {
         let link_id = self.id;
@@ -946,8 +955,7 @@ impl LinkStateWrapper {
     /// use the address we saved in our state (from the original request).
     ///
     fn process_authorize_repsonse(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
-        let addrs = self.get_actor_addresses();
-        let locked_fsm = self.locked_fsm.lock().unwrap();
+        let mut locked_fsm = self.locked_fsm.lock().unwrap();
 
         match (self.link_type, locked_fsm.state) {
             (LinkType::NodeToAdapter, LinkState::RegisterAA) => {} // ok
@@ -960,10 +968,10 @@ impl LinkStateWrapper {
 
         // Send a Grant message, consume the response and then send in an event
         // indicating we got it (ReceivedGrantResponse).
-        drop(locked_fsm);
 
         // Will call back via ReceivedGrantResponse event if successful.
-        self.send_grant_zpr_address_request(asm, addrs);
+        self.send_grant_zpr_address_request(asm, &locked_fsm.actor_addresses);
+        self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_RETRY_TIMER);
         Ok(())
     }
 
@@ -1006,11 +1014,16 @@ impl LinkStateWrapper {
                     if let Some(bs) = asm.bsauth.as_ref() {
                         match bs.authenticate(&challenge) {
                             Ok(blobstr) => {
-                                locked_fsm.set_state(LinkState::RegisterAA);
-                                drop(locked_fsm);
                                 // The send function below will invoke a state event callback.
                                 // We staty in RegisterAA state until we get a grant.
                                 self.send_acquire_zpr_address_request(asm, &blobstr);
+                                locked_fsm.set_state(LinkState::RegisterAA);
+                                locked_fsm.auth_blob = Some(blobstr);
+                                self.set_timeout(
+                                    asm,
+                                    &mut locked_fsm,
+                                    config::DEFAULT_REQUEST_RETRY_TIMER,
+                                );
                             }
                             Err(e) => {
                                 error!(target: LINK_STATE, "Link {link_id} failed to self-authenticate: {e:?}");
@@ -1106,7 +1119,7 @@ impl LinkStateWrapper {
     }
 
     /// Send the Grant message
-    fn send_grant_zpr_address_request(&self, asm: &Arc<Assembly>, addrs: Vec<IpAddress>) {
+    fn send_grant_zpr_address_request(&self, asm: &Arc<Assembly>, addrs: &[IpAddress]) {
         let link_id = self.id;
         let task_asm = asm.clone();
 
@@ -1187,7 +1200,7 @@ impl LinkStateWrapper {
         blob: ZdpAuthCodeBlob,
     ) -> Result<(), LinkStateError> {
         let link_id = self.id;
-        let locked_fsm = self.locked_fsm.lock().unwrap();
+        let mut locked_fsm = self.locked_fsm.lock().unwrap();
 
         if locked_fsm.state != LinkState::RegisterAA {
             error!(
@@ -1197,9 +1210,11 @@ impl LinkStateWrapper {
             return Ok(());
         }
 
-        drop(locked_fsm);
         info!(target: LINK_STATE, "Link {link_id}: authentication success, client_id={}", blob.client_id);
-        self.send_acquire_zpr_address_request(asm, &blob.encode());
+        let blobstr = blob.encode();
+        self.send_acquire_zpr_address_request(asm, &blobstr);
+        locked_fsm.auth_blob = Some(blobstr);
+        self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_RETRY_TIMER);
         Ok(())
     }
 
@@ -1232,18 +1247,61 @@ impl LinkStateWrapper {
 
     fn process_timeout(
         &self,
-        _asm: &Arc<Assembly>,
+        asm: &Arc<Assembly>,
         logical_clock: u64,
     ) -> Result<(), LinkStateError> {
-        let locked_fsm = self.locked_fsm.lock().unwrap();
+        let mut locked_fsm = self.locked_fsm.lock().unwrap();
         if logical_clock != locked_fsm.logical_clock {
             // timeout was for some earlier state & we won the task abort race; ignore
             return Ok(());
         }
 
         // handle the timeout...
+        match (self.link_type, locked_fsm.state) {
+            // all these states use timeout simply for retransmits
+            (LinkType::AdapterToNode, LinkState::RegisterAA)
+            | (LinkType::NodeToAdapter, LinkState::RegisterAA)
+            | (LinkType::NodeToAdapter, LinkState::WaitForInitAuth) => {
+                locked_fsm.timeout_count += 1;
 
-        Ok(())
+                if locked_fsm.timeout_count >= config::DEFAULT_REQUEST_RETRY_COUNT {
+                    error!(target: LINK_STATE, "Link {} timed out in state {:?}", self.id, locked_fsm.state);
+                    drop(locked_fsm);
+                    return self.process_error_response(&asm);
+                }
+
+                self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_RETRY_TIMER);
+                self.retransmit(asm, &mut locked_fsm);
+                Ok(())
+            }
+
+            (_, _) => Err(LinkStateError::InvalidOperation(
+                "Ignoring unexpected timeout".to_owned(),
+            )),
+        }
+    }
+
+    /// Invoked due to a state transition timeout while waiting for a reply; retransmits the associated request.
+    fn retransmit(
+        &self,
+        asm: &Arc<Assembly>,
+        locked_fsm: &mut std::sync::MutexGuard<'_, LinkStateMachine>,
+    ) {
+        match (self.link_type, locked_fsm.state) {
+            (LinkType::AdapterToNode, LinkState::RegisterAA) => {
+                self.send_acquire_zpr_address_request(asm, &locked_fsm.auth_blob.as_ref().unwrap())
+            }
+
+            (LinkType::NodeToAdapter, LinkState::RegisterAA) => {
+                self.send_grant_zpr_address_request(asm, &locked_fsm.actor_addresses)
+            }
+
+            (LinkType::NodeToAdapter, LinkState::WaitForInitAuth) => {
+                self.send_init_authentication_request(asm)
+            }
+
+            (_, _) => (),
+        }
     }
 
     /// Validate a received shutdown request

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -57,24 +57,6 @@ pub async fn send_per_flow_mgmt(
     send_mgmt_helper(asm, link_id, packet_type, Some(stream_id), None, packet).await
 }
 
-pub async fn send_non_flow_mgmt_response(
-    asm: &Assembly,
-    link_id: zpr::LinkId,
-    packet_type: zdp::ZdpPacketType,
-    sequence_number: zpr::SeqNum,
-    packet: Packet,
-) {
-    send_mgmt_helper(
-        asm,
-        link_id,
-        packet_type,
-        None,
-        Some(sequence_number),
-        packet,
-    )
-    .await
-}
-
 pub async fn send_per_flow_mgmt_response(
     asm: &Assembly,
     link_id: zpr::LinkId,
@@ -120,29 +102,6 @@ async fn send_mgmt_helper(
     asm.mgmt_substrate_egress
         .enqueue_packet(link_id, packet)
         .await;
-}
-
-/// Sender function for non-per flow request management packet.
-/// Requires the type of ZDP packet being sent as well as the type of the
-/// expected response packet.
-/// pkt_fn allows the function to create the proper body of the ZDP packet to send
-/// Returns the received packet without any ZdpHeader (just management response body) or an error
-pub async fn send_sync_non_flow_req(
-    asm: &Assembly,
-    link_id: zpr::LinkId,
-    zdp_request_type: zdp::ZdpPacketType,
-    zdp_response_type: zdp::ZdpPacketType,
-    pkt_fn: impl Fn(&mut Packet) + Send + 'static,
-) -> Result<Packet, SyncReqError> {
-    send_sync_req_helper(
-        asm,
-        link_id,
-        zdp_request_type,
-        zdp_response_type,
-        None,
-        pkt_fn,
-    )
-    .await
 }
 
 /// Sender function for per flow request management packet.

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -117,7 +117,7 @@ pub async fn handle_echo_response(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
 ///
 pub async fn handle_init_authentication_request(
     asm: &Arc<Assembly>,
-    seq_num: zpr::SeqNum,
+    _seq_num: zpr::SeqNum,
     mut pkt: Packet,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
@@ -154,14 +154,13 @@ pub async fn handle_init_authentication_request(
     }
 
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpInitAuthenticationResponseHeader>();
+    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpInitAuthenticationResponse>();
     hdr.status_code = zdp::ResponseCode::Success;
 
-    super::core::send_non_flow_mgmt_response(
+    super::core::send_non_flow_mgmt(
         asm,
         ingress_link_id,
         zdp::ZdpPacketType::InitAuthenticationResponse,
-        seq_num,
         rsp_pkt,
     )
     .await;
@@ -170,6 +169,21 @@ pub async fn handle_init_authentication_request(
         ingress_link_id,
         LinkEvent::ReceivedInitAuth((is_bootstrap, challenge_opt)),
     );
+
+    Ok(())
+}
+
+pub async fn handle_init_authentication_response(
+    _asm: &Arc<Assembly>,
+    mut pkt: Packet,
+) -> HandleMgmtResult {
+    let Ok(hdr) = zdp::ZdpInitAuthenticationResponse::read_from_buf(&mut pkt) else {
+        return Err((HandleMgmtError::BadStructure, pkt));
+    };
+
+    let link_id = pkt.metadata().ingress_link_id;
+    let status = hdr.status_code;
+    debug!(target: ZDP, "Link {link_id}: Received InitAuthenticationResponse, status: {status:?}");
 
     Ok(())
 }

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -403,7 +403,7 @@ pub async fn handle_acquire_zpr_address_request(
 /// If the request indicates a fail, we send the event with empty address list.
 pub async fn handle_grant_zpr_address_request(
     asm: &Arc<Assembly>,
-    seq_num: zpr::SeqNum,
+    _seq_num: zpr::SeqNum,
     mut pkt: Packet,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
@@ -456,17 +456,34 @@ pub async fn handle_grant_zpr_address_request(
 
     // Send an ACK.
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpGrantZprAddressResponseHeader>();
+    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpGrantZprAddressResponse>();
     hdr.status_code = status_code;
 
-    super::core::send_non_flow_mgmt_response(
+    super::core::send_non_flow_mgmt(
         asm,
         ingress_link_id,
         zdp::ZdpPacketType::GrantZprAddressResponse,
-        seq_num,
         rsp_pkt,
     )
     .await;
+    Ok(())
+}
+
+pub async fn handle_grant_zpr_address_response(
+    asm: &Arc<Assembly>,
+    mut pkt: Packet,
+) -> HandleMgmtResult {
+    let Ok(hdr) = zdp::ZdpGrantZprAddressResponse::read_from_buf(&mut pkt) else {
+        return Err((HandleMgmtError::BadStructure, pkt));
+    };
+
+    let link_id = pkt.metadata().ingress_link_id;
+    let resp_code = hdr.status_code;
+    debug!(target: ZDP, "Link {link_id}: received GrantZprAddressResponse, status: {resp_code:?}");
+    let _ = asm
+        .process_link_state_event(link_id, LinkEvent::ReceivedGrantResponse(resp_code))
+        .map_err(|_| ());
+
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -345,7 +345,7 @@ pub async fn handle_hello_response(asm: &Arc<Assembly>, mut pkt: Packet) -> Hand
 ///
 pub async fn handle_acquire_zpr_address_request(
     asm: &Arc<Assembly>,
-    seq_num: zpr::SeqNum,
+    _seq_num: zpr::SeqNum,
     mut pkt: Packet,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
@@ -361,14 +361,13 @@ pub async fn handle_acquire_zpr_address_request(
 
     // Send an ACK.
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpAcquireZprAddressResponseHeader>();
+    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpAcquireZprAddressResponse>();
     hdr.status_code = status_code;
 
-    super::core::send_non_flow_mgmt_response(
+    super::core::send_non_flow_mgmt(
         asm,
         ingress_link_id,
         zdp::ZdpPacketType::AcquireZprAddressResponse,
-        seq_num,
         rsp_pkt,
     )
     .await;
@@ -390,6 +389,24 @@ pub async fn handle_acquire_zpr_address_request(
     ) {
         error!(target: ZDP, "Link {ingress_link_id}: Failed to process ReceivedAcquireZprAddressRequest event: {:?}", e);
     }
+
+    Ok(())
+}
+
+pub async fn handle_acquire_zpr_address_response(
+    asm: &Arc<Assembly>,
+    mut pkt: Packet,
+) -> HandleMgmtResult {
+    let Ok(hdr) = zdp::ZdpAcquireZprAddressResponse::read_from_buf(&mut pkt) else {
+        return Err((HandleMgmtError::BadStructure, pkt));
+    };
+
+    let link_id = pkt.metadata().ingress_link_id;
+    let resp_code = hdr.status_code;
+    debug!("Link {link_id} Received AcquireZprAddressResponse, status: {resp_code:?}");
+    let _ = asm
+        .process_link_state_event(link_id, LinkEvent::ReceivedAcquireResponse(resp_code))
+        .map_err(|_| ());
 
     Ok(())
 }

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -99,42 +99,25 @@ pub async fn send_init_authentication_request(
     link_id: zpr::LinkId,
     flags: u8,
     payload: auth::ZdpInitAuthenticationPayload,
-) -> Result<zdp::ResponseCode, ()> {
+) -> zpr::SeqNum {
     debug!(target: ZDP, "Link {link_id}: sending IntitAuthenticationRequest, flags: {flags:x?}");
-    let response = core::send_sync_non_flow_req(
+
+    let mut req = core::new_heap_packet();
+
+    let hdr = zdp::ZdpInitAuthenticationRequestHeader {
+        flags,
+        data_len: (size_of::<auth::ZdpInitAuthenticationPayload>() as u16).into(),
+    };
+    hdr.write_to_buf(&mut req).unwrap();
+    payload.write_to_buf(&mut req).unwrap();
+
+    core::send_non_flow_mgmt(
         asm,
         link_id,
         zdp::ZdpPacketType::InitAuthenticationRequest,
-        zdp::ZdpPacketType::InitAuthenticationResponse,
-        move |mut req| {
-            let hdr = zdp::ZdpInitAuthenticationRequestHeader {
-                flags,
-                data_len: (size_of::<auth::ZdpInitAuthenticationPayload>() as u16).into(),
-            };
-            hdr.write_to_buf(&mut req).unwrap();
-            payload.write_to_buf(&mut req).unwrap();
-        },
+        req,
     )
-    .await;
-
-    match response {
-        Ok(mut init_auth_res) => {
-            let Ok(hdr) =
-                zdp::ZdpInitAuthenticationResponseHeader::read_from_buf(&mut init_auth_res)
-            else {
-                core::count_event(asm, &mut init_auth_res, CounterType::BadStructure);
-                return Err(());
-            };
-            let status = hdr.status_code;
-            debug!(target: ZDP, "Link {link_id}: Received InitAuthenticationResponse, status: {status:?}");
-            Ok(status)
-        }
-
-        Err(err) => {
-            warn!(target: ZDP, "Link {link_id}: error with InitAuthenticationRequest: {}", err);
-            Err(())
-        }
-    }
+    .await
 }
 
 /// Send an AcquireZPRAddressRequest (TODO: not yet in RFC 6)

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -150,72 +150,52 @@ pub async fn send_acquire_zpr_address_request(
     asm: &Assembly,
     link_id: zpr::LinkId,
     actor_addrs: &[IpAddr],
-    blob: Option<Vec<u8>>,
-) -> Result<zdp::ResponseCode, ()> {
-    // Copy the blob amd addrs for use in closure below.
-    let blob_data = blob.unwrap_or_default();
-    let c_actor_addrs = actor_addrs.to_owned();
+    blob: Option<&[u8]>,
+) -> zpr::SeqNum {
+    let blob = blob.unwrap_or_default();
 
-    let response = core::send_sync_non_flow_req(
+    let mut req = core::new_heap_packet();
+
+    let ip_version = if actor_addrs.is_empty() {
+        zpr::L3Type::Ipv6 // whatever, doesn't matter since count is zero.
+    } else {
+        actor_addrs[0].l3_type()
+    };
+    let hdr = zdp::ZdpAcquireZprAddressRequestHeader {
+        blob_len: (blob.len() as u16).into(),
+        ip_version,
+        addr_count: actor_addrs.len() as u8,
+    };
+    hdr.write_to_buf(&mut req).unwrap();
+    req.put_slice(blob);
+    for addr in actor_addrs {
+        match addr {
+            IpAddr::V4(addr) => {
+                if ip_version != zpr::L3Type::Ipv4 {
+                    panic!(
+                        "attempt to send an IPv4 address with IPv6 type acquire zpr address packet"
+                    )
+                }
+                req.put(&addr.octets()[..])
+            }
+            IpAddr::V6(addr) => {
+                if ip_version != zpr::L3Type::Ipv6 {
+                    panic!(
+                        "attempt to send an IPv6 address with IPv4 type acquire zpr address packet"
+                    )
+                }
+                req.put(&addr.octets()[..])
+            }
+        }
+    }
+
+    core::send_non_flow_mgmt(
         asm,
         link_id,
         zdp::ZdpPacketType::AcquireZprAddressRequest,
-        zdp::ZdpPacketType::AcquireZprAddressResponse,
-        move |mut req| {
-            let ip_version = if c_actor_addrs.is_empty() {
-                zpr::L3Type::Ipv6 // whatever, doesn't matter since count is zero.
-            } else {
-                c_actor_addrs[0].l3_type()
-            };
-            let hdr = zdp::ZdpAcquireZprAddressRequestHeader {
-                blob_len: (blob_data.len() as u16).into(),
-                ip_version,
-                addr_count: c_actor_addrs.len() as u8,
-            };
-            hdr.write_to_buf(&mut req).unwrap();
-            req.put_slice(&blob_data);
-            for addr in &c_actor_addrs {
-                match addr {
-                    IpAddr::V4(addr) => {
-                        if ip_version != zpr::L3Type::Ipv4 {
-                            panic!("attempt to send an IPv4 address with IPv6 type acquire zpr address packet")
-                        }
-                        req.put(&addr.octets()[..])
-                    },
-                    IpAddr::V6(addr) => {
-                        if ip_version != zpr::L3Type::Ipv6 {
-                            panic!("attempt to send an IPv6 address with IPv4 type acquire zpr address packet")
-                        }
-                        req.put(&addr.octets()[..])
-                    },
-                }
-            }
-        },
+        req,
     )
-    .await;
-
-    match response {
-        Ok(mut rpkt) => {
-            let Ok(hdr) = zdp::ZdpAcquireZprAddressResponseHeader::read_from_buf(&mut rpkt) else {
-                core::count_event(asm, &mut rpkt, CounterType::BadStructure);
-                return Err(());
-            };
-            let resp_code = hdr.status_code;
-            debug!(
-                "Link {link_id} Received AcquireZprAddressResponse, status: {:?}",
-                resp_code
-            );
-            Ok(resp_code)
-        }
-
-        Err(err) => {
-            warn!(
-                "Link {link_id}: error with AcquireZprAddressResponse: {}",
-                err
-            );
-            Err(())
-        }
-    }
+    .await
 }
 
 /// Send an GrantZprAddressRequest (TODO: not yet in RFC 6)

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -232,70 +232,50 @@ pub async fn send_grant_zpr_address_request(
     link_id: zpr::LinkId,
     status_code: zdp::ResponseCode,
     actor_addrs: &[IpAddr],
-) -> Result<zdp::ResponseCode, ()> {
-    let mut c_actor_addrs = Vec::new();
-    c_actor_addrs.extend_from_slice(actor_addrs);
-
+) -> zpr::SeqNum {
     info!(target: ZDP, "Link {link_id} - sending GrantZprAddressRequest, status: {status_code:?}");
-    let response = core::send_sync_non_flow_req(
+
+    let mut req = core::new_heap_packet();
+
+    let ip_version = if actor_addrs.is_empty() {
+        zpr::L3Type::Ipv6 // whatever, doesn't matter since count is zero.
+    } else {
+        actor_addrs[0].l3_type()
+    };
+    let hdr = zdp::ZdpGrantZprAddressRequestHeader {
+        status_code,
+        ip_version,
+        addr_count: actor_addrs.len() as u8,
+    };
+    hdr.write_to_buf(&mut req).unwrap();
+    for addr in actor_addrs {
+        match addr {
+            IpAddr::V4(addr) => {
+                if ip_version != zpr::L3Type::Ipv4 {
+                    panic!(
+                        "attempt to send an IPv4 address with IPv6 type grant zpr address packet"
+                    )
+                }
+                req.put(&addr.octets()[..])
+            }
+            IpAddr::V6(addr) => {
+                if ip_version != zpr::L3Type::Ipv6 {
+                    panic!(
+                        "attempt to send an IPv6 address with IPv4 type grant zpr address packet"
+                    )
+                }
+                req.put(&addr.octets()[..])
+            }
+        }
+    }
+
+    core::send_non_flow_mgmt(
         asm,
         link_id,
         zdp::ZdpPacketType::GrantZprAddressRequest,
-        zdp::ZdpPacketType::GrantZprAddressResponse,
-        move |mut req| {
-            let ip_version = if c_actor_addrs.is_empty() {
-                zpr::L3Type::Ipv6 // whatever, doesn't matter since count is zero.
-            } else {
-                c_actor_addrs[0].l3_type()
-            };
-            let hdr = zdp::ZdpGrantZprAddressRequestHeader {
-                status_code,
-                ip_version,
-                addr_count: c_actor_addrs.len() as u8,
-            };
-            hdr.write_to_buf(&mut req).unwrap();
-            for addr in &c_actor_addrs {
-                match addr {
-                    IpAddr::V4(addr) => {
-                        if ip_version != zpr::L3Type::Ipv4 {
-                            panic!("attempt to send an IPv4 address with IPv6 type grant zpr address packet")
-                        }
-                        req.put(&addr.octets()[..])
-                    },
-                    IpAddr::V6(addr) => {
-                        if ip_version != zpr::L3Type::Ipv6 {
-                            panic!("attempt to send an IPv6 address with IPv4 type grant zpr address packet")
-                        }
-                        req.put(&addr.octets()[..])
-                    },
-                }
-            }
-        },
+        req,
     )
-    .await;
-
-    match response {
-        Ok(mut rpkt) => {
-            let Ok(hdr) = zdp::ZdpGrantZprAddressResponseHeader::read_from_buf(&mut rpkt) else {
-                core::count_event(asm, &mut rpkt, CounterType::BadStructure);
-                return Err(());
-            };
-            let resp_code = hdr.status_code;
-            debug!(
-                "Link {link_id}: received GrantZprAddressResponse, status: {:?}",
-                resp_code
-            );
-            Ok(resp_code)
-        }
-
-        Err(err) => {
-            warn!(
-                "Link {link_id}: error with GrantZprAddressResponse: {}",
-                err
-            );
-            Err(())
-        }
-    }
+    .await
 }
 
 /// send a Terminate Request (RFC 6.5 § 6.3.3)

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -125,6 +125,10 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
                 handlers::handle_grant_zpr_address_request(asm, seq_num, pkt).await
             }
 
+            ZdpPacketType::GrantZprAddressResponse => {
+                handlers::handle_grant_zpr_address_response(asm, pkt).await
+            }
+
             packet_type => {
                 warn!("unhandled mgmt packet type {:?}", packet_type);
                 Err((HandleMgmtError::UnknownType(packet_type.0), pkt))

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -117,6 +117,10 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
                 handlers::handle_init_authentication_request(asm, seq_num, pkt).await
             }
 
+            ZdpPacketType::InitAuthenticationResponse => {
+                handlers::handle_init_authentication_response(asm, pkt).await
+            }
+
             ZdpPacketType::AcquireZprAddressRequest => {
                 handlers::handle_acquire_zpr_address_request(asm, seq_num, pkt).await
             }

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -121,6 +121,10 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
                 handlers::handle_acquire_zpr_address_request(asm, seq_num, pkt).await
             }
 
+            ZdpPacketType::AcquireZprAddressResponse => {
+                handlers::handle_acquire_zpr_address_response(asm, pkt).await
+            }
+
             ZdpPacketType::GrantZprAddressRequest => {
                 handlers::handle_grant_zpr_address_request(asm, seq_num, pkt).await
             }

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -65,7 +65,7 @@ impl ZdpPacketType {
         // so this logic becomes a simple range check
 
         match self {
-            Self::BindActorAddressResponse | Self::InitAuthenticationResponse => true,
+            Self::BindActorAddressResponse => true,
             _ => false,
         }
     }
@@ -152,7 +152,7 @@ pub struct ZdpInitAuthenticationRequestHeader {
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
-pub struct ZdpInitAuthenticationResponseHeader {
+pub struct ZdpInitAuthenticationResponse {
     pub status_code: ResponseCode,
 }
 

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -67,8 +67,7 @@ impl ZdpPacketType {
         match self {
             Self::BindActorAddressResponse
             | Self::AcquireZprAddressResponse
-            | Self::InitAuthenticationResponse
-            | Self::GrantZprAddressResponse => true,
+            | Self::InitAuthenticationResponse => true,
             _ => false,
         }
     }
@@ -188,7 +187,7 @@ pub struct ZdpGrantZprAddressRequestHeader {
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
-pub struct ZdpGrantZprAddressResponseHeader {
+pub struct ZdpGrantZprAddressResponse {
     pub status_code: ResponseCode,
 }
 

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -65,9 +65,7 @@ impl ZdpPacketType {
         // so this logic becomes a simple range check
 
         match self {
-            Self::BindActorAddressResponse
-            | Self::AcquireZprAddressResponse
-            | Self::InitAuthenticationResponse => true,
+            Self::BindActorAddressResponse | Self::InitAuthenticationResponse => true,
             _ => false,
         }
     }
@@ -171,7 +169,7 @@ pub struct ZdpAcquireZprAddressRequestHeader {
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
-pub struct ZdpAcquireZprAddressResponseHeader {
+pub struct ZdpAcquireZprAddressResponse {
     pub status_code: ResponseCode,
 }
 


### PR DESCRIPTION
Link state authentication message flow now no longer uses the sync-request mechanism.  Instead each request and response is an explicit unidirectional message.  Specifically we have the following changes here:
* InitAuthentication, AcquireZprAddress, and GrantZprAddress are all converted to unidirectional message flow pairs
* the new link state timeout mechanism is used to retry sending messages should the expected response in each state not be received (just the same as the sync-request mechanism provided before)
* the node now enters into WaitForInitAuth while waiting for InitAuthenticationResponse, and only proceeds to RegisterAA once that is received.  (Else we don't know whether we're waiting for that, or GrantZprAddressResponse.)  Aside – I think generally RegisterAA should be broken up into smaller states, but that can be tackled outside of this PR.
* The sync-message API for _non-flow_ messages is now no longer used, so that's removed.