### PR TITLE
correctly handle self addr of 0.0.0.0

### DIFF
--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -269,20 +269,56 @@ fn main() -> ExitCode {
             None,
         )
         .unwrap();
+
         socket.set_nonblocking(true).unwrap();
         batch_io::set_recv_packet_info(&socket, true).unwrap();
+
+        // SO_REUSEPORT allows us to open multiple sockets for the same 5-tuple
         socket.set_reuse_port(true).unwrap();
+
+        // First bind to our self address.
+        // If the port is unspecified, one will be selected by the OS.
+        // (The IP address may also be unspecified, but the OS will not select one here.)
         socket
             .bind(&socket2::SockAddr::from(config.self_addr))
             .expect(&format!(
                 "unable to bind to self_addr ({})",
                 config.self_addr
             ));
+
         if config.self_addr.port() == 0 {
+            // Update the port of our configured self address to match
+            // what the OS chose.  This ensures that all sockets we open share
+            // the same port.
             let port = socket.local_addr().unwrap().as_socket().unwrap().port();
             config.self_addr.set_port(port);
             info!(target: STARTUP, "assigned substrate UDP port {port}");
         }
+
+        if let Some(node_addr) = config.node_addr {
+            // If we are an adapter (and thus have a remote node address), connect to that here.
+            // We don't actually care that this sets the default destination (since we always
+            // set it when sending).  Rather, this forces the OS to choose a local address
+            // if we didn't specify one in the bind call above.
+            socket
+                .connect(&socket2::SockAddr::from(node_addr))
+                .expect(&format!("unable to connect to node_addr ({})", node_addr));
+
+            if config.self_addr.ip().is_unspecified() {
+                // Update the address of our configured self address to match
+                // what the OS chose.  This ensures that all sockets we open share
+                // the same port.
+                let addr = socket
+                    .local_addr()
+                    .unwrap()
+                    .as_socket()
+                    .unwrap()
+                    .scoped_ip();
+                config.self_addr.set_scoped_ip(addr);
+                info!(target: STARTUP, "assigned substrate address {addr}");
+            }
+        }
+
         substrate_sockets.push(socket.into());
     }
 

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -281,6 +281,7 @@ impl From<Ipv6Addr> for ScopedIpv6Addr {
 
 pub trait SocketAddrExt {
     fn scoped_ip(&self) -> ScopedIpAddr;
+    fn set_scoped_ip(&mut self, new_ip: ScopedIpAddr);
 }
 
 impl SocketAddrExt for std::net::SocketAddr {
@@ -289,6 +290,19 @@ impl SocketAddrExt for std::net::SocketAddr {
             std::net::SocketAddr::V4(v4) => ScopedIpAddr::V4(*v4.ip()),
             std::net::SocketAddr::V6(v6) => {
                 ScopedIpAddr::V6(ScopedIpv6Addr::new(*v6.ip(), v6.scope_id()))
+            }
+        }
+    }
+
+    fn set_scoped_ip(&mut self, new_ip: ScopedIpAddr) {
+        match new_ip {
+            ScopedIpAddr::V4(v4) => self.set_ip(v4.into()),
+            ScopedIpAddr::V6(sv6) => {
+                self.set_ip(sv6.ip.into());
+                match self {
+                    std::net::SocketAddr::V4(_) => panic!("should not happen"),
+                    std::net::SocketAddr::V6(v6) => v6.set_scope_id(sv6.scope_id),
+                }
             }
         }
     }


### PR DESCRIPTION
Needed to use `connect()` to request the OS to explicitly assign us an appropriate address which we then use as our chosen address for the remainder of the session.