### PR TITLE
do not leave substrate sockets connected for macOS compatibility

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -3107,11 +3107,12 @@ dependencies = [
 
 [[package]]
 name = "zpr-ext"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "libc",
  "nix",
+ "socket2",
  "tokio",
  "zerocopy 0.8.9",
 ]

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -40,7 +40,7 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 zerocopy = { version = "0.8.3", features = ["derive", "std"] }
 zpr = { path = "../../zpr" }
-zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "zerocopy"] }
+zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "socket2", "zerocopy"] }
 serde_json = "1.0.140"
 url = "2.5.4"
 

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -88,6 +88,7 @@ use pki::load_noise_public_key;
 use queues::*;
 use sys::ZprTun;
 use tun_ctl::TunCtl;
+use zpr_ext::socket2::SockAddrExt;
 
 use crate::vs_types::AuthServicesList;
 
@@ -315,15 +316,16 @@ fn main() -> ExitCode {
         }
 
         if let Some(node_addr) = config.node_addr {
-            // If we are an adapter (and thus have a remote node address), connect to that here.
-            // We don't actually care that this sets the default destination (since we always
-            // set it when sending).  Rather, this forces the OS to choose a local address
-            // if we didn't specify one in the bind call above.
-            socket
-                .connect(&socket2::SockAddr::from(node_addr))
-                .expect(&format!("unable to connect to node_addr ({})", node_addr));
-
             if config.self_addr.ip().is_unspecified() {
+                // If we are an adapter (and thus have a remote node address),
+                // but we don't have a specified self address (and thus did not
+                // specify one in the bind call above), temporarily connect to
+                // the remote node address to forcee the OS to choose a local
+                // address.
+                socket
+                    .connect(&socket2::SockAddr::from(node_addr))
+                    .expect(&format!("unable to connect to node_addr ({})", node_addr));
+
                 // Update the address of our configured self address to match
                 // what the OS chose.  This ensures that all sockets we open share
                 // the same port.
@@ -335,6 +337,14 @@ fn main() -> ExitCode {
                     .scoped_ip();
                 config.self_addr.set_scoped_ip(addr);
                 info!(target: STARTUP, "assigned substrate address {addr}");
+
+                // Now drop the connection.  We will still specify it manually
+                // for each packet sent (and it's an error to do both).
+                match socket.connect(&socket2::SockAddr::new_unspec()) {
+                    Ok(()) => (),
+                    Err(err) if err.raw_os_error() == Some(libc::EAFNOSUPPORT) => (),
+                    res => res.expect("unable to disconnect socket"),
+                }
             }
         }
 

--- a/zpr-ext/Cargo.lock
+++ b/zpr-ext/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "bytes",
  "libc",
  "nix",
+ "socket2",
  "tokio",
  "zerocopy",
 ]

--- a/zpr-ext/Cargo.toml
+++ b/zpr-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zpr-ext"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 license = "Apache-2.0"
 
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 bytes = { version = "1.7.1", optional = true }
 libc = { version = "0.2.155" }
 nix = { version = "0.29.0", features = ["ioctl", "net", "socket"] }
+socket2 = { version = "0.5", optional = true }
 tokio = { version = "1.37.0", features = ["net"], optional = true }
 zerocopy = { version = "0.8.3", optional = true }
 
@@ -18,5 +19,6 @@ tokio = { version = "1.37.0", features = ["macros", "time", "rt"] }
 # Each feature flag is the name of a library the user is already using
 # and would like to have "extended".
 bytes = ["dep:bytes"]
+socket2 = ["dep:socket2"]
 tokio = ["dep:tokio"]
 zerocopy = ["dep:zerocopy"]

--- a/zpr-ext/src/lib.rs
+++ b/zpr-ext/src/lib.rs
@@ -10,6 +10,9 @@ pub mod std;
 #[cfg(feature = "bytes")]
 pub mod bytes;
 
+#[cfg(feature = "socket2")]
+pub mod socket2;
+
 #[cfg(feature = "tokio")]
 pub mod tokio;
 

--- a/zpr-ext/src/socket2.rs
+++ b/zpr-ext/src/socket2.rs
@@ -1,0 +1,19 @@
+pub trait SockAddrExt {
+    fn new_unspec() -> Self;
+}
+
+impl SockAddrExt for socket2::SockAddr {
+    fn new_unspec() -> Self {
+        // SAFETY: AF_UNSPEC is compatible with any sockaddr struct
+        unsafe {
+            Self::try_init(|sas, sl| {
+                // SAFETY: the caller has provided valid pointers to initialized storage
+                (*sas).ss_family = libc::AF_UNSPEC as _;
+                *sl = std::mem::size_of::<libc::sockaddr>() as _;
+                Ok(())
+            })
+            .unwrap()
+            .1
+        }
+    }
+}


### PR DESCRIPTION
We only need to connect the substrate socket (just one) in order to determine which address the OS thinks is a suitable source address, then we can disconnect.  So, this change does that, since macOS gets upset if we don't.