### PR TITLE
Sequence numbers!

### DIFF
--- a/adapter/ph/src/counters.rs
+++ b/adapter/ph/src/counters.rs
@@ -80,7 +80,8 @@ pub enum CounterType {
     QueueBackpressure,
     DroppedAwaitingBind,
     DroppedNop,           // normal, not an error drop
-    DroppedDuplicate,     // some sort of duplicate detected
+    DroppedTooOld,        // "old" management packet received (possible duplicate)
+    DroppedDuplicate,     // duplicate management packet detected
     DroppedNoSA,          // no security association on link
     InternalRoutingError, // a packet ended up somewhere it shouldn't have due to a coding error
 
@@ -88,6 +89,8 @@ pub enum CounterType {
     ActorSlowpath,    // exited fastpath from actor output, sent to mgmt
     BadMgmtResponse,
     UnexpectedMgmtResponse,
+    LostPacket,       // lost management packet detected
+    OutOfOrderPacket, // out-of-order management packet detected (and processed)
 
     UnknownPeer,
     PeerRemoved,
@@ -139,6 +142,7 @@ impl CounterType {
             // Packet drops
             Self::QueueBackpressure => "QueueBackpressure",
             Self::DroppedAwaitingBind => "Dropped Awaiting Bind",
+            Self::DroppedTooOld => "Dropped Too Old",
             Self::DroppedDuplicate => "Dropped Duplicate",
             Self::DroppedNop => "Dropped No Operation",
             Self::DroppedNoSA => "Dropped No Security Association",
@@ -149,6 +153,8 @@ impl CounterType {
             Self::ActorSlowpath => "Actor Slowpath",
             Self::BadMgmtResponse => "Bad Management Response",
             Self::UnexpectedMgmtResponse => "Unexpected Management Response",
+            Self::LostPacket => "Lost Packet",
+            Self::OutOfOrderPacket => "Out Of Order Packet",
 
             // Peer operation failures
             Self::UnknownPeer => "Unknown Peer",

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -692,7 +692,7 @@ impl LinkStateWrapper {
 
             (_, _) => {
                 return Err(LinkStateError::InvalidOperation(
-                    "Discarded unsolicited register address request".to_string(),
+                    "Discarded unsolicited acquire ZPR address request".to_string(),
                 ))
             }
         }
@@ -822,11 +822,11 @@ impl LinkStateWrapper {
         let locked_fsm = self.locked_fsm.lock().unwrap();
         match (self.link_type, locked_fsm.state) {
             (LinkType::AdapterToNode, LinkState::RegisterAA) => {
-                debug!(target: LINK_STATE, "link {link_id} acquire ZDP address response (ACK) message recieved, code {:?}", code);
+                debug!(target: LINK_STATE, "link {link_id} acquire ZDP address response (ACK) message received, code {:?}", code);
                 Ok(())
             }
             (_, _) => Err(LinkStateError::InvalidOperation(
-                "Discarded unsolicited acquire zpr adress response".to_string(),
+                "Discarded unsolicited acquire zpr address response".to_string(),
             )),
         }
     }
@@ -856,7 +856,7 @@ impl LinkStateWrapper {
                 }
             }
             (_, _) => Err(LinkStateError::InvalidOperation(
-                "Discarded unsolicited authorize response".to_string(),
+                "Discarded unsolicited grant response".to_string(),
             )),
         }
     }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -53,6 +53,7 @@ mod pki;
 mod queues;
 mod rcu;
 mod sample_ring;
+mod seq_nums;
 mod signal_worker;
 mod special_peers;
 mod sync_req;

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -7,6 +7,7 @@ use crate::assembly::Assembly;
 use crate::config;
 use crate::counters::CounterType;
 use crate::packet::Packet;
+use crate::seq_nums;
 use crate::zdp;
 use thiserror::Error;
 use tokio::time::sleep;
@@ -39,8 +40,17 @@ pub fn send_non_flow_mgmt(
     packet_type: zdp::ZdpPacketType,
     packet: Packet,
 ) -> zpr::SeqNum {
-    let seq_num = 0; // TODO, zpr-core/839
-    send_mgmt_helper(asm, link_id, packet_type, None, None, packet);
+    let Some(peer_state) = asm.peer_table.get(link_id) else {
+        // no more peer; packet will be dropped; return a dummy sequence number
+        return zpr::SeqNum::default();
+    };
+
+    let seq_num = peer_state.sn_gen.generate_seq_num();
+
+    drop(peer_state);
+
+    send_mgmt_helper(asm, link_id, packet_type, None, Some(seq_num), packet);
+
     seq_num
 }
 
@@ -94,8 +104,7 @@ fn send_mgmt_helper(
     hdr.packet_type = packet_type;
 
     if let Some(sequence_number) = sequence_number {
-        // uses only suffix of sequence number
-        hdr.sequence_number = (sequence_number as u16).into();
+        hdr.sequence_number = seq_nums::truncate_seq_num(sequence_number).into();
     }
 
     // It's possible (but unlikely) the MgmtSubstrateEgress queue fills up.
@@ -199,7 +208,7 @@ async fn send_sync_req_helper(
     match_received(asm, response, SyncReqError::Timeout, zdp_response_type)
 }
 
-/// Determines whether the message recieved in response to the request is
+/// Determines whether the message received in response to the request is
 /// a) a packet and not an error, and b) the expected packet type
 // TODO: rename/move this
 fn match_received(

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -1,13 +1,15 @@
 use crate::assembly::Assembly;
-use crate::counters::CounterType;
+use crate::counters::{CounterType, Counters};
 use crate::link_state::LinkEvent;
 use crate::logging::targets::{LINK_STATE, ZDP};
 use crate::mgmt;
 use crate::mgmt::handlers::{self, HandleMgmtError, HandleMgmtResult};
 use crate::packet::Packet;
 use crate::queues::MgmtProcessorMessage;
+use crate::seq_nums::*;
 use crate::zdp::*;
 use std::sync::Arc;
+use strum::IntoEnumIterator;
 use tokio::sync::mpsc;
 use tracing::*;
 use zpr;
@@ -56,16 +58,54 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
         return Err((HandleMgmtError::BadStructure, pkt));
     };
 
+    let seq_num;
+
+    if base_hdr.packet_type.is_per_flow() {
+        // VERY HACK:
+        // Right now BindActorAddressRequest still uses the "old-style" sync-response mechanism.
+        // Therefore we must exempt it from standardized sequence number processing.
+        // Conveniently, it's also the only per-flow message we actually process here.
+        // So we use that as a proxy to detect this type of message (in order not to have to parse
+        // the flow header here) and use traditional sequence number processing.
+
+        seq_num = base_hdr.sequence_number.get() as u64;
+    } else {
+        let truncated_seq_num = base_hdr.sequence_number.get();
+
+        let maybe_seq_num;
+        {
+            let Some(peer_state) = asm.peer_table.get(pkt.metadata().ingress_link_id) else {
+                mgmt::core::count_event(asm, &mut pkt, CounterType::PeerRemoved);
+                return Ok(());
+            };
+
+            let mut sn_track = peer_state.sn_track.lock().unwrap();
+            maybe_seq_num = sn_track.process_seq_num(truncated_seq_num);
+            count_seq_num_tracker_stats(&asm.counters, &mut sn_track);
+        }
+
+        let Some(sn) = maybe_seq_num else {
+            // Possible duplicate packet, drop!
+            // (Counted above by `count_seq_num_tracker_stats()`).
+            debug!(
+                target: ZDP,
+                "Link {}: dropping mgmt message type {:?} truncated_seq_num {truncated_seq_num}",
+                pkt.metadata().ingress_link_id,
+                base_hdr.packet_type,
+            );
+
+            return Ok(());
+        };
+
+        seq_num = sn;
+    }
+
     debug!(
         target: ZDP,
-        "Link {}: handling mgmt message type {:?} seq_num {}",
+        "Link {}: handling mgmt message type {:?} seq_num {seq_num}",
         pkt.metadata().ingress_link_id,
         base_hdr.packet_type,
-        base_hdr.sequence_number
     );
-
-    // TODO: reconstitute full seq num given expected seq num state
-    let seq_num = base_hdr.sequence_number.get() as u64;
 
     if base_hdr.packet_type.is_per_flow() {
         let Ok(per_flow_hdr) = ZdpPerFlowHeader::read_from_buf(&mut pkt) else {
@@ -142,5 +182,23 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
                 Err((HandleMgmtError::UnknownType(packet_type.0), pkt))
             }
         }
+    }
+}
+
+/// Maps a `SeqnumTrackerStat` to a `CounterType`.
+fn seq_num_tracker_stat_to_counter(sn_stat: SeqNumTrackerStat) -> CounterType {
+    match sn_stat {
+        SeqNumTrackerStat::TooOld => CounterType::DroppedTooOld,
+        SeqNumTrackerStat::Duplicate => CounterType::DroppedDuplicate,
+        SeqNumTrackerStat::Lost => CounterType::LostPacket,
+        SeqNumTrackerStat::OutOfOrder => CounterType::OutOfOrderPacket,
+    }
+}
+
+/// Pulls stats delta from `SeqNumTracker` and feeds them into the global counters.
+fn count_seq_num_tracker_stats(counters: &Counters, sn_track: &mut SeqNumTracker) {
+    for stat in SeqNumTrackerStat::iter() {
+        counters[seq_num_tracker_stat_to_counter(stat)]
+            .increase_by(sn_track.fetch_reset_stat(stat));
     }
 }

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -6,6 +6,7 @@ use crate::link_state::{LinkStateWrapper, LinkType};
 use crate::net_defs::ScopedIpAddr;
 use crate::queues;
 use crate::rcu::{RcuBox, RcuCslabEntryGuard, RcuOptionGuard};
