### PR TITLE
Mk/870 asa - Send ASA from VS to Node

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -1212,7 +1212,7 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libnode"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "openssl",
@@ -1565,6 +1565,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
  "zerocopy 0.8.9",
  "zpr",
  "zpr-ext",
@@ -2559,8 +2560,8 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsapi"
-version = "0.2.0"
-source = "git+https://github.com/org-zpr/zpr-vsapi-rs.git?tag=v0.2.0#802c695e457845d2e7ade47c3a3b5ba037f377a4"
+version = "0.4.0"
+source = "git+https://github.com/org-zpr/zpr-vsapi-rs.git?tag=v0.4.1#2e41d0af057268d4b965b026a9b412dbe5483f99"
 dependencies = [
  "thrift",
 ]

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -42,6 +42,7 @@ zerocopy = { version = "0.8.3", features = ["derive", "std"] }
 zpr = { path = "../../zpr" }
 zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "zerocopy"] }
 serde_json = "1.0.140"
+url = "2.5.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-tun = { version = "0.11.5" }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -20,6 +20,7 @@ use crate::queues::*;
 use crate::special_peers::SpecialPeerName;
 use crate::tun_ctl::TunCtl;
 use crate::visa_table;
+use crate::vs_types::AuthServicesList;
 
 use enum_map::EnumMap;
 use km_noise::NoiseKeypair;
