### PR TITLE
Mk/869 aaa - pass ASA to the client adapter

### DIFF
--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -37,6 +37,8 @@ pub enum PhMode {
     Adapter,
 }
 
+pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
 /// Interface to full assembly of all stages.
 ///
 /// This is the "public interface" that all stages of the system use to talk

--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -84,7 +84,7 @@ FiCJxns37RAqhGyryo9L0cryIEPwerjtNoLxmg94rfdovRmY+pm+HokRbD4Vycw=
 "#;
 
 /// This is the data payload in a [zdp::PacketType::InitAuthenticationRequest] packet.
-#[derive(Clone, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned, Debug, Default)]
+#[derive(Clone, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned, Default)]
 #[repr(packed)]
 pub struct ZdpInitAuthenticationPayload {
     /// 8 bytes random data
@@ -95,6 +95,31 @@ pub struct ZdpInitAuthenticationPayload {
 
     /// blake3 hmac over nonce and ctime
     pub hmac: [u8; 32],
+}
+
+// Implement our own Debug to format the buffers in human friendly way.
+impl std::fmt::Debug for ZdpInitAuthenticationPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let nonce_str = self
+            .nonce
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<Vec<String>>()
+            .join("");
+        let hmac_str = self
+            .hmac
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<Vec<String>>()
+            .join("");
+        write!(
+            f,
+            "ZdpInitAuthenticationPayload {{ nonce: [{}], ctime: {}, hmac: [{}] }}",
+            nonce_str,
+            self.ctime.get(),
+            hmac_str,
+        )
+    }
 }
 
 /// The "self signed" authentication BLOB which originates on an adatper and is

--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -2,7 +2,7 @@
 //! when we need to join a ZPRnet but there are no authentication services
 //! attached yet.  Also includes other "auth" related functionality.
 
-use std::net::SocketAddr;
+use std::net::{Ipv6Addr, SocketAddr};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -44,6 +44,44 @@ pub const MAX_BLOB_AGE_SECONDS: u64 = 120; // 2 minutes
 
 /// Default port used by authentication services running the zpr-oauthrsa protocol.
 pub const DEFAULT_ZPR_OAUTH_RSA_PORT: u16 = 4000;
+
+// "fd5a:5052:1::10" TODO: needs to come from dock (which gets it from VS)
+pub const HARD_CODED_BAS_ADDR: Ipv6Addr = Ipv6Addr::new(0xfd5a, 0x5052, 0x1, 0, 0, 0, 0, 0x10);
+
+// TODO: Not sure how we get these out or if we need them.
+pub const HARD_CODED_BAS_TLS_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
+MIIFmzCCA4OgAwIBAgIUJSg4OHOfPqY+lD7ymZy6akX/ZZ8wDQYJKoZIhvcNAQEL
+BQAwXTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAktZMRMwEQYDVQQHDApMb3Vpc3Zp
+bGxlMQswCQYDVQQKDAJBSTEMMAoGA1UECwwDWlBSMREwDwYDVQQDDAhhdXRoLnpw
+cjAeFw0yNTA0MTYxOTQ4MjRaFw0yNjA0MTYxOTQ4MjRaMF0xCzAJBgNVBAYTAlVT
+MQswCQYDVQQIDAJLWTETMBEGA1UEBwwKTG91aXN2aWxsZTELMAkGA1UECgwCQUkx
+DDAKBgNVBAsMA1pQUjERMA8GA1UEAwwIYXV0aC56cHIwggIiMA0GCSqGSIb3DQEB
+AQUAA4ICDwAwggIKAoICAQDl6DwVoQJsWAOTK4JWZYp3YL7b647ypIadVioKaGAk
+1Fk4FwogcZG/tBqsxCCW+pv7FXfjbwp6ChrxUGaTZUGzF5ft5L7q4oqSKOHvL1i9
+DiyU3xwk/biMiPTyuB8YYIiwQDiHAtYncJVMGMJPefDTl8OPNsjGQyJI+xuoBP/n
+PhbNIgn6E8YxrNl0/u+xWHjM6iOe5bZhXH1nkJQ+hviTxAtRDfayGM0nXrkEzdkC
+Aav95Kgp91cIa2lgoPpHm+HwQANp8jEPvsTVFMbwlPuFx9nopyXLzAdkgv9Z3+S3
+W9ISFWdaAQ4TJDrWfAQyPgPy8UPLOzoK/TC9qbRx2QLQaY3v6+hurnWUm0cHAZ5n
+zs8KflWXfRR+DA3Vc4aDF5vhT0IBDxs5rGu3/gtlJKwfwzMGDtprtuAXpXyZ48yM
+f17WymXsamWDIN58cHjPWgLYoUsr87HtRFGVmlqvCBzaQf4zGCOoW5LWSlkzD2da
+6ak3xBbogGExSk7RAhi9XLCl0LKfjTRsEGuAKpbGvt4h8i2Bq5YLmrzrqzI5XDYt
+u3W1hWwSwwAzK6SHvYLyOMTI75UMy9Zsh4VoUJUNkYm4XgO0WFaA9bs5Cq73d1zY
+i70s8jccheYhoAVXOWLDBQxCu2beHR7tkNXwyZ/RBhL/4/tyc+FKzF6C9sE9f6hv
+EQIDAQABo1MwUTAdBgNVHQ4EFgQU+bscgkfPxWQLdX4AypBqXnzmvxwwHwYDVR0j
+BBgwFoAU+bscgkfPxWQLdX4AypBqXnzmvxwwDwYDVR0TAQH/BAUwAwEB/zANBgkq
+hkiG9w0BAQsFAAOCAgEASZvKIbzeXKd1WuMmZT7kCywYqmWfgo7O51VNWni3FLdQ
+5De44BGIOVUFn+0vC0xQQbQ4iM9yTMb27AQJGm9Aor92w9G7LvR6Mp5py16eJb+F
+MSMZwN7PqK/QdnbIwiUGplDkKndd1dA/ZcHg5oJdE1areX0Zw8ZZ5yZoO12xnhc4
+AK2Mop897EGSYHyrxidYbocPj5Bn7m3mVC7U2quh1HwnZzbWfpx9g8Ry4T8kUco3
+dwZa2RHWhy2yrky2t3pg5tqaw79f/pXoTkcxvRSwZU3EcY23rq5OYQc7SLBIMm/a
+n8ZSJIduRRTLNE7T6Y7o43jDU8u+tcfB5ZE9ytuJA/NgtIYeEiNHMRepYNI2pffj
+MGELMS4xR3NIEyA6ZGVRBnI4dDr/3AmliOKKSt77iueSYCaPDBaxbbwcvEBBJtB0
+TPzKFsY5IH5ve5pZu7IhHIbE/yrAicbNtfX487WQTZfY+Qo8bf+XbdQIcRzkD+Q4
+VAvgJld9s5RI6x8CocU/PQvtQcWPFj//SbnnaMv2TTMLYgP+XWFwD1K1WQFpx2PK
+YM6AGtFc6p9klbags4r80QK+yEwYiBaNjDKmiNfQ1J38HCmd9lnMbzt9p7T838fP
+FiCJxns37RAqhGyryo9L0cryIEPwerjtNoLxmg94rfdovRmY+pm+HokRbD4Vycw=
+-----END CERTIFICATE-----
+"#;
 
 /// This is the data payload in a [zdp::PacketType::InitAuthenticationRequest] packet.
 #[derive(Clone, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned, Debug, Default)]

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -26,7 +26,7 @@ use zpr::LinkId;
 use zpr::ZPI_ENCRYPTED_HEADER_FLAG;
 
 // "fd5a:5052:1::10" TODO: needs to come from dock (which gets it from VS)
