### PR TITLE
Mk/910-aaa-1 Part 1 of the AAA address processing

### DIFF
--- a/adapter/cli/Cargo.lock
+++ b/adapter/cli/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "open-enum",
  "strum",

--- a/adapter/ph/src/address_pool.rs
+++ b/adapter/ph/src/address_pool.rs
@@ -75,6 +75,11 @@ impl AddressPool {
         IpAddress::new_from_std_v6(&addr)
     }
 
+    /// Returns the number of active AAA addresses in the pool.
+    pub fn len(&self) -> usize {
+        self.active.len()
+    }
+
     /// Return an address to the pool (by removing it from the active set).
     /// Returns an error of the address is not an AAA address.
     /// Not an error if address is not in the active set.
@@ -133,14 +138,14 @@ mod tests {
 
         // Get an address
         let addr = pool.get_aaa_address();
-        let initial_active_size = pool.active.len();
+        let initial_active_size = pool.len();
 
         // Should be able to release it without error
         let result = pool.release_address(addr);
         assert!(result.is_ok());
 
         // Pool should have gained one address back, active should have lost one
-        assert_eq!(pool.active.len(), initial_active_size - 1);
+        assert_eq!(pool.len(), initial_active_size - 1);
     }
 
     #[test]
@@ -226,7 +231,7 @@ mod tests {
         }
 
         assert_eq!(allocated_addresses.len(), 1000);
-        assert_eq!(pool.active.len(), 1000);
+        assert_eq!(pool.len(), 1000);
     }
 
     #[test]
@@ -268,13 +273,13 @@ mod tests {
         addr_bytes[15] = 0x9a;
 
         let non_active_addr = IpAddress { v6: addr_bytes };
-        let initial_active_size = pool.active.len();
+        let initial_active_size = pool.len();
 
         // Should succeed but not change pool sizes (address wasn't active)
         let result = pool.release_address(non_active_addr);
         assert!(result.is_ok());
 
-        assert_eq!(pool.active.len(), initial_active_size);
+        assert_eq!(pool.len(), initial_active_size);
     }
 
     #[test]
@@ -351,7 +356,7 @@ mod tests {
         assert_ne!(addr4, addr3);
 
         // Verify pool state
-        assert_eq!(pool.active.len(), 3); // addr1 (as addr3), addr2, addr4
+        assert_eq!(pool.len(), 3); // addr1 (as addr3), addr2, addr4
     }
 
     #[test]

--- a/adapter/ph/src/address_pool.rs
+++ b/adapter/ph/src/address_pool.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::HashSet;
 use openssl::rand::rand_bytes;
 use std::net::Ipv6Addr;
 use thiserror::Error;
@@ -7,6 +7,10 @@ use crate::net_defs::IpAddress;
 
 /// Maximum allowed AAA ID value (40 bits)
 const MAX_AAA_ID: u64 = 0xffffffffff;
+
+/// Maximum number of active AAA addresses. As currently implemented, this sets a
+/// limit on the number of active links.
+const MAX_ACTIVE_AAA_ADDRESSES: usize = 5000;
 
 
 /// The base AAA address. This just has the constant 8 byte prefix.