+use crate::seq_nums::*;
 use crate::special_peers::*;
 use crate::sync_req;
 use bytes::Bytes;
@@ -37,6 +38,8 @@ pub struct PeerState {
     pub mgmt_processor: queues::MgmtProcessor,
     pub mgmt_processor_worker: task::JoinHandle<()>,
     pub auth_key: [u8; 32], // set in ::new and never changed.
+    pub sn_gen: SeqNumGenerator,
+    pub sn_track: Mutex<SeqNumTracker>,
     km_state: PeerKmState,
 }
 
@@ -97,6 +100,8 @@ impl PeerState {
             sync_req_state: sync_req::SyncReqState::new(),
             mgmt_processor,
             mgmt_processor_worker,
+            sn_gen: SeqNumGenerator::new(),
+            sn_track: Mutex::new(SeqNumTracker::new()),
             km_state: PeerKmState::new(),
             auth_key: key,
         }
@@ -398,6 +403,7 @@ impl VacantPeerTableEntry<'_> {
 pub mod test {
 
     use super::*;
+    use std::sync::Mutex;
 
     #[allow(dead_code)]
     pub fn create_dummy_peer_state(
@@ -417,6 +423,8 @@ pub mod test {
             sync_req_state: sync_req::SyncReqState::new(),
             mgmt_processor,
             mgmt_processor_worker: task::spawn(async {}),
+            sn_gen: SeqNumGenerator::new(),
+            sn_track: Mutex::new(SeqNumTracker::new()),
             km_state: PeerKmState::new(),
             auth_key: [42u8; AUTH_KEY_SIZE_BYTES],
         }

--- a/adapter/ph/src/seq_nums.rs
+++ b/adapter/ph/src/seq_nums.rs
@@ -1,0 +1,149 @@
+use enum_map::{Enum, EnumMap};
+use std::sync::atomic::*;
+use zpr::SeqNum;
+
+/// Generates outgoing sequence numbers.
+pub struct SeqNumGenerator {
+    next: AtomicU64,
+}
+
+impl SeqNumGenerator {
+    /// Initialize a new sequence number generator.
+    ///
+    /// The first sequence number output will be 0.
+    pub fn new() -> Self {
+        Self {
+            next: AtomicU64::new(0),
+        }
+    }
+
+    /// Generate and return the next sequence number.
+    pub fn generate_seq_num(&self) -> SeqNum {
+        self.next.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+/// Truncate a sequence number to 16 bits for sending over the ether.
+pub fn truncate_seq_num(sn: SeqNum) -> u16 {
+    (sn & 0xFFFF) as u16
+}
+
+#[derive(Enum)]
+pub enum SeqNumTrackerStat {
+    /// how many packets were rejected due to being "too old" (and therefore possibly duplicates)
+    TooOld,
+    /// how many packets were rejected due to being known duplicates
+    Duplicate,
+    /// how many packets were never receieved in time to be validated and processed
+    Lost,
+    /// how many packets were received and processed with a sequence number
+    /// earlier than the latest seen at the time
+    OutOfOrder,
+}
+
+/// Tracks incoming sequence numbers.
+///
+/// Both reifies truncated sequence numbers into full sequence numbers,
+/// and tracks which have been seen to detect duplicate messages.
+pub struct SeqNumTracker {
+    highest_seen: SeqNum,
+    window: u64,
+    stats: EnumMap<SeqNumTrackerStat, u64>,
+}
+
+impl SeqNumTracker {
+    const WINDOW_SIZE: usize = 64;
+
+    /// Create a new sequence number tracker.
+    ///
+    /// Initialized to accept sequence numbers starting at 0,
+    /// and to reject (consider as old/already received) all
+    /// earlier sequence numbers.
+    pub fn new() -> Self {
+        Self {
+            highest_seen: SeqNum::MAX,
+            window: u64::MAX,
+            stats: Default::default(),
+        }
+    }
+
+    /// Query the highest sequence number seen so far.
+    /// (Useful for explicitly synchronizing.)
+    pub fn highest_seen(&self) -> SeqNum {
+        self.highest_seen
+    }
+
+    /// Query the ratio of messages which have been missed
+    /// within the reception window.
+    pub fn drop_rate(&self) -> f32 {
+        (self.window.count_zeros() as f32) / (Self::WINDOW_SIZE as f32)
+    }
+
+    /// Reinitialize the tracker such that the given sequence number
+    /// is considered the latest seen, and all prior are considered
+    /// already received also.
+    pub fn resynchronize(&mut self, highest_seen: SeqNum) {
+        self.highest_seen = highest_seen;
+        self.window = u64::MAX;
+    }
+
+    /// Reify the truncated sequence number into an offset relative to the
+    /// reference sequence number, under the assumption that it is within a
+    /// window centered on the highest seen value thus far.
+    fn reify_seq_num_relative(reference: SeqNum, sn: u16) -> i64 {
+        (sn.wrapping_sub((reference & 0xFFFF) as u16)
+            .wrapping_add(0x8000) as i64)
+            - 0x8000
+    }
+
+    /// Process the truncated sequence number of a received packet.
+    ///
+    /// The truncated sequence number is reified into a full sequence number
+    /// according to the current window position.  If this packet
+    /// is sufficiently recent and hasn't already been seen, this full
+    /// sequence number is returned and the packet can be safely processed.
+    /// Else, `None` is returned, and the packet should be ignored,
+    /// as it may be a duplicate.
+    pub fn process_seq_num(&mut self, sn: u16) -> Option<SeqNum> {
+        let offset = Self::reify_seq_num_relative(self.highest_seen, sn);
+
+        if offset <= -(Self::WINDOW_SIZE as i64) {
+            // Too old!  Reject.
+            self.stats[SeqNumTrackerStat::TooOld] += 1;
+            return None;
+        }
+
+        if offset > 0 {
+            // Newer than any we've seen prior; accept, shift the window, and mark.
+            self.highest_seen = self.highest_seen.wrapping_add(offset as SeqNum);
+
+            if offset >= Self::WINDOW_SIZE as i64 {
+                self.stats[SeqNumTrackerStat::Lost] += self.window.count_zeros() as u64;
+                self.window = 0;
+            } else {
+                self.stats[SeqNumTrackerStat::Lost] +=
+                    (self.window >> ((Self::WINDOW_SIZE as i64) - offset)).count_zeros() as u64;
+                self.window <<= offset;
+            }
+            self.window |= 1;
+
+            return Some(self.highest_seen);
+        }
+
+        if (self.window >> -offset) & 1 != 0 {
+            // Already seen.  Reject.
+            self.stats[SeqNumTrackerStat::Duplicate] += 1;
+            return None;
+        }
+
+        // Old, but within our window.  Accept and mark.
+        self.stats[SeqNumTrackerStat::OutOfOrder] += 1;
+        self.window |= 1 << -offset;
+        return Some(self.highest_seen.wrapping_sub((-offset) as SeqNum));
+    }
+
+    /// Fetch & reset the specified stat.
+    pub fn fetch_reset_stat(&mut self, stat: SeqNumTrackerStat) -> u64 {
+        std::mem::take(&mut self.stats[stat])
+    }
+}

--- a/adapter/ph/src/seq_nums.rs
+++ b/adapter/ph/src/seq_nums.rs
@@ -28,7 +28,7 @@ pub fn truncate_seq_num(sn: SeqNum) -> u16 {
     (sn & 0xFFFF) as u16
 }
 
-#[derive(Clone, Copy, Enum, strum::EnumIter)]
+#[derive(Clone, Copy, Debug, Enum, strum::EnumIter)]
 pub enum SeqNumTrackerStat {
     /// how many packets were rejected due to being "too old" (and therefore possibly duplicates)
     TooOld,
@@ -94,9 +94,17 @@ impl SeqNumTracker {
     /// reference sequence number, under the assumption that it is within a
     /// window centered on the highest seen value thus far.
     fn reify_seq_num_relative(reference: SeqNum, sn: u16) -> i64 {
-        (sn.wrapping_sub((reference & 0xFFFF) as u16)
-            .wrapping_add(0x8000) as i64)
-            - 0x8000
+        // We operate under the assumption that the difference between the
+        // true sequence number and `reference` is in the range [-2^15, 2^15).
+
+        // Under that assumption, we can subtract the truncated versions
+        // of both to produce a 16-bit 2s-complement value representing
+        // this difference.
+        let diff = sn.wrapping_sub((reference & 0xFFFF) as u16);
+
+        // Convert the 16-bit 2s-complement value into a 64-bit signed value,
+        // by adding 0x8000, casting to signed, and subtracting 0x8000.
+        (diff.wrapping_add(0x8000) as i64) - 0x8000
     }
 
     /// Process the truncated sequence number of a received packet.
@@ -121,11 +129,12 @@ impl SeqNumTracker {
             self.highest_seen = self.highest_seen.wrapping_add(offset as SeqNum);
 
             if offset >= Self::WINDOW_SIZE as i64 {
-                self.stats[SeqNumTrackerStat::Lost] += self.window.count_zeros() as u64;
+                self.stats[SeqNumTrackerStat::Lost] += (self.window.count_zeros() as u64)
+                    + ((offset as u64) - (Self::WINDOW_SIZE as u64));
                 self.window = 0;
             } else {
-                self.stats[SeqNumTrackerStat::Lost] +=
-                    (self.window >> ((Self::WINDOW_SIZE as i64) - offset)).count_zeros() as u64;
+                self.stats[SeqNumTrackerStat::Lost] += (offset as u64)
+                    - ((self.window >> ((Self::WINDOW_SIZE as i64) - offset)).count_ones() as u64);
                 self.window <<= offset;
             }
             self.window |= 1;
@@ -153,7 +162,12 @@ impl SeqNumTracker {
 
 #[cfg(test)]
 mod tests {
-    use super::{truncate_seq_num, SeqNumTracker};
+    use super::{truncate_seq_num, SeqNumTracker, SeqNumTrackerStat as Stat};
+    use enum_map::{enum_map, EnumMap};
+
+    fn fetch_reset_all_stats(snt: &mut SeqNumTracker) -> EnumMap<Stat, u64> {
+        EnumMap::from_fn(|s| snt.fetch_reset_stat(s))
+    }
 
     #[test]
     fn basic_tracking() {
@@ -164,6 +178,7 @@ mod tests {
         }
 
         assert_eq!(snt.highest_seen(), 4);
+        assert_eq!(fetch_reset_all_stats(&mut snt), enum_map! { _ => 0 });
     }
 
     #[test]
@@ -177,6 +192,7 @@ mod tests {
         }
 
         assert_eq!(snt.highest_seen(), 0x12345b);
+        assert_eq!(fetch_reset_all_stats(&mut snt), enum_map! { _ => 0 });
     }
 
     #[test]
@@ -190,6 +206,7 @@ mod tests {
         }
 
         assert_eq!(snt.highest_seen(), 0x130002);
+        assert_eq!(fetch_reset_all_stats(&mut snt), enum_map! { _ => 0 });
     }
 
     #[test]
@@ -200,6 +217,11 @@ mod tests {
         assert_eq!(snt.process_seq_num(0xF000), None);
         assert_eq!(snt.highest_seen(), 0);
         assert_eq!(snt.process_seq_num(1), Some(1));
+
+        assert_eq!(
+            fetch_reset_all_stats(&mut snt),
+            enum_map! { Stat::TooOld => 1, _ => 0 }
+        );
     }
 
     #[test]
@@ -213,6 +235,11 @@ mod tests {
         assert_eq!(snt.process_seq_num(0xF000), None);
         assert_eq!(snt.highest_seen(), 0x15001);
         assert_eq!(snt.process_seq_num(0x5002), Some(0x15002));
+
+        assert_eq!(
+            fetch_reset_all_stats(&mut snt),
+            enum_map! { Stat::TooOld => 2, _ => 0 }
+        );
     }
 
     #[test]
@@ -223,18 +250,30 @@ mod tests {
         assert_eq!(snt.process_seq_num(0x1000), Some(0x1000));
         assert_eq!(snt.highest_seen(), 0x1000);
         assert_eq!(snt.process_seq_num(0x1001), Some(0x1001));
+
+        // note, the 62 unreceived packets still in the new window aren't lost yet
+        assert_eq!(
+            fetch_reset_all_stats(&mut snt),
+            enum_map! { Stat::Lost => 0xFFF - 62, _ => 0 }
+        );
     }
 
     #[test]
     fn skip_wrapping() {
         let mut snt = SeqNumTracker::new();
-        snt.resynchronize(0x9000);
+        snt.resynchronize(0x8FFF);
 
-        assert_eq!(snt.process_seq_num(0x9001), Some(0x9001));
+        assert_eq!(snt.process_seq_num(0x9000), Some(0x9000));
         assert_eq!(snt.process_seq_num(0xB000), Some(0xB000));
         assert_eq!(snt.highest_seen(), 0xB000);
         assert_eq!(snt.process_seq_num(0x1000), Some(0x11000));
         assert_eq!(snt.highest_seen(), 0x11000);
+
+        // note, the 63 unreceived packets still in the new window aren't lost yet
+        assert_eq!(
+            fetch_reset_all_stats(&mut snt),
+            enum_map! { Stat::Lost => 0x7FFE - 63, _ => 0 }
+        );
     }
 
     #[test]
@@ -247,6 +286,11 @@ mod tests {
         assert_eq!(snt.process_seq_num(truncate_seq_num(4)), Some(4));
         assert_eq!(snt.process_seq_num(truncate_seq_num(3)), Some(3));
         assert_eq!(snt.highest_seen(), 4);
+
+        assert_eq!(
+            fetch_reset_all_stats(&mut snt),
+            enum_map! { Stat::OutOfOrder => 2, _ => 0 }
+        );
     }
 
     #[test]
@@ -263,6 +307,11 @@ mod tests {
             assert_eq!(snt.process_seq_num(truncate_seq_num(i)), None);
             assert_eq!(snt.highest_seen(), 4);
         }
+
+        assert_eq!(
+            fetch_reset_all_stats(&mut snt),
+            enum_map! { Stat::Duplicate => 6, _ => 0 }
+        );
     }
 
     #[test]
@@ -277,9 +326,101 @@ mod tests {
 
         for i in 0..5 {
             assert_eq!(
+                snt.process_seq_num(truncate_seq_num(0xfff - i)),
+                Some(0xfff - i)
+            );
+        }
+
+        for i in 0..5 {
+            assert_eq!(
                 snt.process_seq_num(truncate_seq_num(0x1001 + i)),
                 Some(0x1001 + i)
             );
         }
+
+        assert_eq!(
+            fetch_reset_all_stats(&mut snt),
+            enum_map! { Stat::Lost => 0x1000 - 63, Stat::OutOfOrder => 5, _ => 0 }
+        );
+    }
+
+    #[test]
+    fn test_clear_stats() {
+        let mut snt = SeqNumTracker::new();
+
+        // Out of order
+        snt.process_seq_num(1);
+        snt.process_seq_num(0);
+
+        // Duplicate
+        snt.process_seq_num(0);
+
+        // Too old
+        snt.process_seq_num(0xF000);
+
+        // Lose a packet
+        snt.process_seq_num(66);
+
+        assert_eq!(fetch_reset_all_stats(&mut snt), enum_map! { _ => 1 });
+        assert_eq!(fetch_reset_all_stats(&mut snt), enum_map! { _ => 0 });
+    }
+
+    #[test]
+    fn test_reify() {
+        assert_eq!(SeqNumTracker::reify_seq_num_relative(0x2000, 0x2000), 0);
+        assert_eq!(SeqNumTracker::reify_seq_num_relative(0x2000, 0x2001), 1);
+        assert_eq!(SeqNumTracker::reify_seq_num_relative(0x2000, 0x1FFF), -1);
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0x2000, 0x3000),
+            0x1000
+        );
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0x2000, 0x1000),
+            -0x1000
+        );
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0x2000, 0x9000),
+            0x7000
+        );
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0x2000, 0xF000),
+            -0x3000
+        );
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0x2000, 0xB000),
+            -0x7000
+        );
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0x2000, 0xA000),
+            -0x8000
+        );
+
+        assert_eq!(SeqNumTracker::reify_seq_num_relative(0xE000, 0xE000), 0);
+        assert_eq!(SeqNumTracker::reify_seq_num_relative(0xE000, 0xDFFF), -1);
+        assert_eq!(SeqNumTracker::reify_seq_num_relative(0xE000, 0xE001), 1);
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0xE000, 0xD000),
+            -0x1000
+        );
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0xE000, 0xF000),
+            0x1000
+        );
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0xE000, 0x7000),
+            -0x7000
+        );
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0xE000, 0x1000),
+            0x3000
+        );
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0xE000, 0x5000),
+            0x7000
+        );
+        assert_eq!(
+            SeqNumTracker::reify_seq_num_relative(0xE000, 0x6000),
+            -0x8000
+        );
     }
 }