-const HARD_CODED_BAS_ADDR: Ipv6Addr = Ipv6Addr::new(0xfd5a, 0x5052, 0x1, 0, 0, 0, 0, 0x10);
+pub const HARD_CODED_BAS_ADDR: Ipv6Addr = Ipv6Addr::new(0xfd5a, 0x5052, 0x1, 0, 0, 0, 0, 0x10);
 
 // TODO: Not sure how we get these out or if we need them.
 const HARD_CODED_BAS_TLS_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
@@ -178,7 +178,7 @@ pub enum LinkEvent {
     Start,
     KeyingDone,
     ReceivedHelloRequest(IpAddress), // Actors ZPR address - TODO: implement AAAs
-    ReceivedHelloResponse(ResponseCode),
+    ReceivedHelloResponse(ResponseCode, Option<Vec<SocketAddr>>), // (response code, ASA addresses)
 
     ReceivedInitAuth((bool, Option<auth::ZdpInitAuthenticationPayload>)), // (bootstrap_flag, challenge)
 
@@ -237,6 +237,7 @@ pub struct LinkData {
     // For now, keep-alives are attempted every 3 seconds
     // Assuming no loss, 100 samples will store 5 minutes of latency data
     latency_data: SampleRing<Duration, 100>,
+    asa_addresses: Option<Vec<SocketAddr>>, // Addresses of ASA servers told to us by our peer, if any
 }
 
 impl LinkData {
@@ -245,6 +246,7 @@ impl LinkData {
             echo_success: 0,
             echo_timeout: 0,
             latency_data: SampleRing::new(Duration::ZERO),
+            asa_addresses: None,
         }
     }
 }