@@ -25,11 +29,12 @@ pub enum AddressPoolError {
 
 /// A pool of addresses for the ZPR network. Only supports AAA addresses
 /// at the moment.  Not thread safe.
+///
+/// Each new address gets a unique 40-bit ID.
 pub struct AddressPool {
     node_id: [u16; 2],
-    first_aaa_id: u64,
-    next_aaa_id: u64,
-    returns: VecDeque<u64>, // FIFO
+    pool: HashSet<u64>,
+    active: HashSet<u64>,
 }
 
 
@@ -37,21 +42,25 @@ impl AddressPool {
     /// `node_id` is the lower 24 bits of the passed value. If the value is larger
     /// than 24 bits it will be truncated.
     pub fn new(node_id: u32) -> Self {
-        let mut initial = [0u8; 8];
-        rand_bytes(&mut initial).unwrap();
-        let first_aaa_id = u64::from_be_bytes(initial) & MAX_AAA_ID;
+        let mut pool = HashSet::with_capacity(MAX_ACTIVE_AAA_ADDRESSES);
+
+        let mut buf = [0u8; 8];
+        for _i in 0..MAX_ACTIVE_AAA_ADDRESSES {
+            rand_bytes(&mut buf).unwrap();
+            let mut id = u64::from_be_bytes(buf) & MAX_AAA_ID;
+            while !pool.insert(id) {
+                id = (id + 1) % MAX_AAA_ID;
+            }
+        }
         AddressPool {
-            node_id: [(node_id >> 16) as u16, (node_id & 0xFF) as u16],
-            first_aaa_id,
-            next_aaa_id: first_aaa_id,
-            returns: VecDeque::new(),
+            node_id: [(node_id >> 8) as u16, (node_id & 0xFF) as u16],
+            pool,
+            active: HashSet::new(),
         }
     }
 
     /// Get an available AAA address.
     ///
-    /// If a previosly allocated address is available, it will be reused.
-    /// Otherwise, a new address will be allocated.
     ///
     /// ## Panics
     ///   - If the pool runs out of addresses, this function will panic.
@@ -60,17 +69,14 @@ impl AddressPool {
         addr_bytes[..4].copy_from_slice(&BASE_AAA_ADDRESS[..4]);
         addr_bytes[4] = self.node_id[0];
 
-        let this_id = if self.returns.is_empty() {
-            let aaa_id = self.next_aaa_id;
-            self.next_aaa_id = (self.next_aaa_id + 1) % MAX_AAA_ID;
-            if aaa_id == self.first_aaa_id {
-                panic!("ran out of AAA addresses");
-            }
-            aaa_id
-        } else {
-            // Reuse an address from the returns queue
-            self.returns.pop_front().unwrap()
-        };
+        if self.pool.is_empty() {
+            panic!("Address pool is empty, cannot allocate new aaa address");
+        }
+
+        // remove an ID from the pool:
+        let this_id = self.pool.iter().next().cloned().unwrap();
+        self.pool.remove(&this_id);
+        self.active.insert(this_id);
 
         // We use the bottom 40 bits of the ID as the last 40 bits of the IP address.
 
@@ -85,21 +91,352 @@ impl AddressPool {
 
     /// Return an address to the pool.
     /// Returns an error of the address is not an AAA address.
+    /// Not an error if address is not in the active set.
     pub fn release_address(&mut self, address: IpAddress) -> Result<(), AddressPoolError> {
         if address.v6[6] != 0x0a || address.v6[7] != 0xaa {
             return Err(AddressPoolError::InvalidAddress)
         }
 
-        // Extract the ID from the address
-        let id = ((address.v6[5] as u64) << 32)
-                | ((address.v6[6] as u64) << 16)
-                | (address.v6[7] as u64);
+        // Address looks like:
+        // fd5a:5052:0000:0aaa:0000:00xx:xxxx:xxxx
+        //                            ^^ ^^^^ ^^^^ <-- This is the AAA ID
+
+        // Extract the 40-bit ID from the address
+        let id = u64::from_be_bytes([0, 0, 0,
+            address.v6[11], address.v6[12], address.v6[13], address.v6[14], address.v6[15]
+        ]);
         if id >= MAX_AAA_ID {
             return Err(AddressPoolError::InvalidAddress);
         }
 
-        // Return it to our queue.
-        self.returns.push_back(id);
+        if self.active.remove(&id) {
+            // If the address was active, we can return it to the pool.
+            self.pool.insert(id);
+        }
+        // If it wasn't active, we just ignore it.
+
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_get_aaa_address() {
+        let mut pool = AddressPool::new(0x123456);
+
+        // Should be able to get an address without panicking
+        let addr = pool.get_aaa_address();
+
+        // Should be IPv6 (not IPv4-mapped)
+        assert!(!addr.is_v4());
+
+        // Should have the AAA prefix in bytes 6-7
+        assert_eq!(addr.v6[6], 0x0a);
+        assert_eq!(addr.v6[7], 0xaa);
+    }
+
+    #[test]
+    fn test_basic_release_address() {
+        let mut pool = AddressPool::new(0x123456);
+
+        // Get an address
+        let addr = pool.get_aaa_address();
+        let initial_pool_size = pool.pool.len();
+        let initial_active_size = pool.active.len();
+
+        // Should be able to release it without error
+        let result = pool.release_address(addr);
+        assert!(result.is_ok());
+
+        // Pool should have gained one address back, active should have lost one
+        assert_eq!(pool.pool.len(), initial_pool_size + 1);
+        assert_eq!(pool.active.len(), initial_active_size - 1);
+    }
+
+    #[test]
+    fn test_address_pool_new() {
+        let node_id = 0x123456u32;
+        let pool = AddressPool::new(node_id);
+
+        // Check that node_id is properly stored
+        // For 0x123456: upper 16 bits = 0x1234, lower 8 bits = 0x56
+        assert_eq!(pool.node_id[0], 0x1234); // (node_id >> 8) = 0x1234
+        assert_eq!(pool.node_id[1], 0x56);   // (node_id & 0xFF) = 0x56
+
+        // Check that pool is initialized with the correct number of addresses
+        assert_eq!(pool.pool.len(), MAX_ACTIVE_AAA_ADDRESSES);
+
+        // Check that active set is empty initially
+        assert!(pool.active.is_empty());
+
+        // All pool IDs should be within valid range
+        for &id in &pool.pool {
+            assert!(id <= MAX_AAA_ID);
+        }
+    }
+
+    #[test]
+    fn test_address_pool_new_truncates_node_id() {
+        // Test with a node_id larger than 24 bits
+        let large_node_id = 0xFFFFFFFFu32;
+        let pool = AddressPool::new(large_node_id);
+
+        // Should be truncated to 24 bits
+        // (0xFFFFFFFF >> 8) & 0xFFFF = 0xFFFF
+        // 0xFFFFFFFF & 0xFF = 0xFF
+        assert_eq!(pool.node_id[0], 0xFFFF);
+        assert_eq!(pool.node_id[1], 0xFF);
+    }
+
+    #[test]
+    fn test_get_aaa_address_structure() {
+        let node_id = 0x123456u32;
+        let mut pool = AddressPool::new(node_id);
+
+        let addr = pool.get_aaa_address();
+
+        // Check the base prefix (first 8 bytes should match BASE_AAA_ADDRESS)
+        assert_eq!(addr.v6[0], 0xfd);
+        assert_eq!(addr.v6[1], 0x5a);
+        assert_eq!(addr.v6[2], 0x50);
+        assert_eq!(addr.v6[3], 0x52);
+        assert_eq!(addr.v6[4], 0x00);
+        assert_eq!(addr.v6[5], 0x00);
+        assert_eq!(addr.v6[6], 0x0a);
+        assert_eq!(addr.v6[7], 0xaa);
+
+        // Check that node_id[0] is embedded in the address
+        // addr_bytes[4] = self.node_id[0] = 0x1234
+        assert_eq!(addr.v6[8], 0x12);  // high byte of node_id[0]
+        assert_eq!(addr.v6[9], 0x34);  // low byte of node_id[0]
+    }
+
+    #[test]
+    fn test_get_aaa_address_uniqueness() {
+        let mut pool = AddressPool::new(0x123456);
+
+        let addr1 = pool.get_aaa_address();
+        let addr2 = pool.get_aaa_address();
+
+        // Addresses should be different (no duplicates possible)
+        assert_ne!(addr1, addr2);
+
+        // They should have the same prefix and node_id part
+        assert_eq!(addr1.v6[..10], addr2.v6[..10]);
+
+        // The ID portion should be different (last 5 bytes contain the ID)
+        assert_ne!(addr1.v6[10..], addr2.v6[10..]);
+    }
+
+    #[test]
+    fn test_no_duplicate_active_addresses() {
+        let mut pool = AddressPool::new(0x123456);
+        let mut allocated_addresses = std::collections::HashSet::new();
+
+        // Allocate "many" addresses and ensure no duplicates
+        for _ in 0..1000 {
+            let addr = pool.get_aaa_address();
+            assert!(!allocated_addresses.contains(&addr), "Duplicate address generated");
+            allocated_addresses.insert(addr);
+        }
+
+        assert_eq!(allocated_addresses.len(), 1000);
+        assert_eq!(pool.active.len(), 1000);
+    }
+
+    #[test]
+    fn test_pool_exhaustion() {
+        let mut pool = AddressPool::new(0x123456);
+        let mut addresses = Vec::new();
+
+        // Allocate all available addresses
+        for _ in 0..MAX_ACTIVE_AAA_ADDRESSES {
+            addresses.push(pool.get_aaa_address());
+        }
+
+        // Pool should be empty now
+        assert!(pool.pool.is_empty());
+        assert_eq!(pool.active.len(), MAX_ACTIVE_AAA_ADDRESSES);
+
+        // Next allocation should panic
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            pool.get_aaa_address();
+        }));
+        assert!(result.is_err(), "Should panic when pool is exhausted");
+    }
+
+    #[test]
+    fn test_release_address_invalid_prefix() {
+        let mut pool = AddressPool::new(0x123456);
+
+        // Create an IPv4 address (invalid)
+        let invalid_addr = IpAddress::new_from_v4([192, 168, 1, 1]);
+        let result = pool.release_address(invalid_addr);
+
+        assert!(matches!(result, Err(AddressPoolError::InvalidAddress)));
+    }
+
+    #[test]
+    fn test_release_address_invalid_aaa_prefix() {
+        let mut pool = AddressPool::new(0x123456);
+
+        // Create an IPv6 address with wrong AAA prefix
+        let mut addr_bytes = [0u8; 16];
+        addr_bytes[0..8].copy_from_slice(&[0xfd, 0x5a, 0x50, 0x52, 0x00, 0x00, 0x0b, 0xbb]); // Wrong AAA prefix
+        let invalid_addr = IpAddress { v6: addr_bytes };
+
+        let result = pool.release_address(invalid_addr);
+
+        assert!(matches!(result, Err(AddressPoolError::InvalidAddress)));
+    }
+
+    #[test]
+    fn test_release_non_active_address() {
+        let mut pool = AddressPool::new(0x123456);
+
+        // Create a valid AAA address that was never allocated by this pool
+        let mut addr_bytes = [0u8; 16];
+        addr_bytes[0..8].copy_from_slice(&[0xfd, 0x5a, 0x50, 0x52, 0x00, 0x00, 0x0a, 0xaa]);
+        addr_bytes[11] = 0x12;
+        addr_bytes[12] = 0x34;
+        addr_bytes[13] = 0x56;
+        addr_bytes[14] = 0x78;
+        addr_bytes[15] = 0x9a;
+
+        let non_active_addr = IpAddress { v6: addr_bytes };
+        let initial_pool_size = pool.pool.len();
+        let initial_active_size = pool.active.len();
+
+        // Should succeed but not change pool sizes (address wasn't active)
+        let result = pool.release_address(non_active_addr);
+        assert!(result.is_ok());
+
+        assert_eq!(pool.pool.len(), initial_pool_size);
+        assert_eq!(pool.active.len(), initial_active_size);
+    }
+
+
+    #[test]
+    fn test_multiple_releases_same_address() {
+        let mut pool = AddressPool::new(0x123456);
+
+        let addr = pool.get_aaa_address();
+        let initial_pool_size = pool.pool.len();
+
+        // Release the same address multiple times
+        pool.release_address(addr).unwrap();
+        pool.release_address(addr).unwrap();
+        pool.release_address(addr).unwrap();
+
+        // Should only be returned to pool once (no duplicates in pool)
+        assert_eq!(pool.pool.len(), initial_pool_size + 1);
+        assert!(!pool.active.contains(&extract_id_from_address(&addr)));
+    }
+
+    #[test]
+    fn test_address_pool_different_node_ids() {
+        let mut pool1 = AddressPool::new(0x111111);
+        let mut pool2 = AddressPool::new(0x222222);
+
+        let addr1 = pool1.get_aaa_address();
+        let addr2 = pool2.get_aaa_address();
+
+        // Addresses should be different due to different node IDs
+        assert_ne!(addr1, addr2);
+
+        // But they should have the same base prefix
+        assert_eq!(addr1.v6[..8], addr2.v6[..8]);
+
+        // Node ID portions should be different
+        assert_ne!(addr1.v6[8..10], addr2.v6[8..10]);
+    }
+
+    #[test]
+    fn test_release_address_with_invalid_large_id() {
+        let mut pool = AddressPool::new(0x123456);
+
+        // Create an address with an ID that's too large
+        let mut addr_bytes = [0u8; 16];
+        addr_bytes[0..8].copy_from_slice(&[0xfd, 0x5a, 0x50, 0x52, 0x00, 0x00, 0x0a, 0xaa]);
+
+        // Set all bytes to 0xFF to create an ID > MAX_AAA_ID
+        addr_bytes[11] = 0xFF;
+        addr_bytes[12] = 0xFF;
+        addr_bytes[13] = 0xFF;
+        addr_bytes[14] = 0xFF;
+        addr_bytes[15] = 0xFF;
+
+        let invalid_addr = IpAddress { v6: addr_bytes };
+        let result = pool.release_address(invalid_addr);
+
+        assert!(matches!(result, Err(AddressPoolError::InvalidAddress)));
+    }
+
+    #[test]
+    fn test_mixed_allocation_and_release() {
+        let mut pool = AddressPool::new(0x123456);
+
+        // Get some addresses
+        let addr1 = pool.get_aaa_address();
+        let addr2 = pool.get_aaa_address();
+
+        // Release one
+        pool.release_address(addr1).unwrap();
+
+        // Get more addresses
+        let addr3 = pool.get_aaa_address(); // usually will reuse addr1
+        let addr4 = pool.get_aaa_address(); // Should be new
+
+        assert_ne!(addr4, addr1);
+        assert_ne!(addr4, addr2);
+        assert_ne!(addr4, addr3);
+
+        // Verify pool state
+        assert_eq!(pool.active.len(), 3); // addr1 (as addr3), addr2, addr4
+    }
+
+    #[test]
+    fn test_node_id_encoding_in_address() {
+        let node_id = 0xABCDEF;
+        let mut pool = AddressPool::new(node_id);
+
+        let addr = pool.get_aaa_address();
+
+        // Extract node_id from the address
+        // pool.node_id[0] should be (0xABCDEF >> 8) = 0xABCD
+        // pool.node_id[1] should be (0xABCDEF & 0xFF) = 0xEF
+
+        // addr_bytes[4] = self.node_id[0]
+        let node_id_part1 = u16::from_be_bytes([addr.v6[8], addr.v6[9]]);
+        assert_eq!(node_id_part1, 0xABCD);
+
+        // Check that node_id[1] is used in addr_bytes[5]
+        // addr_bytes[5] = (self.node_id[1] << 8) | (this_id >> 32) as u16;
+        let addr_byte5 = u16::from_be_bytes([addr.v6[10], addr.v6[11]]);
+        let node_id_part2 = (addr_byte5 >> 8) as u8;
+        assert_eq!(node_id_part2, 0xEF);
+    }
+
+    #[test]
+    fn test_pool_uniqueness_at_creation() {
+        let pool = AddressPool::new(0x123456);
+
+        // Verify that all IDs in the pool are unique
+        assert_eq!(pool.pool.len(), MAX_ACTIVE_AAA_ADDRESSES);
+
+        // Convert to Vec and check for duplicates by comparing lengths
+        let ids: Vec<u64> = pool.pool.iter().cloned().collect();
+        let unique_ids: std::collections::HashSet<u64> = ids.iter().cloned().collect();
+        assert_eq!(ids.len(), unique_ids.len(), "Pool should contain only unique IDs");
+    }
+
+    // Helper function to extract AAA ID from an address for testing
+    fn extract_id_from_address(addr: &IpAddress) -> u64 {
+        u64::from_be_bytes([0, 0, 0,
+            addr.v6[11], addr.v6[12], addr.v6[13], addr.v6[14], addr.v6[15]
+        ])
     }
 }

--- a/adapter/ph/src/address_pool.rs
+++ b/adapter/ph/src/address_pool.rs
@@ -1,0 +1,119 @@
+use std::collections::VecDeque;
+use openssl::rand::rand_bytes;
+use std::sync;
+use std::net::Ipv6Addr;
+use thiserror::Error;
+
+use crate::net_defs::IpAddress;
+
+/// Maximum allowed AAA ID value (40 bits)
+const MAX_AAA_ID: u64 = 0xffffffffff;
+
+/// Maximum allowed node ID value (24 bits)
+const MAX_NODE_ID: u32 = 0xffffff;
+
+/// The base AAA address. This just has the constant 8 byte prefix.
+/// This will be followed by the node ID and then the AAA ID.
+const BASE_AAA_ADDRESS: [u16; 8] = [
+    0xfd5a, 0x5052, 0x0000, 0x0aaa,
+    0x0000, 0x0000, 0x0000, 0x0000,
+];
+
+#[derive(Debug, Error)]
+pub enum AddressPoolError {
+    #[error("invalid address")]
+    InvalidAddress,
+}
+
+
+/// A pool of addresses for the ZPR network. Only supports AAA addresses
+/// at the moment.
+pub struct AddressPool {
+    node_id: [u16; 2],
+    first_aaa_id: u64,
+    state: sync::Mutex<StateData>,
+}
+
+struct StateData {
+    next_aaa_id: u64,
+    returns: VecDeque<u64>, // FIFO
+}
+
+impl AddressPool {
+    /// `node_id` is the lower 24 bits of the passed value. If the value is larger
+    /// than 24 bits it will be truncated.
+    pub fn new(node_id: u32) -> Self {
+        let mut initial = [0u8; 8];
+        rand_bytes(&mut initial).unwrap();
+        let first_aaa_id = u64::from_be_bytes(initial) & MAX_AAA_ID;
+
+        let state = sync::Mutex::new(StateData {
+            next_aaa_id: first_aaa_id,
+            returns: VecDeque::new(),
+        });
+
+        AddressPool {
+            node_id: [(node_id >> 16) as u16, (node_id & 0xFF) as u16],
+            first_aaa_id,
+            state,
+        }
+    }
+
+    /// Get an available AAA address.
+    ///
+    /// If a previosly allocated address is available, it will be reused.
+    /// Otherwise, a new address will be allocated.
+    ///
+    /// ## Panics
+    ///   - If the pool runs out of addresses, this function will panic.
+    pub fn get_aaa_address(&mut self) -> IpAddress {
+        let mut addr_bytes = [0u16; 8];
+        addr_bytes.copy_from_slice(&BASE_AAA_ADDRESS[..4]);
+        addr_bytes[4] = self.node_id[0];
+
+
+        let mut state = self.state.lock().unwrap();
+
+        let this_id = if state.returns.is_empty() {
+            let aaa_id = state.next_aaa_id;
+            state.next_aaa_id = (state.next_aaa_id + 1) % MAX_AAA_ID;
+            if aaa_id == self.first_aaa_id {
+                panic!("ran out of AAA addresses");
+            }
+            aaa_id
+        } else {
+            // Reuse an address from the returns queue
+            state.returns.pop_front().unwrap()
+        };
+
+        // We use the bottom 40 bits of the ID as the last 40 bits of the IP address.
+
+        addr_bytes[5] = (self.node_id[1] << 8) | (this_id >> 32) as u16;
+        addr_bytes[6] = (this_id >> 16) as u16;
+        addr_bytes[7] = (this_id & 0xFFFF) as u16;
+
+        let addr = Ipv6Addr::from(addr_bytes);
+        IpAddress::new_from_std_v6(&addr)
+    }
+
+
+    /// Return an address to the pool.
+    /// Currently only AAA addresses are supported.
+    pub fn release_address(&self, address: IpAddress) -> Result<(), AddressPoolError> {
+        if address.v6[6] != 0x0a || address.v6[7] != 0xaa {
+            return Err(AddressPoolError::InvalidAddress)
+        }
+
+        // Extract the ID from the address
+        let id = ((address.v6[5] as u64) << 32)
+                | ((address.v6[6] as u64) << 16)
+                | (address.v6[7] as u64);
+        if id >= MAX_AAA_ID {
+            return Err(AddressPoolError::InvalidAddress);
+        }
+
+        // Return it to our queue.
+        self.state.lock().unwrap().returns.push_back(id);
+        Ok(())
+    }
+}

--- a/adapter/ph/src/address_pool.rs
+++ b/adapter/ph/src/address_pool.rs
@@ -27,17 +27,14 @@ pub enum AddressPoolError {
 
 
 /// A pool of addresses for the ZPR network. Only supports AAA addresses
-/// at the moment.
+/// at the moment.  Not thread safe.
 pub struct AddressPool {
     node_id: [u16; 2],
     first_aaa_id: u64,
-    state: sync::Mutex<StateData>,
-}
-
-struct StateData {
     next_aaa_id: u64,
     returns: VecDeque<u64>, // FIFO
 }
+
 
 impl AddressPool {
     /// `node_id` is the lower 24 bits of the passed value. If the value is larger
@@ -46,16 +43,11 @@ impl AddressPool {
         let mut initial = [0u8; 8];
         rand_bytes(&mut initial).unwrap();
         let first_aaa_id = u64::from_be_bytes(initial) & MAX_AAA_ID;
-
-        let state = sync::Mutex::new(StateData {
-            next_aaa_id: first_aaa_id,
-            returns: VecDeque::new(),
-        });
-
         AddressPool {
             node_id: [(node_id >> 16) as u16, (node_id & 0xFF) as u16],
             first_aaa_id,
-            state,
+            next_aaa_id: first_aaa_id,
+            returns: VecDeque::new(),
         }
     }
 
@@ -71,19 +63,16 @@ impl AddressPool {
         addr_bytes.copy_from_slice(&BASE_AAA_ADDRESS[..4]);
         addr_bytes[4] = self.node_id[0];
 
-
-        let mut state = self.state.lock().unwrap();
-
-        let this_id = if state.returns.is_empty() {
-            let aaa_id = state.next_aaa_id;
-            state.next_aaa_id = (state.next_aaa_id + 1) % MAX_AAA_ID;
+        let this_id = if self.returns.is_empty() {
+            let aaa_id = self.next_aaa_id;
+            self.next_aaa_id = (self.next_aaa_id + 1) % MAX_AAA_ID;
             if aaa_id == self.first_aaa_id {
                 panic!("ran out of AAA addresses");
             }
             aaa_id
         } else {
             // Reuse an address from the returns queue
-            state.returns.pop_front().unwrap()
+            self.returns.pop_front().unwrap()
         };
 
         // We use the bottom 40 bits of the ID as the last 40 bits of the IP address.
@@ -99,7 +88,7 @@ impl AddressPool {
 
     /// Return an address to the pool.
     /// Currently only AAA addresses are supported.
-    pub fn release_address(&self, address: IpAddress) -> Result<(), AddressPoolError> {
+    pub fn release_address(&mut self, address: IpAddress) -> Result<(), AddressPoolError> {
         if address.v6[6] != 0x0a || address.v6[7] != 0xaa {
             return Err(AddressPoolError::InvalidAddress)
         }
@@ -113,7 +102,7 @@ impl AddressPool {
         }
 
         // Return it to our queue.
-        self.state.lock().unwrap().returns.push_back(id);
+        self.returns.push_back(id);
         Ok(())
     }
 }

--- a/adapter/ph/src/address_pool.rs
+++ b/adapter/ph/src/address_pool.rs
@@ -1,44 +1,52 @@
-use std::collections::HashSet;
 use openssl::rand::rand_bytes;
+use std::collections::HashSet;
 use std::net::Ipv6Addr;
 use thiserror::Error;
 
+use crate::config;
 use crate::net_defs::IpAddress;
 
 /// Maximum allowed AAA ID value (40 bits)
 const MAX_AAA_ID: u64 = 0xffffffffff;
 
-/// Maximum number of active AAA addresses. As currently implemented, this sets a
-/// limit on the number of active links.
-const MAX_ACTIVE_AAA_ADDRESSES: usize = 5000;
-
+/// Maximum number of active AAA addresses. As currently implemented this is
+/// tied to the maximum number of active links on a ph.  This is because the
+/// link only returns its address to the pool when it is shut down.
+///
+/// TODO: Better would be to return the address once the adapter gets a real
+///       ZPR address.  But we still do not know the mechanics for re-auth so
+///       we have this more naive implementation for now.
+const MAX_ACTIVE_AAA_ADDRESSES: usize = config::MAX_ACTIVE_LINKS;
 
 /// The base AAA address. This just has the constant 8 byte prefix.
 /// This will be followed by the node ID and then the AAA ID.
 const BASE_AAA_ADDRESS: [u16; 8] = [
-    0xfd5a, 0x5052, 0x0000, 0x0aaa,
-    0x0000, 0x0000, 0x0000, 0x0000,
+    0xfd5a, 0x5052, 0x0000, 0x0aaa, 0x0000, 0x0000, 0x0000, 0x0000,
 ];
 
 #[derive(Debug, Error)]
 pub enum AddressPoolError {
     #[error("invalid address")]
     InvalidAddress,
-}
 
+    #[error("now more addresses available in the pool")]
+    AddressUnavailable,
+}
 
 /// A pool of addresses for the ZPR network. Only supports AAA addresses
 /// at the moment.  Not thread safe.
 ///
 /// Each new address gets a unique 40-bit ID.
+///
 pub struct AddressPool {
     node_id: [u16; 2],
     pool: HashSet<u64>,
     active: HashSet<u64>,
 }
 
-
 impl AddressPool {
+    /// Creates the pool of AAA addresses.
+    ///
     /// `node_id` is the lower 24 bits of the passed value. If the value is larger
     /// than 24 bits it will be truncated.
     pub fn new(node_id: u32) -> Self {
@@ -49,7 +57,7 @@ impl AddressPool {
             rand_bytes(&mut buf).unwrap();
             let mut id = u64::from_be_bytes(buf) & MAX_AAA_ID;
             while !pool.insert(id) {
-                id = (id + 1) % MAX_AAA_ID;
+                id = (id.wrapping_add(1)) % MAX_AAA_ID;
             }
         }
         AddressPool {
@@ -64,13 +72,13 @@ impl AddressPool {
     ///
     /// ## Panics
     ///   - If the pool runs out of addresses, this function will panic.
-    pub fn get_aaa_address(&mut self) -> IpAddress {
+    pub fn get_aaa_address(&mut self) -> Result<IpAddress, AddressPoolError> {
         let mut addr_bytes = [0u16; 8];
         addr_bytes[..4].copy_from_slice(&BASE_AAA_ADDRESS[..4]);
         addr_bytes[4] = self.node_id[0];
 
         if self.pool.is_empty() {
-            panic!("Address pool is empty, cannot allocate new aaa address");
+            return Err(AddressPoolError::AddressUnavailable);
         }
 
         // remove an ID from the pool:
@@ -85,16 +93,15 @@ impl AddressPool {
         addr_bytes[7] = (this_id & 0xFFFF) as u16;
 
         let addr = Ipv6Addr::from(addr_bytes);
-        IpAddress::new_from_std_v6(&addr)
+        Ok(IpAddress::new_from_std_v6(&addr))
     }
-
 
     /// Return an address to the pool.
     /// Returns an error of the address is not an AAA address.
     /// Not an error if address is not in the active set.
     pub fn release_address(&mut self, address: IpAddress) -> Result<(), AddressPoolError> {
         if address.v6[6] != 0x0a || address.v6[7] != 0xaa {
-            return Err(AddressPoolError::InvalidAddress)
+            return Err(AddressPoolError::InvalidAddress);
         }
 
         // Address looks like:
@@ -102,8 +109,15 @@ impl AddressPool {
         //                            ^^ ^^^^ ^^^^ <-- This is the AAA ID
 
         // Extract the 40-bit ID from the address
-        let id = u64::from_be_bytes([0, 0, 0,
-            address.v6[11], address.v6[12], address.v6[13], address.v6[14], address.v6[15]
+        let id = u64::from_be_bytes([
+            0,
+            0,
+            0,
+            address.v6[11],
+            address.v6[12],
+            address.v6[13],
+            address.v6[14],
+            address.v6[15],
         ]);
         if id >= MAX_AAA_ID {
             return Err(AddressPoolError::InvalidAddress);
@@ -128,7 +142,7 @@ mod tests {
         let mut pool = AddressPool::new(0x123456);
 
         // Should be able to get an address without panicking
-        let addr = pool.get_aaa_address();
+        let addr = pool.get_aaa_address().unwrap();
 
         // Should be IPv6 (not IPv4-mapped)
         assert!(!addr.is_v4());
@@ -143,7 +157,7 @@ mod tests {
         let mut pool = AddressPool::new(0x123456);
 
         // Get an address
-        let addr = pool.get_aaa_address();
+        let addr = pool.get_aaa_address().unwrap();
         let initial_pool_size = pool.pool.len();
         let initial_active_size = pool.active.len();
 
@@ -164,7 +178,7 @@ mod tests {
         // Check that node_id is properly stored
         // For 0x123456: upper 16 bits = 0x1234, lower 8 bits = 0x56
         assert_eq!(pool.node_id[0], 0x1234); // (node_id >> 8) = 0x1234
-        assert_eq!(pool.node_id[1], 0x56);   // (node_id & 0xFF) = 0x56
+        assert_eq!(pool.node_id[1], 0x56); // (node_id & 0xFF) = 0x56
 
         // Check that pool is initialized with the correct number of addresses
         assert_eq!(pool.pool.len(), MAX_ACTIVE_AAA_ADDRESSES);
@@ -196,7 +210,7 @@ mod tests {
         let node_id = 0x123456u32;
         let mut pool = AddressPool::new(node_id);
 
-        let addr = pool.get_aaa_address();
+        let addr = pool.get_aaa_address().unwrap();
 
         // Check the base prefix (first 8 bytes should match BASE_AAA_ADDRESS)
         assert_eq!(addr.v6[0], 0xfd);
@@ -210,16 +224,16 @@ mod tests {
 
         // Check that node_id[0] is embedded in the address
         // addr_bytes[4] = self.node_id[0] = 0x1234
-        assert_eq!(addr.v6[8], 0x12);  // high byte of node_id[0]
-        assert_eq!(addr.v6[9], 0x34);  // low byte of node_id[0]
+        assert_eq!(addr.v6[8], 0x12); // high byte of node_id[0]
+        assert_eq!(addr.v6[9], 0x34); // low byte of node_id[0]
     }
 
     #[test]
     fn test_get_aaa_address_uniqueness() {
         let mut pool = AddressPool::new(0x123456);
 
-        let addr1 = pool.get_aaa_address();
-        let addr2 = pool.get_aaa_address();
+        let addr1 = pool.get_aaa_address().unwrap();
+        let addr2 = pool.get_aaa_address().unwrap();
 
         // Addresses should be different (no duplicates possible)
         assert_ne!(addr1, addr2);
@@ -238,8 +252,11 @@ mod tests {
 
         // Allocate "many" addresses and ensure no duplicates
         for _ in 0..1000 {
-            let addr = pool.get_aaa_address();
-            assert!(!allocated_addresses.contains(&addr), "Duplicate address generated");
+            let addr = pool.get_aaa_address().unwrap();
+            assert!(
+                !allocated_addresses.contains(&addr),
+                "Duplicate address generated"
+            );
             allocated_addresses.insert(addr);
         }
 
@@ -254,18 +271,15 @@ mod tests {
 
         // Allocate all available addresses
         for _ in 0..MAX_ACTIVE_AAA_ADDRESSES {
-            addresses.push(pool.get_aaa_address());
+            addresses.push(pool.get_aaa_address().unwrap());
         }
 
         // Pool should be empty now
         assert!(pool.pool.is_empty());
         assert_eq!(pool.active.len(), MAX_ACTIVE_AAA_ADDRESSES);
 
-        // Next allocation should panic
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            pool.get_aaa_address();
-        }));
-        assert!(result.is_err(), "Should panic when pool is exhausted");
+        let result = pool.get_aaa_address();
+        assert!(result.is_err(), "Should error out when pool is exhausted");
     }
 
     #[test]
@@ -318,12 +332,11 @@ mod tests {
         assert_eq!(pool.active.len(), initial_active_size);
     }
 
-
     #[test]
     fn test_multiple_releases_same_address() {
         let mut pool = AddressPool::new(0x123456);
 
-        let addr = pool.get_aaa_address();
+        let addr = pool.get_aaa_address().unwrap();
         let initial_pool_size = pool.pool.len();
 
         // Release the same address multiple times
@@ -341,8 +354,8 @@ mod tests {
         let mut pool1 = AddressPool::new(0x111111);
         let mut pool2 = AddressPool::new(0x222222);
 
-        let addr1 = pool1.get_aaa_address();
-        let addr2 = pool2.get_aaa_address();
+        let addr1 = pool1.get_aaa_address().unwrap();
+        let addr2 = pool2.get_aaa_address().unwrap();
 
         // Addresses should be different due to different node IDs
         assert_ne!(addr1, addr2);
@@ -380,15 +393,15 @@ mod tests {
         let mut pool = AddressPool::new(0x123456);
 
         // Get some addresses
-        let addr1 = pool.get_aaa_address();
-        let addr2 = pool.get_aaa_address();
+        let addr1 = pool.get_aaa_address().unwrap();
+        let addr2 = pool.get_aaa_address().unwrap();
 
         // Release one
         pool.release_address(addr1).unwrap();
 
         // Get more addresses
-        let addr3 = pool.get_aaa_address(); // usually will reuse addr1
-        let addr4 = pool.get_aaa_address(); // Should be new
+        let addr3 = pool.get_aaa_address().unwrap(); // usually will reuse addr1
+        let addr4 = pool.get_aaa_address().unwrap(); // Should be new
 
         assert_ne!(addr4, addr1);
         assert_ne!(addr4, addr2);
@@ -403,7 +416,7 @@ mod tests {
         let node_id = 0xABCDEF;
         let mut pool = AddressPool::new(node_id);
 
-        let addr = pool.get_aaa_address();
+        let addr = pool.get_aaa_address().unwrap();
 
         // Extract node_id from the address
         // pool.node_id[0] should be (0xABCDEF >> 8) = 0xABCD
@@ -430,13 +443,24 @@ mod tests {
         // Convert to Vec and check for duplicates by comparing lengths
         let ids: Vec<u64> = pool.pool.iter().cloned().collect();
         let unique_ids: std::collections::HashSet<u64> = ids.iter().cloned().collect();
-        assert_eq!(ids.len(), unique_ids.len(), "Pool should contain only unique IDs");
+        assert_eq!(
+            ids.len(),
+            unique_ids.len(),
+            "Pool should contain only unique IDs"
+        );
     }
 
     // Helper function to extract AAA ID from an address for testing
     fn extract_id_from_address(addr: &IpAddress) -> u64 {
-        u64::from_be_bytes([0, 0, 0,
-            addr.v6[11], addr.v6[12], addr.v6[13], addr.v6[14], addr.v6[15]
+        u64::from_be_bytes([
+            0,
+            0,
+            0,
+            addr.v6[11],
+            addr.v6[12],
+            addr.v6[13],
+            addr.v6[14],
+            addr.v6[15],
         ])
     }
 }

--- a/adapter/ph/src/address_pool.rs
+++ b/adapter/ph/src/address_pool.rs
@@ -1,6 +1,5 @@
 use std::collections::VecDeque;
 use openssl::rand::rand_bytes;
-use std::sync;
 use std::net::Ipv6Addr;
 use thiserror::Error;
 
@@ -9,8 +8,6 @@ use crate::net_defs::IpAddress;
 /// Maximum allowed AAA ID value (40 bits)
 const MAX_AAA_ID: u64 = 0xffffffffff;
 
-/// Maximum allowed node ID value (24 bits)
-const MAX_NODE_ID: u32 = 0xffffff;
 
 /// The base AAA address. This just has the constant 8 byte prefix.
 /// This will be followed by the node ID and then the AAA ID.
@@ -60,7 +57,7 @@ impl AddressPool {
     ///   - If the pool runs out of addresses, this function will panic.
     pub fn get_aaa_address(&mut self) -> IpAddress {
         let mut addr_bytes = [0u16; 8];
-        addr_bytes.copy_from_slice(&BASE_AAA_ADDRESS[..4]);
+        addr_bytes[..4].copy_from_slice(&BASE_AAA_ADDRESS[..4]);
         addr_bytes[4] = self.node_id[0];
 
         let this_id = if self.returns.is_empty() {
@@ -87,7 +84,7 @@ impl AddressPool {
 
 
     /// Return an address to the pool.
-    /// Currently only AAA addresses are supported.
+    /// Returns an error of the address is not an AAA address.
     pub fn release_address(&mut self, address: IpAddress) -> Result<(), AddressPoolError> {
         if address.v6[6] != 0x0a || address.v6[7] != 0xaa {
             return Err(AddressPoolError::InvalidAddress)

--- a/adapter/ph/src/address_pool.rs
+++ b/adapter/ph/src/address_pool.rs
@@ -103,12 +103,7 @@ impl AddressPool {
             address.v6[14],
             address.v6[15],
         ]);
-        if id >= MAX_AAA_ID {
-            return Err(AddressPoolError::InvalidAddress);
-        }
-
         let _present = self.active.remove(&id);
-
         Ok(())
     }
 }
@@ -316,24 +311,22 @@ mod tests {
     }
 
     #[test]
-    fn test_release_address_with_invalid_large_id() {
+    fn test_release_address_with_valid_large_id() {
         let mut pool = AddressPool::new(0x123456);
 
         // Create an address with an ID that's too large
         let mut addr_bytes = [0u8; 16];
         addr_bytes[0..8].copy_from_slice(&[0xfd, 0x5a, 0x50, 0x52, 0x00, 0x00, 0x0a, 0xaa]);
 
-        // Set all bytes to 0xFF to create an ID > MAX_AAA_ID
+        // Set all bytes to 0xFF to create an ID of MAX_AAA_ID
         addr_bytes[11] = 0xFF;
         addr_bytes[12] = 0xFF;
         addr_bytes[13] = 0xFF;
         addr_bytes[14] = 0xFF;
         addr_bytes[15] = 0xFF;
 
-        let invalid_addr = IpAddress { v6: addr_bytes };
-        let result = pool.release_address(invalid_addr);
-
-        assert!(matches!(result, Err(AddressPoolError::InvalidAddress)));
+        let ret_addr = IpAddress { v6: addr_bytes };
+        let _result = pool.release_address(ret_addr).unwrap();
     }
 
     #[test]

--- a/adapter/ph/src/address_pool.rs
+++ b/adapter/ph/src/address_pool.rs
@@ -7,16 +7,12 @@ use crate::config;
 use crate::net_defs::IpAddress;
 
 /// Maximum allowed AAA ID value (40 bits)
-const MAX_AAA_ID: u64 = 0xffffffffff;
-
-/// Maximum number of active AAA addresses. As currently implemented this is
-/// tied to the maximum number of active links on a ph.  This is because the
-/// link only returns its address to the pool when it is shut down.
 ///
-/// TODO: Better would be to return the address once the adapter gets a real
-///       ZPR address.  But we still do not know the mechanics for re-auth so
-///       we have this more naive implementation for now.
-const MAX_ACTIVE_AAA_ADDRESSES: usize = config::MAX_ACTIVE_LINKS;
+/// Note that since we generate the IDs randomly, we can support about
+/// one million active addresses until we get into collision issues from
+/// the birthday problem.
+/// That should be sufficient for the immediate future.
+const MAX_AAA_ID: u64 = 0xffffffffff;
 
 /// The base AAA address. This just has the constant 8 byte prefix.
 /// This will be followed by the node ID and then the AAA ID.
@@ -28,63 +24,46 @@ const BASE_AAA_ADDRESS: [u16; 8] = [
 pub enum AddressPoolError {
     #[error("invalid address")]
     InvalidAddress,
-
-    #[error("now more addresses available in the pool")]
-    AddressUnavailable,
 }
 
-/// A pool of addresses for the ZPR network. Only supports AAA addresses
+/// A "pool" of addresses for the ZPR network. Only supports AAA addresses
 /// at the moment.  Not thread safe.
 ///
 /// Each new address gets a unique 40-bit ID.
 ///
 pub struct AddressPool {
     node_id: [u16; 2],
-    pool: HashSet<u64>,
-    active: HashSet<u64>,
+    active: HashSet<u64>, // Holds 40-bit IDs of active addresses
 }
 
 impl AddressPool {
-    /// Creates the pool of AAA addresses.
+    /// Initialize the pool of AAA addresses.
     ///
     /// `node_id` is the lower 24 bits of the passed value. If the value is larger
     /// than 24 bits it will be truncated.
     pub fn new(node_id: u32) -> Self {
-        let mut pool = HashSet::with_capacity(MAX_ACTIVE_AAA_ADDRESSES);
-
-        let mut buf = [0u8; 8];
-        for _i in 0..MAX_ACTIVE_AAA_ADDRESSES {
-            rand_bytes(&mut buf).unwrap();
-            let mut id = u64::from_be_bytes(buf) & MAX_AAA_ID;
-            while !pool.insert(id) {
-                id = (id.wrapping_add(1)) % MAX_AAA_ID;
-            }
-        }
         AddressPool {
             node_id: [(node_id >> 8) as u16, (node_id & 0xFF) as u16],
-            pool,
-            active: HashSet::new(),
+            active: HashSet::with_capacity(config::MAX_ACTIVE_LINKS),
         }
     }
 
-    /// Get an available AAA address.
+    /// Returns a random AAA address that is not already in our active set,
+    /// before returning it is stored in our active set.
     ///
-    ///
-    /// ## Panics
-    ///   - If the pool runs out of addresses, this function will panic.
-    pub fn get_aaa_address(&mut self) -> Result<IpAddress, AddressPoolError> {
+    /// Caller should "return" the address when done with it by calling
+    /// [AddressPool::release_address].
+    pub fn get_aaa_address(&mut self) -> IpAddress {
         let mut addr_bytes = [0u16; 8];
         addr_bytes[..4].copy_from_slice(&BASE_AAA_ADDRESS[..4]);
         addr_bytes[4] = self.node_id[0];
 
-        if self.pool.is_empty() {
-            return Err(AddressPoolError::AddressUnavailable);
+        let mut buf = [0u8; 8];
+        rand_bytes(&mut buf).unwrap();
+        let mut this_id = u64::from_be_bytes(buf) & MAX_AAA_ID;
+        while !self.active.insert(this_id) {
+            this_id = (this_id.wrapping_add(1)) % MAX_AAA_ID;
         }
-
-        // remove an ID from the pool:
-        let this_id = self.pool.iter().next().cloned().unwrap();
-        self.pool.remove(&this_id);
-        self.active.insert(this_id);
 
         // We use the bottom 40 bits of the ID as the last 40 bits of the IP address.
 
@@ -93,10 +72,10 @@ impl AddressPool {
         addr_bytes[7] = (this_id & 0xFFFF) as u16;
 
         let addr = Ipv6Addr::from(addr_bytes);
-        Ok(IpAddress::new_from_std_v6(&addr))
+        IpAddress::new_from_std_v6(&addr)
     }
 
-    /// Return an address to the pool.
+    /// Return an address to the pool (by removing it from the active set).
     /// Returns an error of the address is not an AAA address.
     /// Not an error if address is not in the active set.
     pub fn release_address(&mut self, address: IpAddress) -> Result<(), AddressPoolError> {
@@ -123,11 +102,7 @@ impl AddressPool {
             return Err(AddressPoolError::InvalidAddress);
         }
 
-        if self.active.remove(&id) {
-            // If the address was active, we can return it to the pool.
-            self.pool.insert(id);
-        }
-        // If it wasn't active, we just ignore it.
+        let _present = self.active.remove(&id);
 
         Ok(())
     }
@@ -142,7 +117,7 @@ mod tests {
         let mut pool = AddressPool::new(0x123456);
 
         // Should be able to get an address without panicking
-        let addr = pool.get_aaa_address().unwrap();
+        let addr = pool.get_aaa_address();
 
         // Should be IPv6 (not IPv4-mapped)
         assert!(!addr.is_v4());
@@ -157,8 +132,7 @@ mod tests {
         let mut pool = AddressPool::new(0x123456);
 
         // Get an address
-        let addr = pool.get_aaa_address().unwrap();
-        let initial_pool_size = pool.pool.len();
+        let addr = pool.get_aaa_address();
         let initial_active_size = pool.active.len();
 
         // Should be able to release it without error
@@ -166,7 +140,6 @@ mod tests {
         assert!(result.is_ok());
 
         // Pool should have gained one address back, active should have lost one
-        assert_eq!(pool.pool.len(), initial_pool_size + 1);
         assert_eq!(pool.active.len(), initial_active_size - 1);
     }
 
@@ -180,16 +153,8 @@ mod tests {
         assert_eq!(pool.node_id[0], 0x1234); // (node_id >> 8) = 0x1234
         assert_eq!(pool.node_id[1], 0x56); // (node_id & 0xFF) = 0x56
 
-        // Check that pool is initialized with the correct number of addresses
-        assert_eq!(pool.pool.len(), MAX_ACTIVE_AAA_ADDRESSES);
-
         // Check that active set is empty initially
         assert!(pool.active.is_empty());
-
-        // All pool IDs should be within valid range
-        for &id in &pool.pool {
-            assert!(id <= MAX_AAA_ID);
-        }
     }
 
     #[test]
@@ -210,7 +175,7 @@ mod tests {
         let node_id = 0x123456u32;
         let mut pool = AddressPool::new(node_id);
 
-        let addr = pool.get_aaa_address().unwrap();
+        let addr = pool.get_aaa_address();
 
         // Check the base prefix (first 8 bytes should match BASE_AAA_ADDRESS)
         assert_eq!(addr.v6[0], 0xfd);
@@ -232,8 +197,8 @@ mod tests {
     fn test_get_aaa_address_uniqueness() {
         let mut pool = AddressPool::new(0x123456);
 
-        let addr1 = pool.get_aaa_address().unwrap();
-        let addr2 = pool.get_aaa_address().unwrap();
+        let addr1 = pool.get_aaa_address();
+        let addr2 = pool.get_aaa_address();
 
         // Addresses should be different (no duplicates possible)
         assert_ne!(addr1, addr2);
@@ -252,7 +217,7 @@ mod tests {
 
         // Allocate "many" addresses and ensure no duplicates
         for _ in 0..1000 {
-            let addr = pool.get_aaa_address().unwrap();
+            let addr = pool.get_aaa_address();
             assert!(
                 !allocated_addresses.contains(&addr),
                 "Duplicate address generated"
@@ -262,24 +227,6 @@ mod tests {
 
         assert_eq!(allocated_addresses.len(), 1000);
         assert_eq!(pool.active.len(), 1000);
-    }
-
-    #[test]
-    fn test_pool_exhaustion() {
-        let mut pool = AddressPool::new(0x123456);
-        let mut addresses = Vec::new();
-
-        // Allocate all available addresses
-        for _ in 0..MAX_ACTIVE_AAA_ADDRESSES {
-            addresses.push(pool.get_aaa_address().unwrap());
-        }
-
-        // Pool should be empty now
-        assert!(pool.pool.is_empty());
-        assert_eq!(pool.active.len(), MAX_ACTIVE_AAA_ADDRESSES);
-
-        let result = pool.get_aaa_address();
-        assert!(result.is_err(), "Should error out when pool is exhausted");
     }
 
     #[test]
@@ -321,14 +268,12 @@ mod tests {
         addr_bytes[15] = 0x9a;
 
         let non_active_addr = IpAddress { v6: addr_bytes };
-        let initial_pool_size = pool.pool.len();
         let initial_active_size = pool.active.len();
 
         // Should succeed but not change pool sizes (address wasn't active)
         let result = pool.release_address(non_active_addr);
         assert!(result.is_ok());
 
-        assert_eq!(pool.pool.len(), initial_pool_size);
         assert_eq!(pool.active.len(), initial_active_size);
     }
 
@@ -336,8 +281,7 @@ mod tests {
     fn test_multiple_releases_same_address() {
         let mut pool = AddressPool::new(0x123456);
 
-        let addr = pool.get_aaa_address().unwrap();
-        let initial_pool_size = pool.pool.len();
+        let addr = pool.get_aaa_address();
 
         // Release the same address multiple times
         pool.release_address(addr).unwrap();
@@ -345,7 +289,6 @@ mod tests {
         pool.release_address(addr).unwrap();
 
         // Should only be returned to pool once (no duplicates in pool)
-        assert_eq!(pool.pool.len(), initial_pool_size + 1);
         assert!(!pool.active.contains(&extract_id_from_address(&addr)));
     }
 
@@ -354,8 +297,8 @@ mod tests {
         let mut pool1 = AddressPool::new(0x111111);
         let mut pool2 = AddressPool::new(0x222222);
 
-        let addr1 = pool1.get_aaa_address().unwrap();
-        let addr2 = pool2.get_aaa_address().unwrap();
+        let addr1 = pool1.get_aaa_address();
+        let addr2 = pool2.get_aaa_address();
 
         // Addresses should be different due to different node IDs
         assert_ne!(addr1, addr2);
@@ -393,15 +336,15 @@ mod tests {
         let mut pool = AddressPool::new(0x123456);
 
         // Get some addresses
-        let addr1 = pool.get_aaa_address().unwrap();
-        let addr2 = pool.get_aaa_address().unwrap();
+        let addr1 = pool.get_aaa_address();
+        let addr2 = pool.get_aaa_address();
 
         // Release one
         pool.release_address(addr1).unwrap();
 
         // Get more addresses
-        let addr3 = pool.get_aaa_address().unwrap(); // usually will reuse addr1
-        let addr4 = pool.get_aaa_address().unwrap(); // Should be new
+        let addr3 = pool.get_aaa_address();
+        let addr4 = pool.get_aaa_address();
 
         assert_ne!(addr4, addr1);
         assert_ne!(addr4, addr2);
@@ -416,7 +359,7 @@ mod tests {
         let node_id = 0xABCDEF;
         let mut pool = AddressPool::new(node_id);
 
-        let addr = pool.get_aaa_address().unwrap();
+        let addr = pool.get_aaa_address();
 
         // Extract node_id from the address
         // pool.node_id[0] should be (0xABCDEF >> 8) = 0xABCD
@@ -431,23 +374,6 @@ mod tests {
         let addr_byte5 = u16::from_be_bytes([addr.v6[10], addr.v6[11]]);
         let node_id_part2 = (addr_byte5 >> 8) as u8;
         assert_eq!(node_id_part2, 0xEF);
-    }
-
-    #[test]
-    fn test_pool_uniqueness_at_creation() {
-        let pool = AddressPool::new(0x123456);
-
-        // Verify that all IDs in the pool are unique
-        assert_eq!(pool.pool.len(), MAX_ACTIVE_AAA_ADDRESSES);
-
-        // Convert to Vec and check for duplicates by comparing lengths
-        let ids: Vec<u64> = pool.pool.iter().cloned().collect();
-        let unique_ids: std::collections::HashSet<u64> = ids.iter().cloned().collect();
-        assert_eq!(
-            ids.len(),
-            unique_ids.len(),
-            "Pool should contain only unique IDs"
-        );
     }
 
     // Helper function to extract AAA ID from an address for testing

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -96,7 +96,7 @@ pub struct Assembly {
     pub bsauth: Option<RsaBootstrapAuth>,
     pub rsauth: Option<OAuthRsa>,
     pub system_start_time: std::time::Instant,
-    pub address_pool: AddressPool,
+    pub address_pool: std::sync::Mutex<AddressPool>,
 }
 
 #[derive(Debug, Error)]
@@ -463,7 +463,7 @@ pub mod test {
             system_start_time: std::time::Instant::now(),
             bsauth: None,
             rsauth: None,
-            address_pool: AddressPool::new(31337),
+            address_pool: std::sync::Mutex::new(AddressPool::new(31337)),
         }
     }
 }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -96,7 +96,7 @@ pub struct Assembly {
     pub bsauth: Option<RsaBootstrapAuth>,
     pub rsauth: Option<OAuthRsa>,
     pub system_start_time: std::time::Instant,
-    pub address_pool: std::sync::Mutex<AddressPool>,
+    pub address_pool: std::sync::Mutex<Option<AddressPool>>, // Nodes only.
 }
 
 #[derive(Debug, Error)]
@@ -463,7 +463,7 @@ pub mod test {
             system_start_time: std::time::Instant::now(),
             bsauth: None,
             rsauth: None,
-            address_pool: std::sync::Mutex::new(AddressPool::new(31337)),
+            address_pool: std::sync::Mutex::new(None),
         }
     }
 }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -98,7 +98,7 @@ pub struct Assembly {
     pub bsauth: Option<RsaBootstrapAuth>,
     pub rsauth: Option<OAuthRsa>,
     pub system_start_time: std::time::Instant,
-    pub address_pool: std::sync::Mutex<Option<AddressPool>>, // Nodes only.
+    pub address_pool: std::sync::Mutex<Option<AddressPool>>, // Nodes only (and required for nodes)
 }
 
 #[derive(Debug, Error)]

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -1,4 +1,5 @@
 use crate::adapter_tables;
+use crate::address_pool::AddressPool;
 use crate::auth::{OAuthRsa, RsaBootstrapAuth};
 use crate::capture_worker::CaptureWorker;
 use crate::config;
@@ -95,6 +96,7 @@ pub struct Assembly {
     pub bsauth: Option<RsaBootstrapAuth>,
     pub rsauth: Option<OAuthRsa>,
     pub system_start_time: std::time::Instant,
+    pub address_pool: AddressPool,
 }
 
 #[derive(Debug, Error)]
@@ -461,6 +463,7 @@ pub mod test {
             system_start_time: std::time::Instant::now(),
             bsauth: None,
             rsauth: None,
+            address_pool: AddressPool::new(31337),
         }
     }
 }

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -28,6 +28,9 @@ pub const DEFAULT_MESSAGE_HEADROOM: usize = 256;
 pub const DEFAULT_REQUEST_RETRY_COUNT: usize = 3;
 pub const DEFAULT_REQUEST_RETRY_TIMER: std::time::Duration = std::time::Duration::from_secs(1);
 
+/// How long to wait for an actor to finish out of band authentication.
+pub const ACTOR_AUTHENTICATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 pub const ANCILLARY_BUFFER_SIZE: usize = 128;
 
 const DEFAULT_BUFFER_COUNT: usize = 512; // should be at least 5x batch size; see fastpath_worker.rs for explanation

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -16,6 +16,9 @@ use crate::pki::{load_cert, load_noise_private_key, NOISE_KEY_LEN};
 
 use crate::main_args::{ArgsError, CommonArgs};
 
+/// Upper bound on number of active links (peers) that the PH can manage.
+pub const MAX_ACTIVE_LINKS: usize = 1024;
+
 /// Size of a packet buffer.
 pub const PACKET_BUFFER_SIZE: usize = 4096 * 3;
 

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -125,7 +125,6 @@ pub async fn launch_signal_worker(
                     KmSignal::SaEstablished(sa) => {
                         debug!(target: KEY_MGMT, "multiplexor: link {}: SA established (SEND_ZPIS: {}, RECV_ZPIS: {}",
                             linkmsg.link_id, sa.send_zpis, sa.recv_zpis);
-
                         match asm.peer_table.set_security_association(linkmsg.link_id, sa) {
                             Ok(_) => (),
                             Err(e) => {

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -409,8 +409,8 @@ impl LinkStateWrapper {
         }
 
         match event {
-            LinkEvent::Start => self.start(asm),
-            LinkEvent::KeyingDone => self.keying_done(asm),
+            LinkEvent::Start => self.process_start(asm),
+            LinkEvent::KeyingDone => self.process_keying_done(asm),
             LinkEvent::ReceivedHelloRequest(peer_zpr_addr) => {
                 self.process_hello_request(asm, peer_zpr_addr)
             }
@@ -471,7 +471,7 @@ impl LinkStateWrapper {
     /// Start an inactive link/tether
     /// Transitions from Inactive -> Keying
     /// Will trigger key management messages to be sent if this is an adapter
-    fn start(&self, asm: &Assembly) -> Result<(), LinkStateError> {
+    fn process_start(&self, asm: &Assembly) -> Result<(), LinkStateError> {
         assert!(self.id != zpr::LINK_ID_UNKNOWN);
         let link_id = self.id;
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
@@ -523,10 +523,10 @@ impl LinkStateWrapper {
         }
     }
 
-    /// The Key Manager calls this when it is done initial keying
+    /// The Key Manager sends in the [LinkEvent::KeyingDone] event when it is done with initial keying.
     /// Transitions from Keying -> Helloing
     /// Will trigger a Hello to be sent if this is an adapter
-    fn keying_done(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
+    fn process_keying_done(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
         let link_id = self.id;
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         if locked_fsm.state != LinkState::Keying {

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -130,6 +130,7 @@ pub enum LinkState {
     Active,
     RegisterAA, // aka acquiring ZPR address
     WaitForInitAuth,
+    WaitForAcquireZprAddress,
     Error,
 }
 
@@ -143,6 +144,7 @@ pub enum LinkEvent {
     ReceivedHelloResponse(ResponseCode, Option<Vec<SocketAddr>>), // (response code, ASA addresses)
 
     ReceivedInitAuth((bool, Option<auth::ZdpInitAuthenticationPayload>)), // (bootstrap_flag, challenge)
+    ReceivedInitAuthResponse(ResponseCode),
 
     ReceivedAcquireZprAddressRequest(Option<Vec<IpAddress>>, String), // (requested_addrs, auth_blob)
     ReceivedAcquireResponse(ResponseCode),
@@ -426,6 +428,8 @@ impl LinkStateWrapper {
                 self.process_init_auth(asm, bootstrap_flag, challenge)
             }
 
+            LinkEvent::ReceivedInitAuthResponse(code) => self.process_init_auth_response(asm, code),
+
             LinkEvent::ReceivedGrantZprAddressRequest(addrs) => {
                 self.process_grant_zpr_address_request(asm, addrs)
             }
@@ -593,13 +597,16 @@ impl LinkStateWrapper {
                 Ok(())
             }
             (LinkType::NodeToAdapter, LinkState::Helloing) => {
-                // Node is really waiting now for an Acquire Call.
                 locked_fsm.actor_addresses.push(peer_zpr_addr);
                 debug!(
                     target: LINK_STATE,
                     "Link {link_id} peer is using ZPR addr {}",
                     peer_zpr_addr
                 );
+                // Node is really waiting for an init-auth-response, followed
+                // by the eventual acquire-zpr-address message.
+                // But we transition to that state once we get the zdp
+                // response to init-auth.
                 locked_fsm.set_state(LinkState::WaitForInitAuth);
                 debug!(
                     target: LINK_STATE,
@@ -663,6 +670,7 @@ impl LinkStateWrapper {
                 let mut link_data = self.locked_data.lock().unwrap();
                 link_data.asa_addresses = maybe_asa_addrs.clone();
                 drop(link_data);
+                // The adatper is really waiting for an init-auth-request.
                 locked_fsm.set_state(LinkState::WaitForInitAuth);
                 debug!(
                     target: LINK_STATE,
@@ -696,8 +704,11 @@ impl LinkStateWrapper {
     /// Includes authentication blob from sender, as well as the requested addresses.
     /// Inclusion of requested addresses is temporary.
     ///
+    /// A Node expects this message from an adapter sometime after sending it an
+    /// init-authentication message.
+    ///
     /// This will call off to visa service for checking.
-    /// Results comes back through a RecievedAuthorizeResponse event.
+    /// Results comes back through a ReceivedAuthorizeResponse event.
     fn process_acquire_zpr_address_request(
         &self,
         asm: &Arc<Assembly>,
@@ -708,7 +719,7 @@ impl LinkStateWrapper {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
 
         match (self.link_type, locked_fsm.state) {
-            (LinkType::NodeToAdapter, LinkState::WaitForInitAuth) => {}
+            (LinkType::NodeToAdapter, LinkState::WaitForAcquireZprAddress) => {}
 
             (_, _) => {
                 return Err(LinkStateError::InvalidOperation(
@@ -1045,6 +1056,40 @@ impl LinkStateWrapper {
         Ok(())
     }
 
+    /// The node sends init-authentication to the adapter, the response only serves to
+    /// clear our retry timer.  The adapter will in the meantime take care of doing
+    /// whatever authentication it needs to and will eventually send us an acquire-zpr-address
+    /// message with the authentication results (blob).
+    fn process_init_auth_response(
+        &self,
+        asm: &Arc<Assembly>,
+        response_code: ResponseCode,
+    ) -> Result<(), LinkStateError> {
+        let mut locked_fsm = self.locked_fsm.lock().unwrap();
+        match (self.link_type, locked_fsm.state) {
+            (LinkType::NodeToAdapter, LinkState::WaitForInitAuth) => {
+                debug!(target: LINK_STATE, "Link {} received init auth response with code {:?}", self.id, response_code);
+                if response_code == ResponseCode::Success {
+                    locked_fsm.set_state(LinkState::WaitForAcquireZprAddress);
+                    // In this state we are waiting on the adapter to perform authentication and
+                    // that may involve external services and could be quite slow relative to a
+                    // straightforward ZDP response.  So, we set a longer timeout.  We do not retransmit
+                    // anything... if we do not get auth within a reasonable amount of time we shut down
+                    // the link.
+                    self.set_timeout(asm, &mut locked_fsm, config::ACTOR_AUTHENTICATION_TIMEOUT);
+                    Ok(())
+                } else {
+                    error!(target: LINK_STATE, "Link {} received init auth response with non-success response {:?}", self.id, response_code);
+                    drop(locked_fsm);
+                    self.initiate_close(asm, TerminateReason::Other)
+                }
+            }
+            (_, _) => Err(LinkStateError::InvalidOperation(
+                "Discarded unsolicited init auth response".to_string(),
+            )),
+        }
+    }
+
     /// Send off the Inti-Authentication message with a blob that the receiver could
     /// use for authentication.
     fn send_init_authentication_request(&self, asm: &Arc<Assembly>) {
@@ -1239,6 +1284,14 @@ impl LinkStateWrapper {
                 Ok(())
             }
 
+            (LinkType::NodeToAdapter, LinkState::WaitForAcquireZprAddress) => {
+                // This is a timeout while waiting for the adapter to authenticate.
+                // Timeout here means we give up on the link.
+                error!(target: LINK_STATE, "Link {} timed out in state {:?}", self.id, locked_fsm.state);
+                drop(locked_fsm);
+                return self.process_error_response(&asm);
+            }
+
             (_, _) => Err(LinkStateError::InvalidOperation(format!(
                 "Ignoring unexpected timeout in state {:?}",
                 locked_fsm.state
@@ -1265,7 +1318,10 @@ impl LinkStateWrapper {
                 self.send_init_authentication_request(asm)
             }
 
-            (_, _) => (),
+            (_, _) => panic!(
+                "call to retransmit in state {:?} but not implemented",
+                locked_fsm.state
+            ),
         }
     }
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -13,7 +13,7 @@ use crate::special_peers::SpecialPeerName;
 use crate::visa_mgmt;
 use crate::zdp::{self, ResponseCode, TerminateReason};
 
-use openssl::x509::X509;
+use openssl::x509::{X509, X509Name};
 use std::fmt::{Display, Formatter};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
@@ -139,6 +139,7 @@ pub enum LinkEvent {
     Start,
     KeyingDone,
     ReceivedHelloRequest(IpAddress), // Actors ZPR address - TODO: implement AAAs
+    AssignedAAA(IpAddress), // Assigned AAA address for this link
     ReceivedHelloResponse(ResponseCode, Option<Vec<SocketAddr>>), // (response code, ASA addresses)
 
     ReceivedInitAuth((bool, Option<auth::ZdpInitAuthenticationPayload>)), // (bootstrap_flag, challenge)
@@ -199,6 +200,7 @@ pub struct LinkData {
     // Assuming no loss, 100 samples will store 5 minutes of latency data
     latency_data: SampleRing<Duration, 100>,
     asa_addresses: Option<Vec<SocketAddr>>, // Addresses of ASA servers told to us by our peer, if any
+    aaa_address: Option<IpAddress>, // AAA address assigned this link (if any)
 }
 
 impl LinkData {
@@ -208,6 +210,7 @@ impl LinkData {
             echo_timeout: 0,
             latency_data: SampleRing::new(Duration::ZERO),
             asa_addresses: None,
+            aaa_address: None,
         }
     }
 }

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -192,6 +192,7 @@ pub enum LinkStatus {
     Down,
 }
 
+/// Lives in a [LinkStateWrapper]
 pub struct LinkData {
     echo_success: u64, // Echo requests received response
     echo_timeout: u64, // Echo requests timed out
@@ -411,6 +412,9 @@ impl LinkStateWrapper {
             LinkEvent::ReceivedHelloRequest(peer_zpr_addr) => {
                 self.process_hello_request(asm, peer_zpr_addr)
             }
+            LinkEvent::AssignedAAA(addr) => {
+                self.process_assigned_aaa(asm, addr)
+            }
             LinkEvent::ReceivedHelloResponse(code, maybe_asa_addrs) => {
                 self.process_hello_response(asm, code, maybe_asa_addrs)
             }
@@ -618,6 +622,22 @@ impl LinkStateWrapper {
                 "ReceivedHelloRequest",
             )),
         }
+    }
+
+
+    /// This is called when we receive an AAA address assignment.
+    /// Does not generate an error.
+    fn process_assigned_aaa(
+        &self,
+        asm: &Arc<Assembly>,
+        aaa_addr: IpAddress,
+    ) -> Result<(), LinkStateError> {
+        // Just keep track of this for cleanup later.
+        let link_id = self.id;
+        debug!(target: LINK_STATE, "Link {link_id} assigned AAA address {aaa_addr}");
+        let mut link_data = self.locked_data.lock().unwrap();
+        link_data.aaa_address = Some(aaa_addr);
+        Ok(())
     }
 
     /// This is kicked off by [LinkEvent::ReceivedHelloResponse].
@@ -1298,6 +1318,14 @@ impl LinkStateWrapper {
         let link_id = self.id;
         let mut join_set = tokio::task::JoinSet::new();
         info!(target: LINK_STATE, "Link {link_id} is clearing its state");
+
+        let mut link_data = self.locked_data.lock().unwrap();
+        if let Some(aaa_addr) = link_data.aaa_address.take() {
+            match asm.address_pool.lock().unwrap().release_address(aaa_addr) {
+                Ok(_) => debug!(target: LINK_STATE, "Link {link_id} released AAA address {aaa_addr}"),
+                Err(e) => error!(target: LINK_STATE, "Failed to release AAA address {aaa_addr}: {e:?}")
+            };
+        }
 
         asm.peer_table.clear_peer_state(link_id);
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -590,7 +590,7 @@ impl LinkStateWrapper {
     /// Does not generate any packets
     fn process_hello_request(
         &self,
-        asm: &Arc<Assembly>,
+        _asm: &Arc<Assembly>,
         peer_zpr_addr: IpAddress,
     ) -> Result<(), LinkStateError> {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
@@ -608,17 +608,7 @@ impl LinkStateWrapper {
                     "Link {link_id} peer is using ZPR addr {}",
                     peer_zpr_addr
                 );
-                // Node is really waiting for an init-auth-response, followed
-                // by the eventual acquire-zpr-address message.
-                // But we transition to that state once we get the zdp
-                // response to init-auth.
-                locked_fsm.set_state(LinkState::WaitForInitAuth);
-                debug!(
-                    target: LINK_STATE,
-                    "Link {link_id} finished helloing.  Waiting for other side to respond to init-auth"
-                );
-                self.send_init_authentication_request(asm);
-                self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_RETRY_TIMER);
+                // State transition processing happens in [LinkStateWrapper::process_sent_hello_response]
                 Ok(())
             }
             (LinkType::AdapterToNode, _) => {

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -13,7 +13,7 @@ use crate::special_peers::SpecialPeerName;
 use crate::visa_mgmt;
 use crate::zdp::{self, ResponseCode, TerminateReason};
 
-use openssl::x509::{X509, X509Name};
+use openssl::x509::X509;
 use std::fmt::{Display, Formatter};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
@@ -139,7 +139,7 @@ pub enum LinkEvent {
     Start,
     KeyingDone,
     ReceivedHelloRequest(IpAddress), // Actors ZPR address - TODO: implement AAAs
-    AssignedAAA(IpAddress), // Assigned AAA address for this link
+    AssignedAAA(IpAddress),          // Assigned AAA address for this link
     ReceivedHelloResponse(ResponseCode, Option<Vec<SocketAddr>>), // (response code, ASA addresses)
 
     ReceivedInitAuth((bool, Option<auth::ZdpInitAuthenticationPayload>)), // (bootstrap_flag, challenge)
@@ -201,7 +201,7 @@ pub struct LinkData {
     // Assuming no loss, 100 samples will store 5 minutes of latency data
     latency_data: SampleRing<Duration, 100>,
     asa_addresses: Option<Vec<SocketAddr>>, // Addresses of ASA servers told to us by our peer, if any
-    aaa_address: Option<IpAddress>, // AAA address assigned this link (if any)
+    aaa_address: Option<IpAddress>,         // AAA address assigned this link (if any)
 }
 
 impl LinkData {
@@ -412,9 +412,7 @@ impl LinkStateWrapper {
             LinkEvent::ReceivedHelloRequest(peer_zpr_addr) => {
                 self.process_hello_request(asm, peer_zpr_addr)
             }
-            LinkEvent::AssignedAAA(addr) => {
-                self.process_assigned_aaa(asm, addr)
-            }
+            LinkEvent::AssignedAAA(addr) => self.process_assigned_aaa(asm, addr),
             LinkEvent::ReceivedHelloResponse(code, maybe_asa_addrs) => {
                 self.process_hello_response(asm, code, maybe_asa_addrs)
             }
@@ -624,12 +622,11 @@ impl LinkStateWrapper {
         }
     }
 
-
     /// This is called when we receive an AAA address assignment.
     /// Does not generate an error.
     fn process_assigned_aaa(
         &self,
-        asm: &Arc<Assembly>,
+        _asm: &Arc<Assembly>,
         aaa_addr: IpAddress,
     ) -> Result<(), LinkStateError> {
         // Just keep track of this for cleanup later.
@@ -1321,10 +1318,16 @@ impl LinkStateWrapper {
 
         let mut link_data = self.locked_data.lock().unwrap();
         if let Some(aaa_addr) = link_data.aaa_address.take() {
-            match asm.address_pool.lock().unwrap().release_address(aaa_addr) {
-                Ok(_) => debug!(target: LINK_STATE, "Link {link_id} released AAA address {aaa_addr}"),
-                Err(e) => error!(target: LINK_STATE, "Failed to release AAA address {aaa_addr}: {e:?}")
-            };
+            if let Some(pool) = asm.address_pool.lock().unwrap().as_mut() {
+                match pool.release_address(aaa_addr) {
+                    Ok(_) => {
+                        debug!(target: LINK_STATE, "Link {link_id} released AAA address {aaa_addr}")
+                    }
+                    Err(e) => {
+                        error!(target: LINK_STATE, "Failed to release AAA address {aaa_addr}: {e:?}")
+                    }
+                };
+            }
         }
 
         asm.peer_table.clear_peer_state(link_id);

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -449,7 +449,7 @@ fn main() -> ExitCode {
         system_start_time,
         bsauth: config.bootstrap,
         rsauth: config.rsaoauth,
-        address_pool: std::sync::Mutex::new(maybe_aaa_pool), // TODO: Get node ID from node ZPR address
+        address_pool: std::sync::Mutex::new(maybe_aaa_pool),
     });
 
     //

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -431,7 +431,7 @@ fn main() -> ExitCode {
         system_start_time,
         bsauth: config.bootstrap,
         rsauth: config.rsaoauth,
-        address_pool: AddressPool::new(0), // TODO: Get node ID from node ZPR address
+        address_pool: std::sync::Mutex::new(AddressPool::new(0)), // TODO: Get node ID from node ZPR address
     });
 
     //

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -17,6 +17,7 @@ use tracing::*;
 
 mod adapter_manager_worker;
 mod adapter_tables;
+mod address_pool;
 mod admin_worker;
 mod assembly;
 mod auth;
@@ -73,6 +74,7 @@ mod zprtun;
 #[cfg(test)]
 mod km_testdata;
 
+use address_pool::AddressPool;
 use assembly::{Assembly, PhMode};
 use capture_worker::CaptureWorker;
 use fastpath::FastpathWorkerConfig;
@@ -429,6 +431,7 @@ fn main() -> ExitCode {
         system_start_time,
         bsauth: config.bootstrap,
         rsauth: config.rsaoauth,
+        address_pool: AddressPool::new(0), // TODO: Get node ID from node ZPR address
     });
 
     //

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -371,6 +371,7 @@ fn main() -> ExitCode {
 
     let mut vsconn;
     let vs_outq;
+    let mut maybe_aaa_pool = None;
 
     if ph_mode == PhMode::Node {
         let node_name = config::get_noise_cn(&config.certificate_file)
@@ -394,6 +395,17 @@ fn main() -> ExitCode {
             )
             .expect("error launching Visa Service connection manager"),
         );
+
+        // For the purposes of assigning AAA addresses, we take the bottom 24 bits of the nodes
+        // ZPR address as it's ID.
+        let node_id = match node_zpr_addr {
+            IpAddr::V4(addr) => u32::from_be_bytes(addr.octets()) & 0x00FFFFFF,
+            IpAddr::V6(addr) => {
+                u32::from_be_bytes(addr.octets()[12..16].try_into().unwrap()) & 0x00FFFFFF
+            }
+        };
+        info!(target: STARTUP, "node ID is {node_id:#010x}");
+        maybe_aaa_pool = Some(AddressPool::new(node_id));
     } else {
         vsconn = None;
         vs_outq = None;
@@ -431,7 +443,7 @@ fn main() -> ExitCode {
         system_start_time,
         bsauth: config.bootstrap,
         rsauth: config.rsaoauth,
-        address_pool: std::sync::Mutex::new(AddressPool::new(0)), // TODO: Get node ID from node ZPR address
+        address_pool: std::sync::Mutex::new(maybe_aaa_pool), // TODO: Get node ID from node ZPR address
     });
 
     //

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -30,6 +30,10 @@ use zpr_ext::zerocopy::{FromBytesExt, IntoBytesExt};
 pub enum HandleMgmtError {
     #[error("unknown packet type: {0}")]
     UnknownType(u8),
+
+    #[error("message not permitted")]
+    MessageNotPermitted,
+
     #[error("bad packet structure")]
     BadStructure,
 }
@@ -39,6 +43,7 @@ impl From<HandleMgmtError> for counters::CounterType {
         match err {
             HandleMgmtError::UnknownType(_type) => Self::UnknownType,
             HandleMgmtError::BadStructure => Self::BadStructure,
+            HandleMgmtError::MessageNotPermitted => Self::OtherError,
         }
     }
 }
@@ -267,15 +272,16 @@ pub async fn handle_terminate_indication(
 /// handle a Hello Request (RFC 6.5 § 6.3.4)
 /// Reads the hello, fire a ReceivedHelloRequest event, and then sends a response.
 ///
-/// ## Preconditions:
-/// - This adapter is running as a node.
 pub async fn handle_hello_request(
     asm: &Arc<Assembly>,
     _seq_num: zpr::SeqNum,
     mut pkt: Packet,
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
-
+    if asm.ph_mode != PhMode::Node {
+        warn!(target: ZDP, "Link {ingress_link_id} received Hello Request but not in node mode");
+        return Err((HandleMgmtError::MessageNotPermitted, pkt));
+    }
     debug!(target: ZDP, "Received Hello Request for link {ingress_link_id}");
 
     let Ok(hdr) = zdp::ZdpHelloRequestHeader::read_from_buf(&mut pkt) else {
@@ -349,8 +355,8 @@ pub async fn handle_hello_request(
                     Ok(()) => (),
                 }
             } else {
-                // This is violation of precondition. If we are a node, we must have a pool.
-                panic!("adapter handling a hello-request has no address pool");
+                // Programming error: if we are a node, we must have a pool.
+                panic!("adapter (node) handling a hello-request missing address pool");
             }
         }
     }
@@ -399,7 +405,7 @@ pub async fn handle_hello_request(
         }
     } else {
         // TODO: The framework within which this function is called does not allow us to
-        // returns an error back which would trigger a link shutdown.  So we do it manually
+        // return an error back which would trigger a link shutdown.  So we do it manually
         // and just return Ok() though things are not in fact OK.
         info!(target: ZDP, "Link {ingress_link_id}: HelloRequest processing failed, shutting down link");
         match asm.process_link_state_event(ingress_link_id, LinkEvent::Error) {

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -1,6 +1,6 @@
 //! Handlers for management requests.
 
-use crate::adapter_tables;
+use crate::{adapter_tables, special_peers};
 use crate::assembly::{self, Assembly, PhMode, VERSION};
 use crate::auth;
 use crate::config;
@@ -10,6 +10,7 @@ use crate::link_state::LinkEvent;
 use crate::logging::targets::{FLOW_MGMT, REPORTING, ZDP};
 use crate::net_defs::{ip_number, IpAddress};
 use crate::packet::Packet;
+use crate::special_peers::SpecialPeerName;
 use crate::tlv::{self, TlvEncoding};
 use crate::zdp;
 use bytes::{Buf, BufMut};
@@ -323,6 +324,42 @@ pub async fn handle_hello_request(
         auth::DEFAULT_ZPR_OAUTH_RSA_PORT,
     );
     TlvEncoding::new_asa(service_addr).put(&mut rsp_pkt);
+
+    // An AAA address is required when we have an authentication service available.
+    // Special case- the visa service does not use an AAA address.
+    // Also the adapter may end up using bootstrap auth in which case it can ignore
+    // the AAA address.
+
+    // First check the CN on this link to see if it is the visa service.
+    let visa_service_link_id = asm.peer_table.lookup_special_peer(SpecialPeerName::VisaServiceAdapter);
+    match visa_service_link_id {
+        Some(id) if id.get() == ingress_link_id => {
+            // This is the visa service, so we do not need an AAA address.
+            debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - no AAA address needed for visa service");
+        }
+        _ => {
+            // We need to include an AAA address.
+            let aaa_address: IpAddress = asm.address_pool.get_aaa_address();
+            debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {aaa_address}");
+            TlvEncoding::new_aaa(aaa_address).put(&mut rsp_pkt);
+            // TODO: when a address is cleaned up, the address is returned to the pool.
+            // In order to do that it needs to be in PeerState.
+            //   ...
+            //   And then can be returned in clear_peer_state
+            // OR, it needs to be in the link_state somewhere.
+            //
+            // Either way we need to return it from link_state.clean_up_link_state.
+            match asm.process_link_state_event(ingress_link_id, LinkEvent::AssignedAAA(aaa_address)) {
+                Err(e) => {
+                    // Unrecoverable?
+                    error!(target: ZDP, "Link {ingress_link_id}: Failed to process AssignedAAA event: {e}");
+                }
+                Ok(()) => ()
+            }
+        }
+    }
+
+
 
     super::core::send_non_flow_mgmt(
         asm,

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -334,7 +334,8 @@ pub async fn handle_hello_request(
             // Then we need an AAA.
             if let Some(pool) = asm.address_pool.lock().unwrap().as_mut() {
                 let addr = pool.get_aaa_address();
-                debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {addr}");
+                debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {addr} (active pool size: {})",
+                    pool.len());
                 aaa_address = Some(addr);
 
                 // Store the AAA in the link memory so we can free it later.

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -350,7 +350,7 @@ pub async fn handle_hello_request(
                 match asm.process_link_state_event(ingress_link_id, LinkEvent::AssignedAAA(addr)) {
                     Err(e) => {
                         // Highly improbable
-                        error!(target: ZDP, "Link {ingress_link_id}: failed to process AssignedAAA event: {e}");
+                        panic!("Link {ingress_link_id}: failed to process AssignedAAA event: {e}");
                     }
                     Ok(()) => (),
                 }
@@ -396,18 +396,22 @@ pub async fn handle_hello_request(
         rsp_pkt,
     );
 
-    if response_status == zdp::ResponseCode::Success {
+    let close_link = if response_status == zdp::ResponseCode::Success {
         match asm.process_link_state_event(ingress_link_id, LinkEvent::SentHelloResponse) {
             Err(e) => {
                 error!(target: ZDP, "Link {ingress_link_id}: Failed to process SentHelloResponse event: {:?}", e);
+                true
             }
-            Ok(()) => (),
+            Ok(()) => false,
         }
     } else {
         // TODO: The framework within which this function is called does not allow us to
         // return an error back which would trigger a link shutdown.  So we do it manually
         // and just return Ok() though things are not in fact OK.
         info!(target: ZDP, "Link {ingress_link_id}: HelloRequest processing failed, shutting down link");
+        true
+    };
+    if close_link {
         match asm.process_link_state_event(ingress_link_id, LinkEvent::Error) {
             Err(e) => {
                 error!(target: ZDP, "Link {ingress_link_id}: failed to process Error event: {e}");
@@ -415,6 +419,7 @@ pub async fn handle_hello_request(
             Ok(()) => (),
         }
     }
+
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -342,21 +342,15 @@ pub async fn handle_hello_request(
             let aaa_address: IpAddress = asm.address_pool.lock().unwrap().get_aaa_address();
             debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {aaa_address}");
             TlvEncoding::new_aaa(aaa_address).put(&mut rsp_pkt);
-
-            // TODO: when a address is cleaned up, the address is returned to the pool.
-
             match asm.process_link_state_event(ingress_link_id, LinkEvent::AssignedAAA(aaa_address)) {
                 Err(e) => {
-                    // Unrecoverable?
-                    error!(target: ZDP, "Link {ingress_link_id}: Failed to process AssignedAAA event: {e}");
+                    // Highly improbable
+                    error!(target: ZDP, "Link {ingress_link_id}: failed to process AssignedAAA event: {e}");
                 }
                 Ok(()) => ()
             }
         }
     }
-
-
-
     super::core::send_non_flow_mgmt(
         asm,
         ingress_link_id,

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -1,6 +1,6 @@
 //! Handlers for management requests.
 
-use crate::{adapter_tables, special_peers};
+use crate::adapter_tables;
 use crate::assembly::{self, Assembly, PhMode, VERSION};
 use crate::auth;
 use crate::config;
@@ -264,6 +264,9 @@ pub async fn handle_terminate_indication(
 
 /// handle a Hello Request (RFC 6.5 § 6.3.4)
 /// Reads the hello, fire a ReceivedHelloRequest event, and then sends a response.
+///
+/// ## Preconditions:
+/// - This adapter is running as a node.
 pub async fn handle_hello_request(
     asm: &Arc<Assembly>,
     _seq_num: zpr::SeqNum,
@@ -307,50 +310,77 @@ pub async fn handle_hello_request(
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
     let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpHelloResponseHeader>();
 
-    hdr.status = match asm
+    let mut response_status = match asm
         .process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloRequest(actor_addr))
     {
         Err(_) => zdp::ResponseCode::Other,
         Ok(()) => zdp::ResponseCode::Success,
     };
 
+    let mut aaa_address: Option<IpAddress> = None;
+
+    if response_status != zdp::ResponseCode::Success {
+        // Already failing!  Fall through to sending of response.
+        hdr.status = response_status;
+    } else {
+        // We need an AAA address if an authentication service is available and the connecting adapter
+        // is not fronting the visa service.
+
+        let is_visa_service = asm
+            .peer_table
+            .lookup_special_peer(SpecialPeerName::VisaServiceAdapter)
+            .map_or(false, |id| id.get() == ingress_link_id);
+
+        let auth_service_avaialable = asm.rsauth.is_some();
+
+        if !is_visa_service && auth_service_avaialable {
+            // Then we need an AAA.
+            if let Some(pool) = asm.address_pool.lock().unwrap().as_mut() {
+                if let Ok(addr) = pool.get_aaa_address() {
+                    debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {addr}");
+                    aaa_address = Some(addr);
+
+                    // Store the AAA in the link memory so we can free it later.
+                    match asm
+                        .process_link_state_event(ingress_link_id, LinkEvent::AssignedAAA(addr))
+                    {
+                        Err(e) => {
+                            // Highly improbable
+                            error!(target: ZDP, "Link {ingress_link_id}: failed to process AssignedAAA event: {e}");
+                        }
+                        Ok(()) => (),
+                    }
+                } else {
+                    // Uh oh, this is trouble. Need to fail the hello and shutdown the link.
+                    warn!(target: ZDP, "Link {ingress_link_id}: HelloRequest fails - no AAA address available");
+                    response_status = zdp::ResponseCode::Other;
+                }
+            } else {
+                // This is violation of precondition. If we are a node, we must have a pool.
+                panic!("adapter handling a hello-request has no address pool");
+            }
+        }
+    }
+
+    hdr.status = response_status;
+
+    // Policy ID and version are always included, even if not SUCCESS.
     let policy_id: i64 = 0; // TODO: We get policy ID from visa service. Record that somewhere, access it here.
     TlvEncoding::new_policy_id(policy_id).put(&mut rsp_pkt);
     TlvEncoding::new_version(VERSION).put(&mut rsp_pkt);
 
-    // TODO: This info needs to come from the visa service
-    let service_addr = SocketAddr::new(
-        IpAddr::V6(auth::HARD_CODED_BAS_ADDR),
-        auth::DEFAULT_ZPR_OAUTH_RSA_PORT,
-    );
-    TlvEncoding::new_asa(service_addr).put(&mut rsp_pkt);
-
-    // An AAA address is required when we have an authentication service available.
-    // Special case- the visa service does not use an AAA address.
-    // Also the adapter may end up using bootstrap auth in which case it can ignore
-    // the AAA address.
-
-    // First check the CN on this link to see if it is the visa service.
-    let visa_service_link_id = asm.peer_table.lookup_special_peer(SpecialPeerName::VisaServiceAdapter);
-    match visa_service_link_id {
-        Some(id) if id.get() == ingress_link_id => {
-            // This is the visa service, so we do not need an AAA address.
-            debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - no AAA address needed for visa service");
-        }
-        _ => {
-            // We need to include an AAA address.
-            let aaa_address: IpAddress = asm.address_pool.lock().unwrap().get_aaa_address();
-            debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {aaa_address}");
-            TlvEncoding::new_aaa(aaa_address).put(&mut rsp_pkt);
-            match asm.process_link_state_event(ingress_link_id, LinkEvent::AssignedAAA(aaa_address)) {
-                Err(e) => {
-                    // Highly improbable
-                    error!(target: ZDP, "Link {ingress_link_id}: failed to process AssignedAAA event: {e}");
-                }
-                Ok(()) => ()
-            }
+    if response_status == zdp::ResponseCode::Success {
+        // TODO: This info needs to come from the visa service
+        let service_addr = SocketAddr::new(
+            IpAddr::V6(auth::HARD_CODED_BAS_ADDR),
+            auth::DEFAULT_ZPR_OAUTH_RSA_PORT,
+        );
+        TlvEncoding::new_asa(service_addr).put(&mut rsp_pkt);
+        if let Some(aaa_addr) = aaa_address {
+            TlvEncoding::new_aaa(aaa_addr).put(&mut rsp_pkt);
         }
     }
+
     super::core::send_non_flow_mgmt(
         asm,
         ingress_link_id,
@@ -358,6 +388,20 @@ pub async fn handle_hello_request(
         rsp_pkt,
     );
 
+    // TODO: The framework within which this function is called does not allow us to
+    // returns an error back which would trigger a link shutdown.  So we do it manually
+    // and just return Ok() though things are not in fact OK.
+
+    if response_status != zdp::ResponseCode::Success {
+        // Kick off link shutdown
+        info!(target: ZDP, "Link {ingress_link_id}: HelloRequest processing failed, shutting down link");
+        match asm.process_link_state_event(ingress_link_id, LinkEvent::Error) {
+            Err(e) => {
+                error!(target: ZDP, "Link {ingress_link_id}: failed to process Error event: {e}");
+            }
+            Ok(()) => (),
+        }
+    }
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -339,16 +339,12 @@ pub async fn handle_hello_request(
         }
         _ => {
             // We need to include an AAA address.
-            let aaa_address: IpAddress = asm.address_pool.get_aaa_address();
+            let aaa_address: IpAddress = asm.address_pool.lock().unwrap().get_aaa_address();
             debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {aaa_address}");
             TlvEncoding::new_aaa(aaa_address).put(&mut rsp_pkt);
+
             // TODO: when a address is cleaned up, the address is returned to the pool.
-            // In order to do that it needs to be in PeerState.
-            //   ...
-            //   And then can be returned in clear_peer_state
-            // OR, it needs to be in the link_state somewhere.
-            //
-            // Either way we need to return it from link_state.clean_up_link_state.
+
             match asm.process_link_state_event(ingress_link_id, LinkEvent::AssignedAAA(aaa_address)) {
                 Err(e) => {
                     // Unrecoverable?

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -425,36 +425,38 @@ pub async fn handle_hello_response(asm: &Arc<Assembly>, mut pkt: Packet) -> Hand
     // A tlv has a type (number) and a value.
     let tlv_data =
         tlv::parse_from_buf(&mut pkt).map_err(|_| (HandleMgmtError::BadStructure, pkt))?;
-    if let Some(ver) = tlv_data.get(&tlv::DataType::VERSION) {
-        info!(target: ZDP, "Link {link_id}: HelloResponse - peer version is : {}", ver[0]);
-    } else {
-        warn!(target: ZDP, "Link {link_id}: HelloResponse did not include version");
-    }
-    if let Some(policy_id) = tlv_data.get(&tlv::DataType::POLICY_ID) {
-        info!(target: ZDP, "Link {link_id}: HelloResponse - peer policy ID is : {}", policy_id[0]);
-    } else {
-        warn!(target: ZDP, "Link {link_id}: HelloResponse did not include policy ID");
-    }
 
     let mut asa_addresses = Vec::<SocketAddr>::new();
 
-    if let Some(asa_entries) = tlv_data.get(&tlv::DataType::ASA) {
-        for asa_entry in asa_entries {
-            match asa_entry {
-                tlv::TlvValue::SocketAddr(sa) => {
-                    info!(target: ZDP, "Link {link_id}: HelloResponse includes ASA address:{sa}");
-                    asa_addresses.push(sa.clone());
-                }
-                _ => {
-                    warn!(target: ZDP, "Link {link_id}: HelloResponse ASA value type is wrong: {asa_entry:?}");
+    for (tlv_type, tlv_value) in &tlv_data {
+        match tlv_type {
+            &tlv::DataType::VERSION => {
+                info!(target: ZDP, "Link {link_id}: HelloResponse - peer version is : {}", tlv_value[0]);
+            }
+            &tlv::DataType::POLICY_ID => {
+                info!(target: ZDP, "Link {link_id}: HelloResponse - peer policy ID is : {}", tlv_value[0]);
+            }
+            &tlv::DataType::ASA => {
+                for asa_entry in tlv_value {
+                    match asa_entry {
+                        tlv::TlvValue::SocketAddr(sa) => {
+                            info!(target: ZDP, "Link {link_id}: HelloResponse includes ASA address:{sa}");
+                            asa_addresses.push(sa.clone());
+                        }
+                        _ => {
+                            warn!(target: ZDP, "Link {link_id}: HelloResponse ASA value type is wrong: {asa_entry:?}");
+                        }
+                    }
                 }
             }
+            _ => {
+                info!(target: ZDP, "Link {link_id}: HelloResponse includes ignored TLV type: {tlv_type}");
+            }
         }
-    } else {
-        warn!(target: ZDP, "Link {link_id}: HelloResponse did not include ASA TLV");
     }
 
     let maybe_asa_addrs = if asa_addresses.is_empty() {
+        warn!(target: ZDP, "Link {link_id}: HelloResponse did not include ASA TLV");
         None
     } else {
         Some(asa_addresses)

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -115,7 +115,7 @@ pub async fn handle_echo_response(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
 /// TODO: Not yet in RFC 6
 ///
 /// Message from node requesting authentication.
-///
+/// Sends a [zdp::ZdpInitAuthenticationResponse] back.
 ///
 pub async fn handle_init_authentication_request(
     asm: &Arc<Assembly>,
@@ -174,8 +174,10 @@ pub async fn handle_init_authentication_request(
     Ok(())
 }
 
+/// Process the InitAuthenticationResponse message.
+/// Just inform the link_state that we got this.
 pub async fn handle_init_authentication_response(
-    _asm: &Arc<Assembly>,
+    asm: &Arc<Assembly>,
     mut pkt: Packet,
 ) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpInitAuthenticationResponse::read_from_buf(&mut pkt) else {
@@ -185,7 +187,7 @@ pub async fn handle_init_authentication_response(
     let link_id = pkt.metadata().ingress_link_id;
     let status = hdr.status_code;
     debug!(target: ZDP, "Link {link_id}: Received InitAuthenticationResponse, status: {status:?}");
-
+    let _ = asm.process_link_state_event(link_id, LinkEvent::ReceivedInitAuthResponse(status));
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -310,7 +310,7 @@ pub async fn handle_hello_request(
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
     let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpHelloResponseHeader>();
 
-    let mut response_status = match asm
+    let response_status = match asm
         .process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloRequest(actor_addr))
     {
         Err(_) => zdp::ResponseCode::Other,
@@ -319,10 +319,7 @@ pub async fn handle_hello_request(
 
     let mut aaa_address: Option<IpAddress> = None;
 
-    if response_status != zdp::ResponseCode::Success {
-        // Already failing!  Fall through to sending of response.
-        hdr.status = response_status;
-    } else {
+    if response_status == zdp::ResponseCode::Success {
         // We need an AAA address if an authentication service is available and the connecting adapter
         // is not fronting the visa service.
 
@@ -336,24 +333,17 @@ pub async fn handle_hello_request(
         if !is_visa_service && auth_service_avaialable {
             // Then we need an AAA.
             if let Some(pool) = asm.address_pool.lock().unwrap().as_mut() {
-                if let Ok(addr) = pool.get_aaa_address() {
-                    debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {addr}");
-                    aaa_address = Some(addr);
+                let addr = pool.get_aaa_address();
+                debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {addr}");
+                aaa_address = Some(addr);
 
-                    // Store the AAA in the link memory so we can free it later.
-                    match asm
-                        .process_link_state_event(ingress_link_id, LinkEvent::AssignedAAA(addr))
-                    {
-                        Err(e) => {
-                            // Highly improbable
-                            error!(target: ZDP, "Link {ingress_link_id}: failed to process AssignedAAA event: {e}");
-                        }
-                        Ok(()) => (),
+                // Store the AAA in the link memory so we can free it later.
+                match asm.process_link_state_event(ingress_link_id, LinkEvent::AssignedAAA(addr)) {
+                    Err(e) => {
+                        // Highly improbable
+                        error!(target: ZDP, "Link {ingress_link_id}: failed to process AssignedAAA event: {e}");
                     }
-                } else {
-                    // Uh oh, this is trouble. Need to fail the hello and shutdown the link.
-                    warn!(target: ZDP, "Link {ingress_link_id}: HelloRequest fails - no AAA address available");
-                    response_status = zdp::ResponseCode::Other;
+                    Ok(()) => (),
                 }
             } else {
                 // This is violation of precondition. If we are a node, we must have a pool.

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -4,11 +4,11 @@ use crate::forwarding_tables::PeerForwardingTable;
 use crate::km::{KeyManager, KmTransportSA};
 use crate::link_state::{LinkStateWrapper, LinkType};
 use crate::net_defs::ScopedIpAddr;
-use crate::queues;
 use crate::rcu::{RcuBox, RcuCslabEntryGuard, RcuOptionGuard};
 use crate::seq_nums::*;
 use crate::special_peers::*;
 use crate::sync_req;
+use crate::{config, queues};
 use bytes::Bytes;
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::DashMap;
@@ -27,7 +27,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use zpr::{self, LinkId, SubstrateAddr, LINK_ID_UNKNOWN};
 
-const PEER_TABLE_SIZE: usize = 1024;
+const PEER_TABLE_SIZE: usize = config::MAX_ACTIVE_LINKS;
 
 pub struct PeerState {
     pub substrate_addr: SubstrateAddr,

--- a/adapter/ph/src/tlv.rs
+++ b/adapter/ph/src/tlv.rs
@@ -1,6 +1,6 @@
 use bytes::Buf;
 use std::collections::HashMap;
-use std::net::{Ipv4Addr, Ipv6Addr, IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use thiserror::Error;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
@@ -55,7 +55,7 @@ impl TlvEncoding {
     /// TODO: Test v6 variant
     #[allow(dead_code)]
     pub fn new_aaa(addr: IpAddress) -> TlvEncoding {
-        let ipa: IpAddr  = addr.into();
+        let ipa: IpAddr = addr.into();
         match ipa {
             IpAddr::V4(ipa) => TlvEncoding {
                 tlv_type: DataType::AAA,

--- a/adapter/ph/src/tlv.rs
+++ b/adapter/ph/src/tlv.rs
@@ -1,8 +1,10 @@
 use bytes::Buf;
 use std::collections::HashMap;
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{Ipv4Addr, Ipv6Addr, IpAddr, SocketAddr};
 use thiserror::Error;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::net_defs::IpAddress;
 
 const SOCKADDR_LEN_V4: u8 = 6; // 4 bytes for IPv4 + 2 bytes for port
 const SOCKADDR_LEN_V6: u8 = 18; // 16 bytes for IPv6 + 2 bytes for port
@@ -50,11 +52,19 @@ impl TlvEncoding {
     }
 
     /// Actor Authentication Address
+    /// TODO: Test v6 variant
     #[allow(dead_code)]
-    pub fn new_aaa(addr: Ipv4Addr) -> TlvEncoding {
-        TlvEncoding {
-            tlv_type: DataType::AAA,
-            value: TlvValue::Ipv4Addr(addr),
+    pub fn new_aaa(addr: IpAddress) -> TlvEncoding {
+        let ipa: IpAddr  = addr.into();
+        match ipa {
+            IpAddr::V4(ipa) => TlvEncoding {
+                tlv_type: DataType::AAA,
+                value: TlvValue::Ipv4Addr(ipa),
+            },
+            IpAddr::V6(ipa) => TlvEncoding {
+                tlv_type: DataType::AAA,
+                value: TlvValue::Ipv6Addr(ipa),
+            },
         }
     }
 

--- a/adapter/ph/src/tlv.rs
+++ b/adapter/ph/src/tlv.rs
@@ -52,7 +52,6 @@ impl TlvEncoding {
     }
 
     /// Actor Authentication Address
-    /// TODO: Test v6 variant
     #[allow(dead_code)]
     pub fn new_aaa(addr: IpAddress) -> TlvEncoding {
         let ipa: IpAddr = addr.into();
@@ -892,5 +891,147 @@ mod tests {
         // Test that Display formatting works correctly
         assert_eq!(format!("{}", tlv_v4), "192.168.1.1:8080");
         assert_eq!(format!("{}", tlv_v6), "[2001:db8::1]:443");
+    }
+
+    #[test]
+    fn test_new_aaa_ipv4_encoding() {
+        let mut buf = BytesMut::new();
+        let test_ipv4 = Ipv4Addr::new(192, 168, 1, 100);
+        let ip_address = IpAddress::from(test_ipv4);
+
+        // Create AAA TLV using new_aaa function
+        let aaa_encoding = TlvEncoding::new_aaa(ip_address);
+        aaa_encoding.put(&mut buf);
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::AAA).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::Ipv4Addr(addr) => assert_eq!(*addr, test_ipv4),
+            _ => panic!("Expected Ipv4Addr value for AAA created with new_aaa"),
+        }
+    }
+
+    #[test]
+    fn test_new_aaa_ipv6_encoding() {
+        let mut buf = BytesMut::new();
+        let test_ipv6 = Ipv6Addr::new(
+            0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334,
+        );
+        let ip_address = IpAddress::from(test_ipv6);
+
+        // Create AAA TLV using new_aaa function
+        let aaa_encoding = TlvEncoding::new_aaa(ip_address);
+        aaa_encoding.put(&mut buf);
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::AAA).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::Ipv6Addr(addr) => assert_eq!(*addr, test_ipv6),
+            _ => panic!("Expected Ipv6Addr value for AAA created with new_aaa"),
+        }
+    }
+
+    #[test]
+    fn test_new_aaa_localhost_addresses() {
+        let mut buf = BytesMut::new();
+
+        // Test IPv4 localhost
+        let ipv4_localhost = IpAddress::from(Ipv4Addr::LOCALHOST);
+        let aaa_v4 = TlvEncoding::new_aaa(ipv4_localhost);
+        aaa_v4.put(&mut buf);
+
+        // Test IPv6 localhost
+        let ipv6_localhost = IpAddress::from(Ipv6Addr::LOCALHOST);
+        let aaa_v6 = TlvEncoding::new_aaa(ipv6_localhost);
+        aaa_v6.put(&mut buf);
+
+        // Parse both back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify we have one TLV type with two values
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::AAA).unwrap();
+        assert_eq!(values.len(), 2);
+
+        // Check IPv4 localhost
+        match &values[0] {
+            TlvValue::Ipv4Addr(addr) => assert_eq!(*addr, Ipv4Addr::LOCALHOST),
+            _ => panic!("Expected Ipv4Addr value for IPv4 localhost AAA"),
+        }
+
+        // Check IPv6 localhost
+        match &values[1] {
+            TlvValue::Ipv6Addr(addr) => assert_eq!(*addr, Ipv6Addr::LOCALHOST),
+            _ => panic!("Expected Ipv6Addr value for IPv6 localhost AAA"),
+        }
+    }
+
+    #[test]
+    fn test_new_aaa_tlv_structure_ipv4() {
+        let mut buf = BytesMut::new();
+        let test_ipv4 = Ipv4Addr::new(10, 0, 0, 1);
+        let ip_address = IpAddress::from(test_ipv4);
+
+        // Create AAA TLV using new_aaa function
+        let aaa_encoding = TlvEncoding::new_aaa(ip_address);
+        aaa_encoding.put(&mut buf);
+
+        // Verify the buffer structure manually
+        let bytes = buf.as_ref();
+
+        // Check header
+        assert_eq!(bytes[0], DataType::AAA); // TLV type
+        assert_eq!(bytes[1], 4); // TLV length (4 bytes for IPv4)
+
+        // Check IPv4 address bytes (10.0.0.1)
+        assert_eq!(bytes[2], 10);
+        assert_eq!(bytes[3], 0);
+        assert_eq!(bytes[4], 0);
+        assert_eq!(bytes[5], 1);
+    }
+
+    #[test]
+    fn test_new_aaa_tlv_structure_ipv6() {
+        let mut buf = BytesMut::new();
+        let test_ipv6 = Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1);
+        let ip_address = IpAddress::from(test_ipv6);
+
+        // Create AAA TLV using new_aaa function
+        let aaa_encoding = TlvEncoding::new_aaa(ip_address);
+        aaa_encoding.put(&mut buf);
+
+        // Verify the buffer structure manually
+        let bytes = buf.as_ref();
+
+        // Check header
+        assert_eq!(bytes[0], DataType::AAA); // TLV type
+        assert_eq!(bytes[1], 16); // TLV length (16 bytes for IPv6)
+
+        // Check first few bytes of IPv6 address (2001:db8::1)
+        assert_eq!(bytes[2], 0x20);
+        assert_eq!(bytes[3], 0x01);
+        assert_eq!(bytes[4], 0x0d);
+        assert_eq!(bytes[5], 0xb8);
+
+        // Check that bytes 6-15 are zero (representing the compressed ::)
+        for i in 6..17 {
+            assert_eq!(bytes[i], 0);
+        }
+
+        // Check last byte is 1
+        assert_eq!(bytes[17], 1);
     }
 }


### PR DESCRIPTION
In which the node hands an AAA address down to a client adapter (but receiver does not yet use it).

Includes some reworking of the sending of hello responses which I know will create a headache once I merge in the ASA PR.

Major highlight is a new thing to create and manage the address pool which hangs off the Assembly.  Basically, addresses are picked randomly but we track the ones in use.  So the link_state needs to return them to the pool as part of clean up.

Closes #910