--- a/adapter/ph/src/seq_nums.rs
+++ b/adapter/ph/src/seq_nums.rs
@@ -150,3 +150,136 @@ impl SeqNumTracker {
         std::mem::take(&mut self.stats[stat])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{truncate_seq_num, SeqNumTracker};
+
+    #[test]
+    fn basic_tracking() {
+        let mut snt = SeqNumTracker::new();
+
+        for i in 0..5 {
+            assert_eq!(snt.process_seq_num(truncate_seq_num(i)), Some(i));
+        }
+
+        assert_eq!(snt.highest_seen(), 4);
+    }
+
+    #[test]
+    fn offset_sn() {
+        let mut snt = SeqNumTracker::new();
+
+        snt.resynchronize(0x123456); // wrap the truncated SN
+
+        for i in 0x123457..0x12345c {
+            assert_eq!(snt.process_seq_num(truncate_seq_num(i)), Some(i));
+        }
+
+        assert_eq!(snt.highest_seen(), 0x12345b);
+    }
+
+    #[test]
+    fn wrap_tsn() {
+        let mut snt = SeqNumTracker::new();
+
+        snt.resynchronize(0x12fffd); // wrap the truncated SN
+
+        for i in 0x12fffe..0x130003 {
+            assert_eq!(snt.process_seq_num(truncate_seq_num(i)), Some(i));
+        }
+
+        assert_eq!(snt.highest_seen(), 0x130002);
+    }
+
+    #[test]
+    fn too_old_basic() {
+        let mut snt = SeqNumTracker::new();
+
+        assert_eq!(snt.process_seq_num(0), Some(0));
+        assert_eq!(snt.process_seq_num(0xF000), None);
+        assert_eq!(snt.highest_seen(), 0);
+        assert_eq!(snt.process_seq_num(1), Some(1));
+    }
+
+    #[test]
+    fn too_old_wrapping() {
+        let mut snt = SeqNumTracker::new();
+        snt.resynchronize(0x15000);
+
+        assert_eq!(snt.process_seq_num(0x5001), Some(0x15001));
+        assert_eq!(snt.process_seq_num(0x3000), None);
+        assert_eq!(snt.highest_seen(), 0x15001);
+        assert_eq!(snt.process_seq_num(0xF000), None);
+        assert_eq!(snt.highest_seen(), 0x15001);
+        assert_eq!(snt.process_seq_num(0x5002), Some(0x15002));
+    }
+
+    #[test]
+    fn skip_basic() {
+        let mut snt = SeqNumTracker::new();
+
+        assert_eq!(snt.process_seq_num(0), Some(0));
+        assert_eq!(snt.process_seq_num(0x1000), Some(0x1000));
+        assert_eq!(snt.highest_seen(), 0x1000);
+        assert_eq!(snt.process_seq_num(0x1001), Some(0x1001));
+    }
+
+    #[test]
+    fn skip_wrapping() {
+        let mut snt = SeqNumTracker::new();
+        snt.resynchronize(0x9000);
+
+        assert_eq!(snt.process_seq_num(0x9001), Some(0x9001));
+        assert_eq!(snt.process_seq_num(0xB000), Some(0xB000));
+        assert_eq!(snt.highest_seen(), 0xB000);
+        assert_eq!(snt.process_seq_num(0x1000), Some(0x11000));
+        assert_eq!(snt.highest_seen(), 0x11000);
+    }
+
+    #[test]
+    fn out_of_order() {
+        let mut snt = SeqNumTracker::new();
+
+        assert_eq!(snt.process_seq_num(truncate_seq_num(0)), Some(0));
+        assert_eq!(snt.process_seq_num(truncate_seq_num(2)), Some(2));
+        assert_eq!(snt.process_seq_num(truncate_seq_num(1)), Some(1));
+        assert_eq!(snt.process_seq_num(truncate_seq_num(4)), Some(4));
+        assert_eq!(snt.process_seq_num(truncate_seq_num(3)), Some(3));
+        assert_eq!(snt.highest_seen(), 4);
+    }
+
+    #[test]
+    fn duplicate_basic() {
+        let mut snt = SeqNumTracker::new();
+
+        assert_eq!(snt.process_seq_num(0xFFFF), None);
+
+        for i in 0..5 {
+            assert_eq!(snt.process_seq_num(truncate_seq_num(i)), Some(i));
+        }
+
+        for i in 0..5 {
+            assert_eq!(snt.process_seq_num(truncate_seq_num(i)), None);
+            assert_eq!(snt.highest_seen(), 4);
+        }
+    }
+
+    #[test]
+    fn duplicate_skip() {
+        let mut snt = SeqNumTracker::new();
+
+        for i in 0..5 {
+            assert_eq!(snt.process_seq_num(truncate_seq_num(i)), Some(i));
+        }
+
+        assert_eq!(snt.process_seq_num(0x1000), Some(0x1000));
+
+        for i in 0..5 {
+            assert_eq!(
+                snt.process_seq_num(truncate_seq_num(0x1001 + i)),
+                Some(0x1001 + i)
+            );
+        }
+    }
+}