@@ -436,7 +438,9 @@ impl LinkStateWrapper {
             LinkEvent::ReceivedHelloRequest(peer_zpr_addr) => {
                 self.process_hello_request(asm, peer_zpr_addr)
             }
-            LinkEvent::ReceivedHelloResponse(code) => self.process_hello_response(asm, code),
+            LinkEvent::ReceivedHelloResponse(code, maybe_asa_addrs) => {
+                self.process_hello_response(asm, code, maybe_asa_addrs)
+            }
 
             LinkEvent::ReceivedAcquireZprAddressRequest(addrs, blob) => {
                 self.process_acquire_zpr_address_request(asm, addrs, blob)
@@ -664,6 +668,7 @@ impl LinkStateWrapper {
         &self,
         asm: &Arc<Assembly>,
         code: ResponseCode,
+        maybe_asa_addrs: Option<Vec<SocketAddr>>,
     ) -> Result<(), LinkStateError> {
         if code == ResponseCode::Other {
             // Received an error response.
@@ -675,6 +680,9 @@ impl LinkStateWrapper {
 
         match (self.link_type, locked_fsm.state) {
             (LinkType::AdapterToNode, LinkState::Helloing) => {
+                let mut link_data = self.locked_data.lock().unwrap();
+                link_data.asa_addresses = maybe_asa_addrs.clone();
+                drop(link_data);
                 locked_fsm.set_state(LinkState::WaitForInitAuth);
                 debug!(
                     target: LINK_STATE,
@@ -684,6 +692,9 @@ impl LinkStateWrapper {
                 Ok(())
             }
             (LinkType::NodeToNode, LinkState::Helloing) => {
+                let mut link_data = self.locked_data.lock().unwrap();
+                link_data.asa_addresses = maybe_asa_addrs.clone();
+                drop(link_data);
                 locked_fsm.set_state(LinkState::Active);
                 debug!(target: LINK_STATE, "Link {link_id} finished helloing.  Becoming active");
                 Ok(())
@@ -986,6 +997,9 @@ impl LinkStateWrapper {
     ) -> Result<(), LinkStateError> {
         let link_id = self.id;
 
+        // Grab a copy of our ASA addresses.
+        let asa_addrs = self.locked_data.lock().unwrap().asa_addresses.clone();
+
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         match (self.link_type, locked_fsm.state) {
             // NOTE: This is not exactly right, in general we can get an InitAuth at any time, though we
@@ -1025,11 +1039,10 @@ impl LinkStateWrapper {
                     locked_fsm.set_state(LinkState::RegisterAA);
                     info!(target: LINK_STATE, "Link {link_id} received init auth, time to talk to authentication service");
 
-                    // TODO: Presumably we would get the ZPR address of the auth service
-                    //       from our node somehow. What about the cert?
-                    if asm.rsauth.is_some() {
+                    // TODO: We get the ZPR address of the auth services from our node. What about the cert?
+                    if asm.rsauth.is_some() && asa_addrs.is_some() {
                         drop(locked_fsm);
-                        self.do_https_authenticate(asm);
+                        self.do_https_authenticate(asm, asa_addrs.unwrap());
                     } else {
                         error!(target: LINK_STATE, "Link {link_id} no auth service configured");
                         locked_fsm.set_state(LinkState::Error);
@@ -1144,13 +1157,22 @@ impl LinkStateWrapper {
     /// Run the HTTPS authentication process in a tokio task.
     /// - [LinkEvent::AuthenticationSuccess] on success
     /// - [LinkEvent::AuthenticationFailure] on failure
-    fn do_https_authenticate(&self, asm: &Arc<Assembly>) {
+    ///
+    /// TODO: Figure out what it means if there are multiple ASA addresses.
+    /// For now this uses the first address in the list.
+    fn do_https_authenticate(&self, asm: &Arc<Assembly>, asa_addrs: Vec<SocketAddr>) {
         let link_id = self.id;
 
-        let service_addr = SocketAddr::new(
-            IpAddr::V6(HARD_CODED_BAS_ADDR),
-            auth::DEFAULT_ZPR_OAUTH_RSA_PORT,
-        );
+        if asa_addrs.is_empty() {
+            error!(target: LINK_STATE, "Link {link_id}: no ASA addresses provided for authentication");
+            if let Err(e) = asm.process_link_state_event(link_id, LinkEvent::AuthenticationFailure)
+            {
+                error!(target: LINK_STATE, "Link {link_id}: event handling error {e}");
+            }
+            return;
+        }
+        let service_addr = asa_addrs[0];
+
         let tls_cert = X509::from_pem(HARD_CODED_BAS_TLS_CERT_PEM.as_bytes()).unwrap();
         let task_asm = asm.clone();
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -15,53 +15,14 @@ use crate::zdp::{self, ResponseCode, TerminateReason};
 
 use openssl::x509::X509;
 use std::fmt::{Display, Formatter};
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use thiserror::Error;
 use tokio::sync::broadcast;
 use tokio::time::MissedTickBehavior;
 use tracing::*;
-use zpr::LinkId;
-use zpr::ZPI_ENCRYPTED_HEADER_FLAG;
-
-// "fd5a:5052:1::10" TODO: needs to come from dock (which gets it from VS)
-pub const HARD_CODED_BAS_ADDR: Ipv6Addr = Ipv6Addr::new(0xfd5a, 0x5052, 0x1, 0, 0, 0, 0, 0x10);
-
-// TODO: Not sure how we get these out or if we need them.
-const HARD_CODED_BAS_TLS_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
-MIIFmzCCA4OgAwIBAgIUJSg4OHOfPqY+lD7ymZy6akX/ZZ8wDQYJKoZIhvcNAQEL
-BQAwXTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAktZMRMwEQYDVQQHDApMb3Vpc3Zp
-bGxlMQswCQYDVQQKDAJBSTEMMAoGA1UECwwDWlBSMREwDwYDVQQDDAhhdXRoLnpw
-cjAeFw0yNTA0MTYxOTQ4MjRaFw0yNjA0MTYxOTQ4MjRaMF0xCzAJBgNVBAYTAlVT
-MQswCQYDVQQIDAJLWTETMBEGA1UEBwwKTG91aXN2aWxsZTELMAkGA1UECgwCQUkx
-DDAKBgNVBAsMA1pQUjERMA8GA1UEAwwIYXV0aC56cHIwggIiMA0GCSqGSIb3DQEB
-AQUAA4ICDwAwggIKAoICAQDl6DwVoQJsWAOTK4JWZYp3YL7b647ypIadVioKaGAk
-1Fk4FwogcZG/tBqsxCCW+pv7FXfjbwp6ChrxUGaTZUGzF5ft5L7q4oqSKOHvL1i9
-DiyU3xwk/biMiPTyuB8YYIiwQDiHAtYncJVMGMJPefDTl8OPNsjGQyJI+xuoBP/n
-PhbNIgn6E8YxrNl0/u+xWHjM6iOe5bZhXH1nkJQ+hviTxAtRDfayGM0nXrkEzdkC
-Aav95Kgp91cIa2lgoPpHm+HwQANp8jEPvsTVFMbwlPuFx9nopyXLzAdkgv9Z3+S3
-W9ISFWdaAQ4TJDrWfAQyPgPy8UPLOzoK/TC9qbRx2QLQaY3v6+hurnWUm0cHAZ5n
-zs8KflWXfRR+DA3Vc4aDF5vhT0IBDxs5rGu3/gtlJKwfwzMGDtprtuAXpXyZ48yM
-f17WymXsamWDIN58cHjPWgLYoUsr87HtRFGVmlqvCBzaQf4zGCOoW5LWSlkzD2da
-6ak3xBbogGExSk7RAhi9XLCl0LKfjTRsEGuAKpbGvt4h8i2Bq5YLmrzrqzI5XDYt
-u3W1hWwSwwAzK6SHvYLyOMTI75UMy9Zsh4VoUJUNkYm4XgO0WFaA9bs5Cq73d1zY
-i70s8jccheYhoAVXOWLDBQxCu2beHR7tkNXwyZ/RBhL/4/tyc+FKzF6C9sE9f6hv
-EQIDAQABo1MwUTAdBgNVHQ4EFgQU+bscgkfPxWQLdX4AypBqXnzmvxwwHwYDVR0j
-BBgwFoAU+bscgkfPxWQLdX4AypBqXnzmvxwwDwYDVR0TAQH/BAUwAwEB/zANBgkq
-hkiG9w0BAQsFAAOCAgEASZvKIbzeXKd1WuMmZT7kCywYqmWfgo7O51VNWni3FLdQ
-5De44BGIOVUFn+0vC0xQQbQ4iM9yTMb27AQJGm9Aor92w9G7LvR6Mp5py16eJb+F
-MSMZwN7PqK/QdnbIwiUGplDkKndd1dA/ZcHg5oJdE1areX0Zw8ZZ5yZoO12xnhc4
-AK2Mop897EGSYHyrxidYbocPj5Bn7m3mVC7U2quh1HwnZzbWfpx9g8Ry4T8kUco3
-dwZa2RHWhy2yrky2t3pg5tqaw79f/pXoTkcxvRSwZU3EcY23rq5OYQc7SLBIMm/a
-n8ZSJIduRRTLNE7T6Y7o43jDU8u+tcfB5ZE9ytuJA/NgtIYeEiNHMRepYNI2pffj
-MGELMS4xR3NIEyA6ZGVRBnI4dDr/3AmliOKKSt77iueSYCaPDBaxbbwcvEBBJtB0
-TPzKFsY5IH5ve5pZu7IhHIbE/yrAicbNtfX487WQTZfY+Qo8bf+XbdQIcRzkD+Q4
-VAvgJld9s5RI6x8CocU/PQvtQcWPFj//SbnnaMv2TTMLYgP+XWFwD1K1WQFpx2PK
-YM6AGtFc6p9klbags4r80QK+yEwYiBaNjDKmiNfQ1J38HCmd9lnMbzt9p7T838fP
-FiCJxns37RAqhGyryo9L0cryIEPwerjtNoLxmg94rfdovRmY+pm+HokRbD4Vycw=
------END CERTIFICATE-----
-"#;
+use zpr::{LinkId, ZPI_ENCRYPTED_HEADER_FLAG};
 
 /// State machine for links and docking sessions
 
@@ -1173,7 +1134,7 @@ impl LinkStateWrapper {
         }
         let service_addr = asa_addrs[0];
 
-        let tls_cert = X509::from_pem(HARD_CODED_BAS_TLS_CERT_PEM.as_bytes()).unwrap();
+        let tls_cert = X509::from_pem(auth::HARD_CODED_BAS_TLS_CERT_PEM.as_bytes()).unwrap();
         let task_asm = asm.clone();
 
         tokio::task::spawn_local(async move {

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -58,6 +58,7 @@ mod special_peers;
 mod sync_req;
 mod sys;
 mod test_packet;
+mod tlv;
 mod tun_ctl;
 mod two_way_queue;
 mod visa_mgmt;

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -1,17 +1,19 @@
 //! Handlers for management requests.
 
 use crate::adapter_tables;
-use crate::assembly::{self, Assembly, PhMode};
+use crate::assembly::{self, Assembly, PhMode, VERSION};
 use crate::auth;
 use crate::config;
 use crate::counters;
 use crate::defs::*;
-use crate::link_state::LinkEvent;
+use crate::link_state::{LinkEvent, HARD_CODED_BAS_ADDR};
 use crate::logging::targets::{FLOW_MGMT, REPORTING, ZDP};
 use crate::net_defs::{ip_number, IpAddress};
 use crate::packet::Packet;
+use crate::tlv::{self, TlvEncoding};
 use crate::zdp;
 use bytes::{Buf, BufMut};
+use std::net::{IpAddr, SocketAddr};
 use std::num::NonZero;
 use std::sync::Arc;
 use thiserror::Error;
@@ -300,6 +302,17 @@ pub async fn handle_hello_request(
         Ok(()) => zdp::ResponseCode::Success,
     };
 
+    let policy_id: i64 = 0; // TODO: We get policy ID from visa service. Record that somewhere, access it here.
+    TlvEncoding::new_policy_id(policy_id).put(&mut rsp_pkt);
+    TlvEncoding::new_version(VERSION).put(&mut rsp_pkt);
+
+    // TODO: This info needs to come from the visa service
+    let service_addr = SocketAddr::new(
+        IpAddr::V6(HARD_CODED_BAS_ADDR),
+        auth::DEFAULT_ZPR_OAUTH_RSA_PORT,
+    );
+    TlvEncoding::new_asa(service_addr).put(&mut rsp_pkt);
+
     super::core::send_non_flow_mgmt(
         asm,
         ingress_link_id,
@@ -319,8 +332,51 @@ pub async fn handle_hello_response(asm: &Arc<Assembly>, mut pkt: Packet) -> Hand
     let link_id = pkt.metadata().ingress_link_id;
     let status = hdr.status;
     debug!(target: ZDP, "Link {link_id}: received HelloResponse, status: {status:?}");
+
+    // Following status are the TLVs.
+    // A tlv has a type (number) and a value.
+    let tlv_data =
+        tlv::parse_from_buf(&mut pkt).map_err(|_| (HandleMgmtError::BadStructure, pkt))?;
+    if let Some(ver) = tlv_data.get(&tlv::DataType::VERSION) {
+        info!(target: ZDP, "Link {link_id}: HelloResponse - peer version is : {}", ver[0]);
+    } else {
+        warn!(target: ZDP, "Link {link_id}: HelloResponse did not include version");
+    }
+    if let Some(policy_id) = tlv_data.get(&tlv::DataType::POLICY_ID) {
+        info!(target: ZDP, "Link {link_id}: HelloResponse - peer policy ID is : {}", policy_id[0]);
+    } else {
+        warn!(target: ZDP, "Link {link_id}: HelloResponse did not include policy ID");
+    }
+
+    let mut asa_addresses = Vec::<SocketAddr>::new();
+
+    if let Some(asa_entries) = tlv_data.get(&tlv::DataType::ASA) {
+        for asa_entry in asa_entries {
+            match asa_entry {
+                tlv::TlvValue::SocketAddr(sa) => {
+                    info!(target: ZDP, "Link {link_id}: HelloResponse includes ASA address:{sa}");
+                    asa_addresses.push(sa.clone());
+                }
+                _ => {
+                    warn!(target: ZDP, "Link {link_id}: HelloResponse ASA value type is wrong: {asa_entry:?}");
+                }
+            }
+        }
+    } else {
+        warn!(target: ZDP, "Link {link_id}: HelloResponse did not include ASA TLV");
+    }
+
+    let maybe_asa_addrs = if asa_addresses.is_empty() {
+        None
+    } else {
+        Some(asa_addresses)
+    };
+
     let _ = asm
-        .process_link_state_event(link_id, LinkEvent::ReceivedHelloResponse(status))
+        .process_link_state_event(
+            link_id,
+            LinkEvent::ReceivedHelloResponse(status, maybe_asa_addrs),
+        )
         .map_err(|_| ());
 
     Ok(())

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -6,7 +6,7 @@ use crate::auth;
 use crate::config;
 use crate::counters;
 use crate::defs::*;
-use crate::link_state::{LinkEvent, HARD_CODED_BAS_ADDR};
+use crate::link_state::LinkEvent;
 use crate::logging::targets::{FLOW_MGMT, REPORTING, ZDP};
 use crate::net_defs::{ip_number, IpAddress};
 use crate::packet::Packet;
@@ -308,7 +308,7 @@ pub async fn handle_hello_request(
 
     // TODO: This info needs to come from the visa service
     let service_addr = SocketAddr::new(
-        IpAddr::V6(HARD_CODED_BAS_ADDR),
+        IpAddr::V6(auth::HARD_CODED_BAS_ADDR),
         auth::DEFAULT_ZPR_OAUTH_RSA_PORT,
     );
     TlvEncoding::new_asa(service_addr).put(&mut rsp_pkt);

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -15,11 +15,22 @@ pub const IPV6_ADDRESS_SIZE: usize = 16;
 /// "Flat" (non-enum) representation of an IPv4 or IPv6 address, used
 /// internally to represent ZPR addresses.
 #[derive(
-    FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Hash, Debug, PartialEq, Eq,
+    FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Hash, PartialEq, Eq,
 )]
 #[repr(transparent)]
 pub struct IpAddress {
     pub v6: [u8; IPV6_ADDRESS_SIZE],
+}
+
+// Implement our own Debug in order to prety print addresses in logs.
+impl std::fmt::Debug for IpAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_v4() {
+            write!(f, "IpAddress(V4: {self})")
+        } else {
+            write!(f, "IpAddress(V6: {self})")
+        }
+    }
 }
 
 impl IpAddress {

--- a/adapter/ph/src/tlv.rs
+++ b/adapter/ph/src/tlv.rs
@@ -1,0 +1,886 @@
+use bytes::Buf;
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use thiserror::Error;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+const SOCKADDR_LEN_V4: u8 = 6; // 4 bytes for IPv4 + 2 bytes for port
+const SOCKADDR_LEN_V6: u8 = 18; // 16 bytes for IPv6 + 2 bytes for port
+
+#[derive(Debug, Error)]
+pub enum TlvError {
+    #[error("bad TLV structure")]
+    BadStructure,
+}
+
+/// A single byte that identifies the type of TLV data.
+type TlvType = u8;
+
+/// Repository of all our TLV types.
+pub struct DataType;
+impl DataType {
+    pub const NULL: TlvType = 0; // Note that Null type has no other fields. So is just one byte.
+
+    pub const POLICY_ID: TlvType = 1;
+    pub const VERSION: TlvType = 2;
+    pub const AAA: TlvType = 3; // Actor Authentication Address - temporary address actor may use for authentication
+    pub const ASA: TlvType = 4; // Authentication Service SocketAddress
+}
+
+/// TlvEncoding is a designed to be an easy way to create and write TLV data
+/// into a buffer.
+pub struct TlvEncoding {
+    tlv_type: TlvType,
+    value: TlvValue,
+}
+
+impl TlvEncoding {
+    pub fn new_policy_id(policy_id: i64) -> TlvEncoding {
+        TlvEncoding {
+            tlv_type: DataType::POLICY_ID,
+            value: TlvValue::I64(policy_id),
+        }
+    }
+
+    pub fn new_version(version: &str) -> TlvEncoding {
+        TlvEncoding {
+            tlv_type: DataType::VERSION,
+            value: TlvValue::Str(version.to_string()),
+        }
+    }
+
+    /// Actor Authentication Address
+    #[allow(dead_code)]
+    pub fn new_aaa(addr: Ipv4Addr) -> TlvEncoding {
+        TlvEncoding {
+            tlv_type: DataType::AAA,
+            value: TlvValue::Ipv4Addr(addr),
+        }
+    }
+
+    /// Authentication Service Address
+    pub fn new_asa(sock_addr: SocketAddr) -> TlvEncoding {
+        TlvEncoding {
+            tlv_type: DataType::ASA,
+            value: TlvValue::SocketAddr(sock_addr),
+        }
+    }
+
+    /// Write this encoding to the buffer, advancing the buffer position.
+    pub fn put(&self, buf: &mut dyn bytes::BufMut) {
+        match &self.value {
+            TlvValue::I64(v) => put_i64(buf, self.tlv_type, *v),
+            TlvValue::Str(v) => put_str(buf, self.tlv_type, v),
+            TlvValue::Ipv6Addr(v) => put_ipv6addr(buf, self.tlv_type, v),
+            TlvValue::Ipv4Addr(v) => put_ipv4addr(buf, self.tlv_type, v),
+            TlvValue::SocketAddr(v) => put_socketaddr(buf, self.tlv_type, v),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum TlvValue {
+    I64(i64),
+    Str(String),
+    Ipv6Addr(Ipv6Addr),
+    Ipv4Addr(Ipv4Addr),
+    SocketAddr(SocketAddr),
+}
+
+impl std::fmt::Display for TlvValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TlvValue::I64(v) => write!(f, "{v}"),
+            TlvValue::Str(v) => write!(f, "{v}"),
+            TlvValue::Ipv6Addr(v) => write!(f, "{v}"),
+            TlvValue::Ipv4Addr(v) => write!(f, "{v}"),
+            TlvValue::SocketAddr(v) => write!(f, "{}", v),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(packed)]
+#[allow(dead_code)]
+struct TLVHdr {
+    pub tlv_type: TlvType,
+    pub tlv_length: u8,
+    // Followed by tlv_length bytes of value
+}
+
+fn put_i64(buf: &mut dyn bytes::BufMut, tlv_type: TlvType, value: i64) {
+    let hdr = TLVHdr {
+        tlv_type,
+        tlv_length: 8, // Length of i64 is always 8 bytes
+    };
+    buf.put_slice(&hdr.as_bytes());
+    buf.put_i64(value);
+}
+
+/// Will truncate string value if it is longer than 255 bytes.
+fn put_str(buf: &mut dyn bytes::BufMut, tlv_type: TlvType, value: &str) {
+    let strlen = if value.len() > 255 {
+        255
+    } else {
+        value.len() as u8
+    };
+    let hdr = TLVHdr {
+        tlv_type,
+        tlv_length: strlen,
+    };
+    buf.put_slice(&hdr.as_bytes());
+    buf.put_slice(&value.as_bytes()[..strlen as usize]);
+}
+
+fn put_ipv6addr(buf: &mut dyn bytes::BufMut, tlv_type: TlvType, value: &Ipv6Addr) {
+    let hdr = TLVHdr {
+        tlv_type,
+        tlv_length: 16,
+    };
+    buf.put_slice(&hdr.as_bytes());
+    buf.put_slice(&value.octets());
+}
+
+fn put_ipv4addr(buf: &mut dyn bytes::BufMut, tlv_type: TlvType, value: &Ipv4Addr) {
+    let hdr = TLVHdr {
+        tlv_type,
+        tlv_length: 4,
+    };
+    buf.put_slice(&hdr.as_bytes());
+    buf.put_slice(&value.octets());
+}
+
+fn put_socketaddr(
+    buf: &mut dyn bytes::BufMut,
+    tlv_type: TlvType,
+    sock_addr: &std::net::SocketAddr,
+) {
+    match sock_addr {
+        std::net::SocketAddr::V4(v4) => {
+            let hdr = TLVHdr {
+                tlv_type,
+                tlv_length: SOCKADDR_LEN_V4,
+            };
+            buf.put_slice(&hdr.as_bytes());
+            buf.put_slice(&v4.ip().octets());
+            buf.put_u16(v4.port());
+        }
+        std::net::SocketAddr::V6(v6) => {
+            let hdr = TLVHdr {
+                tlv_type,
+                tlv_length: SOCKADDR_LEN_V6, // 16 bytes for IPv6 + 2 bytes for port
+            };
+            buf.put_slice(&hdr.as_bytes());
+            buf.put_slice(&v6.ip().octets());
+            buf.put_u16(v6.port());
+        }
+    }
+}
+
+/// Parse TLV data out of a buffer, advancing the internal position.  Only known
+/// TLV types are parsed, unknown are skipped.
+/// Null entries (type 0) are skipped over and not returned.
+pub fn parse_from_buf(
+    buf: &mut dyn bytes::Buf,
+) -> Result<HashMap<TlvType, Vec<TlvValue>>, TlvError> {
+    let mut tlv_map = HashMap::new();
+
+    // The null type just uses 1 byte.
+    while buf.remaining() >= 1 {
+        // Read first byte to determine type.
+        let tlv_type = buf.get_u8();
+        if tlv_type == DataType::NULL {
+            // Null type has no length or value, just skip it.
+            continue;
+        }
+        if buf.remaining() < 1 {
+            return Err(TlvError::BadStructure); // Not enough room for the length byte
+        }
+        let tlv_length = buf.get_u8();
+        if buf.remaining() < tlv_length as usize {
+            return Err(TlvError::BadStructure); // Not enough room for value
+        }
+        match tlv_type {
+            DataType::POLICY_ID => {
+                if tlv_length != 8 {
+                    return Err(TlvError::BadStructure); // Policy ID must be 8 bytes
+                }
+                let value = buf.get_i64();
+                tlv_map
+                    .entry(tlv_type)
+                    .or_insert_with(Vec::new)
+                    .push(TlvValue::I64(value));
+            }
+            DataType::VERSION => {
+                let strbuf = buf.copy_to_bytes(tlv_length as usize);
+                let ver_str = String::from_utf8_lossy(&strbuf);
+                tlv_map
+                    .entry(tlv_type)
+                    .or_insert_with(Vec::new)
+                    .push(TlvValue::Str(ver_str.to_string()));
+            }
+            DataType::AAA => {
+                let addr_val = parse_address_value(buf, tlv_length)?;
+                tlv_map
+                    .entry(tlv_type)
+                    .or_insert_with(Vec::new)
+                    .push(addr_val);
+            }
+            DataType::ASA => {
+                // Parse a socket addr. Which in memory is the IPv4 or IPv6 address followed by a 16bit port number.
+                match tlv_length {
+                    6 => {
+                        let ipv4u32 = buf.get_u32();
+                        let port = buf.get_u16();
+                        let ipv4_addr = Ipv4Addr::from(ipv4u32.to_be_bytes());
+                        tlv_map.entry(tlv_type).or_insert_with(Vec::new).push(
+                            TlvValue::SocketAddr(SocketAddr::V4(std::net::SocketAddrV4::new(
+                                ipv4_addr, port,
+                            ))),
+                        );
+                    }
+                    18 => {
+                        let mut addr_buf = [0u8; 16];
+                        buf.copy_to_slice(&mut addr_buf); // Read 16 bytes for IPv6 address
+                        let port = buf.get_u16();
+                        let ipv6_addr = Ipv6Addr::from(addr_buf);
+                        tlv_map.entry(tlv_type).or_insert_with(Vec::new).push(
+                            TlvValue::SocketAddr(SocketAddr::V6(std::net::SocketAddrV6::new(
+                                ipv6_addr, port, 0, 0,
+                            ))),
+                        );
+                    }
+                    _ => {
+                        return Err(TlvError::BadStructure); // Invalid length for ASA
+                    }
+                }
+            }
+            _ => {
+                // For unknown types, just skip the value.
+                buf.advance(tlv_length as usize);
+            }
+        }
+    }
+    Ok(tlv_map)
+}
+
+fn parse_address_value(buf: &mut dyn bytes::Buf, tlv_length: u8) -> Result<TlvValue, TlvError> {
+    if buf.remaining() < tlv_length as usize {
+        return Err(TlvError::BadStructure); // Not enough data for address value
+    }
+    match tlv_length {
+        4 => {
+            let addr_bytes = buf.get_u32().to_be_bytes();
+            let value = Ipv4Addr::from(addr_bytes);
+            Ok(TlvValue::Ipv4Addr(value))
+        }
+        16 => {
+            let mut addr_bytes = [0u8; 16];
+            buf.copy_to_slice(&mut addr_bytes);
+            let value = Ipv6Addr::from(addr_bytes);
+            Ok(TlvValue::Ipv6Addr(value))
+        }
+        _ => {
+            Err(TlvError::BadStructure) // Unsupported address length
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::{BufMut, BytesMut};
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn test_put_and_parse_i64() {
+        let mut buf = BytesMut::new();
+        let test_value = 0x0123456789abcdef_i64;
+
+        // Write the TLV
+        put_i64(&mut buf, DataType::POLICY_ID, test_value);
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::POLICY_ID).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::I64(value) => assert_eq!(*value, test_value),
+            _ => panic!("Expected I64 value for POLICY_ID"),
+        }
+    }
+
+    #[test]
+    fn test_put_and_parse_string() {
+        let mut buf = BytesMut::new();
+        let test_value = "test_version_1.2.3";
+
+        // Write the TLV
+        put_str(&mut buf, DataType::VERSION, test_value);
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::VERSION).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::Str(value) => assert_eq!(value, test_value),
+            _ => panic!("Expected Str value for VERSION"),
+        }
+    }
+
+    #[test]
+    fn test_put_and_parse_string_truncation() {
+        let mut buf = BytesMut::new();
+        let test_value = "a".repeat(300); // String longer than 255 bytes
+
+        // Write the TLV
+        put_str(&mut buf, DataType::VERSION, &test_value);
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result is truncated to 255 bytes
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::VERSION).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::Str(value) => {
+                assert_eq!(value.len(), 255);
+                assert_eq!(value, &"a".repeat(255));
+            }
+            _ => panic!("Expected Str value for VERSION"),
+        }
+    }
+
+    #[test]
+    fn test_put_and_parse_ipv6() {
+        let mut buf = BytesMut::new();
+        let test_addr = Ipv6Addr::new(
+            0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334,
+        );
+
+        // Write the TLV
+        put_ipv6addr(&mut buf, DataType::AAA, &test_addr);
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::AAA).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::Ipv6Addr(addr) => assert_eq!(*addr, test_addr),
+            _ => panic!("Expected Ipv6Addr value for AAA"),
+        }
+    }
+
+    #[test]
+    fn test_put_and_parse_ipv4() {
+        let mut buf = BytesMut::new();
+        let test_addr = Ipv4Addr::new(10, 0, 0, 1);
+
+        // Write the TLV using the helper function
+        put_ipv4addr(&mut buf, DataType::AAA, &test_addr);
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::AAA).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::Ipv4Addr(addr) => assert_eq!(*addr, test_addr),
+            _ => panic!("Expected Ipv4Addr value for ASA"),
+        }
+    }
+
+    #[test]
+    fn test_parse_ipv4_address() {
+        let mut buf = BytesMut::new();
+        let test_addr = Ipv4Addr::new(192, 168, 1, 1);
+
+        // Manually construct IPv4 TLV (since we don't have a put_ipv4addr function)
+        let hdr = TLVHdr {
+            tlv_type: DataType::AAA,
+            tlv_length: 4,
+        };
+        buf.put_slice(&hdr.as_bytes());
+        buf.put_slice(&test_addr.octets());
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::AAA).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::Ipv4Addr(addr) => assert_eq!(*addr, test_addr),
+            _ => panic!("Expected Ipv4Addr value for ASA"),
+        }
+    }
+
+    #[test]
+    fn test_parse_multiple_tlvs() {
+        let mut buf = BytesMut::new();
+        let policy_id = 12345_i64;
+        let version = "v2.0.1";
+        let ipv6_addr = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+
+        // Write multiple TLVs
+        put_i64(&mut buf, DataType::POLICY_ID, policy_id);
+        put_str(&mut buf, DataType::VERSION, version);
+        put_ipv6addr(&mut buf, DataType::AAA, &ipv6_addr);
+
+        // Parse them back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify all values
+        assert_eq!(result.len(), 3);
+
+        let policy_values = result.get(&DataType::POLICY_ID).unwrap();
+        assert_eq!(policy_values.len(), 1);
+        match &policy_values[0] {
+            TlvValue::I64(value) => assert_eq!(*value, policy_id),
+            _ => panic!("Expected I64 value for POLICY_ID"),
+        }
+
+        let version_values = result.get(&DataType::VERSION).unwrap();
+        assert_eq!(version_values.len(), 1);
+        match &version_values[0] {
+            TlvValue::Str(value) => assert_eq!(value, version),
+            _ => panic!("Expected Str value for VERSION"),
+        }
+
+        let aaa_values = result.get(&DataType::AAA).unwrap();
+        assert_eq!(aaa_values.len(), 1);
+        match &aaa_values[0] {
+            TlvValue::Ipv6Addr(addr) => assert_eq!(*addr, ipv6_addr),
+            _ => panic!("Expected Ipv6Addr value for AAA"),
+        }
+    }
+
+    #[test]
+    fn test_parse_with_null_types() {
+        let mut buf = BytesMut::new();
+
+        // Add a NULL type
+        buf.put_u8(DataType::NULL);
+
+        // Add a real TLV
+        put_i64(&mut buf, DataType::POLICY_ID, 42);
+
+        // Add another NULL type
+        buf.put_u8(DataType::NULL);
+
+        // Parse
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Should only have the POLICY_ID, nulls should be skipped
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::POLICY_ID).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::I64(value) => assert_eq!(*value, 42),
+            _ => panic!("Expected I64 value for POLICY_ID"),
+        }
+    }
+
+    #[test]
+    fn test_parse_unknown_type() {
+        let mut buf = BytesMut::new();
+
+        // Add an unknown TLV type
+        let unknown_type = 99_u8;
+        let unknown_data = [0x01, 0x02, 0x03, 0x04];
+        buf.put_u8(unknown_type);
+        buf.put_u8(unknown_data.len() as u8);
+        buf.put_slice(&unknown_data);
+
+        // Add a known TLV
+        put_i64(&mut buf, DataType::POLICY_ID, 123);
+
+        // Parse
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Should only have the known TLV, unknown should be skipped
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::POLICY_ID).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::I64(value) => assert_eq!(*value, 123),
+            _ => panic!("Expected I64 value for POLICY_ID"),
+        }
+    }
+
+    #[test]
+    fn test_parse_bad_structure_incomplete_length() {
+        let mut buf = BytesMut::new();
+
+        // Add a TLV type without length byte
+        buf.put_u8(DataType::POLICY_ID);
+        // Missing length byte
+
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader);
+
+        assert!(matches!(result, Err(TlvError::BadStructure)));
+    }
+
+    #[test]
+    fn test_parse_bad_structure_incomplete_value() {
+        let mut buf = BytesMut::new();
+
+        // Add a TLV header claiming 8 bytes but only provide 4
+        buf.put_u8(DataType::POLICY_ID);
+        buf.put_u8(8); // Claims 8 bytes
+        buf.put_u32(0x12345678); // Only provides 4 bytes
+
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader);
+
+        assert!(matches!(result, Err(TlvError::BadStructure)));
+    }
+
+    #[test]
+    fn test_parse_bad_policy_id_length() {
+        let mut buf = BytesMut::new();
+
+        // Add a POLICY_ID with wrong length
+        buf.put_u8(DataType::POLICY_ID);
+        buf.put_u8(4); // Wrong length, should be 8
+        buf.put_u32(0x12345678);
+
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader);
+
+        assert!(matches!(result, Err(TlvError::BadStructure)));
+    }
+
+    #[test]
+    fn test_parse_bad_address_length() {
+        let mut buf = BytesMut::new();
+
+        // Add an address TLV with invalid length
+        buf.put_u8(DataType::AAA);
+        buf.put_u8(8); // Invalid length for address (should be 4 or 16)
+        buf.put_u64(0x0123456789abcdef);
+
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader);
+
+        assert!(matches!(result, Err(TlvError::BadStructure)));
+    }
+
+    #[test]
+    fn test_empty_buffer() {
+        let buf = BytesMut::new();
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_multiple_values_same_type() {
+        let mut buf = BytesMut::new();
+
+        // Add multiple VERSION TLVs
+        put_str(&mut buf, DataType::VERSION, "v1.0.0");
+        put_str(&mut buf, DataType::VERSION, "v2.0.0");
+        put_str(&mut buf, DataType::VERSION, "v3.0.0");
+
+        // Add multiple POLICY_ID TLVs
+        put_i64(&mut buf, DataType::POLICY_ID, 100);
+        put_i64(&mut buf, DataType::POLICY_ID, 200);
+
+        // Parse them back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify we have 2 different TLV types
+        assert_eq!(result.len(), 2);
+
+        // Check VERSION values
+        let version_values = result.get(&DataType::VERSION).unwrap();
+        assert_eq!(version_values.len(), 3);
+        match &version_values[0] {
+            TlvValue::Str(value) => assert_eq!(value, "v1.0.0"),
+            _ => panic!("Expected Str value for VERSION[0]"),
+        }
+        match &version_values[1] {
+            TlvValue::Str(value) => assert_eq!(value, "v2.0.0"),
+            _ => panic!("Expected Str value for VERSION[1]"),
+        }
+        match &version_values[2] {
+            TlvValue::Str(value) => assert_eq!(value, "v3.0.0"),
+            _ => panic!("Expected Str value for VERSION[2]"),
+        }
+
+        // Check POLICY_ID values
+        let policy_values = result.get(&DataType::POLICY_ID).unwrap();
+        assert_eq!(policy_values.len(), 2);
+        match &policy_values[0] {
+            TlvValue::I64(value) => assert_eq!(*value, 100),
+            _ => panic!("Expected I64 value for POLICY_ID[0]"),
+        }
+        match &policy_values[1] {
+            TlvValue::I64(value) => assert_eq!(*value, 200),
+            _ => panic!("Expected I64 value for POLICY_ID[1]"),
+        }
+    }
+
+    #[test]
+    fn test_put_and_parse_sockaddr_v4() {
+        let mut buf = BytesMut::new();
+        let test_addr = SocketAddr::V4(std::net::SocketAddrV4::new(
+            Ipv4Addr::new(192, 168, 1, 100),
+            8080,
+        ));
+
+        // Write the TLV
+        put_socketaddr(&mut buf, DataType::ASA, &test_addr);
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::ASA).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::SocketAddr(addr) => assert_eq!(*addr, test_addr),
+            _ => panic!("Expected SocketAddr value for ASA"),
+        }
+    }
+
+    #[test]
+    fn test_put_and_parse_sockaddr_v6() {
+        let mut buf = BytesMut::new();
+        let test_addr = SocketAddr::V6(std::net::SocketAddrV6::new(
+            Ipv6Addr::new(
+                0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334,
+            ),
+            9090,
+            0,
+            0,
+        ));
+
+        // Write the TLV
+        put_socketaddr(&mut buf, DataType::ASA, &test_addr);
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::ASA).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::SocketAddr(addr) => assert_eq!(*addr, test_addr),
+            _ => panic!("Expected SocketAddr value for ASA"),
+        }
+    }
+
+    #[test]
+    fn test_parse_multiple_sockaddrs() {
+        let mut buf = BytesMut::new();
+        let addr_v4_1 = SocketAddr::V4(std::net::SocketAddrV4::new(
+            Ipv4Addr::new(10, 0, 0, 1),
+            3000,
+        ));
+        let addr_v4_2 = SocketAddr::V4(std::net::SocketAddrV4::new(
+            Ipv4Addr::new(172, 16, 0, 1),
+            4000,
+        ));
+        let addr_v6 = SocketAddr::V6(std::net::SocketAddrV6::new(
+            Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1),
+            5000,
+            0,
+            0,
+        ));
+
+        // Write multiple ASA TLVs with different socket addresses
+        put_socketaddr(&mut buf, DataType::ASA, &addr_v4_1);
+        put_socketaddr(&mut buf, DataType::ASA, &addr_v4_2);
+        put_socketaddr(&mut buf, DataType::ASA, &addr_v6);
+
+        // Parse them back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify all values
+        assert_eq!(result.len(), 1); // Only one TLV type (ASA)
+        let asa_values = result.get(&DataType::ASA).unwrap();
+        assert_eq!(asa_values.len(), 3); // Three socket addresses
+
+        match &asa_values[0] {
+            TlvValue::SocketAddr(addr) => assert_eq!(*addr, addr_v4_1),
+            _ => panic!("Expected SocketAddr value for ASA[0]"),
+        }
+        match &asa_values[1] {
+            TlvValue::SocketAddr(addr) => assert_eq!(*addr, addr_v4_2),
+            _ => panic!("Expected SocketAddr value for ASA[1]"),
+        }
+        match &asa_values[2] {
+            TlvValue::SocketAddr(addr) => assert_eq!(*addr, addr_v6),
+            _ => panic!("Expected SocketAddr value for ASA[2]"),
+        }
+    }
+
+    #[test]
+    fn test_sockaddr_tlv_structure() {
+        let mut buf = BytesMut::new();
+        let test_addr_v4 = SocketAddr::V4(std::net::SocketAddrV4::new(
+            Ipv4Addr::new(127, 0, 0, 1),
+            8443,
+        ));
+
+        // Write the TLV
+        put_socketaddr(&mut buf, DataType::ASA, &test_addr_v4);
+
+        // Verify the buffer structure manually
+        let bytes = buf.as_ref();
+
+        // Check header
+        assert_eq!(bytes[0], DataType::ASA); // TLV type
+        assert_eq!(bytes[1], SOCKADDR_LEN_V4); // TLV length (6 bytes for IPv4 + port)
+
+        // Check IPv4 address bytes (127.0.0.1)
+        assert_eq!(bytes[2], 127);
+        assert_eq!(bytes[3], 0);
+        assert_eq!(bytes[4], 0);
+        assert_eq!(bytes[5], 1);
+
+        // Check port bytes (8443 in big-endian)
+        let port_bytes = &bytes[6..8];
+        let port = u16::from_be_bytes([port_bytes[0], port_bytes[1]]);
+        assert_eq!(port, 8443);
+    }
+
+    #[test]
+    fn test_sockaddr_v6_tlv_structure() {
+        let mut buf = BytesMut::new();
+        let test_addr_v6 = SocketAddr::V6(std::net::SocketAddrV6::new(
+            Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1),
+            443,
+            0,
+            0,
+        ));
+
+        // Write the TLV
+        put_socketaddr(&mut buf, DataType::ASA, &test_addr_v6);
+
+        // Verify the buffer structure manually
+        let bytes = buf.as_ref();
+
+        // Check header
+        assert_eq!(bytes[0], DataType::ASA); // TLV type
+        assert_eq!(bytes[1], SOCKADDR_LEN_V6); // TLV length (18 bytes for IPv6 + port)
+
+        // Check first few bytes of IPv6 address (2001:db8::1)
+        assert_eq!(bytes[2], 0x20);
+        assert_eq!(bytes[3], 0x01);
+        assert_eq!(bytes[4], 0x0d);
+        assert_eq!(bytes[5], 0xb8);
+
+        // Check port bytes at the end (443 in big-endian)
+        let port_bytes = &bytes[18..20];
+        let port = u16::from_be_bytes([port_bytes[0], port_bytes[1]]);
+        assert_eq!(port, 443);
+    }
+
+    #[test]
+    fn test_parse_bad_asa_length() {
+        let mut buf = BytesMut::new();
+
+        // Add an ASA TLV with invalid length (not 6 or 18)
+        buf.put_u8(DataType::ASA);
+        buf.put_u8(8); // Invalid length for ASA (should be 6 for IPv4 or 18 for IPv6)
+        buf.put_u64(0x0123456789abcdef);
+
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader);
+
+        assert!(matches!(result, Err(TlvError::BadStructure)));
+    }
+
+    #[test]
+    fn test_mixed_asa_and_aaa() {
+        let mut buf = BytesMut::new();
+
+        // Add an AAA (plain IP address)
+        let ipv4_addr = Ipv4Addr::new(10, 0, 0, 1);
+        put_ipv4addr(&mut buf, DataType::AAA, &ipv4_addr);
+
+        // Add an ASA (socket address)
+        let socket_addr = SocketAddr::V4(std::net::SocketAddrV4::new(
+            Ipv4Addr::new(10, 0, 0, 2),
+            8080,
+        ));
+        put_socketaddr(&mut buf, DataType::ASA, &socket_addr);
+
+        // Parse them back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify we have 2 different TLV types
+        assert_eq!(result.len(), 2);
+
+        // Check AAA (plain IP address)
+        let aaa_values = result.get(&DataType::AAA).unwrap();
+        assert_eq!(aaa_values.len(), 1);
+        match &aaa_values[0] {
+            TlvValue::Ipv4Addr(addr) => assert_eq!(*addr, ipv4_addr),
+            _ => panic!("Expected Ipv4Addr value for AAA"),
+        }
+
+        // Check ASA (socket address)
+        let asa_values = result.get(&DataType::ASA).unwrap();
+        assert_eq!(asa_values.len(), 1);
+        match &asa_values[0] {
+            TlvValue::SocketAddr(addr) => assert_eq!(*addr, socket_addr),
+            _ => panic!("Expected SocketAddr value for ASA"),
+        }
+    }
+
+    #[test]
+    fn test_tlv_value_display_sockaddr() {
+        let addr_v4 = SocketAddr::V4(std::net::SocketAddrV4::new(
+            Ipv4Addr::new(192, 168, 1, 1),
+            8080,
+        ));
+        let addr_v6 = SocketAddr::V6(std::net::SocketAddrV6::new(
+            Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1),
+            443,
+            0,
+            0,
+        ));
+
+        let tlv_v4 = TlvValue::SocketAddr(addr_v4);
+        let tlv_v6 = TlvValue::SocketAddr(addr_v6);
+
+        // Test that Display formatting works correctly
+        assert_eq!(format!("{}", tlv_v4), "192.168.1.1:8080");
+        assert_eq!(format!("{}", tlv_v6), "[2001:db8::1]:443");
+    }
+}

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -3,7 +3,6 @@
 use open_enum::open_enum;
 use zerocopy::byteorder::network_endian::*;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
-
 use zpr;
 
 #[open_enum]
@@ -133,10 +132,11 @@ pub struct ZdpHelloRequestHeader {
 #[repr(packed)]
 pub struct ZdpHelloResponseHeader {
     pub status: ResponseCode,
-    pub policy_id_len: u8,
-    // Policy ID
-    // Version info len
-    // Version info
+    // Followed by any nubmer of response TLVs.  The TLV
+    // format is:
+    //   - TLV type (u8)
+    //   - TLV length (u8)
+    //   - TLV value (variable length)
 }
 
 /// Bitflags for the [ZdpInitAuthenticationRequestHeader] flags field.


### PR DESCRIPTION
Instead of hard coding the asa address in client adapter, pass it as a TLV entry in the HelloResponse.

Note that the address is still hard coded, just now it's only on the dock.  A follow on story will remove the hardcoding and get the value from the visa service.

* This includes a fairly generic TLV mechanism.
* I made use of the LinkData struct in link_state, is that correct place for the state (the ASA addresses)?

Closes #869 