### PR TITLE
add "none" logging target and DEBUG_TARGETS parameter to integ test

### DIFF
--- a/adapter/ph/src/logging.rs
+++ b/adapter/ph/src/logging.rs
@@ -24,6 +24,7 @@ pub mod targets {
     // ultimately lies with a dependency of X).
 
     pub const ALL: &str = "all";
+    pub const NONE: &str = "none";
     pub const CAPTURE: &str = "capture";
     pub const DATAPATH: &str = "datapath";
     pub const FLOW_MGMT: &str = "flow_mgmt";
@@ -42,6 +43,7 @@ pub mod targets {
 
     pub const ALL_TARGETS: &[&str] = &[
         ALL,
+        NONE,
         CAPTURE,
         DATAPATH,
         FLOW_MGMT,
@@ -75,14 +77,20 @@ where
     for target in debug.into_iter() {
         if target == targets::ALL {
             targets = targets.with_default(Level::DEBUG);
+        } else if target == targets::NONE {
+            targets = targets.with_default(Level::INFO);
         } else {
             targets = targets.with_target(target, Level::DEBUG);
         }
     }
 
+    let debugged_targets = targets.clone();
+
     for target in quiet.into_iter() {
         if target == targets::ALL {
             targets = targets.with_default(Level::ERROR);
+        } else if target == targets::NONE {
+            targets = debugged_targets.clone();
         } else {
             targets = targets.with_target(target, Level::ERROR);
         }

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -99,7 +99,7 @@ pub fn send_init_authentication_request(
     flags: u8,
     payload: auth::ZdpInitAuthenticationPayload,
 ) -> zpr::SeqNum {
-    debug!(target: ZDP, "Link {link_id}: sending IntitAuthenticationRequest, flags: {flags:x?}");
+    debug!(target: ZDP, "Link {link_id}: sending InitAuthenticationRequest, flags: {flags:x?}");
 
     let mut req = core::new_heap_packet();
 

--- a/integration-test/one-node-test.sh
+++ b/integration-test/one-node-test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 export RUST_BACKTRACE=1
+DEBUG_TARGETS=${DEBUG_TARGETS:-none}
 
 PH_BIN=$(realpath "$(dirname $0)/../adapter/ph/target/debug/ph")
 PH_DEBUG_BIN=$(realpath "$(dirname $0)/../adapter/cli/target/debug/ph-cli")
@@ -110,6 +111,7 @@ echo "Launching Node"
 
 sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
   node \
+  --debug "$DEBUG_TARGETS" \
   --control-path "$NODE_SOCK" \
   --ca-file ca.crt \
   --certificate-file node.crt \
@@ -123,6 +125,7 @@ echo "Launching Adapters"
 
 sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
+  --debug "$DEBUG_TARGETS" \
   --control-path "$VS_SOCK" \
   --self-addr "$VS_SUBSTRATE_ADDR" \
   --ca-file ca.crt \
@@ -138,6 +141,7 @@ sleep 5
 
 sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
+  --debug "$DEBUG_TARGETS" \
   --control-path "$ADAPTER1_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR" \
   --ca-file ca.crt \
@@ -151,6 +155,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
+  --debug "$DEBUG_TARGETS" \
   --control-path "$ADAPTER2_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR" \
   --ca-file ca.crt \
@@ -167,6 +172,7 @@ if [[ "$NUM_ACTORS" -ge 3 ]]; then
   # on this interface, to test that replies are still routed correctly.
   sudo -E ip netns exec zpr-c sudo -E -u "$ZPR_USER" "$PH_BIN" \
     adapter \
+  --debug "$DEBUG_TARGETS" \
     --control-path "$ADAPTER3_SOCK" \
     --self-addr "$C_SUBSTRATE_ADDR" \
     --ca-file ca.crt \


### PR DESCRIPTION
Added a "none" logging target (which is the default).

Add a new `DEBUG_TARGETS` variable to the integration test which sets the debugging target for all nodes & adapters launched.  Defaults to "none".