### PR TITLE
put a TLV into hello-request instead of hardcoded thing

### DIFF
--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -284,36 +284,51 @@ pub async fn handle_hello_request(
     }
     debug!(target: ZDP, "Received Hello Request for link {ingress_link_id}");
 
-    let Ok(hdr) = zdp::ZdpHelloRequestHeader::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
-    };
-    let bytes_needed = match hdr.ip_version {
-        zpr::L3Type::Ipv4 => 4,
-        zpr::L3Type::Ipv6 => 16,
-        _ => {
-            warn!(target: ZDP, "link {ingress_link_id}: invalid ip_version field");
+    let tlv_data = match tlv::parse_from_buf(&mut pkt) {
+        Ok(data) => data,
+        Err(_) => {
+            error!(target: ZDP, "Link {ingress_link_id}: Failed to parse HelloRequest TLV data");
             return Err((HandleMgmtError::BadStructure, pkt));
         }
     };
-    if pkt.remaining() < bytes_needed {
-        warn!(target: ZDP, "link {ingress_link_id}: packet too short for actor address");
+
+    let mut static_addresses = Vec::<IpAddress>::new();
+
+    for (tlv_type, tlv_value) in &tlv_data {
+        match tlv_type {
+            &tlv::DataType::STATIC_ADDR => {
+                for static_entry in tlv_value {
+                    match static_entry {
+                        tlv::TlvValue::Ipv4Addr(addr) => {
+                            debug!(target: ZDP, "Link {ingress_link_id}: HelloRequest includes static IPv4 address: {addr}");
+                            static_addresses.push(addr.to_owned().into());
+                        }
+                        tlv::TlvValue::Ipv6Addr(addr) => {
+                            debug!(target: ZDP, "Link {ingress_link_id}: HelloRequest includes static IPv6 address: {addr}");
+                            static_addresses.push(addr.to_owned().into());
+                        }
+                        _ => {
+                            warn!(target: ZDP, "Link {ingress_link_id}: HelloRequest static address value type is wrong: {static_entry:?}");
+                        }
+                    }
+                }
+            }
+            _ => {
+                info!(target: ZDP, "Link {ingress_link_id}: HelloRequest includes ignored TLV type: {tlv_type}");
+            }
+        }
+    }
+
+    // TODO: Add support for multiple addresses on same actor?
+    // TODO: For now address is required. But with the AAA stuff coming soon this requirement goes away.
+    if static_addresses.is_empty() {
+        error!(target: ZDP, "Link {ingress_link_id}: HelloRequest did not include static address TLV");
         return Err((HandleMgmtError::BadStructure, pkt));
     }
-    let actor_addr: IpAddress = match hdr.ip_version {
-        zpr::L3Type::Ipv4 => {
-            let Ok(addr_bytes) = <[u8; 4]>::read_from_buf(&mut pkt) else {
-                return Err((HandleMgmtError::BadStructure, pkt));
-            };
-            addr_bytes.into()
-        }
-        zpr::L3Type::Ipv6 => {
-            let Ok(addr_bytes) = <[u8; 16]>::read_from_buf(&mut pkt) else {
-                return Err((HandleMgmtError::BadStructure, pkt));
-            };
-            addr_bytes.into()
-        }
-        _ => panic!("unreachable - already handled this error above"),
-    };
+    if static_addresses.len() > 1 {
+        warn!(target: ZDP, "Link {ingress_link_id}: HelloRequest includes multiple static address requests, only the first one will be used");
+    }
+    let actor_addr = static_addresses.remove(0);
 
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
     let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpHelloResponseHeader>();

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -8,9 +8,9 @@ use super::core;
 use crate::counters::CounterType;
 use crate::defs::*;
 use crate::logging::targets::ZDP;
+use crate::tlv::TlvEncoding;
 use crate::zdp;
 use crate::{assembly::Assembly, auth};
-use crate::tlv::TlvEncoding;
 
 use bytes::{Buf, BufMut};
 use std::net::IpAddr;

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -10,6 +10,7 @@ use crate::defs::*;
 use crate::logging::targets::ZDP;
 use crate::zdp;
 use crate::{assembly::Assembly, auth};
+use crate::tlv::TlvEncoding;
 
 use bytes::{Buf, BufMut};
 use std::net::IpAddr;
@@ -51,34 +52,21 @@ pub fn send_echo_request(asm: &Assembly, link_id: zpr::LinkId) -> zpr::SeqNum {
 
 /// send a Hello Request and wait for the Response (RFC 6.5 § 6.3.4)
 ///
-/// Augmented temporarily with an actors local ZPR addresses.  In future these
-/// will be handed out to the adapter by the dock (first an AAA then a real one).
+/// Until we get AAA working, you must pass the actors configured ZPR
+/// address here as the `actor_addrs` parameter.  Once AAA is working,
+/// the `actor_addrs` parameter will be used to send a request for a
+/// specific static address to the node and it will be optional.
 ///
-/// Note we only use the first address in the list.
-///
-/// ## Panics
-/// - If address list is empty.
 pub fn send_hello_request(
     asm: &Assembly,
     link_id: zpr::LinkId,
     actor_addrs: &[IpAddr],
 ) -> zpr::SeqNum {
-    if actor_addrs.is_empty() {
-        panic!("send_hello_request requires at least one local ZPR address");
-    }
-    let actor_addr = actor_addrs[0].to_owned();
-
     let mut req = core::new_heap_packet();
-
-    let hdr = zdp::ZdpHelloRequestHeader {
-        ip_version: actor_addr.l3_type(),
-    };
-    hdr.write_to_buf(&mut req).unwrap();
-    match actor_addr {
-        IpAddr::V4(addr) => req.put(&addr.octets()[..]),
-        IpAddr::V6(addr) => req.put(&addr.octets()[..]),
+    for addr in actor_addrs {
+        let tlv = TlvEncoding::new_static_addr_std(addr.to_owned());
+        tlv.put(&mut req);
     }
-
     core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::HelloRequest, req)
 }
 

--- a/adapter/ph/src/tlv.rs
+++ b/adapter/ph/src/tlv.rs
@@ -27,6 +27,7 @@ impl DataType {
     pub const VERSION: TlvType = 2;
     pub const AAA: TlvType = 3; // Actor Authentication Address - temporary address actor may use for authentication
     pub const ASA: TlvType = 4; // Authentication Service SocketAddress
+    pub const STATIC_ADDR: TlvType = 5; // Static Address - used for static address requests from an adapter
 }
 
 /// TlvEncoding is a designed to be an easy way to create and write TLV data
@@ -66,6 +67,24 @@ impl TlvEncoding {
             },
         }
     }
+
+    pub fn new_static_addr(addr: IpAddress) -> TlvEncoding {
+        Self::new_static_addr_std(addr.into())
+    }
+
+    pub fn new_static_addr_std(ipa: IpAddr) -> TlvEncoding {
+        match ipa {
+            IpAddr::V4(ipa) => TlvEncoding {
+                tlv_type: DataType::STATIC_ADDR,
+                value: TlvValue::Ipv4Addr(ipa),
+            },
+            IpAddr::V6(ipa) => TlvEncoding {
+                tlv_type: DataType::STATIC_ADDR,
+                value: TlvValue::Ipv6Addr(ipa),
+            },
+        }
+    }
+
 
     /// Authentication Service Address
     pub fn new_asa(sock_addr: SocketAddr) -> TlvEncoding {
@@ -228,7 +247,7 @@ pub fn parse_from_buf(
                     .or_insert_with(Vec::new)
                     .push(TlvValue::Str(ver_str.to_string()));
             }
-            DataType::AAA => {
+            DataType::AAA | DataType::STATIC_ADDR => {
                 let addr_val = parse_address_value(buf, tlv_length)?;
                 tlv_map
                     .entry(tlv_type)
@@ -918,6 +937,31 @@ mod tests {
     }
 
     #[test]
+    fn test_new_static_addr_encoding_ipv4() {
+        let mut buf = BytesMut::new();
+        let test_ipv4 = Ipv4Addr::new(192, 168, 1, 100);
+        let ip_address = IpAddress::from(test_ipv4);
+
+        // Create STATIC_ADDR TLV using new_static_addr function
+        let static_encoding = TlvEncoding::new_static_addr(ip_address);
+        static_encoding.put(&mut buf);
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::STATIC_ADDR).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::Ipv4Addr(addr) => assert_eq!(*addr, test_ipv4),
+            _ => panic!("Expected Ipv4Addr value for STATIC_ADDR created with new_static_addr"),
+        }
+    }
+
+
+    #[test]
     fn test_new_aaa_ipv6_encoding() {
         let mut buf = BytesMut::new();
         let test_ipv6 = Ipv6Addr::new(
@@ -940,6 +984,32 @@ mod tests {
         match &values[0] {
             TlvValue::Ipv6Addr(addr) => assert_eq!(*addr, test_ipv6),
             _ => panic!("Expected Ipv6Addr value for AAA created with new_aaa"),
+        }
+    }
+
+    #[test]
+    fn test_new_static_addr_encoding_ipv6() {
+        let mut buf = BytesMut::new();
+        let test_ipv6 = Ipv6Addr::new(
+            0x2001, 0x0db8, 0x85a3, 0x0000, 0x0000, 0x8a2e, 0x0370, 0x7334,
+        );
+        let ip_address = IpAddress::from(test_ipv6);
+
+        // Create STATIC_ADDR TLV using new_static_addr function
+        let static_encoding = TlvEncoding::new_static_addr(ip_address);
+        static_encoding.put(&mut buf);
+
+        // Parse it back
+        let mut buf_reader = buf.as_ref();
+        let result = parse_from_buf(&mut buf_reader).unwrap();
+
+        // Verify the result
+        assert_eq!(result.len(), 1);
+        let values = result.get(&DataType::STATIC_ADDR).unwrap();
+        assert_eq!(values.len(), 1);
+        match &values[0] {
+            TlvValue::Ipv6Addr(addr) => assert_eq!(*addr, test_ipv6),
+            _ => panic!("Expected Ipv6Addr value for STATIC_ADDR created with new_static_addr"),
         }
     }
 

--- a/adapter/ph/src/tlv.rs
+++ b/adapter/ph/src/tlv.rs
@@ -68,10 +68,13 @@ impl TlvEncoding {
         }
     }
 
+    /// Actor requested static address for an adapter.
+    #[allow(dead_code)]
     pub fn new_static_addr(addr: IpAddress) -> TlvEncoding {
         Self::new_static_addr_std(addr.into())
     }
 
+    /// Actor requested static address for an adapter.
     pub fn new_static_addr_std(ipa: IpAddr) -> TlvEncoding {
         match ipa {
             IpAddr::V4(ipa) => TlvEncoding {
@@ -84,7 +87,6 @@ impl TlvEncoding {
             },
         }
     }
-
 
     /// Authentication Service Address
     pub fn new_asa(sock_addr: SocketAddr) -> TlvEncoding {
@@ -959,7 +961,6 @@ mod tests {
             _ => panic!("Expected Ipv4Addr value for STATIC_ADDR created with new_static_addr"),
         }
     }
-
 
     #[test]
     fn test_new_aaa_ipv6_encoding() {

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -118,12 +118,6 @@ pub struct ZdpReportHeader {
     pub report_data_length: U16,
 }
 
-#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
-#[repr(packed)]
-pub struct ZdpHelloRequestHeader {
-    pub ip_version: zpr::L3Type,
-    // Followed in memory by the IP address.
-}
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -118,7 +118,6 @@ pub struct ZdpReportHeader {
     pub report_data_length: U16,
 }
 
-
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpHelloResponseHeader {


### PR DESCRIPTION
For the AAA stuff we will pass any requested static addresses from a client adapter to a node inside the hello-request.

This patch changes the hello-request "header" so that actually instead of a header it is just an optional set of TLV structures.