### PR TITLE
eliminate use of async tasks for sending messages from link_state

### DIFF
--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -184,8 +184,7 @@ pub async fn launch_message_worker(
     mut msg_queue: mpsc::Receiver<KmLinkMsg<Bytes>>,
 ) {
     while let Some(km_buf_msg) = msg_queue.recv().await {
-        requests::send_key_management(&*asm, km_buf_msg.link_id, zpr::KM_ID_NOISE, &km_buf_msg.msg)
-            .await;
+        requests::send_key_management(&*asm, km_buf_msg.link_id, zpr::KM_ID_NOISE, &km_buf_msg.msg);
     }
 }
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -601,16 +601,7 @@ impl LinkStateWrapper {
     fn maybe_send_hello(&self, asm: &Arc<Assembly>) {
         // IF this is an adapter, it's expected to issue the hello
         if self.link_type == LinkType::AdapterToNode {
-            let link_id = self.id;
-            let task_asm = asm.clone();
-            tokio::task::spawn_local(async move {
-                mgmt::requests::send_hello_request(
-                    &task_asm,
-                    link_id,
-                    &task_asm.local_zpr_addresses,
-                )
-                .await
-            });
+            mgmt::requests::send_hello_request(asm, self.id, &asm.local_zpr_addresses);
         }
         // Otherwise, wait for the adapter to reach out
     }
@@ -793,14 +784,11 @@ impl LinkStateWrapper {
                 // So pretend we are the visa service and handle our own authorization.
                 drop(locked_fsm);
 
-                let task_asm = asm.clone();
-                tokio::task::spawn_local(async move {
-                    if let Err(e) = task_asm
-                        .process_link_state_event(link_id, LinkEvent::ReceivedAuthorizeResponse)
-                    {
-                        error!(target: LINK_STATE, "Link {link_id} failed to process authorize response: {e}");
-                    }
-                });
+                if let Err(e) =
+                    asm.process_link_state_event(link_id, LinkEvent::ReceivedAuthorizeResponse)
+                {
+                    error!(target: LINK_STATE, "Link {link_id} failed to process authorize response: {e}");
+                }
 
                 Ok(())
             }
@@ -1102,34 +1090,23 @@ impl LinkStateWrapper {
             payload = auth::ZdpInitAuthenticationPayload::default(); // empty
         }
 
-        let task_asm = asm.clone();
-
-        tokio::task::spawn_local(async move {
-            mgmt::requests::send_init_authentication_request(&task_asm, link_id, flags, payload)
-                .await
-        });
+        mgmt::requests::send_init_authentication_request(asm, link_id, flags, payload);
     }
 
     /// Send the Grant message
     fn send_grant_zpr_address_request(&self, asm: &Arc<Assembly>, addrs: &[IpAddress]) {
-        let link_id = self.id;
-        let task_asm = asm.clone();
-
         // Convert the IpAddresses into IpAddrs
         let ipaddrs = addrs
             .iter()
             .map(|addr| IpAddr::from(addr))
             .collect::<Vec<_>>();
 
-        tokio::task::spawn_local(async move {
-            mgmt::requests::send_grant_zpr_address_request(
-                &task_asm,
-                link_id,
-                ResponseCode::Success,
-                &ipaddrs,
-            )
-            .await
-        });
+        mgmt::requests::send_grant_zpr_address_request(
+            asm,
+            self.id,
+            ResponseCode::Success,
+            &ipaddrs,
+        );
     }
 
     /// Run the HTTPS authentication process in a tokio task.