@@ -66,6 +67,7 @@ pub struct Assembly {
     pub actor_output_requeue: ActorOutputRequeue,
 
     pub vsconn: Option<libnode::vsconn::VSConnHandle>, // present only on nodes
+    pub vs_auth_services: tokio::sync::RwLock<AuthServicesList>, // present only on nodes, may be empty, managed by visa service
 
     pub visa_table: tokio::sync::RwLock<visa_table::VisaTable>, // Only for nodes
 
@@ -443,6 +445,7 @@ pub mod test {
             actor_output_requeue,
             vsconn,
             visa_table,
+            vs_auth_services: tokio::sync::RwLock::new(AuthServicesList::default()),
             capture_queue,
             capture_worker,
             flow_control,

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -67,7 +67,7 @@ pub struct Assembly {
     pub actor_output_requeue: ActorOutputRequeue,
 
     pub vsconn: Option<libnode::vsconn::VSConnHandle>, // present only on nodes
-    pub vs_auth_services: tokio::sync::RwLock<AuthServicesList>, // present only on nodes, may be empty, managed by visa service
+    pub vs_auth_services: std::sync::RwLock<AuthServicesList>, // present only on nodes, may be empty, managed by visa service
 
     pub visa_table: tokio::sync::RwLock<visa_table::VisaTable>, // Only for nodes
 
@@ -445,7 +445,7 @@ pub mod test {
             actor_output_requeue,
             vsconn,
             visa_table,
-            vs_auth_services: tokio::sync::RwLock::new(AuthServicesList::default()),
+            vs_auth_services: std::sync::RwLock::new(AuthServicesList::default()),
             capture_queue,
             capture_worker,
             flow_control,

--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -42,7 +42,6 @@ pub const BLOB_TYPE_AC: &str = "AC";
 /// be no older than this.
 pub const MAX_BLOB_AGE_SECONDS: u64 = 120; // 2 minutes
 
-
 // TODO: Not sure how we get these out or if we need them.
 pub const HARD_CODED_BAS_TLS_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
 MIIFmzCCA4OgAwIBAgIUJSg4OHOfPqY+lD7ymZy6akX/ZZ8wDQYJKoZIhvcNAQEL

--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -2,7 +2,7 @@
 //! when we need to join a ZPRnet but there are no authentication services
 //! attached yet.  Also includes other "auth" related functionality.
 
-use std::net::{Ipv6Addr, SocketAddr};
+use std::net::SocketAddr;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -42,11 +42,6 @@ pub const BLOB_TYPE_AC: &str = "AC";
 /// be no older than this.
 pub const MAX_BLOB_AGE_SECONDS: u64 = 120; // 2 minutes
 
-/// Default port used by authentication services running the zpr-oauthrsa protocol.
-pub const DEFAULT_ZPR_OAUTH_RSA_PORT: u16 = 4000;
-
-// "fd5a:5052:1::10" TODO: needs to come from dock (which gets it from VS)
-pub const HARD_CODED_BAS_ADDR: Ipv6Addr = Ipv6Addr::new(0xfd5a, 0x5052, 0x1, 0, 0, 0, 0, 0x10);
 
 // TODO: Not sure how we get these out or if we need them.
 pub const HARD_CODED_BAS_TLS_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -24,6 +24,7 @@ pub const DEFAULT_MESSAGE_HEADROOM: usize = 256;
 
 pub const DEFAULT_REQUEST_RETRY_COUNT: usize = 3;
 pub const DEFAULT_REQUEST_RETRY_TIMER: std::time::Duration = std::time::Duration::from_secs(1);
+pub const DEFAULT_TERMINATE_RESPONSE_TIMER: std::time::Duration = std::time::Duration::from_secs(1);
 
 pub const ANCILLARY_BUFFER_SIZE: usize = 128;
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -579,7 +579,7 @@ impl LinkStateWrapper {
     /// Does not generate any packets
     fn process_hello_request(
         &self,
-        asm: &Arc<Assembly>,
+        _asm: &Arc<Assembly>,
         peer_zpr_addr: IpAddress,
     ) -> Result<(), LinkStateError> {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
@@ -598,13 +598,6 @@ impl LinkStateWrapper {
                     "Link {link_id} peer is using ZPR addr {}",
                     peer_zpr_addr
                 );
-                locked_fsm.set_state(LinkState::WaitForInitAuth);
-                debug!(
-                    target: LINK_STATE,
-                    "Link {link_id} finished helloing.  Waiting for other side to respond to init-auth"
-                );
-                self.send_init_authentication_request(asm);
-                self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_RETRY_TIMER);
                 Ok(())
             }
             (LinkType::AdapterToNode, _) => {

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -561,17 +561,19 @@ impl LinkStateWrapper {
         debug!(target: LINK_STATE, "Link {link_id} finished keying.  Starting hello");
 
         locked_fsm.set_state(LinkState::Helloing);
-        drop(locked_fsm);
-        self.maybe_send_hello(asm);
-        Ok(())
-    }
 
-    fn maybe_send_hello(&self, asm: &Arc<Assembly>) {
         // IF this is an adapter, it's expected to issue the hello
         if self.link_type == LinkType::AdapterToNode {
-            mgmt::requests::send_hello_request(asm, self.id, &asm.local_zpr_addresses);
+            let _seqnum =
+                mgmt::requests::send_hello_request(asm, self.id, &asm.local_zpr_addresses);
+            self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_RETRY_TIMER);
+            debug!(
+                target: LINK_STATE,
+                "Link {link_id} sent HelloRequest.  Waiting for other side to respond."
+            );
         }
-        // Otherwise, wait for the adapter to reach out
+        // Otherwise we are a node so wait for an adapter to reach out
+        Ok(())
     }
 
     /// Update link state based on received hello request
@@ -1233,7 +1235,8 @@ impl LinkStateWrapper {
             // all these states use timeout simply for retransmits
             (LinkType::AdapterToNode, LinkState::RegisterAA)
             | (LinkType::NodeToAdapter, LinkState::RegisterAA)
-            | (LinkType::NodeToAdapter, LinkState::WaitForInitAuth) => {
+            | (LinkType::NodeToAdapter, LinkState::WaitForInitAuth)
+            | (LinkType::AdapterToNode, LinkState::Helloing) => {
                 locked_fsm.timeout_count += 1;
 
                 if locked_fsm.timeout_count >= config::DEFAULT_REQUEST_RETRY_COUNT {
@@ -1242,6 +1245,7 @@ impl LinkStateWrapper {
                     return self.process_error_response(&asm);
                 }
 
+                warn!(target: LINK_STATE, "Link {} timed out in state {:?}, retransmitting", self.id, locked_fsm.state);
                 self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_RETRY_TIMER);
                 self.retransmit(asm, &mut locked_fsm);
                 Ok(())
@@ -1282,7 +1286,14 @@ impl LinkStateWrapper {
                 self.send_init_authentication_request(asm)
             }
 
-            (_, _) => (),
+            (LinkType::AdapterToNode, LinkState::Helloing) => {
+                mgmt::requests::send_hello_request(asm, self.id, &asm.local_zpr_addresses);
+            }
+
+            (_, _) => {
+                // Programming error
+                error!(target: LINK_STATE, "Link {} requests retansmit in state {:?}: not implemented", self.id, locked_fsm.state);
+            }
         }
     }
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1247,6 +1247,15 @@ impl LinkStateWrapper {
                 Ok(())
             }
 
+            (_, LinkState::Closing) => {
+                // This is a timeout while we are waiting for a terminate response post initiate close.
+                // Now we finish the job,
+                debug!(target: LINK_STATE, "Link {} received timeout waiting on terminate response, shutting down link", self.id);
+                drop(locked_fsm);
+                self.complete_close(asm);
+                Ok(())
+            }
+
             (_, _) => Err(LinkStateError::InvalidOperation(format!(
                 "Ignoring unexpected timeout in state {:?}",
                 locked_fsm.state
@@ -1304,6 +1313,7 @@ impl LinkStateWrapper {
     /// Initiate the shutdown of the link
     /// Transitions to Closing from any running state
     /// Generates a Terminate Request packet
+    /// Sets a timeout in case we do not get a terminate response.
     fn initiate_close(
         &self,
         asm: &Arc<Assembly>,
@@ -1314,6 +1324,11 @@ impl LinkStateWrapper {
 
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         locked_fsm.set_state(LinkState::Closing);
+        self.set_timeout(
+            asm,
+            &mut locked_fsm,
+            config::DEFAULT_TERMINATE_RESPONSE_TIMER,
+        );
         mgmt::requests::send_terminate_request(asm, self.id, reason);
         Ok(())
     }

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -140,6 +140,7 @@ pub enum LinkEvent {
     KeyingDone,
     ReceivedHelloRequest(IpAddress), // Actors ZPR address - TODO: implement AAAs
     ReceivedHelloResponse(ResponseCode, Option<Vec<SocketAddr>>), // (response code, ASA addresses)
+    SentHelloResponse,
 
     ReceivedInitAuth((bool, Option<auth::ZdpInitAuthenticationPayload>)), // (bootstrap_flag, challenge)
 
@@ -412,6 +413,8 @@ impl LinkStateWrapper {
                 self.process_hello_response(asm, code, maybe_asa_addrs)
             }
 
+            LinkEvent::SentHelloResponse => self.process_sent_hello_response(asm),
+
             LinkEvent::ReceivedAcquireZprAddressRequest(addrs, blob) => {
                 self.process_acquire_zpr_address_request(asm, addrs, blob)
             }
@@ -613,6 +616,35 @@ impl LinkStateWrapper {
             (_, _) => Err(LinkStateError::UnexpectedTransition(
                 locked_fsm.state,
                 "ReceivedHelloRequest",
+            )),
+        }
+    }
+
+    fn process_sent_hello_response(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
+        let mut locked_fsm = self.locked_fsm.lock().unwrap();
+        let link_id = self.id;
+        match (self.link_type, locked_fsm.state) {
+            // Node->Adapter - we are in helloing state until we have fired off our
+            // HelloResponse.  At that point we can send an init-auth request.
+            (LinkType::NodeToAdapter, LinkState::Helloing) => {
+                locked_fsm.set_state(LinkState::WaitForInitAuth);
+                self.send_init_authentication_request(asm);
+                self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_RETRY_TIMER);
+                debug!(
+                    target: LINK_STATE,
+                    "Link {link_id} finished helloing.  Waiting for other side to respond to init-auth"
+                );
+                Ok(())
+            }
+            (LinkType::AdapterToNode, _) => {
+                // Adapters should not be sending hello-response to a node.
+                Err(LinkStateError::InvalidOperation(
+                    "Adapter should not send hello-response".to_string(),
+                ))
+            }
+            (_, _) => Err(LinkStateError::UnexpectedTransition(
+                locked_fsm.state,
+                "SentHelloResponse",
             )),
         }
     }
@@ -936,6 +968,9 @@ impl LinkStateWrapper {
     }
 
     /// Handle an init-auth message from sender.
+    ///
+    /// This is a slow function that is called AFTER we send a reply to the
+    /// init-auth message.
     ///
     /// If this is bootstrap and we are configured for bootstrap we can self-authenticate
     /// and send in an AcquireZprAddressRequest.

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1252,7 +1252,7 @@ impl LinkStateWrapper {
                 // Now we finish the job,
                 debug!(target: LINK_STATE, "Link {} received timeout waiting on terminate response, shutting down link", self.id);
                 drop(locked_fsm);
-                self.complete_close(asm);
+                self.clean_up_link_state(asm).detach_all();
                 Ok(())
             }
 
@@ -1333,7 +1333,9 @@ impl LinkStateWrapper {
         Ok(())
     }
 
-    /// Tear down link state
+    /// Tear down link state.
+    /// This sends notice to the visa service that we have lost an actor.
+    /// Sends a CloseDone event (which triggers [LinkStateWrapper::complete_close])
     fn clean_up_link_state(&self, asm: &Arc<Assembly>) -> tokio::task::JoinSet<()> {
         let link_id = self.id;
         let mut join_set = tokio::task::JoinSet::new();

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -63,6 +63,7 @@ mod tun_ctl;
 mod two_way_queue;
 mod visa_mgmt;
 mod visa_table;
+mod vs_types;
 mod vs_worker;
 mod vss_worker;
 mod zdp;
@@ -84,6 +85,8 @@ use pki::load_noise_public_key;
 use queues::*;
 use sys::ZprTun;
 use tun_ctl::TunCtl;
+
+use crate::vs_types::AuthServicesList;
 
 /// Creates a nonblocking local socket pair suitable for transferring
 /// PACKET_BUFFER_SIZE-sized messages.
@@ -410,6 +413,7 @@ fn main() -> ExitCode {
         visa_table: tokio::sync::RwLock::new(visa_table::VisaTable::new_with_vs_visas(
             &node_zpr_addr,
         )),
+        vs_auth_services: tokio::sync::RwLock::new(AuthServicesList::default()),
         capture_queue: Capture::new(cap_inq),
         capture_worker: CaptureWorker::new(),
         flow_control: FlowControl::new(),

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -413,7 +413,7 @@ fn main() -> ExitCode {
         visa_table: tokio::sync::RwLock::new(visa_table::VisaTable::new_with_vs_visas(
             &node_zpr_addr,
         )),
-        vs_auth_services: tokio::sync::RwLock::new(AuthServicesList::default()),
+        vs_auth_services: std::sync::RwLock::new(AuthServicesList::default()),
         capture_queue: Capture::new(cap_inq),
         capture_worker: CaptureWorker::new(),
         flow_control: FlowControl::new(),

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -323,7 +323,7 @@ pub async fn handle_hello_request(
             // If we have a list of services, include them in the response.
             // TODO: The ASA is set as a SocketAddr which doesn't feel quite right.  Maybe should be a URI.
             for authservice in &svclist.services {
-                if let Some(sa) = authservice.to_socket_addr() {
+                if let Some(sa) = authservice.get_socket_addr() {
                     TlvEncoding::new_asa(sa).put(&mut rsp_pkt);
                 } else {
                     warn!(target: ZDP, "Link {ingress_link_id}: HelloResponse - service {} has no valid ASA address", authservice.service_id);

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -341,6 +341,13 @@ pub async fn handle_hello_request(
         rsp_pkt,
     );
 
+    match asm.process_link_state_event(ingress_link_id, LinkEvent::SentHelloResponse) {
+        Err(e) => {
+            error!(target: ZDP, "Link {ingress_link_id}: Failed to process SentHelloResponse event: {:?}", e);
+        }
+        Ok(()) => (),
+    }
+
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -13,7 +13,7 @@ use crate::packet::Packet;
 use crate::tlv::{self, TlvEncoding};
 use crate::zdp;
 use bytes::{Buf, BufMut};
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::num::NonZero;
 use std::sync::Arc;
 use thiserror::Error;
@@ -317,13 +317,22 @@ pub async fn handle_hello_request(
     TlvEncoding::new_policy_id(policy_id).put(&mut rsp_pkt);
     TlvEncoding::new_version(VERSION).put(&mut rsp_pkt);
 
-    // TODO: This info needs to come from the visa service
-    let service_addr = SocketAddr::new(
-        IpAddr::V6(auth::HARD_CODED_BAS_ADDR),
-        auth::DEFAULT_ZPR_OAUTH_RSA_PORT,
-    );
-    TlvEncoding::new_asa(service_addr).put(&mut rsp_pkt);
-
+    {
+        let svclist = asm.vs_auth_services.read().await;
+        if svclist.is_valid() {
+            // If we have a list of services, include them in the response.
+            // TODO: The ASA is set as a SocketAddr which doesn't feel quite right.  Maybe should be a URI.
+            for authservice in &svclist.services {
+                if let Some(sa) = authservice.to_socket_addr() {
+                    TlvEncoding::new_asa(sa).put(&mut rsp_pkt);
+                } else {
+                    warn!(target: ZDP, "Link {ingress_link_id}: HelloResponse - service {} has no valid ASA address", authservice.service_id);
+                }
+            }
+        } else {
+            warn!(target: ZDP, "Link {ingress_link_id}: HelloResponse - no valid auth services available");
+        }
+    }
     super::core::send_non_flow_mgmt(
         asm,
         ingress_link_id,

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -324,6 +324,7 @@ pub async fn handle_hello_request(
             // TODO: The ASA is set as a SocketAddr which doesn't feel quite right.  Maybe should be a URI.
             for authservice in &svclist.services {
                 if let Some(sa) = authservice.get_socket_addr() {
+                    debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - adding ASA address: {sa}");
                     TlvEncoding::new_asa(sa).put(&mut rsp_pkt);
                 } else {
                     warn!(target: ZDP, "Link {ingress_link_id}: HelloResponse - service {} has no valid ASA address", authservice.service_id);

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -318,7 +318,7 @@ pub async fn handle_hello_request(
     TlvEncoding::new_version(VERSION).put(&mut rsp_pkt);
 
     {
-        let svclist = asm.vs_auth_services.read().await;
+        let svclist = asm.vs_auth_services.read().unwrap();
         if svclist.is_valid() {
             // If we have a list of services, include them in the response.
             // TODO: The ASA is set as a SocketAddr which doesn't feel quite right.  Maybe should be a URI.

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -220,7 +220,7 @@ pub async fn handle_services_update(
                 continue;
             }
             if service.address.is_none() {
-                error!(target: VISA_MGMT, "service descriptor with no address (id={}", service.service_id.unwrap_or_default());
+                error!(target: VISA_MGMT, "service descriptor with no address (id={})", service.service_id.unwrap_or_default());
                 continue;
             }
             match vs_types::ServiceDescriptor::try_from(service) {

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -4,11 +4,16 @@ use crate::link_state::{LinkEvent, LinkStateError};
 use crate::logging::targets::VISA_MGMT;
 use crate::net_defs::IpAddress;
 use crate::visa_table;
+use crate::vs_types;
 use libnode::vsapi;
 use std::num::NonZero;
 use std::sync::Arc;
+use std::time::{Duration, UNIX_EPOCH};
 use tracing::*;
 use zpr::{LinkId, VisaId};
+
+
+
 
 pub fn authorize_connect(
     asm: &Arc<Assembly>,
@@ -191,4 +196,48 @@ pub async fn handle_revocation(
         .write()
         .await
         .revoke(&asm.peer_table, visa_id)
+}
+
+pub async fn handle_services_update(
+    asm: &Arc<Assembly>,
+    services: vsapi::ServicesList,
+) -> Result<(), visa_table::VisaTableError> {
+
+    let expiration = if let Some(unixts) = services.expiration {
+        UNIX_EPOCH + Duration::from_secs(unixts as u64)
+    } else {
+        error!(target: VISA_MGMT, "visa service sends services list with no expiration set");
+        UNIX_EPOCH // not present? Already expired then.
+    };
+
+    let mut vs_auth_services = Vec::new();
+
+    if let Some(services) = services.services {
+        debug!(target: VISA_MGMT, "received services update with {} entries", services.len());
+        for service in services {
+            if service.type_ != vsapi::ServiceType::ACTOR_AUTHENTICATION {
+                continue;
+            }
+            if service.address.is_none() {
+                error!(target: VISA_MGMT, "service descriptor with no address (id={}", service.service_id.unwrap_or_default());
+                continue;
+            }
+            match vs_types::ServiceDescriptor::try_from(service) {
+                Ok(sd) => {
+                    vs_auth_services.push(sd);
+                }
+                Err(e) => {
+                    error!(target: VISA_MGMT, "failed to parse vsapi service descriptor: {e}");
+                    continue;
+                }
+            }
+        }
+    } else {
+        // Got update with nothing.
+        debug!(target: VISA_MGMT, "received empty services update, clearing vs_auth_services");
+    }
+    // The update is always a complete replacement of the list of services, and may be empty.
+    let mut svcs = asm.vs_auth_services.write().await;
+    svcs.update(expiration, vs_auth_services);
+    Ok(())
 }

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -239,7 +239,7 @@ pub async fn handle_services_update(
     }
     debug!(target: VISA_MGMT, "updating auth services with {} entries, expires at {expiration:?}", vs_auth_services.len());
     // The update is always a complete replacement of the list of services, and may be empty.
-    let mut svcs = asm.vs_auth_services.write().await;
+    let mut svcs = asm.vs_auth_services.write().unwrap();
     svcs.update(expiration, vs_auth_services);
     Ok(())
 }

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -236,6 +236,7 @@ pub async fn handle_services_update(
         // Got update with nothing.
         debug!(target: VISA_MGMT, "received empty services update, clearing vs_auth_services");
     }
+    debug!(target: VISA_MGMT, "updating auth services with {} entries", vs_auth_services.len());
     // The update is always a complete replacement of the list of services, and may be empty.
     let mut svcs = asm.vs_auth_services.write().await;
     svcs.update(expiration, vs_auth_services);

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -204,10 +204,15 @@ pub async fn handle_services_update(
 ) -> Result<(), visa_table::VisaTableError> {
 
     let expiration = if let Some(unixts) = services.expiration {
-        UNIX_EPOCH + Duration::from_secs(unixts as u64)
+        if unixts == 0 {
+            // 0 is a special case, meaning "no expiration"
+            None
+        } else {
+            Some(UNIX_EPOCH + Duration::from_secs(unixts as u64))
+        }
     } else {
         error!(target: VISA_MGMT, "visa service sends services list with no expiration set");
-        UNIX_EPOCH // not present? Already expired then.
+        Some(UNIX_EPOCH) // not present? Already expired then.
     };
 
     let mut vs_auth_services = Vec::new();

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -236,7 +236,7 @@ pub async fn handle_services_update(
         // Got update with nothing.
         debug!(target: VISA_MGMT, "received empty services update, clearing vs_auth_services");
     }
-    debug!(target: VISA_MGMT, "updating auth services with {} entries", vs_auth_services.len());
+    debug!(target: VISA_MGMT, "updating auth services with {} entries, exprires at {expiration:?}", vs_auth_services.len());
     // The update is always a complete replacement of the list of services, and may be empty.
     let mut svcs = asm.vs_auth_services.write().await;
     svcs.update(expiration, vs_auth_services);

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -237,7 +237,7 @@ pub async fn handle_services_update(
         // Got update with nothing.
         debug!(target: VISA_MGMT, "received empty services update, clearing vs_auth_services");
     }
-    debug!(target: VISA_MGMT, "updating auth services with {} entries, exprires at {expiration:?}", vs_auth_services.len());
+    debug!(target: VISA_MGMT, "updating auth services with {} entries, expires at {expiration:?}", vs_auth_services.len());
     // The update is always a complete replacement of the list of services, and may be empty.
     let mut svcs = asm.vs_auth_services.write().await;
     svcs.update(expiration, vs_auth_services);

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -12,9 +12,6 @@ use std::time::{Duration, UNIX_EPOCH};
 use tracing::*;
 use zpr::{LinkId, VisaId};
 
-
-
-
 pub fn authorize_connect(
     asm: &Arc<Assembly>,
     link_id: LinkId,
@@ -202,7 +199,6 @@ pub async fn handle_services_update(
     asm: &Arc<Assembly>,
     services: vsapi::ServicesList,
 ) -> Result<(), visa_table::VisaTableError> {
-
     let expiration = if let Some(unixts) = services.expiration {
         if unixts == 0 {
             // 0 is a special case, meaning "no expiration"

--- a/adapter/ph/src/vs_types.rs
+++ b/adapter/ph/src/vs_types.rs
@@ -75,9 +75,9 @@ impl TryFrom<vsapi::ServiceDescriptor> for ServiceDescriptor {
 }
 
 impl ServiceDescriptor {
-    /// Gently try to convert this ServiceDescriptor into a SocketAddr.
+    /// Gently try to extract a SocketAddr from this ServiceDescriptor.
     /// If there are any problems, None is returned.
-    pub fn to_socket_addr(&self) -> Option<std::net::SocketAddr> {
+    pub fn get_socket_addr(&self) -> Option<std::net::SocketAddr> {
         // To create a socket address we need a port, which is on the URI.
         let uri = match Url::parse(&self.service_uri) {
             Ok(u) => u,
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn test_service_descriptor_to_socket_addr_ipv4() {
         let descriptor = create_test_service_descriptor();
-        let socket_addr = descriptor.to_socket_addr();
+        let socket_addr = descriptor.get_socket_addr();
 
         assert!(socket_addr.is_some());
         let addr = socket_addr.unwrap();
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn test_service_descriptor_to_socket_addr_ipv6() {
         let descriptor = create_test_service_descriptor_v6();
-        let socket_addr = descriptor.to_socket_addr();
+        let socket_addr = descriptor.get_socket_addr();
 
         assert!(socket_addr.is_some());
         let addr = socket_addr.unwrap();
@@ -260,7 +260,7 @@ mod tests {
         let mut descriptor = create_test_service_descriptor();
         descriptor.service_uri = "not-a-valid-uri".to_string();
 
-        let socket_addr = descriptor.to_socket_addr();
+        let socket_addr = descriptor.get_socket_addr();
         assert!(socket_addr.is_none());
     }
 
@@ -269,7 +269,7 @@ mod tests {
         let mut descriptor = create_test_service_descriptor();
         descriptor.service_uri = "https://example.com/auth".to_string(); // No port
 
-        let socket_addr = descriptor.to_socket_addr();
+        let socket_addr = descriptor.get_socket_addr();
         assert!(socket_addr.is_none());
     }
 
@@ -278,7 +278,7 @@ mod tests {
         let mut descriptor = create_test_service_descriptor();
         descriptor.service_uri = "http://example.com/auth".to_string(); // HTTP default port
 
-        let socket_addr = descriptor.to_socket_addr();
+        let socket_addr = descriptor.get_socket_addr();
         // This should return None because url.port() returns None for default ports
         assert!(socket_addr.is_none());
     }
@@ -288,7 +288,7 @@ mod tests {
         let mut descriptor = create_test_service_descriptor();
         descriptor.service_uri = "http://example.com:8080/auth".to_string();
 
-        let socket_addr = descriptor.to_socket_addr();
+        let socket_addr = descriptor.get_socket_addr();
         assert!(socket_addr.is_some());
         assert_eq!(socket_addr.unwrap().port(), 8080);
     }

--- a/adapter/ph/src/vs_types.rs
+++ b/adapter/ph/src/vs_types.rs
@@ -89,13 +89,7 @@ impl ServiceDescriptor {
             Some(p) => p,
             None => return None, // No port in URI, so no SocketAddr for you
         };
-        if self.zpr_address.is_v4() {
-            let ip4 = Ipv4Addr::try_from(self.zpr_address).unwrap();
-            Some(std::net::SocketAddr::new(IpAddr::V4(ip4), port))
-        } else {
-            let ip6 = Ipv6Addr::try_from(self.zpr_address).unwrap();
-            Some(std::net::SocketAddr::new(IpAddr::V6(ip6), port))
-        }
+        Some(std::net::SocketAddr::new(self.zpr_address.into(), port))
     }
 }
 

--- a/adapter/ph/src/vs_types.rs
+++ b/adapter/ph/src/vs_types.rs
@@ -96,3 +96,201 @@ impl ServiceDescriptor {
         }
     }
 }
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use libnode::vsapi;
+
+    // Helper function to create a test ServiceDescriptor
+    fn create_test_service_descriptor() -> ServiceDescriptor {
+        ServiceDescriptor {
+            service_id: "test-service-123".to_string(),
+            service_uri: "https://auth.example.com:8443/auth".to_string(),
+            zpr_address: IpAddress::new_from_v4([192, 168, 1, 100]),
+        }
+    }
+
+    // Helper function to create a test ServiceDescriptor with IPv6
+    fn create_test_service_descriptor_v6() -> ServiceDescriptor {
+        let ipv6_addr: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        ServiceDescriptor {
+            service_id: "test-service-ipv6".to_string(),
+            service_uri: "https://auth.example.com:9443/auth".to_string(),
+            zpr_address: IpAddress::new_from_std_v6(&ipv6_addr),
+        }
+    }
+
+    #[test]
+    fn test_auth_services_list_update() {
+        let mut list = AuthServicesList::default();
+        let future_time = SystemTime::now() + Duration::from_secs(3600);
+        let services = vec![create_test_service_descriptor()];
+
+        list.update(future_time, services.clone());
+
+        assert_eq!(list.expiration, future_time);
+        assert_eq!(list.services.len(), 1);
+        assert_eq!(list.services[0].service_id, "test-service-123");
+    }
+
+    #[test]
+    fn test_auth_services_list_is_expired() {
+        let mut list = AuthServicesList::default();
+
+        // Test with past time
+        let past_time = SystemTime::now() - Duration::from_secs(3600);
+        list.expiration = past_time;
+        assert!(list.is_expired());
+
+        // Test with future time
+        let future_time = SystemTime::now() + Duration::from_secs(3600);
+        list.expiration = future_time;
+        assert!(!list.is_expired());
+    }
+
+    #[test]
+    fn test_auth_services_list_is_empty() {
+        let mut list = AuthServicesList::default();
+        assert!(list.is_empty());
+
+        list.services.push(create_test_service_descriptor());
+        assert!(!list.is_empty());
+    }
+
+    #[test]
+    fn test_auth_services_list_is_valid() {
+        let mut list = AuthServicesList::default();
+
+        // Empty and expired
+        assert!(!list.is_valid());
+
+        // Non-empty but expired
+        list.services.push(create_test_service_descriptor());
+        assert!(!list.is_valid());
+
+        // Non-empty and not expired
+        list.expiration = SystemTime::now() + Duration::from_secs(3600);
+        assert!(list.is_valid());
+
+        // Empty but not expired
+        list.services.clear();
+        assert!(!list.is_valid());
+    }
+
+    #[test]
+    fn test_service_descriptor_try_from_valid() {
+        let vsapi_descriptor = vsapi::ServiceDescriptor {
+            type_: vsapi::ServiceType::ACTOR_AUTHENTICATION,
+            service_id: Some("test-service".to_string()),
+            uri: Some("https://example.com:8443/auth".to_string()),
+            address: Some(vec![192, 168, 1, 100]),
+        };
+
+        let result = ServiceDescriptor::try_from(vsapi_descriptor);
+        assert!(result.is_ok());
+
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.service_id, "test-service");
+        assert_eq!(descriptor.service_uri, "https://example.com:8443/auth");
+        assert_eq!(descriptor.zpr_address, IpAddress::new_from_v4([192, 168, 1, 100]));
+    }
+
+
+    #[test]
+    fn test_service_descriptor_try_from_no_address() {
+        let vsapi_descriptor = vsapi::ServiceDescriptor {
+            type_: vsapi::ServiceType::ACTOR_AUTHENTICATION,
+            service_id: Some("test-service".to_string()),
+            uri: Some("https://example.com:8443/auth".to_string()),
+            address: None,
+        };
+
+        let result = ServiceDescriptor::try_from(vsapi_descriptor);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "vsapi::ServiceDescriptor address is empty");
+    }
+
+    #[test]
+    fn test_service_descriptor_try_from_defaults() {
+        let vsapi_descriptor = vsapi::ServiceDescriptor {
+            type_: vsapi::ServiceType::ACTOR_AUTHENTICATION,
+            service_id: None, // Should use default (empty string)
+            uri: None,        // Should use default (empty string)
+            address: Some(vec![10, 0, 0, 1]),
+        };
+
+        let result = ServiceDescriptor::try_from(vsapi_descriptor);
+        assert!(result.is_ok());
+
+        let descriptor = result.unwrap();
+        assert_eq!(descriptor.service_id, "");
+        assert_eq!(descriptor.service_uri, "");
+    }
+
+    #[test]
+    fn test_service_descriptor_to_socket_addr_ipv4() {
+        let descriptor = create_test_service_descriptor();
+        let socket_addr = descriptor.to_socket_addr();
+
+        assert!(socket_addr.is_some());
+        let addr = socket_addr.unwrap();
+        assert_eq!(addr.port(), 8443);
+        assert!(addr.ip().is_ipv4());
+        assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)));
+    }
+
+    #[test]
+    fn test_service_descriptor_to_socket_addr_ipv6() {
+        let descriptor = create_test_service_descriptor_v6();
+        let socket_addr = descriptor.to_socket_addr();
+
+        assert!(socket_addr.is_some());
+        let addr = socket_addr.unwrap();
+        assert_eq!(addr.port(), 9443);
+        assert!(addr.ip().is_ipv6());
+        assert_eq!(addr.ip(), IpAddr::V6("2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_service_descriptor_to_socket_addr_invalid_uri() {
+        let mut descriptor = create_test_service_descriptor();
+        descriptor.service_uri = "not-a-valid-uri".to_string();
+
+        let socket_addr = descriptor.to_socket_addr();
+        assert!(socket_addr.is_none());
+    }
+
+    #[test]
+    fn test_service_descriptor_to_socket_addr_no_port() {
+        let mut descriptor = create_test_service_descriptor();
+        descriptor.service_uri = "https://example.com/auth".to_string(); // No port
+
+        let socket_addr = descriptor.to_socket_addr();
+        assert!(socket_addr.is_none());
+    }
+
+    #[test]
+    fn test_service_descriptor_to_socket_addr_default_port() {
+        let mut descriptor = create_test_service_descriptor();
+        descriptor.service_uri = "http://example.com/auth".to_string(); // HTTP default port
+
+        let socket_addr = descriptor.to_socket_addr();
+        // This should return None because url.port() returns None for default ports
+        assert!(socket_addr.is_none());
+    }
+
+    #[test]
+    fn test_service_descriptor_to_socket_addr_explicit_port() {
+        let mut descriptor = create_test_service_descriptor();
+        descriptor.service_uri = "http://example.com:8080/auth".to_string();
+
+        let socket_addr = descriptor.to_socket_addr();
+        assert!(socket_addr.is_some());
+        assert_eq!(socket_addr.unwrap().port(), 8080);
+    }
+
+}

--- a/adapter/ph/src/vs_types.rs
+++ b/adapter/ph/src/vs_types.rs
@@ -1,0 +1,98 @@
+use crate::net_defs::IpAddress;
+
+use libnode::vsapi;
+
+use std::convert::TryFrom;
+use std::time::SystemTime;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use url::Url;
+
+
+/// A parsed [vsapi::ServicesList].  Note that all the services in here will be of
+/// type [vsapi::ServiceType::ACTOR_AUTHENTICATION].
+#[derive(Debug, Clone)]
+pub struct AuthServicesList {
+    pub expiration: SystemTime,
+    pub services: Vec<ServiceDescriptor>,
+}
+
+impl Default for AuthServicesList {
+    fn default() -> Self {
+        AuthServicesList {
+            expiration: SystemTime::UNIX_EPOCH,
+            services: Vec::new(),
+        }
+    }
+}
+
+impl AuthServicesList {
+    pub fn update(&mut self, expiration: SystemTime, services: Vec<ServiceDescriptor>) {
+        self.expiration = expiration;
+        self.services = services;
+    }
+
+    pub fn is_expired(&self) -> bool {
+        SystemTime::now() >= self.expiration
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.services.is_empty()
+    }
+
+    /// The list is "valid" it is non-empty and not expired.
+    pub fn is_valid(&self) -> bool {
+        !self.is_empty() && !self.is_expired()
+    }
+}
+
+
+/// A parsed [vsapi::ServiceDescriptor] that we use to keep ASA records.
+#[derive(Debug, Clone)]
+pub struct ServiceDescriptor {
+    pub service_id: String,
+    pub service_uri: String,
+    pub zpr_address: IpAddress,
+}
+
+impl TryFrom<vsapi::ServiceDescriptor> for ServiceDescriptor {
+    type Error = &'static str;
+
+    fn try_from(value: vsapi::ServiceDescriptor) -> Result<Self, Self::Error> {
+        if value.type_ != vsapi::ServiceType::ACTOR_AUTHENTICATION {
+            return Err("vsapi::ServiceDescriptor is not of type ACTOR_AUTHENTICATION");
+        }
+        if value.address.is_none() {
+            return Err("vsapi::ServiceDescriptor address is empty");
+        }
+        let zpraddr = IpAddress::try_from(value.address.unwrap())
+            .map_err(|_| "Failed to parse zpr_address in ServiceDescriptor")?;
+        Ok(ServiceDescriptor {
+            service_id: value.service_id.unwrap_or_default(),
+            service_uri: value.uri.unwrap_or_default(),
+            zpr_address: zpraddr,
+        })
+    }
+}
+
+impl ServiceDescriptor {
+    /// Gently try to convert this ServiceDescriptor into a SocketAddr.
+    /// If there are any problems, None is returned.
+    pub fn to_socket_addr(&self) -> Option<std::net::SocketAddr> {
+        // To create a socket address we need a port, which is on the URI.
+        let uri = match Url::parse(&self.service_uri) {
+            Ok(u) => u,
+            Err(_) => return None, // Invalid URI
+        };
+        let port = match uri.port() {
+            Some(p) => p,
+            None => return None, // No port in URI, so no SocketAddr for you
+        };
+        if self.zpr_address.is_v4() {
+            let ip4 = Ipv4Addr::try_from(self.zpr_address).unwrap();
+            Some(std::net::SocketAddr::new(IpAddr::V4(ip4), port))
+        } else {
+            let ip6 = Ipv6Addr::try_from(self.zpr_address).unwrap();
+            Some(std::net::SocketAddr::new(IpAddr::V6(ip6), port))
+        }
+    }
+}

--- a/adapter/ph/src/vs_types.rs
+++ b/adapter/ph/src/vs_types.rs
@@ -3,10 +3,9 @@ use crate::net_defs::IpAddress;
 use libnode::vsapi;
 
 use std::convert::TryFrom;
-use std::time::SystemTime;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::time::SystemTime;
 use url::Url;
-
 
 /// A parsed [vsapi::ServicesList].  Note that all the services in here will be of
 /// type [vsapi::ServiceType::ACTOR_AUTHENTICATION].
@@ -48,7 +47,6 @@ impl AuthServicesList {
         !self.is_empty() && !self.is_expired()
     }
 }
-
 
 /// A parsed [vsapi::ServiceDescriptor] that we use to keep ASA records.
 #[derive(Debug, Clone)]
@@ -101,13 +99,11 @@ impl ServiceDescriptor {
     }
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
     use libnode::vsapi;
+    use std::time::Duration;
 
     // Helper function to create a test ServiceDescriptor
     fn create_test_service_descriptor() -> ServiceDescriptor {
@@ -200,9 +196,11 @@ mod tests {
         let descriptor = result.unwrap();
         assert_eq!(descriptor.service_id, "test-service");
         assert_eq!(descriptor.service_uri, "https://example.com:8443/auth");
-        assert_eq!(descriptor.zpr_address, IpAddress::new_from_v4([192, 168, 1, 100]));
+        assert_eq!(
+            descriptor.zpr_address,
+            IpAddress::new_from_v4([192, 168, 1, 100])
+        );
     }
-
 
     #[test]
     fn test_service_descriptor_try_from_no_address() {
@@ -215,7 +213,10 @@ mod tests {
 
         let result = ServiceDescriptor::try_from(vsapi_descriptor);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "vsapi::ServiceDescriptor address is empty");
+        assert_eq!(
+            result.unwrap_err(),
+            "vsapi::ServiceDescriptor address is empty"
+        );
     }
 
     #[test]
@@ -296,5 +297,4 @@ mod tests {
         assert!(socket_addr.is_some());
         assert_eq!(socket_addr.unwrap().port(), 8080);
     }
-
 }

--- a/adapter/ph/src/vs_types.rs
+++ b/adapter/ph/src/vs_types.rs
@@ -3,7 +3,6 @@ use crate::net_defs::IpAddress;
 use libnode::vsapi;
 
 use std::convert::TryFrom;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::time::SystemTime;
 use url::Url;
 
@@ -97,6 +96,7 @@ impl ServiceDescriptor {
 mod tests {
     use super::*;
     use libnode::vsapi;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::time::Duration;
 
     // Helper function to create a test ServiceDescriptor

--- a/adapter/ph/src/vs_types.rs
+++ b/adapter/ph/src/vs_types.rs
@@ -12,27 +12,31 @@ use url::Url;
 /// type [vsapi::ServiceType::ACTOR_AUTHENTICATION].
 #[derive(Debug, Clone)]
 pub struct AuthServicesList {
-    pub expiration: SystemTime,
+    pub expiration: Option<SystemTime>, // 0 value means "no expiration"
     pub services: Vec<ServiceDescriptor>,
 }
 
 impl Default for AuthServicesList {
     fn default() -> Self {
         AuthServicesList {
-            expiration: SystemTime::UNIX_EPOCH,
+            expiration: Some(SystemTime::UNIX_EPOCH),
             services: Vec::new(),
         }
     }
 }
 
 impl AuthServicesList {
-    pub fn update(&mut self, expiration: SystemTime, services: Vec<ServiceDescriptor>) {
+    pub fn update(&mut self, expiration: Option<SystemTime>, services: Vec<ServiceDescriptor>) {
         self.expiration = expiration;
         self.services = services;
     }
 
     pub fn is_expired(&self) -> bool {
-        SystemTime::now() >= self.expiration
+        if let Some(exp) = self.expiration {
+            SystemTime::now() >= exp
+        } else {
+            false
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -127,7 +131,7 @@ mod tests {
     #[test]
     fn test_auth_services_list_update() {
         let mut list = AuthServicesList::default();
-        let future_time = SystemTime::now() + Duration::from_secs(3600);
+        let future_time = Some(SystemTime::now() + Duration::from_secs(3600));
         let services = vec![create_test_service_descriptor()];
 
         list.update(future_time, services.clone());
@@ -142,12 +146,12 @@ mod tests {
         let mut list = AuthServicesList::default();
 
         // Test with past time
-        let past_time = SystemTime::now() - Duration::from_secs(3600);
+        let past_time = Some(SystemTime::now() - Duration::from_secs(3600));
         list.expiration = past_time;
         assert!(list.is_expired());
 
         // Test with future time
-        let future_time = SystemTime::now() + Duration::from_secs(3600);
+        let future_time = Some(SystemTime::now() + Duration::from_secs(3600));
         list.expiration = future_time;
         assert!(!list.is_expired());
     }
@@ -173,7 +177,7 @@ mod tests {
         assert!(!list.is_valid());
 
         // Non-empty and not expired
-        list.expiration = SystemTime::now() + Duration::from_secs(3600);
+        list.expiration = Some(SystemTime::now() + Duration::from_secs(3600));
         assert!(list.is_valid());
 
         // Empty but not expired

--- a/adapter/ph/src/vs_worker.rs
+++ b/adapter/ph/src/vs_worker.rs
@@ -5,8 +5,15 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::*;
 
+
+// TODO: It might be nice to get a message here when we establlish a a node connection to
+// the VS API.  Then we could send a request for the services list.  Not a big deal until
+// we have more than one node. With one node, we are always going to get a push
+// update via the VSS API as we are the only way the VS can talk to the ZPRnet.
+
 pub async fn launch(_asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSOutput>) {
     while let Some(msg) = queue.recv().await {
+        // Only thing that comes out of this queue is a ping-success message.
         debug!(target: VISA_MGMT, "received VS message {msg:?}; ignoring! (unimplemented)");
     }
 }

--- a/adapter/ph/src/vs_worker.rs
+++ b/adapter/ph/src/vs_worker.rs
@@ -5,14 +5,17 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::*;
 
-// TODO: It might be nice to get a message here when we establlish a a node connection to
+// TODO: It might be nice to get a message here when we establish a a node connection to
 // the VS API.  Then we could send a request for the services list.  Not a big deal until
 // we have more than one node. With one node, we are always going to get a push
 // update via the VSS API as we are the only way the VS can talk to the ZPRnet.
 
 pub async fn launch(_asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSOutput>) {
     while let Some(msg) = queue.recv().await {
-        // Only thing that comes out of this queue is a ping-success message.
-        debug!(target: VISA_MGMT, "received VS message {msg:?}; ignoring! (unimplemented)");
+        match msg {
+            VSOutput::PingSuccess(config_id, policy_version) => {
+                debug!(target: VISA_MGMT, "visa service is alive (config_id: {config_id}, policy_version: {policy_version})");
+            }
+        }
     }
 }

--- a/adapter/ph/src/vs_worker.rs
+++ b/adapter/ph/src/vs_worker.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::*;
 
-
 // TODO: It might be nice to get a message here when we establlish a a node connection to
 // the VS API.  Then we could send a request for the services list.  Not a big deal until
 // we have more than one node. With one node, we are always going to get a push

--- a/adapter/ph/src/vss_worker.rs
+++ b/adapter/ph/src/vss_worker.rs
@@ -21,6 +21,12 @@ pub async fn launch(asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSSMsg>) {
                     error!(target: VISA_MGMT, "Error revoking visa: {e}");
                 }
             }
+            VSSMsg::PushedServices(services) => {
+                let result = visa_mgmt::handle_services_update(&asm, services);
+                if let Err(e) = result.await {
+                    error!(target: VISA_MGMT, "Error processing services update: {e}");
+                }
+            }
             _ => {
                 error!(target: VISA_MGMT, "received VSS message {msg}; ignoring! (unimplemented)");
             }

--- a/libnode/Cargo.lock
+++ b/libnode/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libnode"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "openssl",
@@ -674,8 +674,8 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vsapi"
-version = "0.2.0"
-source = "git+https://github.com/org-zpr/zpr-vsapi-rs.git?tag=v0.2.0#802c695e457845d2e7ade47c3a3b5ba037f377a4"
+version = "0.4.0"
+source = "git+https://github.com/org-zpr/zpr-vsapi-rs.git?tag=v0.4.1#2e41d0af057268d4b965b026a9b412dbe5483f99"
 dependencies = [
  "thrift",
 ]
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "open-enum",
  "strum",

--- a/libnode/Cargo.toml
+++ b/libnode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libnode"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 
@@ -13,5 +13,5 @@ thrift = "0.17.0"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-util = { version = "0.7.12", features = ["rt"] }
 tracing = "0.1.40"
-vsapi = { git = "https://github.com/org-zpr/zpr-vsapi-rs.git", tag = "v0.2.0" }
+vsapi = { git = "https://github.com/org-zpr/zpr-vsapi-rs.git", tag = "v0.4.1" }
 zpr = { path = "../zpr" }

--- a/libnode/src/display.rs
+++ b/libnode/src/display.rs
@@ -14,6 +14,23 @@ impl fmt::Display for VSSMsg {
                 summarize_visa_hop(f, vh)?;
                 write!(f, ")")
             }
+            VSSMsg::PushedServices(services) => {
+                match services.services {
+                    Some(ref s) => {
+                        write!(f, "PushedServices(services: [")?;
+                        for (i, service) in s.iter().enumerate() {
+                            if i > 0 {
+                                write!(f, ", ")?;
+                            }
+                            write!(f, "{}", service.uri.as_ref().unwrap_or(&"NO_URI".to_string()))?;
+                            write!(f, "/id={}", service.service_id.as_ref().unwrap_or(&"NO_ID".to_string()))?;
+                            write!(f, "/type={:?}", service.type_)?;
+                        }
+                        write!(f, "])")
+                    }
+                    None => write!(f, "PushedServices(services: (none))"),
+                }
+            }
         }
     }
 }

--- a/libnode/src/display.rs
+++ b/libnode/src/display.rs
@@ -14,23 +14,29 @@ impl fmt::Display for VSSMsg {
                 summarize_visa_hop(f, vh)?;
                 write!(f, ")")
             }
-            VSSMsg::PushedServices(services) => {
-                match services.services {
-                    Some(ref s) => {
-                        write!(f, "PushedServices(services: [")?;
-                        for (i, service) in s.iter().enumerate() {
-                            if i > 0 {
-                                write!(f, ", ")?;
-                            }
-                            write!(f, "{}", service.uri.as_ref().unwrap_or(&"NO_URI".to_string()))?;
-                            write!(f, "/id={}", service.service_id.as_ref().unwrap_or(&"NO_ID".to_string()))?;
-                            write!(f, "/type={:?}", service.type_)?;
+            VSSMsg::PushedServices(services) => match services.services {
+                Some(ref s) => {
+                    write!(f, "PushedServices(services: [")?;
+                    for (i, service) in s.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
                         }
-                        write!(f, "])")
+                        write!(
+                            f,
+                            "{}",
+                            service.uri.as_ref().unwrap_or(&"NO_URI".to_string())
+                        )?;
+                        write!(
+                            f,
+                            "/id={}",
+                            service.service_id.as_ref().unwrap_or(&"NO_ID".to_string())
+                        )?;
+                        write!(f, "/type={:?}", service.type_)?;
                     }
-                    None => write!(f, "PushedServices(services: (none))"),
+                    write!(f, "])")
                 }
-            }
+                None => write!(f, "PushedServices(services: (none))"),
+            },
         }
     }
 }

--- a/libnode/src/vscli.rs
+++ b/libnode/src/vscli.rs
@@ -52,6 +52,7 @@ pub trait VSClientI: Send {
         req: vsapi::ConnectRequest,
     ) -> Result<vsapi::ConnectResponse, VSClientError>;
     fn actor_disconnect(&mut self, actor_zpr_addr: IpAddr) -> Result<(), VSClientError>;
+    fn request_services(&mut self) -> Result<vsapi::ServicesResponse, VSClientError>;
 }
 
 /// Wrapper on top of the the THRIFT generated code.
@@ -223,5 +224,14 @@ impl VSClientI for VSClient {
             Ok(_) => Ok(()),
             Err(e) => Err(e.into()),
         }
+    }
+
+    fn request_services(&mut self) -> Result<vsapi::ServicesResponse, VSClientError> {
+        if self.key.is_none() {
+            return Err(VSClientError::NoAPIKey);
+        }
+        let key = self.key.as_ref().unwrap();
+        self.cli.request_services(key.clone())
+            .map_err(|e| e.into())
     }
 }

--- a/libnode/src/vscli.rs
+++ b/libnode/src/vscli.rs
@@ -231,7 +231,6 @@ impl VSClientI for VSClient {
             return Err(VSClientError::NoAPIKey);
         }
         let key = self.key.as_ref().unwrap();
-        self.cli.request_services(key.clone())
-            .map_err(|e| e.into())
+        self.cli.request_services(key.clone()).map_err(|e| e.into())
     }
 }

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -38,7 +38,6 @@ type AuthorizeConnectResponse = Result<vsapi::ConnectResponse, VSClientError>;
 type DisconnectStatus = Result<(), VSClientError>;
 type RequestServicesResponse = Result<vsapi::ServicesResponse, VSClientError>;
 
-
 // The async "commands" that can be sent into the running visa service client.
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -49,9 +48,7 @@ enum VSCommand {
         oneshot::Sender<AuthorizeConnectResponse>,
     ),
     ActorDisconnect(IpAddr, oneshot::Sender<DisconnectStatus>), // takes a ZPR address assigned to the actor
-    RequestServices(
-        oneshot::Sender<RequestServicesResponse>,
-    ),
+    RequestServices(oneshot::Sender<RequestServicesResponse>),
 }
 
 // This will change a bit too. This is for output messages from the visa service. These are asynchronous
@@ -259,9 +256,7 @@ impl VSConn {
         }
     }
 
-    fn handle_request_services(
-        client: &mut Box<dyn VSClientI>,
-    ) -> RequestServicesResponse {
+    fn handle_request_services(client: &mut Box<dyn VSClientI>) -> RequestServicesResponse {
         match client.request_services() {
             Ok(sr) => Ok(sr),
             Err(e) => {
@@ -353,8 +348,7 @@ impl VSConnHandle {
     /// Perform async RequestServices request on the VS API.
     pub async fn request_services(&self) -> RequestServicesResponse {
         let (tx, rx) = oneshot::channel();
-        self.send_command(VSCommand::RequestServices(tx))
-            .await?;
+        self.send_command(VSCommand::RequestServices(tx)).await?;
         rx.await.map_err(|_| VSClientError::ConnClosed)?
     }
 }
@@ -600,12 +594,15 @@ s5JVZ48=
             }
             let response = vsapi::ServicesResponse {
                 services: Some(vsapi::ServicesList {
-                    expiration: Some(SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs() as i64 + 3600), // +1 hour
+                    expiration: Some(
+                        SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap()
+                            .as_secs() as i64
+                            + 3600,
+                    ), // +1 hour
                     services: None,
-                })
+                }),
             };
             Ok(response)
         }
@@ -658,7 +655,6 @@ s5JVZ48=
         assert_eq!(get_counter(CounterT::Ping), 1);
     }
 
-
     #[tokio::test]
     async fn test_request_services() {
         let _lockval = RUN_LOCK.lock().unwrap();
@@ -707,8 +703,6 @@ s5JVZ48=
         assert_eq!(get_counter(CounterT::DeRegister), 1);
         assert_eq!(get_counter(CounterT::Ping), 1);
     }
-
-
 
     #[tokio::test]
     async fn test_visa_req_resp() {

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -36,6 +36,8 @@ pub struct VisaRequest {
 type VisaRequestResponse = Result<vsapi::VisaResponse, VSClientError>;
 type AuthorizeConnectResponse = Result<vsapi::ConnectResponse, VSClientError>;
 type DisconnectStatus = Result<(), VSClientError>;
+type RequestServicesResponse = Result<vsapi::ServicesResponse, VSClientError>;
+
 
 // The async "commands" that can be sent into the running visa service client.
 #[derive(Debug)]
@@ -47,6 +49,9 @@ enum VSCommand {
         oneshot::Sender<AuthorizeConnectResponse>,
     ),
     ActorDisconnect(IpAddr, oneshot::Sender<DisconnectStatus>), // takes a ZPR address assigned to the actor
+    RequestServices(
+        oneshot::Sender<RequestServicesResponse>,
+    ),
 }
 
 // This will change a bit too. This is for output messages from the visa service. These are asynchronous
@@ -233,6 +238,7 @@ impl VSConn {
                         VSCommand::RequestVisa(req, resp_chan) => { let _ = resp_chan.send(Self::handle_request_visa(&mut client, req)); },
                         VSCommand::AuthorizeConnect(cr, resp_chan) => { let _ = resp_chan.send(Self::handle_authorize_connect(&mut client, cr)); },
                         VSCommand::ActorDisconnect(ipa, resp_chan) => { let _ = resp_chan.send(Self::handle_actor_disconnect(&mut client, ipa)); },
+                        VSCommand::RequestServices(resp_chan) => { let _ = resp_chan.send(Self::handle_request_services(&mut client)); },
                     }
                 }
             }
@@ -248,6 +254,18 @@ impl VSConn {
             Ok(vr) => Ok(vr),
             Err(e) => {
                 error!(target: VS_RPC, "failed to request visa: {e}");
+                Err(e)
+            }
+        }
+    }
+
+    fn handle_request_services(
+        client: &mut Box<dyn VSClientI>,
+    ) -> RequestServicesResponse {
+        match client.request_services() {
+            Ok(sr) => Ok(sr),
+            Err(e) => {
+                error!(target: VS_RPC, "failed to request services: {e}");
                 Err(e)
             }
         }
@@ -331,6 +349,14 @@ impl VSConnHandle {
             .await?;
         rx.await.map_err(|_| VSClientError::ConnClosed)?
     }
+
+    /// Perform async RequestServices request on the VS API.
+    pub async fn request_services(&self) -> RequestServicesResponse {
+        let (tx, rx) = oneshot::channel();
+        self.send_command(VSCommand::RequestServices(tx))
+            .await?;
+        rx.await.map_err(|_| VSClientError::ConnClosed)?
+    }
 }
 
 #[cfg(test)]
@@ -409,6 +435,7 @@ s5JVZ48=
         ping_count: u32,
         de_register_count: u32,
         disconnect_count: u32,
+        request_services_count: u32,
         next_error: Option<VSClientError>,
     }
 
@@ -417,6 +444,7 @@ s5JVZ48=
         Ping,
         DeRegister,
         ActorDisconnect,
+        RequestServices,
     }
 
     static RUN_LOCK: Mutex<u32> = Mutex::new(0); // Each test holds this while running.
@@ -426,6 +454,7 @@ s5JVZ48=
         ping_count: 0,
         de_register_count: 0,
         disconnect_count: 0,
+        request_services_count: 0,
         next_error: None,
     });
 
@@ -435,6 +464,7 @@ s5JVZ48=
         test_state.ping_count = 0;
         test_state.de_register_count = 0;
         test_state.disconnect_count = 0;
+        test_state.request_services_count = 0;
         test_state.next_error = None;
     }
 
@@ -445,6 +475,7 @@ s5JVZ48=
             CounterT::Ping => test_state.ping_count,
             CounterT::DeRegister => test_state.de_register_count,
             CounterT::ActorDisconnect => test_state.disconnect_count,
+            CounterT::RequestServices => test_state.request_services_count,
         }
     }
 
@@ -455,6 +486,7 @@ s5JVZ48=
             CounterT::Ping => test_state.ping_count += 1,
             CounterT::DeRegister => test_state.de_register_count += 1,
             CounterT::ActorDisconnect => test_state.disconnect_count += 1,
+            CounterT::RequestServices => test_state.request_services_count += 1,
         }
     }
 
@@ -560,6 +592,23 @@ s5JVZ48=
             }
             Ok(())
         }
+
+        fn request_services(&mut self) -> Result<vsapi::ServicesResponse, VSClientError> {
+            incr(CounterT::RequestServices);
+            if let Some(e) = take_next_error() {
+                return Err(e);
+            }
+            let response = vsapi::ServicesResponse {
+                services: Some(vsapi::ServicesList {
+                    expiration: Some(SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs() as i64 + 3600), // +1 hour
+                    services: None,
+                })
+            };
+            Ok(response)
+        }
     }
 
     fn testvscli_factory(_service_addr: &str) -> Result<Box<dyn VSClientI>, VSClientError> {
@@ -608,6 +657,58 @@ s5JVZ48=
         assert_eq!(get_counter(CounterT::DeRegister), 1);
         assert_eq!(get_counter(CounterT::Ping), 1);
     }
+
+
+    #[tokio::test]
+    async fn test_request_services() {
+        let _lockval = RUN_LOCK.lock().unwrap();
+        reset_state();
+        let certfile = TempFile::new_pem(CERT_DATA);
+
+        let node_addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+
+        let (tx, mut _rx) = mpsc::channel(8);
+
+        let mut claims = BTreeMap::new();
+        claims.insert(String::from("foo"), String::from("fee"));
+        let agnt = new_node_actor(node_addr, "n0", &claims);
+
+        let mut conn = VSConn::new(
+            agnt,
+            tx,
+            "127.0.0.1:0",
+            certfile.get_path(),
+            node_addr,
+            None,
+        )
+        .unwrap();
+
+        conn.set_client_factory(testvscli_factory);
+        let conn_h = conn.handle();
+
+        let ctoken = CancellationToken::new();
+        let vs_tok = ctoken.clone();
+        tokio::spawn(async move {
+            let _ = conn.run(vs_tok).await;
+        });
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let _svc_resp = conn_h.request_services().await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        ctoken.cancel(); // stop the vs
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(get_counter(CounterT::Auth), 1);
+        assert_eq!(get_counter(CounterT::RequestServices), 1);
+        assert_eq!(get_counter(CounterT::DeRegister), 1);
+        assert_eq!(get_counter(CounterT::Ping), 1);
+    }
+
+
 
     #[tokio::test]
     async fn test_visa_req_resp() {

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -119,7 +119,7 @@ impl VSConn {
     /// Create a new Visa Service Connection manager.
     ///
     /// - `node_actor` is the node's Actor representation.  See [new_node_actor] for a helper function to create this.
-    /// - `output_tx` is the channel to send output messages to the node.
+    /// - `output_tx` is the channel to send output messages to the node. The only message left is PING_SUCCESS.
     /// - `service_addr` is ADDR:PORT of the visa service (ADDR should be a ZPR address)
     /// - `node_cert_file` is the path to the node's signed (for now) EC certificate file
     /// - `node_zpr_addr` node ZPR address (not substrate address) as set by network admin

--- a/libnode/src/vss.rs
+++ b/libnode/src/vss.rs
@@ -130,7 +130,7 @@ impl VisaSupportSyncHandler for VisaSupportHandlerImpl {
         self.msg_chan_out
             .blocking_send(VSSMsg::PushedServices(services))
             .or_else(|e| {
-                error!(target: VSS_RPC, "failed to enque services message to node: {e}");
+                error!(target: VSS_RPC, "failed to enqueue services message to node: {e}");
                 Err(thrift::Error::from("enqueue failed"))
             })
     }

--- a/libnode/src/vss.rs
+++ b/libnode/src/vss.rs
@@ -14,7 +14,8 @@ use tracing::{debug, error, info};
 
 use crate::logging::targets::VSS_RPC;
 use vsapi::{
-    self, PolicyInfo, VisaHop, VisaRevocation, VisaSupportSyncHandler, VisaSupportSyncProcessor, ServicesList
+    self, PolicyInfo, ServicesList, VisaHop, VisaRevocation, VisaSupportSyncHandler,
+    VisaSupportSyncProcessor,
 };
 
 /// Default port for the visa support service. Note that the visa support service

--- a/libnode/src/vss.rs
+++ b/libnode/src/vss.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error, info};
 
 use crate::logging::targets::VSS_RPC;
 use vsapi::{
-    self, PolicyInfo, VisaHop, VisaRevocation, VisaSupportSyncHandler, VisaSupportSyncProcessor,
+    self, PolicyInfo, VisaHop, VisaRevocation, VisaSupportSyncHandler, VisaSupportSyncProcessor, ServicesList
 };
 
 /// Default port for the visa support service. Note that the visa support service
@@ -33,6 +33,9 @@ pub enum VSSMsg {
 
     /// Pushed visa revokcations from the visa service.
     PushedRevocation(VisaRevocation),
+
+    /// Pushed list of services. For now will be just Actor Authentication services.
+    PushedServices(ServicesList),
 }
 
 /// The VisaSupportHandlerImpl is a light wrapper around the thrift
@@ -117,5 +120,17 @@ impl VisaSupportSyncHandler for VisaSupportHandlerImpl {
                 })?;
         }
         Ok(())
+    }
+
+    /// Accept the updates list of services from the visa service.  Creates a PushServices
+    /// message.
+    fn handle_services_update(&self, services: ServicesList) -> thrift::Result<()> {
+        debug!(target: VSS_RPC, "handle_services_update");
+        self.msg_chan_out
+            .blocking_send(VSSMsg::PushedServices(services))
+            .or_else(|e| {
+                error!(target: VSS_RPC, "failed to enque services message to node: {e}");
+                Err(thrift::Error::from("enqueue failed"))
+            })
     }
 }

--- a/vs-client/Cargo.lock
+++ b/vs-client/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +155,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -180,6 +215,12 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "etherparse"
@@ -290,6 +331,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +365,16 @@ name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -315,7 +390,7 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libnode"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "openssl",
@@ -909,6 +984,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 name = "vs-client"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
  "etherparse",
  "hex",
@@ -924,8 +1000,8 @@ dependencies = [
 
 [[package]]
 name = "vsapi"
-version = "0.2.0"
-source = "git+https://github.com/org-zpr/zpr-vsapi-rs.git?tag=v0.2.0#802c695e457845d2e7ade47c3a3b5ba037f377a4"
+version = "0.4.0"
+source = "git+https://github.com/org-zpr/zpr-vsapi-rs.git?tag=v0.4.1#2e41d0af057268d4b965b026a9b412dbe5483f99"
 dependencies = [
  "thrift",
 ]
@@ -935,6 +1011,64 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -957,6 +1091,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1053,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "open-enum",
  "strum",

--- a/vs-client/Cargo.toml
+++ b/vs-client/Cargo.toml
@@ -18,3 +18,4 @@ libnode = { path = "../libnode" }
 tokio = "1.40.0"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
+chrono = "0.4.41"

--- a/vs-client/README.md
+++ b/vs-client/README.md
@@ -1,13 +1,13 @@
 # vs-client
 
-A toy client for the visa service. This is for playing with the visa service 
+A toy client for the visa service. This is for playing with the visa service
 API during development.
 
 
 
 ## Usage
 
-First start the visa service locally (ie, without ZPR running).  (Use 
+First start the visa service locally (ie, without ZPR running).  (Use
 something like `-l 127.0.0.1:31337`).
 
 Pass `-h` to get the list of available commands.
@@ -24,10 +24,10 @@ Try hello:
 Or authenticate, which will return an API key.
 
 ```bash
-./vs-client authenticate -s localhost:31337 -c flubber=rubber -c fee=flop --cert ./cert.pem --key ./key.pem
+./vs-client authenticate -s localhost:31337  --cert ./cert.pem --zpr-addr fd5a:90de::1 --node-name n0
 ```
 
-- you need a certificate and a private key.
+- you need a certificate, an address and a name.
 - use `-c` to pass claims.
 
 
@@ -44,7 +44,7 @@ Now you can de-register:
 
 ### Notes
 
-- In order to get full usage you may need to add some IP addresses to your 
+- In order to get full usage you may need to add some IP addresses to your
   local interface and/or use a specially crafted policy.
 
 

--- a/vs-client/src/main.rs
+++ b/vs-client/src/main.rs
@@ -129,6 +129,15 @@ enum Commands {
         )]
         udp: Option<String>,
     },
+    #[command()]
+    /// Call the visa service request-services function.
+    Requestservices {
+        #[arg(short, long, value_name = "HOST:PORT", default_value_t = String::from(DEFAULT_SERVICE))]
+        service: String,
+
+        #[arg(short, long, value_name = "APIKEY")]
+        apikey: String,
+    },
     /// Start a visa support service server in the foreground
     #[command()]
     Runvss {
@@ -271,6 +280,17 @@ fn main() {
                 println!("Either TCP or UDP traffic description must be provided");
             }
         },
+        Some(Commands::Requestservices { service, apikey }) => {
+            match vsclient::request_services(&service, &apikey) {
+                Ok(_) => {
+                    println!("Requestservices command executed successfully");
+                }
+                Err(e) => {
+                    println!("Error: {:?}", e);
+                }
+            }
+        }
+        // Start the visa support service server
         Some(Commands::Runvss { zpr_addr, vss_port }) => {
             match vssd::run_vss(SocketAddr::new(zpr_addr, vss_port)) {
                 Ok(_) => {

--- a/vs-client/src/vsclient.rs
+++ b/vs-client/src/vsclient.rs
@@ -6,8 +6,10 @@ use thrift::transport::{TIoChannel, TTcpChannel};
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::prelude::*;
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, Ipv4Addr, SocketAddr};
 use std::time::SystemTime;
+
+use chrono::DateTime;
 
 use crate::traffic_parser::TrafficDesc;
 use vsapi::{TVisaServiceSyncClient, VisaServiceSyncClient};
@@ -15,7 +17,7 @@ use vsapi::{TVisaServiceSyncClient, VisaServiceSyncClient};
 use libnode::m2;
 use libnode::vsapi;
 
-// ugh!!
+// This is the type alias for the VisaServiceSyncClient using the Thrift binary protocol
 type VSClientT = VisaServiceSyncClient<
     TBinaryInputProtocol<TFramedReadTransport<ReadHalf<TTcpChannel>>>,
     TBinaryOutputProtocol<TFramedWriteTransport<WriteHalf<TTcpChannel>>>,
@@ -323,4 +325,69 @@ pub fn request_visa(service: &str, apikey: &str, traffic: &TrafficDesc) -> thrif
         }
     }
     Ok(())
+}
+
+
+pub fn request_services(service: &str, apikey: &str) -> thrift::Result<()> {
+    let mut client = newclient(service)?;
+    match client.request_services(apikey.into()) {
+        Ok(result) => {
+            println!("RequestServicesResponse:");
+            if let Some(svclist) = result.services {
+                if let Some(timestamp) = svclist.expiration {
+                    let dt = DateTime::from_timestamp(timestamp, 0).unwrap();
+                    let local_dt = dt.with_timezone(&chrono::Local);
+                    // Compute duration until expiration
+                    let duration = local_dt - chrono::Local::now();
+                    println!("  Expiration: {} ~ {}", local_dt.format("%Y-%m-%d %H:%M:%S %Z"), hms(duration));
+                } else {
+                    println!("  Expiration: *NONE*");
+                }
+                if let Some(sdescs) = svclist.services {
+                    println!("  {} Service{}{}", sdescs.len(), if sdescs.len() == 1 { "" } else { "s" }, if sdescs.is_empty() { "" } else { ":" });
+                    for descriptor in sdescs {
+                        println!("    {:?}: {}", descriptor.type_, descriptor.service_id.unwrap_or("*NO_ID*".to_string()));
+                        println!("    URI: {}", descriptor.uri.unwrap_or("*NO_URI*".to_string()));
+                        if let Some(addr_bytes) = descriptor.address {
+                            if addr_bytes.len() == 4 {
+                                // Parse an IPv4 address.
+                                let v4 = Ipv4Addr::new(
+                                    addr_bytes[0],
+                                    addr_bytes[1],
+                                    addr_bytes[2],
+                                    addr_bytes[3],
+                                );
+                                println!("    ZPR_ADDR: {v4}");
+                            } else if addr_bytes.len() == 16 {
+                                let addr_arr: [u8; 16] = addr_bytes.try_into().unwrap();
+                                let v6 = Ipv6Addr::from(addr_arr);
+                                println!("    ZPR_ADDR: {v6}");
+                            } else {
+                                println!("    ZPR_ADDR: *INVALID* {:?}", addr_bytes);
+                            }
+                        } else {
+                            println!("    ZPR_ADDR: *NONE*");
+                        }
+                    }
+                } else {
+                    println!("  No services");
+                }
+            } else {
+                println!("  [empty response]");
+            }
+        }
+        Err(e) => {
+            return Err(e);
+        }
+    }
+    Ok(())
+
+}
+
+
+fn hms(duration: chrono::Duration) -> String {
+    let hours = duration.num_hours();
+    let minutes = duration.num_minutes() % 60;
+    let seconds = duration.num_seconds() % 60;
+    format!("{}h{}m{}s", hours, minutes, seconds)
 }

--- a/vs-client/src/vsclient.rs
+++ b/vs-client/src/vsclient.rs
@@ -6,7 +6,7 @@ use thrift::transport::{TIoChannel, TTcpChannel};
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::prelude::*;
-use std::net::{IpAddr, Ipv6Addr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::SystemTime;
 
 use chrono::DateTime;
@@ -327,7 +327,6 @@ pub fn request_visa(service: &str, apikey: &str, traffic: &TrafficDesc) -> thrif
     Ok(())
 }
 
-
 pub fn request_services(service: &str, apikey: &str) -> thrift::Result<()> {
     let mut client = newclient(service)?;
     match client.request_services(apikey.into()) {
@@ -339,15 +338,31 @@ pub fn request_services(service: &str, apikey: &str) -> thrift::Result<()> {
                     let local_dt = dt.with_timezone(&chrono::Local);
                     // Compute duration until expiration
                     let duration = local_dt - chrono::Local::now();
-                    println!("  Expiration: {} ~ {}", local_dt.format("%Y-%m-%d %H:%M:%S %Z"), hms(duration));
+                    println!(
+                        "  Expiration: {} ~ {}",
+                        local_dt.format("%Y-%m-%d %H:%M:%S %Z"),
+                        hms(duration)
+                    );
                 } else {
                     println!("  Expiration: *NONE*");
                 }
                 if let Some(sdescs) = svclist.services {
-                    println!("  {} Service{}{}", sdescs.len(), if sdescs.len() == 1 { "" } else { "s" }, if sdescs.is_empty() { "" } else { ":" });
+                    println!(
+                        "  {} Service{}{}",
+                        sdescs.len(),
+                        if sdescs.len() == 1 { "" } else { "s" },
+                        if sdescs.is_empty() { "" } else { ":" }
+                    );
                     for descriptor in sdescs {
-                        println!("    {:?}: {}", descriptor.type_, descriptor.service_id.unwrap_or("*NO_ID*".to_string()));
-                        println!("    URI: {}", descriptor.uri.unwrap_or("*NO_URI*".to_string()));
+                        println!(
+                            "    {:?}: {}",
+                            descriptor.type_,
+                            descriptor.service_id.unwrap_or("*NO_ID*".to_string())
+                        );
+                        println!(
+                            "    URI: {}",
+                            descriptor.uri.unwrap_or("*NO_URI*".to_string())
+                        );
                         if let Some(addr_bytes) = descriptor.address {
                             if addr_bytes.len() == 4 {
                                 // Parse an IPv4 address.
@@ -381,9 +396,7 @@ pub fn request_services(service: &str, apikey: &str) -> thrift::Result<()> {
         }
     }
     Ok(())
-
 }
-
 
 fn hms(duration: chrono::Duration) -> String {
     let hours = duration.num_hours();


### PR DESCRIPTION
Completes the movement of the ASA from the visa service all the way to a connecting adapter.  In this step we make the move from the VS to its docking node.

* Use new API in VSS to receive the ASA.  There is also a function on the VSS to request the ASA list, but we are not using it yet.
*  Fix terminate issues with link_state such that now when you kill a client adapter and the node sends a terminate it will timeout and continue to close the link even if no response comes in.
*  Fix minor issues with ordering of the hello and auth messages.