--- a/adapter/ph/src/seq_nums.rs
+++ b/adapter/ph/src/seq_nums.rs
@@ -28,7 +28,7 @@ pub fn truncate_seq_num(sn: SeqNum) -> u16 {
     (sn & 0xFFFF) as u16
 }
 
-#[derive(Enum)]
+#[derive(Clone, Copy, Enum, strum::EnumIter)]
 pub enum SeqNumTrackerStat {
     /// how many packets were rejected due to being "too old" (and therefore possibly duplicates)
     TooOld,
@@ -69,12 +69,14 @@ impl SeqNumTracker {
 
     /// Query the highest sequence number seen so far.
     /// (Useful for explicitly synchronizing.)
+    #[allow(dead_code)]
     pub fn highest_seen(&self) -> SeqNum {
         self.highest_seen
     }
 
     /// Query the ratio of messages which have been missed
     /// within the reception window.
+    #[allow(dead_code)]
     pub fn drop_rate(&self) -> f32 {
         (self.window.count_zeros() as f32) / (Self::WINDOW_SIZE as f32)
     }
@@ -82,6 +84,7 @@ impl SeqNumTracker {
     /// Reinitialize the tracker such that the given sequence number
     /// is considered the latest seen, and all prior are considered
     /// already received also.
+    #[allow(dead_code)]
     pub fn resynchronize(&mut self, highest_seen: SeqNum) {
         self.highest_seen = highest_seen;
         self.window = u64::MAX;


### PR DESCRIPTION
Here, we add a per-link unidirectional sequence number generator (trivial) and tracker.  The tracker does two things:

- Keeps the local idea of the remote's current sequence number in sync with the remote's actual current sequence number.  This is necessary since we send only truncated (16-bit) sequence numbers.
- Detects (within a window of 64 time slots) duplicate packets.  Also detects packets which are "too old" to be found within the window (presuming they aren't old enough to have wrapped the 16-bit truncated sequence number), and packets which were not received within the window.

We then use this for all ZDP packets (both requests and responses, which are no longer distinguished!) _other_ than:

- transit packets
- key management packets
- bind request packets (which still rely on the old-style sync request mechanism)

(Bind requests will be disentangled from the sync request mechanism soon and thenceforth no longer be an exception to this processing.)