@@ -1212,20 +1189,12 @@ impl LinkStateWrapper {
 
     /// Send Acquire message
     fn send_acquire_zpr_address_request(&self, asm: &Arc<Assembly>, blob: &str) {
-        let link_id = self.id;
-        let task_asm = asm.clone();
-
-        let blob_opt = Some(blob.as_bytes().to_owned());
-
-        tokio::task::spawn_local(async move {
-            mgmt::requests::send_acquire_zpr_address_request(
-                &task_asm,
-                link_id,
-                &task_asm.local_zpr_addresses,
-                blob_opt.as_deref(),
-            )
-            .await
-        });
+        mgmt::requests::send_acquire_zpr_address_request(
+            asm,
+            self.id,
+            &asm.local_zpr_addresses,
+            Some(blob.as_bytes()),
+        );
     }
 
     fn process_error_response(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
@@ -1334,10 +1303,7 @@ impl LinkStateWrapper {
 
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         locked_fsm.set_state(LinkState::Closing);
-        let task_asm = asm.clone();
-        tokio::task::spawn_local(async move {
-            mgmt::requests::send_terminate_request(&task_asm, link_id, reason).await
-        });
+        mgmt::requests::send_terminate_request(asm, self.id, reason);
         Ok(())
     }
 
@@ -1400,6 +1366,7 @@ impl LinkStateWrapper {
 
     /// Set a timer to attempt a link restart after a holddown period
     fn setup_restart(&self, asm: &Arc<Assembly>) {
+        // TODO: use timeout mechanism
         let link_id = self.id;
         let task_asm = asm.clone();
         tokio::task::spawn_local(async move {
@@ -1422,7 +1389,7 @@ impl LinkStateWrapper {
             .lock()
             .unwrap()
             .set_state(LinkState::Resetting);
-        mgmt::requests::send_terminate_indication(asm, link_id, TerminateReason::Reset).await;
+        mgmt::requests::send_terminate_indication(asm, link_id, TerminateReason::Reset);
         let _ = self.clean_up_link_state(asm).join_all().await;
     }
 
@@ -1482,7 +1449,7 @@ impl LinkStateWrapper {
 
                 let mut recv = task_events.subscribe();
 
-                let sent_seq_num = mgmt::requests::send_echo_request(&task_asm, link_id).await;
+                let sent_seq_num = mgmt::requests::send_echo_request(&task_asm, link_id);
                 let expected_seq_num = (sent_seq_num & 0xffff) as u16;
 
                 let got_response =

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -33,31 +33,31 @@ pub fn count_event(
 
 /// Send a unidirectional non-flow management message on the given link.
 /// The packet should contain only the message body.
-pub async fn send_non_flow_mgmt(
+pub fn send_non_flow_mgmt(
     asm: &Assembly,
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
     packet: Packet,
 ) -> zpr::SeqNum {
     let seq_num = 0; // TODO, zpr-core/839
-    send_mgmt_helper(asm, link_id, packet_type, None, None, packet).await;
+    send_mgmt_helper(asm, link_id, packet_type, None, None, packet);
     seq_num
 }
 
 /// Send a unidirectional per-flow management message on the given link.
 /// The packet should contain only the message body.
 #[allow(dead_code)]
-pub async fn send_per_flow_mgmt(
+pub fn send_per_flow_mgmt(
     asm: &Assembly,
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
     stream_id: zpr::StreamId,
     packet: Packet,
 ) {
-    send_mgmt_helper(asm, link_id, packet_type, Some(stream_id), None, packet).await
+    send_mgmt_helper(asm, link_id, packet_type, Some(stream_id), None, packet)
 }
 
-pub async fn send_per_flow_mgmt_response(
+pub fn send_per_flow_mgmt_response(
     asm: &Assembly,
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
@@ -73,10 +73,9 @@ pub async fn send_per_flow_mgmt_response(
         Some(sequence_number),
         packet,
     )
-    .await
 }
 
-async fn send_mgmt_helper(
+fn send_mgmt_helper(
     asm: &Assembly,
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
@@ -99,9 +98,12 @@ async fn send_mgmt_helper(
         hdr.sequence_number = (sequence_number as u16).into();
     }
 
-    asm.mgmt_substrate_egress
-        .enqueue_packet(link_id, packet)
-        .await;
+    // It's possible (but unlikely) the MgmtSubstrateEgress queue fills up.
+    // In that case, just ignore the error; act as if the packet was dropped
+    // by the substrate due to congestion.
+    let _ = asm
+        .mgmt_substrate_egress
+        .try_enqueue_packet(link_id, packet);
 }
 
 /// Sender function for per flow request management packet.
@@ -179,8 +181,7 @@ async fn send_sync_req_helper(
             stream_id,
             Some(permit.seq_num()),
             packet,
-        )
-        .await;
+        );
 
         tokio::select! {
             response = &mut response_future => {

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -89,8 +89,7 @@ pub async fn handle_echo_request(
         ingress_link_id,
         zdp::ZdpPacketType::EchoResponse,
         rsp_pkt,
-    )
-    .await;
+    );
 
     Ok(())
 }
@@ -162,8 +161,7 @@ pub async fn handle_init_authentication_request(
         ingress_link_id,
         zdp::ZdpPacketType::InitAuthenticationResponse,
         rsp_pkt,
-    )
-    .await;
+    );
 
     let _ = asm.process_link_state_event(
         ingress_link_id,
@@ -218,8 +216,7 @@ pub async fn handle_terminate_request(
         ingress_link_id,
         zdp::ZdpPacketType::TerminateLinkResponse,
         rsp_pkt,
-    )
-    .await;
+    );
 
     if response_code == zdp::ResponseCode::Success {
         let _ = asm.process_link_state_event(ingress_link_id, LinkEvent::SentTerminate);
@@ -319,8 +316,7 @@ pub async fn handle_hello_request(
         ingress_link_id,
         zdp::ZdpPacketType::HelloResponse,
         rsp_pkt,
-    )
-    .await;
+    );
 
     Ok(())
 }
@@ -383,8 +379,7 @@ pub async fn handle_acquire_zpr_address_request(
         ingress_link_id,
         zdp::ZdpPacketType::AcquireZprAddressResponse,
         rsp_pkt,
-    )
-    .await;
+    );
 
     // Now we can do our async prcessing of the acquire which will involve talking to
     // the visa service.
@@ -495,8 +490,7 @@ pub async fn handle_grant_zpr_address_request(
         ingress_link_id,
         zdp::ZdpPacketType::GrantZprAddressResponse,
         rsp_pkt,
-    )
-    .await;
+    );
     Ok(())
 }
 
@@ -965,8 +959,7 @@ pub async fn handle_bind_actor_address_request(
         ingress_tether_id,
         seq_num,
         rsp_pkt,
-    )
-    .await;
+    );
 
     Ok(())
 }

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -19,12 +19,12 @@ use zpr::{self, L3TypeDeriveable};
 use zpr_ext::zerocopy::{FromBytesExt, IntoBytesExt};
 
 /// send a Key Management message (RFC 6.5 § 6.2.8)
-pub async fn send_key_management(
+pub fn send_key_management(
     asm: &Assembly,
     link_id: zpr::LinkId,
     km_id: zpr::KmId,
     payload: &[u8],
-) {
+) -> zpr::SeqNum {
     let mut pkt = core::new_heap_packet();
 
     let km_hdr = pkt.alloc_zeroed_header::<zdp::ZdpKeyManagementHeader>();
@@ -33,21 +33,20 @@ pub async fn send_key_management(
 
     pkt.put(payload);
 
-    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::KeyManagement, pkt).await;
+    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::KeyManagement, pkt)
 }
 
-#[allow(dead_code)]
 /// send a Discard message (RFC 6.5 § 6.3.1)
-pub async fn send_discard(asm: &Assembly, link_id: zpr::LinkId) -> zpr::SeqNum {
+pub fn send_discard(asm: &Assembly, link_id: zpr::LinkId) -> zpr::SeqNum {
     let pkt = core::new_heap_packet();
-    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::Discard, pkt).await
+    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::Discard, pkt)
 }
 
 /// send an Echo Request (RFC 6.5 § 6.3.2)
-pub async fn send_echo_request(asm: &Assembly, link_id: zpr::LinkId) -> zpr::SeqNum {
+pub fn send_echo_request(asm: &Assembly, link_id: zpr::LinkId) -> zpr::SeqNum {
     let mut pkt = core::new_heap_packet();
     pkt.alloc_zeroed_header::<zdp::ZdpEchoHeader>();
-    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::EchoRequest, pkt).await
+    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::EchoRequest, pkt)
 }
 
 /// send a Hello Request and wait for the Response (RFC 6.5 § 6.3.4)
@@ -59,7 +58,7 @@ pub async fn send_echo_request(asm: &Assembly, link_id: zpr::LinkId) -> zpr::Seq
 ///
 /// ## Panics
 /// - If address list is empty.
-pub async fn send_hello_request(
+pub fn send_hello_request(
     asm: &Assembly,
     link_id: zpr::LinkId,
     actor_addrs: &[IpAddr],
@@ -80,7 +79,7 @@ pub async fn send_hello_request(
         IpAddr::V6(addr) => req.put(&addr.octets()[..]),
     }
 
-    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::HelloRequest, req).await
+    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::HelloRequest, req)
 }
 
 /// Send Init Authentication (NOT YET IN RFC 6)
@@ -94,7 +93,7 @@ pub async fn send_hello_request(
 /// The nonce and hash are returned in the bootstrap authentication BLOB and
 /// are checked by the node before processing.
 ///
-pub async fn send_init_authentication_request(
+pub fn send_init_authentication_request(
     asm: &Assembly,
     link_id: zpr::LinkId,
     flags: u8,
@@ -117,7 +116,6 @@ pub async fn send_init_authentication_request(
         zdp::ZdpPacketType::InitAuthenticationRequest,
         req,
     )
-    .await
 }
 
 /// Send an AcquireZPRAddressRequest (TODO: not yet in RFC 6)
@@ -129,7 +127,7 @@ pub async fn send_init_authentication_request(
 ///
 /// ## Panics
 /// - Panics if all requested addresses are not the same IP version.
-pub async fn send_acquire_zpr_address_request(
+pub fn send_acquire_zpr_address_request(
     asm: &Assembly,
     link_id: zpr::LinkId,
     actor_addrs: &[IpAddr],
@@ -178,7 +176,6 @@ pub async fn send_acquire_zpr_address_request(
         zdp::ZdpPacketType::AcquireZprAddressRequest,
         req,
     )
-    .await
 }
 
 /// Send an GrantZprAddressRequest (TODO: not yet in RFC 6)
@@ -190,7 +187,7 @@ pub async fn send_acquire_zpr_address_request(
 ///
 /// ## Panics
 /// - Panics if all granted addresses are not the same IP version.
-pub async fn send_grant_zpr_address_request(
+pub fn send_grant_zpr_address_request(
     asm: &Assembly,
     link_id: zpr::LinkId,
     status_code: zdp::ResponseCode,
@@ -238,11 +235,10 @@ pub async fn send_grant_zpr_address_request(
         zdp::ZdpPacketType::GrantZprAddressRequest,
         req,
     )
-    .await
 }
 
 /// send a Terminate Request (RFC 6.5 § 6.3.3)
-pub async fn send_terminate_request<'a, 'pktbuf>(
+pub fn send_terminate_request<'a, 'pktbuf>(
     asm: &Assembly,
     link_id: zpr::LinkId,
     reason: zdp::TerminateReason,
@@ -252,15 +248,15 @@ pub async fn send_terminate_request<'a, 'pktbuf>(
         reason_code: reason,
         data_len: 0,
     });
-    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::TerminateLinkRequest, pkt).await
+    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::TerminateLinkRequest, pkt)
 }
 
 /// send a Terminate Indication (RFC 6.5 § 6.3.3)
-pub async fn send_terminate_indication<'a, 'pktbuf>(
+pub fn send_terminate_indication<'a, 'pktbuf>(
     asm: &Assembly,
     link_id: zpr::LinkId,
     reason: zdp::TerminateReason,
-) {
+) -> zpr::SeqNum {
     let mut pkt = core::new_heap_packet();
     let hdr = pkt.alloc_zeroed_header::<zdp::ZdpTerminateLinkIndicationHeader>();
     hdr.reason_code = reason;
@@ -270,7 +266,6 @@ pub async fn send_terminate_indication<'a, 'pktbuf>(
         zdp::ZdpPacketType::TerminateLinkIndication,
         pkt,
     )
-    .await;
 }
 
 #[derive(Debug, Error)]
@@ -348,9 +343,8 @@ pub async fn send_bind_actor_address_request(
     }
 }
 
-#[allow(dead_code)]
 /// send a Report message (RFC 6.5 § 6.3.13)
-pub async fn send_report(asm: &Assembly, link_id: zpr::LinkId, report: &str) {
+pub fn send_report(asm: &Assembly, link_id: zpr::LinkId, report: &str) -> zpr::SeqNum {
     // TODO this condition will need to be adjusted when we have complete ZPR packets
     // with the information at the end of the packet at well
     /*if packet::PACKET_BUFFER_MAX_BODY_SIZE - config::DEFAULT_MESSAGE_HEADROOM < report.len() {
@@ -360,5 +354,5 @@ pub async fn send_report(asm: &Assembly, link_id: zpr::LinkId, report: &str) {
     let hdr = pkt.alloc_zeroed_header::<zdp::ZdpReportHeader>();
     hdr.report_data_length = (report.len() as u16).into();
     pkt.put(report.as_bytes());
-    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::Report, pkt).await;
+    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::Report, pkt)
 }

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -86,6 +86,7 @@ impl MgmtSubstrateEgress {
     /// Blocks until the packet is in the hands of the fastpath.
     /// The packet is marked PRIORITY, which instructs the fastpath to
     /// ensure it eventually gets queued with the OS.
+    #[allow(dead_code)]
     pub async fn enqueue_packet(&self, link_id: zpr::LinkId, mut packet: Packet) {
         packet.metadata_mut().egress_link_id = link_id;
         packet.metadata_mut().flags |= packet::flags::PRIORITY;
@@ -98,7 +99,6 @@ impl MgmtSubstrateEgress {
     /// Try to enqueue the given packet to be egressed on the substrate.
     /// Returns said packet if there is no room in the queue.
     /// Unlike `enqueue_packet()`, the packet is not marked for any special processing.
-    #[allow(dead_code)]
     pub fn try_enqueue_packet(&self, link_id: zpr::LinkId, mut packet: Packet) -> bool {
         packet.metadata_mut().egress_link_id = link_id;
         match self.queue.try_send(&packet) {


### PR DESCRIPTION
Rather than spawn a tiny async task to send each (blocking) message from `link_state`, which forms an implicit unbounded queue in Tokio, we use the non-async interface to `packet_queue` to attempt to enqueue the message in the mgmt->datapath queue, and simply ignore if that fails.  (It's expected it shouldn't, given (a) the queue depth, (b) the rate at which the queue is emptied, (c) the priority that emptying the queue has vs. processing datapath packets, and (d) the slower rate at which mgmt traffic is gerenated.)