### PR TITLE
batch packet counts

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -1,6 +1,6 @@
 use crate::adapter_tables::{AltEntry, AltPep};
 use crate::assembly::{Assembly, PhMode};
-use crate::counters::CounterType;
+use crate::counters::ManagementCounterType;
 use crate::logging::targets::FLOW_MGMT;
 use crate::mgmt;
 use crate::packet::{Packet, PacketBuffer};
@@ -37,7 +37,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, mut pkt: Packet) {
     // if there's already an entry, this is a duplicate request
     // (NOTE: we should be the only ones modifying this table!)
     if asm.alt.get(five_tuple).is_some() {
-        mgmt::core::count_event(asm, &mut pkt, CounterType::DroppedAwaitingBind);
+        mgmt::core::count_event(asm, &mut pkt, ManagementCounterType::DroppedAwaitingBind);
         return;
     }
 
@@ -51,7 +51,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, mut pkt: Packet) {
 
     if dock_link_id != zpr::LINK_ID_UNKNOWN && !asm.is_link_ready(dock_link_id) {
         debug!(target: FLOW_MGMT, "Link {dock_link_id} is not ready to receive traffic yet");
-        mgmt::core::count_event(asm, &mut pkt, CounterType::DroppedNoSA);
+        mgmt::core::count_event(asm, &mut pkt, ManagementCounterType::DroppedNoSA);
         return;
     }
 
@@ -129,7 +129,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, mut pkt: Packet) {
                 Ok(()) => (),
                 Err(TryEnqueueError::Full(_pkt)) => {
                     debug!(target: FLOW_MGMT, "Requeue backpressure on bind of {five_tuple}, dropping initial packet");
-                    asm.counters[CounterType::QueueBackpressure].increment();
+                    asm.counters.management[ManagementCounterType::QueueBackpressure].increment();
                 }
             }
         }

--- a/adapter/ph/src/admin_worker.rs
+++ b/adapter/ph/src/admin_worker.rs
@@ -241,12 +241,16 @@ async fn echo(_asm: &Assembly) -> String {
 
 async fn counters(asm: &Assembly) -> String {
     let mut counts: String = String::new();
+    let _ = write!(&mut counts, "Management counts:\n");
     for (key, &ref value) in &asm.counters.management {
         let _ = write!(&mut counts, "{}: {}\n", key, value.get_count());
     }
 
-    for (key, &ref value) in &asm.counters.fastpath {
-        let _ = write!(&mut counts, "{}: {}\n", key, value.get_count());
+    for (i, fastpath) in asm.counters.fastpaths.lock().unwrap().iter().enumerate() {
+        let _ = write!(&mut counts, "Fastpath #{} counts:\n", i);
+        for (key, &ref value) in fastpath {
+            let _ = write!(&mut counts, "{}: {}\n", key, value.get_count());
+        }
     }
 
     let _ = write!(&mut counts, "Uptime: {:?}\n", asm.get_uptime());
@@ -258,8 +262,11 @@ async fn counters_reset(asm: &Assembly) -> String {
     for value in asm.counters.management.values() {
         value.reset();
     }
-    for value in asm.counters.fastpath.values() {
-        value.reset();
+    
+    for fastpath in asm.counters.fastpaths.lock().unwrap().iter() {
+        for value in fastpath.values() {
+            value.reset();
+        }
     }
 
     String::from("counters_reset\n")

--- a/adapter/ph/src/admin_worker.rs
+++ b/adapter/ph/src/admin_worker.rs
@@ -241,7 +241,11 @@ async fn echo(_asm: &Assembly) -> String {
 
 async fn counters(asm: &Assembly) -> String {
     let mut counts: String = String::new();
-    for (key, &ref value) in &asm.counters {
+    for (key, &ref value) in &asm.counters.management {
+        let _ = write!(&mut counts, "{}: {}\n", key, value.get_count());
+    }
+
+    for (key, &ref value) in &asm.counters.fastpath {
         let _ = write!(&mut counts, "{}: {}\n", key, value.get_count());
     }
 
@@ -251,7 +255,10 @@ async fn counters(asm: &Assembly) -> String {
 }
 
 async fn counters_reset(asm: &Assembly) -> String {
-    for value in asm.counters.values() {
+    for value in asm.counters.management.values() {
+        value.reset();
+    }
+    for value in asm.counters.fastpath.values() {
         value.reset();
     }
 

--- a/adapter/ph/src/admin_worker.rs
+++ b/adapter/ph/src/admin_worker.rs
@@ -262,7 +262,7 @@ async fn counters_reset(asm: &Assembly) -> String {
     for value in asm.counters.management.values() {
         value.reset();
     }
-    
+
     for fastpath in asm.counters.fastpaths.lock().unwrap().iter() {
         for value in fastpath.values() {
             value.reset();

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -23,7 +23,6 @@ use crate::special_peers::SpecialPeerName;
 use crate::tun_ctl::TunCtl;
 use crate::visa_table;
 use crate::vs_types::AuthServicesList;
-
 use km_noise::NoiseKeypair;
 use std::net::IpAddr;
 use std::num::NonZero;

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -24,7 +24,6 @@ use crate::tun_ctl::TunCtl;
 use crate::visa_table;
 use crate::vs_types::AuthServicesList;
 
-use enum_map::EnumMap;
 use km_noise::NoiseKeypair;
 use std::net::IpAddr;
 use std::num::NonZero;
@@ -80,7 +79,7 @@ pub struct Assembly {
     pub capture_worker: CaptureWorker,
     pub flow_control: FlowControl,
 
-    pub counters: EnumMap<CounterType, Counter>,
+    pub counters: Counters,
 
     pub tun_ctl: Box<dyn TunCtl + Send>,
 
@@ -398,7 +397,7 @@ pub mod test {
         pub capture_queue: Option<Capture>,
         pub capture_worker: Option<CaptureWorker>,
         pub flow_control: Option<FlowControl>,
-        pub counters: Option<EnumMap<CounterType, Counter>>,
+        pub counters: Option<Counters>,
         pub tun_ctl: Option<Box<dyn TunCtl + Send>>,
         pub peer_table: Option<peer_table::PeerTable>,
         pub peer_ids: Option<Vec<zpr::LinkId>>,

--- a/adapter/ph/src/counters.rs
+++ b/adapter/ph/src/counters.rs
@@ -12,8 +12,8 @@ pub type ManagementCounters = EnumMap<ManagementCounterType, Counter>;
 /// Struct of the system's performance counters. Broken into
 /// counters used in fastpath and those used for management
 // TODO the only way I could figure out to allow the fastpaths
-// to be able to push a new FastpathCounters to the asm was 
-// to make fastpaths a mutex, but it is less efficient, and I 
+// to be able to push a new FastpathCounters to the asm was
+// to make fastpaths a mutex, but it is less efficient, and I
 // don't think it is necessary, but had to do to appease the compiler
 #[derive(Default)]
 pub struct Counters {
@@ -323,7 +323,11 @@ mod tests {
     #[test]
     fn test_aggregate_increment() {
         let counters: Counters = Default::default();
-        counters.fastpaths.lock().unwrap().push(FastpathCounters::default());
+        counters
+            .fastpaths
+            .lock()
+            .unwrap()
+            .push(FastpathCounters::default());
 
         assert_eq!(
             counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
@@ -366,7 +370,11 @@ mod tests {
     #[test]
     fn test_aggregate_increase_by() {
         let counters: Counters = Default::default();
-        counters.fastpaths.lock().unwrap().push(FastpathCounters::default());
+        counters
+            .fastpaths
+            .lock()
+            .unwrap()
+            .push(FastpathCounters::default());
         assert_eq!(
             counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
             0
@@ -408,12 +416,18 @@ mod tests {
     #[test]
     fn test_aggregate_multiples() {
         let counters: Counters = Default::default();
-        counters.fastpaths.lock().unwrap().push(FastpathCounters::default());
+        counters
+            .fastpaths
+            .lock()
+            .unwrap()
+            .push(FastpathCounters::default());
         let mut counters_batch: FastpathCounters = Default::default();
 
         counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].increase_by(2);
-        counters.fastpaths.lock().unwrap()[0][FastpathCounterType::QueueBackpressure].increase_by(8);
-        counters.fastpaths.lock().unwrap()[0][FastpathCounterType::DispatchedToMgmt].increase_by(75);
+        counters.fastpaths.lock().unwrap()[0][FastpathCounterType::QueueBackpressure]
+            .increase_by(8);
+        counters.fastpaths.lock().unwrap()[0][FastpathCounterType::DispatchedToMgmt]
+            .increase_by(75);
         counters.fastpaths.lock().unwrap()[0][FastpathCounterType::UnknownZpi].increase_by(4);
         counters.fastpaths.lock().unwrap()[0][FastpathCounterType::TtlExpired].increase_by(2);
         counters.management[ManagementCounterType::QueueBackpressure].increase_by(432);
@@ -424,11 +438,13 @@ mod tests {
             2
         );
         assert_eq!(
-            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::QueueBackpressure].get_count(),
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::QueueBackpressure]
+                .get_count(),
             8
         );
         assert_eq!(
-            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::DispatchedToMgmt].get_count(),
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::DispatchedToMgmt]
+                .get_count(),
             75
         );
         assert_eq!(
@@ -483,11 +499,13 @@ mod tests {
             2
         );
         assert_eq!(
-            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::QueueBackpressure].get_count(),
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::QueueBackpressure]
+                .get_count(),
             20
         );
         assert_eq!(
-            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::DispatchedToMgmt].get_count(),
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::DispatchedToMgmt]
+                .get_count(),
             140
         );
         assert_eq!(

--- a/adapter/ph/src/counters.rs
+++ b/adapter/ph/src/counters.rs
@@ -196,6 +196,28 @@ impl fmt::Display for CounterType {
     }
 }
 
+// pub trait Reset {
+//     fn reset(&mut self);
+// }
+
+pub trait Aggregate {
+    fn aggregate(&self, batch_counters: &Counters);
+}
+
+// impl Reset for Counters {
+//     fn reset(&mut self) {
+//         self.clear()
+//     }
+// }
+
+impl Aggregate for Counters {
+    fn aggregate(&self, batch_counters: &Counters) {
+        for (counter_type, count) in batch_counters.iter() {
+            self[counter_type].increase_by(count.get_count());
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -257,5 +279,82 @@ mod tests {
         assert_eq!(counter.get_count(), 975467);
         counter.decrease_by(4543);
         assert_eq!(counter.get_count(), 970924);
+    }
+
+    #[test]
+    fn test_aggregate() {
+        let counters: Counters = Default::default();
+        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+
+        let mut counters_batch: Counters = Default::default();
+        counters_batch[CounterType::DroppedOversize].increase_by(5);
+        assert_eq!(counters_batch[CounterType::DroppedOversize].get_count(), 5);
+        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+
+        counters[CounterType::DroppedOversize].increment();
+        counters.aggregate(&counters_batch);
+        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
+        assert_eq!(counters_batch[CounterType::DroppedOversize].get_count(), 5);
+
+        counters_batch.clear();
+        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
+        assert_eq!(counters_batch[CounterType::DroppedOversize].get_count(), 0);
+    }
+
+    #[test]
+    fn test_aggregate_multiples() {
+        let counters: Counters = Default::default();
+        let mut counters_batch: Counters = Default::default();
+
+        counters[CounterType::InPacksRec].increase_by(2);
+        counters[CounterType::QueueBackpressure].increase_by(8);
+        counters[CounterType::DispatchedToMgmt].increase_by(75);
+        counters[CounterType::UnknownZpi].increase_by(4);
+        counters[CounterType::TtlExpired].increase_by(2);
+
+        assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
+        assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 8);
+        assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 75);
+        assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
+        assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
+
+        counters_batch[CounterType::DroppedOversize].increase_by(28);
+        counters_batch[CounterType::QueueBackpressure].increase_by(12);
+        counters_batch[CounterType::DispatchedToMgmt].increase_by(65);
+        counters_batch[CounterType::UnknownPeer].increase_by(4);
+        counters_batch[CounterType::OtherError].increase_by(1);
+
+        assert_eq!(counters_batch[CounterType::DroppedOversize].get_count(), 28);
+        assert_eq!(
+            counters_batch[CounterType::QueueBackpressure].get_count(),
+            12
+        );
+        assert_eq!(
+            counters_batch[CounterType::DispatchedToMgmt].get_count(),
+            65
+        );
+        assert_eq!(counters_batch[CounterType::UnknownPeer].get_count(), 4);
+        assert_eq!(counters_batch[CounterType::OtherError].get_count(), 1);
+
+        counters.aggregate(&counters_batch);
+        counters_batch.clear();
+
+        assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
+        assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 20);
+        assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 140);
+        assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
+        assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
+        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 28);
+        assert_eq!(counters[CounterType::UnknownPeer].get_count(), 4);
+        assert_eq!(counters[CounterType::OtherError].get_count(), 1);
+
+        assert_eq!(counters_batch[CounterType::DroppedOversize].get_count(), 0);
+        assert_eq!(
+            counters_batch[CounterType::QueueBackpressure].get_count(),
+            0
+        );
+        assert_eq!(counters_batch[CounterType::DispatchedToMgmt].get_count(), 0);
+        assert_eq!(counters_batch[CounterType::UnknownPeer].get_count(), 0);
+        assert_eq!(counters_batch[CounterType::OtherError].get_count(), 0);
     }
 }

--- a/adapter/ph/src/counters.rs
+++ b/adapter/ph/src/counters.rs
@@ -8,14 +8,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub type FastpathCounters = EnumMap<FastpathCounterType, Counter>;
 pub type ManagementCounters = EnumMap<ManagementCounterType, Counter>;
 
-/// Struct of the system's performance counters. Broken into 
+/// Struct of the system's performance counters. Broken into
 /// counters used in fastpath and those used for management
 #[derive(Default)]
 pub struct Counters {
     pub fastpath: FastpathCounters,
     pub management: ManagementCounters,
 }
-
 
 /// Implement counter type. Uses Atomic values, ensuring saftey for values in
 /// multi-thread environment.
@@ -86,9 +85,9 @@ pub enum FastpathCounterType {
     QueueBackpressure,
     DroppedAwaitingBind,
 
-    DispatchedToMgmt,  // exited fastpath from substrate ingress, sent to mgmt
+    DispatchedToMgmt, // exited fastpath from substrate ingress, sent to mgmt
     ActorSlowpath,    // exited fastpath from actor output, sent to mgmt
-    
+
     UnknownPeer,
     PeerRemoved,
 
@@ -192,7 +191,7 @@ impl FastpathCounterType {
 
 impl ManagementCounterType {
     pub fn name(&self) -> &'static str {
-        match *self {            
+        match *self {
             // Packet drops
             Self::QueueBackpressure => "Management QueueBackpressure",
             Self::DroppedAwaitingBind => "Management Dropped Awaiting Bind",
@@ -315,92 +314,92 @@ mod tests {
         assert_eq!(counter.get_count(), 970924);
     }
 
-//     #[test]
-//     fn test_aggregate_increment() {
-//         let counters: Counters = Default::default();
-//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+    //     #[test]
+    //     fn test_aggregate_increment() {
+    //         let counters: Counters = Default::default();
+    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
 
-//         let mut counters_batch: BatchCounters = Default::default();
-//         counters_batch.increment(CounterType::DroppedOversize);
-//         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
-//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+    //         let mut counters_batch: BatchCounters = Default::default();
+    //         counters_batch.increment(CounterType::DroppedOversize);
+    //         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
+    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
 
-//         counters[CounterType::DroppedOversize].increment();
-//         counters.aggregate(&counters_batch);
-//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
-//         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
+    //         counters[CounterType::DroppedOversize].increment();
+    //         counters.aggregate(&counters_batch);
+    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
+    //         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
 
-//         counters_batch.clear();
-//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
-//     }
+    //         counters_batch.clear();
+    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
+    //     }
 
-//     #[test]
-//     fn test_aggregate_increase_by() {
-//         let counters: Counters = Default::default();
-//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+    //     #[test]
+    //     fn test_aggregate_increase_by() {
+    //         let counters: Counters = Default::default();
+    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
 
-//         let mut counters_batch: BatchCounters = Default::default();
-//         counters_batch.increase_by(CounterType::DroppedOversize, 5);
-//         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
-//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+    //         let mut counters_batch: BatchCounters = Default::default();
+    //         counters_batch.increase_by(CounterType::DroppedOversize, 5);
+    //         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
+    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
 
-//         counters[CounterType::DroppedOversize].increment();
-//         counters.aggregate(&counters_batch);
-//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
-//         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
+    //         counters[CounterType::DroppedOversize].increment();
+    //         counters.aggregate(&counters_batch);
+    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
+    //         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
 
-//         counters_batch.clear();
-//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
-//     }
+    //         counters_batch.clear();
+    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
+    //     }
 
-//     #[test]
-//     fn test_aggregate_multiples() {
-//         let counters: Counters = Default::default();
-//         let mut counters_batch: BatchCounters = Default::default();
+    //     #[test]
+    //     fn test_aggregate_multiples() {
+    //         let counters: Counters = Default::default();
+    //         let mut counters_batch: BatchCounters = Default::default();
 
-//         counters[CounterType::InPacksRec].increase_by(2);
-//         counters[CounterType::QueueBackpressure].increase_by(8);
-//         counters[CounterType::DispatchedToMgmt].increase_by(75);
-//         counters[CounterType::UnknownZpi].increase_by(4);
-//         counters[CounterType::TtlExpired].increase_by(2);
+    //         counters[CounterType::InPacksRec].increase_by(2);
+    //         counters[CounterType::QueueBackpressure].increase_by(8);
+    //         counters[CounterType::DispatchedToMgmt].increase_by(75);
+    //         counters[CounterType::UnknownZpi].increase_by(4);
+    //         counters[CounterType::TtlExpired].increase_by(2);
 
-//         assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
-//         assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 8);
-//         assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 75);
-//         assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
-//         assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
+    //         assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
+    //         assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 8);
+    //         assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 75);
+    //         assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
+    //         assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
 
-//         counters_batch.increase_by(CounterType::DroppedOversize, 28);
-//         counters_batch.increase_by(CounterType::QueueBackpressure, 12);
-//         counters_batch.increase_by(CounterType::DispatchedToMgmt, 65);
-//         counters_batch.increase_by(CounterType::UnknownPeer, 4);
-//         counters_batch.increase_by(CounterType::OtherError, 1);
+    //         counters_batch.increase_by(CounterType::DroppedOversize, 28);
+    //         counters_batch.increase_by(CounterType::QueueBackpressure, 12);
+    //         counters_batch.increase_by(CounterType::DispatchedToMgmt, 65);
+    //         counters_batch.increase_by(CounterType::UnknownPeer, 4);
+    //         counters_batch.increase_by(CounterType::OtherError, 1);
 
-//         assert_eq!(
-//             counters_batch[&CounterType::DroppedOversize].get_count(),
-//             28
-//         );
-//         assert_eq!(
-//             counters_batch[&CounterType::QueueBackpressure].get_count(),
-//             12
-//         );
-//         assert_eq!(
-//             counters_batch[&CounterType::DispatchedToMgmt].get_count(),
-//             65
-//         );
-//         assert_eq!(counters_batch[&CounterType::UnknownPeer].get_count(), 4);
-//         assert_eq!(counters_batch[&CounterType::OtherError].get_count(), 1);
+    //         assert_eq!(
+    //             counters_batch[&CounterType::DroppedOversize].get_count(),
+    //             28
+    //         );
+    //         assert_eq!(
+    //             counters_batch[&CounterType::QueueBackpressure].get_count(),
+    //             12
+    //         );
+    //         assert_eq!(
+    //             counters_batch[&CounterType::DispatchedToMgmt].get_count(),
+    //             65
+    //         );
+    //         assert_eq!(counters_batch[&CounterType::UnknownPeer].get_count(), 4);
+    //         assert_eq!(counters_batch[&CounterType::OtherError].get_count(), 1);
 
-//         counters.aggregate(&counters_batch);
-//         counters_batch.clear();
+    //         counters.aggregate(&counters_batch);
+    //         counters_batch.clear();
 
-//         assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
-//         assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 20);
-//         assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 140);
-//         assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
-//         assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
-//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 28);
-//         assert_eq!(counters[CounterType::UnknownPeer].get_count(), 4);
-//         assert_eq!(counters[CounterType::OtherError].get_count(), 1);
-//     }
+    //         assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
+    //         assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 20);
+    //         assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 140);
+    //         assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
+    //         assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
+    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 28);
+    //         assert_eq!(counters[CounterType::UnknownPeer].get_count(), 4);
+    //         assert_eq!(counters[CounterType::OtherError].get_count(), 1);
+    //     }
 }

--- a/adapter/ph/src/counters.rs
+++ b/adapter/ph/src/counters.rs
@@ -1,15 +1,21 @@
 //! Atomic performance counters.
 
 use enum_map::{Enum, EnumMap};
-use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-/// Array of the system's performance counters.
-pub type Counters = EnumMap<CounterType, Counter>;
+// Counters used in the fastpath
+pub type FastpathCounters = EnumMap<FastpathCounterType, Counter>;
+pub type ManagementCounters = EnumMap<ManagementCounterType, Counter>;
 
-/// Hash map to do batch counting in the fastpath
-pub type BatchCounters = HashMap<CounterType, Counter>;
+/// Struct of the system's performance counters. Broken into 
+/// counters used in fastpath and those used for management
+#[derive(Default)]
+pub struct Counters {
+    pub fastpath: FastpathCounters,
+    pub management: ManagementCounters,
+}
+
 
 /// Implement counter type. Uses Atomic values, ensuring saftey for values in
 /// multi-thread environment.
@@ -59,20 +65,16 @@ impl Default for Counter {
         Self::new()
     }
 }
-
-/// Allows for easy access to name of each counter as well as index in
-/// counters array
 #[derive(Debug, Enum, Copy, Clone, Eq, Hash, PartialEq)]
-pub enum CounterType {
+pub enum FastpathCounterType {
     InPacksRec,
     InPacksDrop,
     InPacksSent,
     OutPacksRec,
-    RequeuedPacketsReceived,
-    MgmtPacketsSent,
     OutPacksDrop,
     OutPacksSent,
-    OutPacksErr,
+    RequeuedPacketsReceived,
+    MgmtPacketsSent,
     InCapPacksWrite,
     OutCapPacksWrite,
     InCapPacksDrop,
@@ -83,14 +85,39 @@ pub enum CounterType {
 
     QueueBackpressure,
     DroppedAwaitingBind,
+
+    DispatchedToMgmt,  // exited fastpath from substrate ingress, sent to mgmt
+    ActorSlowpath,    // exited fastpath from actor output, sent to mgmt
+    
+    UnknownPeer,
+    PeerRemoved,
+
+    UnknownZpi,
+    MicvFailure,
+    BadChecksum,
+    DecryptionFailure,
+    EncryptionFailure,
+    UnknownStreamId,
+    BadStructure,
+    OtherError,
+
+    TtlExpired,
+
+    #[cfg(debug_assertions)]
+    ActorPacketsOutOfOrder,
+}
+/// Allows for easy access to name of each counter as well as index in
+/// counters array
+#[derive(Debug, Enum, Copy, Clone, Eq, Hash, PartialEq)]
+pub enum ManagementCounterType {
+    QueueBackpressure,
+    DroppedAwaitingBind,
     DroppedNop,           // normal, not an error drop
     DroppedTooOld,        // "old" management packet received (possible duplicate)
     DroppedDuplicate,     // duplicate management packet detected
     DroppedNoSA,          // no security association on link
     InternalRoutingError, // a packet ended up somewhere it shouldn't have due to a coding error
 
-    DispatchedToMgmt, // exited fastpath from substrate ingress, sent to mgmt
-    ActorSlowpath,    // exited fastpath from actor output, sent to mgmt
     BadMgmtResponse,
     UnexpectedMgmtResponse,
     LostPacket,       // lost management packet detected
@@ -102,14 +129,8 @@ pub enum CounterType {
     PeerHandshakeFailure,
 
     // RFC 6.5 § 8.2.1
-    UnknownZpi,
     SequenceError,
-    MicvFailure,
-    BadChecksum, // internet checksum used in null encrypt/decrypt
-    DecryptionFailure,
-    EncryptionFailure,
     UnknownType,
-    UnknownStreamId,
     BadStructure,
     OtherError,
 
@@ -117,14 +138,9 @@ pub enum CounterType {
     VisaRequestSuccess,
     VisaRequestDenied,
     VisaRequestError,
-
-    TtlExpired,
-
-    #[cfg(debug_assertions)]
-    ActorPacketsOutOfOrder,
 }
 
-impl CounterType {
+impl FastpathCounterType {
     pub fn name(&self) -> &'static str {
         match *self {
             // Basic RX/TX
@@ -136,7 +152,6 @@ impl CounterType {
             Self::MgmtPacketsSent => "Mgmt Packets Sent",
             Self::OutPacksDrop => "Outbound Packets Dropped",
             Self::OutPacksSent => "Outbound Packets Sent",
-            Self::OutPacksErr => "Outbound Packet Send Errors",
             Self::InCapPacksWrite => "Inbound Capture Packets Written",
             Self::OutCapPacksWrite => "Outbound Capture Packets Written",
             Self::InCapPacksDrop => "Inbound Capture Packets Dropped",
@@ -146,45 +161,26 @@ impl CounterType {
             Self::DroppedOversize => "Inbound Oversize Packets Dropped",
 
             // Packet drops
-            Self::QueueBackpressure => "QueueBackpressure",
-            Self::DroppedAwaitingBind => "Dropped Awaiting Bind",
-            Self::DroppedTooOld => "Dropped Too Old",
-            Self::DroppedDuplicate => "Dropped Duplicate",
-            Self::DroppedNop => "Dropped No Operation",
-            Self::DroppedNoSA => "Dropped No Security Association",
-            Self::InternalRoutingError => "Internal Routing Error",
+            Self::QueueBackpressure => "Fastpath QueueBackpressure",
+            Self::DroppedAwaitingBind => "Fastpath Dropped Awaiting Bind",
 
             // Management packets
             Self::DispatchedToMgmt => "Dispatched to Management",
             Self::ActorSlowpath => "Actor Slowpath",
-            Self::BadMgmtResponse => "Bad Management Response",
-            Self::UnexpectedMgmtResponse => "Unexpected Management Response",
-            Self::LostPacket => "Lost Packet",
-            Self::OutOfOrderPacket => "Out Of Order Packet",
 
             // Peer operation failures
-            Self::UnknownPeer => "Unknown Peer",
-            Self::PeerRemoved => "Peer Removed",
-            Self::PeerHandshakeSuccess => "Peer Handshake Success",
-            Self::PeerHandshakeFailure => "Peer Handshake Failure",
+            Self::UnknownPeer => "Fastpath Unknown Peer",
+            Self::PeerRemoved => "Fastpath Peer Removed",
 
             // § 8.2.1 ZDP errors
             Self::UnknownZpi => "Unknown ZPI",
-            Self::SequenceError => "Sequence Error",
             Self::MicvFailure => "MICV Failure",
             Self::BadChecksum => "Bad Checksum",
             Self::DecryptionFailure => "Decryption Failure",
             Self::EncryptionFailure => "Encryption Failure",
-            Self::UnknownType => "Unknown Type",
             Self::UnknownStreamId => "Unknown Stream ID",
-            Self::BadStructure => "Bad Structure",
-            Self::OtherError => "Other Error",
-
-            // Visa counters (Node only)
-            Self::VisaRequested => "Visa Requested",
-            Self::VisaRequestSuccess => "Visa Request Success",
-            Self::VisaRequestDenied => "Visa Request Denied",
-            Self::VisaRequestError => "Visa Request Error",
+            Self::BadStructure => "Fastpath Bad Structure",
+            Self::OtherError => "Fastpath Other Error",
 
             Self::TtlExpired => "TTL Reached 0",
 
@@ -194,58 +190,65 @@ impl CounterType {
     }
 }
 
-impl fmt::Display for CounterType {
+impl ManagementCounterType {
+    pub fn name(&self) -> &'static str {
+        match *self {            
+            // Packet drops
+            Self::QueueBackpressure => "Management QueueBackpressure",
+            Self::DroppedAwaitingBind => "Management Dropped Awaiting Bind",
+            Self::DroppedTooOld => "Dropped Too Old",
+            Self::DroppedDuplicate => "Dropped Duplicate",
+            Self::DroppedNop => "Dropped No Operation",
+            Self::DroppedNoSA => "Dropped No Security Association",
+            Self::InternalRoutingError => "Internal Routing Error",
+
+            // Management packets
+            Self::BadMgmtResponse => "Bad Management Response",
+            Self::UnexpectedMgmtResponse => "Unexpected Management Response",
+            Self::LostPacket => "Lost Packet",
+            Self::OutOfOrderPacket => "Out Of Order Packet",
+
+            // Peer operation failures
+            Self::UnknownPeer => "Management Unknown Peer",
+            Self::PeerRemoved => "Management Peer Removed",
+            Self::PeerHandshakeSuccess => "Peer Handshake Success",
+            Self::PeerHandshakeFailure => "Peer Handshake Failure",
+
+            // § 8.2.1 ZDP errors
+            Self::SequenceError => "Sequence Error",
+            Self::UnknownType => "Unknown Type",
+            Self::BadStructure => "Management Bad Structure",
+            Self::OtherError => "Management Other Error",
+
+            // Visa counters (Node only)
+            Self::VisaRequested => "Visa Requested",
+            Self::VisaRequestSuccess => "Visa Request Success",
+            Self::VisaRequestDenied => "Visa Request Denied",
+            Self::VisaRequestError => "Visa Request Error",
+        }
+    }
+}
+impl fmt::Display for FastpathCounterType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl fmt::Display for ManagementCounterType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name())
     }
 }
 
 pub trait Aggregate {
-    fn aggregate(&self, batch_counters: &BatchCounters);
+    fn aggregate(&self, batches: &FastpathCounters);
 }
 
-impl Aggregate for Counters {
-    fn aggregate(&self, batch_counters: &BatchCounters) {
-        for (counter_type, count) in batch_counters.iter() {
-            self[*counter_type].increase_by(count.get_count());
+impl Aggregate for FastpathCounters {
+    fn aggregate(&self, batches: &FastpathCounters) {
+        for (key, value) in batches.iter() {
+            self[key].increase_by(value.get_count())
         }
-    }
-}
-
-pub trait Increment {
-    fn increment(&mut self, reason: CounterType);
-}
-
-#[allow(dead_code)]
-pub trait IncreaseBy {
-    fn increase_by(&mut self, reason: CounterType, amount: u64);
-}
-
-impl Increment for BatchCounters {
-    fn increment(&mut self, reason: CounterType) {
-        let curr_val = self.get(&reason);
-        let new_val = Counter::new();
-        match curr_val {
-            Some(count) => {
-                new_val.set(count.get_count() + 1);
-            }
-            None => new_val.set(1),
-        };
-        self.insert(reason, new_val);
-    }
-}
-
-impl IncreaseBy for BatchCounters {
-    fn increase_by(&mut self, reason: CounterType, amount: u64) {
-        let curr_val = self.get(&reason);
-        let new_val = Counter::new();
-        match curr_val {
-            Some(count) => {
-                new_val.set(count.get_count() + amount);
-            }
-            None => new_val.set(amount),
-        };
-        self.insert(reason, new_val);
     }
 }
 
@@ -312,92 +315,92 @@ mod tests {
         assert_eq!(counter.get_count(), 970924);
     }
 
-    #[test]
-    fn test_aggregate_increment() {
-        let counters: Counters = Default::default();
-        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+//     #[test]
+//     fn test_aggregate_increment() {
+//         let counters: Counters = Default::default();
+//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
 
-        let mut counters_batch: BatchCounters = Default::default();
-        counters_batch.increment(CounterType::DroppedOversize);
-        assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
-        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+//         let mut counters_batch: BatchCounters = Default::default();
+//         counters_batch.increment(CounterType::DroppedOversize);
+//         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
+//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
 
-        counters[CounterType::DroppedOversize].increment();
-        counters.aggregate(&counters_batch);
-        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
-        assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
+//         counters[CounterType::DroppedOversize].increment();
+//         counters.aggregate(&counters_batch);
+//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
+//         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
 
-        counters_batch.clear();
-        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
-    }
+//         counters_batch.clear();
+//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
+//     }
 
-    #[test]
-    fn test_aggregate_increase_by() {
-        let counters: Counters = Default::default();
-        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+//     #[test]
+//     fn test_aggregate_increase_by() {
+//         let counters: Counters = Default::default();
+//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
 
-        let mut counters_batch: BatchCounters = Default::default();
-        counters_batch.increase_by(CounterType::DroppedOversize, 5);
-        assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
-        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+//         let mut counters_batch: BatchCounters = Default::default();
+//         counters_batch.increase_by(CounterType::DroppedOversize, 5);
+//         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
+//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
 
-        counters[CounterType::DroppedOversize].increment();
-        counters.aggregate(&counters_batch);
-        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
-        assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
+//         counters[CounterType::DroppedOversize].increment();
+//         counters.aggregate(&counters_batch);
+//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
+//         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
 
-        counters_batch.clear();
-        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
-    }
+//         counters_batch.clear();
+//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
+//     }
 
-    #[test]
-    fn test_aggregate_multiples() {
-        let counters: Counters = Default::default();
-        let mut counters_batch: BatchCounters = Default::default();
+//     #[test]
+//     fn test_aggregate_multiples() {
+//         let counters: Counters = Default::default();
+//         let mut counters_batch: BatchCounters = Default::default();
 
-        counters[CounterType::InPacksRec].increase_by(2);
-        counters[CounterType::QueueBackpressure].increase_by(8);
-        counters[CounterType::DispatchedToMgmt].increase_by(75);
-        counters[CounterType::UnknownZpi].increase_by(4);
-        counters[CounterType::TtlExpired].increase_by(2);
+//         counters[CounterType::InPacksRec].increase_by(2);
+//         counters[CounterType::QueueBackpressure].increase_by(8);
+//         counters[CounterType::DispatchedToMgmt].increase_by(75);
+//         counters[CounterType::UnknownZpi].increase_by(4);
+//         counters[CounterType::TtlExpired].increase_by(2);
 
-        assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
-        assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 8);
-        assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 75);
-        assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
-        assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
+//         assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
+//         assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 8);
+//         assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 75);
+//         assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
+//         assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
 
-        counters_batch.increase_by(CounterType::DroppedOversize, 28);
-        counters_batch.increase_by(CounterType::QueueBackpressure, 12);
-        counters_batch.increase_by(CounterType::DispatchedToMgmt, 65);
-        counters_batch.increase_by(CounterType::UnknownPeer, 4);
-        counters_batch.increase_by(CounterType::OtherError, 1);
+//         counters_batch.increase_by(CounterType::DroppedOversize, 28);
+//         counters_batch.increase_by(CounterType::QueueBackpressure, 12);
+//         counters_batch.increase_by(CounterType::DispatchedToMgmt, 65);
+//         counters_batch.increase_by(CounterType::UnknownPeer, 4);
+//         counters_batch.increase_by(CounterType::OtherError, 1);
 
-        assert_eq!(
-            counters_batch[&CounterType::DroppedOversize].get_count(),
-            28
-        );
-        assert_eq!(
-            counters_batch[&CounterType::QueueBackpressure].get_count(),
-            12
-        );
-        assert_eq!(
-            counters_batch[&CounterType::DispatchedToMgmt].get_count(),
-            65
-        );
-        assert_eq!(counters_batch[&CounterType::UnknownPeer].get_count(), 4);
-        assert_eq!(counters_batch[&CounterType::OtherError].get_count(), 1);
+//         assert_eq!(
+//             counters_batch[&CounterType::DroppedOversize].get_count(),
+//             28
+//         );
+//         assert_eq!(
+//             counters_batch[&CounterType::QueueBackpressure].get_count(),
+//             12
+//         );
+//         assert_eq!(
+//             counters_batch[&CounterType::DispatchedToMgmt].get_count(),
+//             65
+//         );
+//         assert_eq!(counters_batch[&CounterType::UnknownPeer].get_count(), 4);
+//         assert_eq!(counters_batch[&CounterType::OtherError].get_count(), 1);
 
-        counters.aggregate(&counters_batch);
-        counters_batch.clear();
+//         counters.aggregate(&counters_batch);
+//         counters_batch.clear();
 
-        assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
-        assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 20);
-        assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 140);
-        assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
-        assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
-        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 28);
-        assert_eq!(counters[CounterType::UnknownPeer].get_count(), 4);
-        assert_eq!(counters[CounterType::OtherError].get_count(), 1);
-    }
+//         assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
+//         assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 20);
+//         assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 140);
+//         assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
+//         assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
+//         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 28);
+//         assert_eq!(counters[CounterType::UnknownPeer].get_count(), 4);
+//         assert_eq!(counters[CounterType::OtherError].get_count(), 1);
+//     }
 }

--- a/adapter/ph/src/counters.rs
+++ b/adapter/ph/src/counters.rs
@@ -216,6 +216,7 @@ pub trait Increment {
     fn increment(&mut self, reason: CounterType);
 }
 
+#[allow(dead_code)]
 pub trait IncreaseBy {
     fn increase_by(&mut self, reason: CounterType, amount: u64);
 }

--- a/adapter/ph/src/counters.rs
+++ b/adapter/ph/src/counters.rs
@@ -1,11 +1,15 @@
 //! Atomic performance counters.
 
 use enum_map::{Enum, EnumMap};
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Array of the system's performance counters.
 pub type Counters = EnumMap<CounterType, Counter>;
+
+/// Hash map to do batch counting in the fastpath
+pub type BatchCounters = HashMap<CounterType, Counter>;
 
 /// Implement counter type. Uses Atomic values, ensuring saftey for values in
 /// multi-thread environment.
@@ -58,7 +62,7 @@ impl Default for Counter {
 
 /// Allows for easy access to name of each counter as well as index in
 /// counters array
-#[derive(Debug, Enum, Copy, Clone)]
+#[derive(Debug, Enum, Copy, Clone, Eq, Hash, PartialEq)]
 pub enum CounterType {
     InPacksRec,
     InPacksDrop,
@@ -196,25 +200,51 @@ impl fmt::Display for CounterType {
     }
 }
 
-// pub trait Reset {
-//     fn reset(&mut self);
-// }
-
 pub trait Aggregate {
-    fn aggregate(&self, batch_counters: &Counters);
+    fn aggregate(&self, batch_counters: &BatchCounters);
 }
 
-// impl Reset for Counters {
-//     fn reset(&mut self) {
-//         self.clear()
-//     }
-// }
-
 impl Aggregate for Counters {
-    fn aggregate(&self, batch_counters: &Counters) {
+    fn aggregate(&self, batch_counters: &BatchCounters) {
         for (counter_type, count) in batch_counters.iter() {
-            self[counter_type].increase_by(count.get_count());
+            self[*counter_type].increase_by(count.get_count());
         }
+    }
+}
+
+pub trait Increment {
+    fn increment(&mut self, reason: CounterType);
+}
+
+pub trait IncreaseBy {
+    fn increase_by(&mut self, reason: CounterType, amount: u64);
+}
+
+impl Increment for BatchCounters {
+    fn increment(&mut self, reason: CounterType) {
+        let curr_val = self.get(&reason);
+        let new_val = Counter::new();
+        match curr_val {
+            Some(count) => {
+                new_val.set(count.get_count() + 1);
+            }
+            None => new_val.set(1),
+        };
+        self.insert(reason, new_val);
+    }
+}
+
+impl IncreaseBy for BatchCounters {
+    fn increase_by(&mut self, reason: CounterType, amount: u64) {
+        let curr_val = self.get(&reason);
+        let new_val = Counter::new();
+        match curr_val {
+            Some(count) => {
+                new_val.set(count.get_count() + amount);
+            }
+            None => new_val.set(amount),
+        };
+        self.insert(reason, new_val);
     }
 }
 
@@ -282,29 +312,47 @@ mod tests {
     }
 
     #[test]
-    fn test_aggregate() {
+    fn test_aggregate_increment() {
         let counters: Counters = Default::default();
         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
 
-        let mut counters_batch: Counters = Default::default();
-        counters_batch[CounterType::DroppedOversize].increase_by(5);
-        assert_eq!(counters_batch[CounterType::DroppedOversize].get_count(), 5);
+        let mut counters_batch: BatchCounters = Default::default();
+        counters_batch.increment(CounterType::DroppedOversize);
+        assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
+        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+
+        counters[CounterType::DroppedOversize].increment();
+        counters.aggregate(&counters_batch);
+        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
+        assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
+
+        counters_batch.clear();
+        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
+    }
+
+    #[test]
+    fn test_aggregate_increase_by() {
+        let counters: Counters = Default::default();
+        assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+
+        let mut counters_batch: BatchCounters = Default::default();
+        counters_batch.increase_by(CounterType::DroppedOversize, 5);
+        assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
 
         counters[CounterType::DroppedOversize].increment();
         counters.aggregate(&counters_batch);
         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
-        assert_eq!(counters_batch[CounterType::DroppedOversize].get_count(), 5);
+        assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
 
         counters_batch.clear();
         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
-        assert_eq!(counters_batch[CounterType::DroppedOversize].get_count(), 0);
     }
 
     #[test]
     fn test_aggregate_multiples() {
         let counters: Counters = Default::default();
-        let mut counters_batch: Counters = Default::default();
+        let mut counters_batch: BatchCounters = Default::default();
 
         counters[CounterType::InPacksRec].increase_by(2);
         counters[CounterType::QueueBackpressure].increase_by(8);
@@ -318,23 +366,26 @@ mod tests {
         assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
         assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
 
-        counters_batch[CounterType::DroppedOversize].increase_by(28);
-        counters_batch[CounterType::QueueBackpressure].increase_by(12);
-        counters_batch[CounterType::DispatchedToMgmt].increase_by(65);
-        counters_batch[CounterType::UnknownPeer].increase_by(4);
-        counters_batch[CounterType::OtherError].increase_by(1);
+        counters_batch.increase_by(CounterType::DroppedOversize, 28);
+        counters_batch.increase_by(CounterType::QueueBackpressure, 12);
+        counters_batch.increase_by(CounterType::DispatchedToMgmt, 65);
+        counters_batch.increase_by(CounterType::UnknownPeer, 4);
+        counters_batch.increase_by(CounterType::OtherError, 1);
 
-        assert_eq!(counters_batch[CounterType::DroppedOversize].get_count(), 28);
         assert_eq!(
-            counters_batch[CounterType::QueueBackpressure].get_count(),
+            counters_batch[&CounterType::DroppedOversize].get_count(),
+            28
+        );
+        assert_eq!(
+            counters_batch[&CounterType::QueueBackpressure].get_count(),
             12
         );
         assert_eq!(
-            counters_batch[CounterType::DispatchedToMgmt].get_count(),
+            counters_batch[&CounterType::DispatchedToMgmt].get_count(),
             65
         );
-        assert_eq!(counters_batch[CounterType::UnknownPeer].get_count(), 4);
-        assert_eq!(counters_batch[CounterType::OtherError].get_count(), 1);
+        assert_eq!(counters_batch[&CounterType::UnknownPeer].get_count(), 4);
+        assert_eq!(counters_batch[&CounterType::OtherError].get_count(), 1);
 
         counters.aggregate(&counters_batch);
         counters_batch.clear();
@@ -347,14 +398,5 @@ mod tests {
         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 28);
         assert_eq!(counters[CounterType::UnknownPeer].get_count(), 4);
         assert_eq!(counters[CounterType::OtherError].get_count(), 1);
-
-        assert_eq!(counters_batch[CounterType::DroppedOversize].get_count(), 0);
-        assert_eq!(
-            counters_batch[CounterType::QueueBackpressure].get_count(),
-            0
-        );
-        assert_eq!(counters_batch[CounterType::DispatchedToMgmt].get_count(), 0);
-        assert_eq!(counters_batch[CounterType::UnknownPeer].get_count(), 0);
-        assert_eq!(counters_batch[CounterType::OtherError].get_count(), 0);
     }
 }

--- a/adapter/ph/src/counters.rs
+++ b/adapter/ph/src/counters.rs
@@ -3,6 +3,7 @@
 use enum_map::{Enum, EnumMap};
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 
 // Counters used in the fastpath
 pub type FastpathCounters = EnumMap<FastpathCounterType, Counter>;
@@ -10,9 +11,13 @@ pub type ManagementCounters = EnumMap<ManagementCounterType, Counter>;
 
 /// Struct of the system's performance counters. Broken into
 /// counters used in fastpath and those used for management
+// TODO the only way I could figure out to allow the fastpaths
+// to be able to push a new FastpathCounters to the asm was 
+// to make fastpaths a mutex, but it is less efficient, and I 
+// don't think it is necessary, but had to do to appease the compiler
 #[derive(Default)]
 pub struct Counters {
-    pub fastpath: FastpathCounters,
+    pub fastpaths: Mutex<Vec<FastpathCounters>>,
     pub management: ManagementCounters,
 }
 
@@ -239,6 +244,7 @@ impl fmt::Display for ManagementCounterType {
     }
 }
 
+// TODO could also impl aggregate as a function of Counters
 pub trait Aggregate {
     fn aggregate(&self, batches: &FastpathCounters);
 }
@@ -314,92 +320,223 @@ mod tests {
         assert_eq!(counter.get_count(), 970924);
     }
 
-    //     #[test]
-    //     fn test_aggregate_increment() {
-    //         let counters: Counters = Default::default();
-    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+    #[test]
+    fn test_aggregate_increment() {
+        let counters: Counters = Default::default();
+        counters.fastpaths.lock().unwrap().push(FastpathCounters::default());
 
-    //         let mut counters_batch: BatchCounters = Default::default();
-    //         counters_batch.increment(CounterType::DroppedOversize);
-    //         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
-    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
+            0
+        );
 
-    //         counters[CounterType::DroppedOversize].increment();
-    //         counters.aggregate(&counters_batch);
-    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
-    //         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 1);
+        let mut counters_batch: FastpathCounters = Default::default();
+        counters_batch[FastpathCounterType::InPacksRec].increment();
+        assert_eq!(
+            counters_batch[FastpathCounterType::InPacksRec].get_count(),
+            1
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
+            0
+        );
 
-    //         counters_batch.clear();
-    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 2);
-    //     }
+        counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].increment();
+        counters.fastpaths.lock().unwrap()[0].aggregate(&counters_batch);
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
+            2
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::InPacksRec].get_count(),
+            1
+        );
 
-    //     #[test]
-    //     fn test_aggregate_increase_by() {
-    //         let counters: Counters = Default::default();
-    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+        counters_batch.clear();
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
+            2
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::InPacksRec].get_count(),
+            0
+        );
+    }
 
-    //         let mut counters_batch: BatchCounters = Default::default();
-    //         counters_batch.increase_by(CounterType::DroppedOversize, 5);
-    //         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
-    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 0);
+    #[test]
+    fn test_aggregate_increase_by() {
+        let counters: Counters = Default::default();
+        counters.fastpaths.lock().unwrap().push(FastpathCounters::default());
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
+            0
+        );
 
-    //         counters[CounterType::DroppedOversize].increment();
-    //         counters.aggregate(&counters_batch);
-    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
-    //         assert_eq!(counters_batch[&CounterType::DroppedOversize].get_count(), 5);
+        let mut counters_batch: FastpathCounters = Default::default();
+        counters_batch[FastpathCounterType::InPacksRec].increase_by(53);
+        assert_eq!(
+            counters_batch[FastpathCounterType::InPacksRec].get_count(),
+            53
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
+            0
+        );
 
-    //         counters_batch.clear();
-    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 6);
-    //     }
+        counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].increase_by(654);
+        counters.fastpaths.lock().unwrap()[0].aggregate(&counters_batch);
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
+            707
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::InPacksRec].get_count(),
+            53
+        );
 
-    //     #[test]
-    //     fn test_aggregate_multiples() {
-    //         let counters: Counters = Default::default();
-    //         let mut counters_batch: BatchCounters = Default::default();
+        counters_batch.clear();
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
+            707
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::InPacksRec].get_count(),
+            0
+        );
+    }
 
-    //         counters[CounterType::InPacksRec].increase_by(2);
-    //         counters[CounterType::QueueBackpressure].increase_by(8);
-    //         counters[CounterType::DispatchedToMgmt].increase_by(75);
-    //         counters[CounterType::UnknownZpi].increase_by(4);
-    //         counters[CounterType::TtlExpired].increase_by(2);
+    #[test]
+    fn test_aggregate_multiples() {
+        let counters: Counters = Default::default();
+        counters.fastpaths.lock().unwrap().push(FastpathCounters::default());
+        let mut counters_batch: FastpathCounters = Default::default();
 
-    //         assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
-    //         assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 8);
-    //         assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 75);
-    //         assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
-    //         assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
+        counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].increase_by(2);
+        counters.fastpaths.lock().unwrap()[0][FastpathCounterType::QueueBackpressure].increase_by(8);
+        counters.fastpaths.lock().unwrap()[0][FastpathCounterType::DispatchedToMgmt].increase_by(75);
+        counters.fastpaths.lock().unwrap()[0][FastpathCounterType::UnknownZpi].increase_by(4);
+        counters.fastpaths.lock().unwrap()[0][FastpathCounterType::TtlExpired].increase_by(2);
+        counters.management[ManagementCounterType::QueueBackpressure].increase_by(432);
+        counters.management[ManagementCounterType::UnexpectedMgmtResponse].increase_by(54);
 
-    //         counters_batch.increase_by(CounterType::DroppedOversize, 28);
-    //         counters_batch.increase_by(CounterType::QueueBackpressure, 12);
-    //         counters_batch.increase_by(CounterType::DispatchedToMgmt, 65);
-    //         counters_batch.increase_by(CounterType::UnknownPeer, 4);
-    //         counters_batch.increase_by(CounterType::OtherError, 1);
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
+            2
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::QueueBackpressure].get_count(),
+            8
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::DispatchedToMgmt].get_count(),
+            75
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::UnknownZpi].get_count(),
+            4
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::TtlExpired].get_count(),
+            2
+        );
+        assert_eq!(
+            counters.management[ManagementCounterType::QueueBackpressure].get_count(),
+            432
+        );
+        assert_eq!(
+            counters.management[ManagementCounterType::UnexpectedMgmtResponse].get_count(),
+            54
+        );
 
-    //         assert_eq!(
-    //             counters_batch[&CounterType::DroppedOversize].get_count(),
-    //             28
-    //         );
-    //         assert_eq!(
-    //             counters_batch[&CounterType::QueueBackpressure].get_count(),
-    //             12
-    //         );
-    //         assert_eq!(
-    //             counters_batch[&CounterType::DispatchedToMgmt].get_count(),
-    //             65
-    //         );
-    //         assert_eq!(counters_batch[&CounterType::UnknownPeer].get_count(), 4);
-    //         assert_eq!(counters_batch[&CounterType::OtherError].get_count(), 1);
+        counters_batch[FastpathCounterType::DroppedOversize].increase_by(28);
+        counters_batch[FastpathCounterType::QueueBackpressure].increase_by(12);
+        counters_batch[FastpathCounterType::DispatchedToMgmt].increase_by(65);
+        counters_batch[FastpathCounterType::UnknownPeer].increase_by(4);
+        counters_batch[FastpathCounterType::OtherError].increase_by(1);
 
-    //         counters.aggregate(&counters_batch);
-    //         counters_batch.clear();
+        assert_eq!(
+            counters_batch[FastpathCounterType::DroppedOversize].get_count(),
+            28
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::QueueBackpressure].get_count(),
+            12
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::DispatchedToMgmt].get_count(),
+            65
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::UnknownPeer].get_count(),
+            4
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::OtherError].get_count(),
+            1
+        );
 
-    //         assert_eq!(counters[CounterType::InPacksRec].get_count(), 2);
-    //         assert_eq!(counters[CounterType::QueueBackpressure].get_count(), 20);
-    //         assert_eq!(counters[CounterType::DispatchedToMgmt].get_count(), 140);
-    //         assert_eq!(counters[CounterType::UnknownZpi].get_count(), 4);
-    //         assert_eq!(counters[CounterType::TtlExpired].get_count(), 2);
-    //         assert_eq!(counters[CounterType::DroppedOversize].get_count(), 28);
-    //         assert_eq!(counters[CounterType::UnknownPeer].get_count(), 4);
-    //         assert_eq!(counters[CounterType::OtherError].get_count(), 1);
-    //     }
+        counters.fastpaths.lock().unwrap()[0].aggregate(&counters_batch);
+        counters_batch.clear();
+
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::InPacksRec].get_count(),
+            2
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::QueueBackpressure].get_count(),
+            20
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::DispatchedToMgmt].get_count(),
+            140
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::UnknownZpi].get_count(),
+            4
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::TtlExpired].get_count(),
+            2
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::DroppedOversize].get_count(),
+            28
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::UnknownPeer].get_count(),
+            4
+        );
+        assert_eq!(
+            counters.fastpaths.lock().unwrap()[0][FastpathCounterType::OtherError].get_count(),
+            1
+        );
+        assert_eq!(
+            counters.management[ManagementCounterType::QueueBackpressure].get_count(),
+            432
+        );
+        assert_eq!(
+            counters.management[ManagementCounterType::UnexpectedMgmtResponse].get_count(),
+            54
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::DroppedOversize].get_count(),
+            0
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::QueueBackpressure].get_count(),
+            0
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::DispatchedToMgmt].get_count(),
+            0
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::UnknownPeer].get_count(),
+            0
+        );
+        assert_eq!(
+            counters_batch[FastpathCounterType::OtherError].get_count(),
+            0
+        );
+    }
 }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -8,7 +8,7 @@ use crate::assembly::{Assembly, PhMode};
 use crate::batch_io::BatchIoEngine;
 use crate::classifier::{self, ClassifierResult};
 use crate::config;
-use crate::counters::{Aggregate, BatchCounters, CounterType, Increment};
+use crate::counters::{FastpathCounters, FastpathCounterType, Aggregate};
 use crate::defs::Direction;
 use crate::km::{Codec, KmTransportSA};
 use crate::km_noise::NOISE_PADLEN;
@@ -69,7 +69,7 @@ pub struct FastpathWorker {
     pub worker_index: usize,
     pub asm: Arc<Assembly>,
     pub buffers: Vec<PacketBuffer>,
-    pub batch_counters: BatchCounters,
+    pub batch_counters: FastpathCounters,
 
     pub return_q: two_way_queue::ReturnQueue<PacketBuffer>,
     pub adapter_manager: AdapterManager,
@@ -106,11 +106,11 @@ impl FastpathWorker {
     }
 
     /// Drop a packet and count the drop with the given reason.
-    pub fn drop_and_count(&mut self, pkt: Packet, reason: impl Into<CounterType>) {
+    pub fn drop_and_count(&mut self, pkt: Packet, reason: impl Into<FastpathCounterType>) {
         let reason = reason.into();
         debug!(target: DATAPATH, "dropping packet because {reason}");
         self.buffers.push(pkt.destroy());
-        self.batch_counters.increment(reason);
+        self.batch_counters[reason].increment();
     }
 
     pub fn get_fresh_packets(&mut self, n: usize, dest: &mut Vec<Packet>) -> usize {
@@ -142,7 +142,7 @@ impl FastpathWorker {
 
         // Read, but do not remove the ZPI header
         let Ok((zpi_hdr, _)) = zdp::ZdpZpiHeader::read_from_prefix(&pkt.body()) else {
-            self.drop_and_count(pkt, CounterType::BadStructure);
+            self.drop_and_count(pkt, FastpathCounterType::BadStructure);
             return;
         };
 
@@ -157,7 +157,7 @@ impl FastpathWorker {
 
         // now pop the ZPI off the packet. We've already checked it.
         if zdp::ZdpZpiHeader::read_from_buf(&mut pkt).is_err() {
-            self.drop_and_count(pkt, CounterType::BadStructure);
+            self.drop_and_count(pkt, FastpathCounterType::BadStructure);
             return;
         }
 
@@ -169,16 +169,16 @@ impl FastpathWorker {
                 interface_addr,
                 pkt,
             ) {
-                Ok(()) => self.batch_counters.increment(CounterType::DispatchedToMgmt),
+                Ok(()) => self.batch_counters[FastpathCounterType::DispatchedToMgmt].increment(),
                 Err(TryEnqueueError::Full(pkt)) => {
-                    self.drop_and_count(pkt, CounterType::QueueBackpressure)
+                    self.drop_and_count(pkt, FastpathCounterType::QueueBackpressure)
                 }
             }
             return;
         }
 
         let Ok(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(&mut pkt) else {
-            return self.drop_and_count(pkt, CounterType::BadStructure);
+            return self.drop_and_count(pkt, FastpathCounterType::BadStructure);
         };
 
         // In ZPI zero only KM messages are allowed (well, and ZPR ARP which we don't support yet)
@@ -190,7 +190,7 @@ impl FastpathWorker {
                 pkt.metadata().ingress_link_id,
                 base_hdr.packet_type
             );
-            self.drop_and_count(pkt, CounterType::OtherError);
+            self.drop_and_count(pkt, FastpathCounterType::OtherError);
             return;
         }
 
@@ -200,16 +200,16 @@ impl FastpathWorker {
             // (instead of this silly code to restore it?)
             *pkt.alloc_zeroed_header() = base_hdr;
             match self.mgmt_dispatch.try_dispatch_mgmt_packet_with_link(pkt) {
-                Ok(()) => self.batch_counters.increment(CounterType::DispatchedToMgmt),
+                Ok(()) => self.batch_counters[FastpathCounterType::DispatchedToMgmt].increment(),
                 Err(TryEnqueueError::Full(pkt)) => {
-                    self.drop_and_count(pkt, CounterType::QueueBackpressure)
+                    self.drop_and_count(pkt, FastpathCounterType::QueueBackpressure)
                 }
             }
             return;
         }
 
         let Ok(per_flow_hdr) = zdp::ZdpPerFlowHeader::read_from_buf(&mut pkt) else {
-            return self.drop_and_count(pkt, CounterType::BadStructure);
+            return self.drop_and_count(pkt, FastpathCounterType::BadStructure);
         };
 
         let ingress_stream_id: zpr::StreamId = per_flow_hdr.stream_id.into();
@@ -227,8 +227,7 @@ impl FastpathWorker {
             self.worker_index,
         ) {
             if old_index != self.worker_index {
-                self.batch_counters
-                    .increment(CounterType::ActorPacketsOutOfOrder);
+                self.batch_counters[FastpathCounterType::ActorPacketsOutOfOrder].increment();
             }
         }
 
@@ -245,7 +244,7 @@ impl FastpathWorker {
         let classification = match classifier::classify(&mut pkt) {
             Ok(cls) => cls,
             Err(_why) => {
-                self.drop_and_count(pkt, CounterType::InPacksDrop);
+                self.drop_and_count(pkt, FastpathCounterType::InPacksDrop);
                 return;
             }
         };
@@ -255,13 +254,13 @@ impl FastpathWorker {
 
             ClassifierResult::FirstFragment | ClassifierResult::SubsequentFragment => {
                 // TODO: handle fragments!
-                self.drop_and_count(pkt, CounterType::InPacksDrop);
+                self.drop_and_count(pkt, FastpathCounterType::InPacksDrop);
                 return;
             }
 
             ClassifierResult::NonIP => {
                 // should never happen; TUN doesn't deal in non-IP
-                self.drop_and_count(pkt, CounterType::InPacksDrop);
+                self.drop_and_count(pkt, FastpathCounterType::InPacksDrop);
                 return;
             }
         }
@@ -269,7 +268,7 @@ impl FastpathWorker {
         let ttl_expired = decrement_ttl(&mut pkt);
         if ttl_expired == true {
             error!(target: DATAPATH,"Packet dropped becuase TTL reached 0");
-            self.drop_and_count(pkt, CounterType::TtlExpired);
+            self.drop_and_count(pkt, FastpathCounterType::TtlExpired);
             return;
         }
 
@@ -291,15 +290,15 @@ impl FastpathWorker {
                 if !allow_bind_request {
                     // avoid the (all-but purely theoretical) chance of a packet loop,
                     // when this is initiated due to a requeue from bind setup code
-                    self.drop_and_count(pkt, CounterType::OtherError);
+                    self.drop_and_count(pkt, FastpathCounterType::OtherError);
                     return;
                 }
 
                 // issue bind request
                 match self.adapter_manager.try_request_tether_id(pkt) {
-                    Ok(()) => self.batch_counters.increment(CounterType::ActorSlowpath),
+                    Ok(()) => self.batch_counters[FastpathCounterType::ActorSlowpath].increment(),
                     Err(TryEnqueueError::Full(pkt)) => {
-                        self.drop_and_count(pkt, CounterType::QueueBackpressure)
+                        self.drop_and_count(pkt, FastpathCounterType::QueueBackpressure)
                     }
                 }
 
@@ -346,7 +345,7 @@ impl FastpathWorker {
             self.forward(pkt);
         } else {
             // Bind request pending; drop this packet
-            self.drop_and_count(pkt, CounterType::DroppedAwaitingBind);
+            self.drop_and_count(pkt, FastpathCounterType::DroppedAwaitingBind);
         }
     }
 
@@ -365,13 +364,13 @@ impl FastpathWorker {
                 let Some(ingress_peer_state) =
                     self.asm.peer_table.get(pkt.metadata().ingress_link_id)
                 else {
-                    self.drop_and_count(pkt, CounterType::UnknownPeer);
+                    self.drop_and_count(pkt, FastpathCounterType::UnknownPeer);
                     return;
                 };
 
                 let Some(pep) = ingress_peer_state.pft.get(pkt.metadata().ingress_stream_id) else {
                     drop(ingress_peer_state);
-                    self.drop_and_count(pkt, CounterType::UnknownStreamId);
+                    self.drop_and_count(pkt, FastpathCounterType::UnknownStreamId);
                     return;
                 };
 
@@ -406,7 +405,7 @@ impl FastpathWorker {
     ) {
         // extract A2A MAC
         let Ok(a2a_hdr) = zdp::ZdpA2aHeader::read_from_buf(&mut pkt) else {
-            self.drop_and_count(pkt, CounterType::BadStructure);
+            self.drop_and_count(pkt, FastpathCounterType::BadStructure);
             return;
         };
 
@@ -417,7 +416,7 @@ impl FastpathWorker {
         let a2a_mac_size = zdp::ZDP_A2A_MAC_SIZE; // TODO: checksum may be shorter depending on A2A SA
 
         if pkt.body().len() < a2a_mac_size {
-            self.drop_and_count(pkt, CounterType::BadStructure);
+            self.drop_and_count(pkt, FastpathCounterType::BadStructure);
             return;
         }
         let mut a2a_mac = [0u8; zdp::ZDP_A2A_MAC_SIZE];
@@ -426,7 +425,7 @@ impl FastpathWorker {
 
         // lookup PEP in DLT and expand compressed packet
         let Some(pep) = self.asm.dlt.get(tether_id) else {
-            self.drop_and_count(pkt, CounterType::UnknownStreamId);
+            self.drop_and_count(pkt, FastpathCounterType::UnknownStreamId);
             return;
         };
 
@@ -436,7 +435,7 @@ impl FastpathWorker {
         // TODO: use actual A2A SAID & keyed hash
         if blake3::hash(pkt.body()).as_bytes()[..a2a_mac_size] != a2a_mac[..a2a_mac_size] {
             drop(pep);
-            return self.drop_and_count(pkt, CounterType::MicvFailure);
+            return self.drop_and_count(pkt, FastpathCounterType::MicvFailure);
         }
 
         // queue decapsulated packet for send to actor
@@ -451,12 +450,12 @@ impl FastpathWorker {
         let (dest_sa, src_intf) = match substrate_egress_common(&self.asm, link_id, &mut pkt) {
             Ok(Some((dest_sa, src_intf))) => (dest_sa, src_intf),
             Ok(None) => {
-                self.drop_and_count(pkt, CounterType::PeerRemoved);
+                self.drop_and_count(pkt, FastpathCounterType::PeerRemoved);
                 return;
             }
             Err(err) => {
                 error!(target: DATAPATH, "egress: link {link_id}: encryption error: {err}");
-                self.drop_and_count(pkt, CounterType::EncryptionFailure);
+                self.drop_and_count(pkt, FastpathCounterType::EncryptionFailure);
                 return;
             }
         };
@@ -474,8 +473,8 @@ impl FastpathWorker {
     }
 
     pub fn aggregate(&mut self) {
-        self.asm.counters.aggregate(&self.batch_counters);
-        self.batch_counters.clear()
+        self.asm.counters.fastpath.aggregate(&self.batch_counters);
+        self.batch_counters.clear();
     }
 }
 
@@ -543,15 +542,15 @@ pub fn maybe_capture_batch<'a>(
 
     match dir {
         Direction::Inbound => {
-            asm.counters[CounterType::InCapPacksWrite].increase_by(num_captured as u64);
-            asm.counters[CounterType::InCapPacksDrop].increase_by(num_dropped as u64);
-            asm.counters[CounterType::InCapPacksFilt].increase_by(num_filtered as u64);
+            asm.counters.fastpath[FastpathCounterType::InCapPacksWrite].increase_by(num_captured as u64);
+            asm.counters.fastpath[FastpathCounterType::InCapPacksDrop].increase_by(num_dropped as u64);
+            asm.counters.fastpath[FastpathCounterType::InCapPacksFilt].increase_by(num_filtered as u64);
         }
 
         Direction::Outbound => {
-            asm.counters[CounterType::OutCapPacksWrite].increase_by(num_captured as u64);
-            asm.counters[CounterType::OutCapPacksDrop].increase_by(num_dropped as u64);
-            asm.counters[CounterType::OutCapPacksFilt].increase_by(num_filtered as u64);
+            asm.counters.fastpath[FastpathCounterType::OutCapPacksWrite].increase_by(num_captured as u64);
+            asm.counters.fastpath[FastpathCounterType::OutCapPacksDrop].increase_by(num_dropped as u64);
+            asm.counters.fastpath[FastpathCounterType::OutCapPacksFilt].increase_by(num_filtered as u64);
         }
     }
 }
@@ -606,7 +605,7 @@ enum DecryptError {
     BadChecksum,
 }
 
-impl From<DecryptError> for CounterType {
+impl From<DecryptError> for FastpathCounterType {
     fn from(value: DecryptError) -> Self {
         match value {
             DecryptError::BadStructure => Self::BadStructure,

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -88,6 +88,7 @@ impl FastpathWorker {
         let adapter_manager = asm.adapter_manager_factory.make(&return_q);
         let mgmt_dispatch = asm.mgmt_dispatch_factory.make(&return_q);
         let batch_counters = Default::default();
+        asm.counters.fastpaths.lock().unwrap().push(FastpathCounters::default());
 
         Self {
             config,
@@ -153,7 +154,7 @@ impl FastpathWorker {
         }
 
         // Watch out -- may not be secure
-        maybe_capture(&self.asm, Direction::Inbound, &mut pkt);
+        maybe_capture(&self.asm, Direction::Inbound, &mut pkt, &self.batch_counters);
 
         // now pop the ZPI off the packet. We've already checked it.
         if zdp::ZdpZpiHeader::read_from_buf(&mut pkt).is_err() {
@@ -447,7 +448,7 @@ impl FastpathWorker {
     pub fn substrate_egress(&mut self, mut pkt: Packet) {
         let link_id = pkt.metadata().egress_link_id;
 
-        let (dest_sa, src_intf) = match substrate_egress_common(&self.asm, link_id, &mut pkt) {
+        let (dest_sa, src_intf) = match substrate_egress_common(&self.asm, link_id, &mut pkt, &self.batch_counters) {
             Ok(Some((dest_sa, src_intf))) => (dest_sa, src_intf),
             Ok(None) => {
                 self.drop_and_count(pkt, FastpathCounterType::PeerRemoved);
@@ -473,7 +474,7 @@ impl FastpathWorker {
     }
 
     pub fn aggregate(&mut self) {
-        self.asm.counters.fastpath.aggregate(&self.batch_counters);
+        self.asm.counters.fastpaths.lock().unwrap()[self.worker_index].aggregate(&self.batch_counters);
         self.batch_counters.clear();
     }
 }
@@ -487,8 +488,8 @@ pub fn encap_zpi(_asm: &Assembly, _link_id: zpr::LinkId, zpi: zpr::Zpi, pkt: &mu
 /// The packet must be a complete ZDP message.
 /// Despite the &mut borrow, the packet will return materially unchanged.
 /// (It will have a link-layer header temporarily added to it.)
-pub fn maybe_capture(asm: &Assembly, dir: Direction, pkt: &mut Packet) {
-    maybe_capture_batch(asm, dir, [pkt])
+pub fn maybe_capture(asm: &Assembly, dir: Direction, pkt: &mut Packet, batch_counters: &FastpathCounters,) {
+    maybe_capture_batch(asm, dir, [pkt], batch_counters)
 }
 
 /// Batch packet capture.
@@ -496,6 +497,7 @@ pub fn maybe_capture_batch<'a>(
     asm: &'a Assembly,
     dir: Direction,
     pkts: impl IntoIterator<Item = &'a mut Packet>,
+    batch_counters: &FastpathCounters,
 ) {
     if !asm.flow_control.program_exists() {
         return;
@@ -542,20 +544,20 @@ pub fn maybe_capture_batch<'a>(
 
     match dir {
         Direction::Inbound => {
-            asm.counters.fastpath[FastpathCounterType::InCapPacksWrite]
+            batch_counters[FastpathCounterType::InCapPacksWrite]
                 .increase_by(num_captured as u64);
-            asm.counters.fastpath[FastpathCounterType::InCapPacksDrop]
+            batch_counters[FastpathCounterType::InCapPacksDrop]
                 .increase_by(num_dropped as u64);
-            asm.counters.fastpath[FastpathCounterType::InCapPacksFilt]
+            batch_counters[FastpathCounterType::InCapPacksFilt]
                 .increase_by(num_filtered as u64);
         }
 
         Direction::Outbound => {
-            asm.counters.fastpath[FastpathCounterType::OutCapPacksWrite]
+            batch_counters[FastpathCounterType::OutCapPacksWrite]
                 .increase_by(num_captured as u64);
-            asm.counters.fastpath[FastpathCounterType::OutCapPacksDrop]
+            batch_counters[FastpathCounterType::OutCapPacksDrop]
                 .increase_by(num_dropped as u64);
-            asm.counters.fastpath[FastpathCounterType::OutCapPacksFilt]
+            batch_counters[FastpathCounterType::OutCapPacksFilt]
                 .increase_by(num_filtered as u64);
         }
     }
@@ -769,6 +771,7 @@ fn substrate_egress_common(
     asm: &Assembly,
     link_id: zpr::LinkId,
     pkt: &mut Packet,
+    batch_counters: &FastpathCounters,
 ) -> Result<Option<(zpr::SubstrateAddr, net_defs::ScopedIpAddr)>, km::EncryptionError> {
     // TODO: should we add ZDP header here also??
 
@@ -819,7 +822,7 @@ fn substrate_egress_common(
     }
 
     encap_zpi(asm, link_id, real_zpi, pkt);
-    maybe_capture(asm, Direction::Outbound, pkt);
+    maybe_capture(asm, Direction::Outbound, pkt, batch_counters);
 
     match transport_sa {
         Some(ref transport_sa) => {

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -8,7 +8,7 @@ use crate::assembly::{Assembly, PhMode};
 use crate::batch_io::BatchIoEngine;
 use crate::classifier::{self, ClassifierResult};
 use crate::config;
-use crate::counters::{Aggregate, CounterType, Counters};
+use crate::counters::{Aggregate, BatchCounters, CounterType, Counters, Increment};
 use crate::defs::Direction;
 use crate::km::{Codec, KmTransportSA};
 use crate::km_noise::NOISE_PADLEN;
@@ -69,7 +69,7 @@ pub struct FastpathWorker {
     pub worker_index: usize,
     pub asm: Arc<Assembly>,
     pub buffers: Vec<PacketBuffer>,
-    pub batch_counters: Counters,
+    pub batch_counters: BatchCounters,
 
     pub return_q: two_way_queue::ReturnQueue<PacketBuffer>,
     pub adapter_manager: AdapterManager,
@@ -110,7 +110,7 @@ impl FastpathWorker {
         let reason = reason.into();
         debug!(target: DATAPATH, "dropping packet because {reason}");
         self.buffers.push(pkt.destroy());
-        self.batch_counters[reason].increment();
+        self.batch_counters.increment(reason);
     }
 
     pub fn get_fresh_packets(&mut self, n: usize, dest: &mut Vec<Packet>) -> usize {
@@ -169,7 +169,7 @@ impl FastpathWorker {
                 interface_addr,
                 pkt,
             ) {
-                Ok(()) => self.batch_counters[CounterType::DispatchedToMgmt].increment(),
+                Ok(()) => self.batch_counters.increment(CounterType::DispatchedToMgmt),
                 Err(TryEnqueueError::Full(pkt)) => {
                     self.drop_and_count(pkt, CounterType::QueueBackpressure)
                 }
@@ -200,7 +200,7 @@ impl FastpathWorker {
             // (instead of this silly code to restore it?)
             *pkt.alloc_zeroed_header() = base_hdr;
             match self.mgmt_dispatch.try_dispatch_mgmt_packet_with_link(pkt) {
-                Ok(()) => self.batch_counters[CounterType::DispatchedToMgmt].increment(),
+                Ok(()) => self.batch_counters.increment(CounterType::DispatchedToMgmt),
                 Err(TryEnqueueError::Full(pkt)) => {
                     self.drop_and_count(pkt, CounterType::QueueBackpressure)
                 }
@@ -227,7 +227,8 @@ impl FastpathWorker {
             self.worker_index,
         ) {
             if old_index != self.worker_index {
-                self.batch_counters[CounterType::ActorPacketsOutOfOrder].increment();
+                self.batch_counters
+                    .increment(CounterType::ActorPacketsOutOfOrder);
             }
         }
 
@@ -296,7 +297,7 @@ impl FastpathWorker {
 
                 // issue bind request
                 match self.adapter_manager.try_request_tether_id(pkt) {
-                    Ok(()) => self.batch_counters[CounterType::ActorSlowpath].increment(),
+                    Ok(()) => self.batch_counters.increment(CounterType::ActorSlowpath),
                     Err(TryEnqueueError::Full(pkt)) => {
                         self.drop_and_count(pkt, CounterType::QueueBackpressure)
                     }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -88,7 +88,11 @@ impl FastpathWorker {
         let adapter_manager = asm.adapter_manager_factory.make(&return_q);
         let mgmt_dispatch = asm.mgmt_dispatch_factory.make(&return_q);
         let batch_counters = Default::default();
-        asm.counters.fastpaths.lock().unwrap().push(FastpathCounters::default());
+        asm.counters
+            .fastpaths
+            .lock()
+            .unwrap()
+            .push(FastpathCounters::default());
 
         Self {
             config,
@@ -154,7 +158,12 @@ impl FastpathWorker {
         }
 
         // Watch out -- may not be secure
-        maybe_capture(&self.asm, Direction::Inbound, &mut pkt, &self.batch_counters);
+        maybe_capture(
+            &self.asm,
+            Direction::Inbound,
+            &mut pkt,
+            &self.batch_counters,
+        );
 
         // now pop the ZPI off the packet. We've already checked it.
         if zdp::ZdpZpiHeader::read_from_buf(&mut pkt).is_err() {
@@ -448,18 +457,19 @@ impl FastpathWorker {
     pub fn substrate_egress(&mut self, mut pkt: Packet) {
         let link_id = pkt.metadata().egress_link_id;
 
-        let (dest_sa, src_intf) = match substrate_egress_common(&self.asm, link_id, &mut pkt, &self.batch_counters) {
-            Ok(Some((dest_sa, src_intf))) => (dest_sa, src_intf),
-            Ok(None) => {
-                self.drop_and_count(pkt, FastpathCounterType::PeerRemoved);
-                return;
-            }
-            Err(err) => {
-                error!(target: DATAPATH, "egress: link {link_id}: encryption error: {err}");
-                self.drop_and_count(pkt, FastpathCounterType::EncryptionFailure);
-                return;
-            }
-        };
+        let (dest_sa, src_intf) =
+            match substrate_egress_common(&self.asm, link_id, &mut pkt, &self.batch_counters) {
+                Ok(Some((dest_sa, src_intf))) => (dest_sa, src_intf),
+                Ok(None) => {
+                    self.drop_and_count(pkt, FastpathCounterType::PeerRemoved);
+                    return;
+                }
+                Err(err) => {
+                    error!(target: DATAPATH, "egress: link {link_id}: encryption error: {err}");
+                    self.drop_and_count(pkt, FastpathCounterType::EncryptionFailure);
+                    return;
+                }
+            };
 
         // queue packet for send via substrate
         self.substrate_egress_q.push(QueuedEgressPacket {
@@ -474,7 +484,8 @@ impl FastpathWorker {
     }
 
     pub fn aggregate(&mut self) {
-        self.asm.counters.fastpaths.lock().unwrap()[self.worker_index].aggregate(&self.batch_counters);
+        self.asm.counters.fastpaths.lock().unwrap()[self.worker_index]
+            .aggregate(&self.batch_counters);
         self.batch_counters.clear();
     }
 }
@@ -488,7 +499,12 @@ pub fn encap_zpi(_asm: &Assembly, _link_id: zpr::LinkId, zpi: zpr::Zpi, pkt: &mu
 /// The packet must be a complete ZDP message.
 /// Despite the &mut borrow, the packet will return materially unchanged.
 /// (It will have a link-layer header temporarily added to it.)
-pub fn maybe_capture(asm: &Assembly, dir: Direction, pkt: &mut Packet, batch_counters: &FastpathCounters,) {
+pub fn maybe_capture(
+    asm: &Assembly,
+    dir: Direction,
+    pkt: &mut Packet,
+    batch_counters: &FastpathCounters,
+) {
     maybe_capture_batch(asm, dir, [pkt], batch_counters)
 }
 
@@ -544,21 +560,15 @@ pub fn maybe_capture_batch<'a>(
 
     match dir {
         Direction::Inbound => {
-            batch_counters[FastpathCounterType::InCapPacksWrite]
-                .increase_by(num_captured as u64);
-            batch_counters[FastpathCounterType::InCapPacksDrop]
-                .increase_by(num_dropped as u64);
-            batch_counters[FastpathCounterType::InCapPacksFilt]
-                .increase_by(num_filtered as u64);
+            batch_counters[FastpathCounterType::InCapPacksWrite].increase_by(num_captured as u64);
+            batch_counters[FastpathCounterType::InCapPacksDrop].increase_by(num_dropped as u64);
+            batch_counters[FastpathCounterType::InCapPacksFilt].increase_by(num_filtered as u64);
         }
 
         Direction::Outbound => {
-            batch_counters[FastpathCounterType::OutCapPacksWrite]
-                .increase_by(num_captured as u64);
-            batch_counters[FastpathCounterType::OutCapPacksDrop]
-                .increase_by(num_dropped as u64);
-            batch_counters[FastpathCounterType::OutCapPacksFilt]
-                .increase_by(num_filtered as u64);
+            batch_counters[FastpathCounterType::OutCapPacksWrite].increase_by(num_captured as u64);
+            batch_counters[FastpathCounterType::OutCapPacksDrop].increase_by(num_dropped as u64);
+            batch_counters[FastpathCounterType::OutCapPacksFilt].increase_by(num_filtered as u64);
         }
     }
 }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -8,7 +8,7 @@ use crate::assembly::{Assembly, PhMode};
 use crate::batch_io::BatchIoEngine;
 use crate::classifier::{self, ClassifierResult};
 use crate::config;
-use crate::counters::{Aggregate, BatchCounters, CounterType, Counters, Increment};
+use crate::counters::{Aggregate, BatchCounters, CounterType, Increment};
 use crate::defs::Direction;
 use crate::km::{Codec, KmTransportSA};
 use crate::km_noise::NOISE_PADLEN;

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -8,7 +8,7 @@ use crate::assembly::{Assembly, PhMode};
 use crate::batch_io::BatchIoEngine;
 use crate::classifier::{self, ClassifierResult};
 use crate::config;
-use crate::counters::{FastpathCounters, FastpathCounterType, Aggregate};
+use crate::counters::{Aggregate, FastpathCounterType, FastpathCounters};
 use crate::defs::Direction;
 use crate::km::{Codec, KmTransportSA};
 use crate::km_noise::NOISE_PADLEN;
@@ -542,15 +542,21 @@ pub fn maybe_capture_batch<'a>(
 
     match dir {
         Direction::Inbound => {
-            asm.counters.fastpath[FastpathCounterType::InCapPacksWrite].increase_by(num_captured as u64);
-            asm.counters.fastpath[FastpathCounterType::InCapPacksDrop].increase_by(num_dropped as u64);
-            asm.counters.fastpath[FastpathCounterType::InCapPacksFilt].increase_by(num_filtered as u64);
+            asm.counters.fastpath[FastpathCounterType::InCapPacksWrite]
+                .increase_by(num_captured as u64);
+            asm.counters.fastpath[FastpathCounterType::InCapPacksDrop]
+                .increase_by(num_dropped as u64);
+            asm.counters.fastpath[FastpathCounterType::InCapPacksFilt]
+                .increase_by(num_filtered as u64);
         }
 
         Direction::Outbound => {
-            asm.counters.fastpath[FastpathCounterType::OutCapPacksWrite].increase_by(num_captured as u64);
-            asm.counters.fastpath[FastpathCounterType::OutCapPacksDrop].increase_by(num_dropped as u64);
-            asm.counters.fastpath[FastpathCounterType::OutCapPacksFilt].increase_by(num_filtered as u64);
+            asm.counters.fastpath[FastpathCounterType::OutCapPacksWrite]
+                .increase_by(num_captured as u64);
+            asm.counters.fastpath[FastpathCounterType::OutCapPacksDrop]
+                .increase_by(num_dropped as u64);
+            asm.counters.fastpath[FastpathCounterType::OutCapPacksFilt]
+                .increase_by(num_filtered as u64);
         }
     }
 }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -8,7 +8,7 @@ use crate::assembly::{Assembly, PhMode};
 use crate::batch_io::BatchIoEngine;
 use crate::classifier::{self, ClassifierResult};
 use crate::config;
-use crate::counters::CounterType;
+use crate::counters::{Aggregate, CounterType, Counters};
 use crate::defs::Direction;
 use crate::km::{Codec, KmTransportSA};
 use crate::km_noise::NOISE_PADLEN;
@@ -69,6 +69,7 @@ pub struct FastpathWorker {
     pub worker_index: usize,
     pub asm: Arc<Assembly>,
     pub buffers: Vec<PacketBuffer>,
+    pub batch_counters: Counters,
 
     pub return_q: two_way_queue::ReturnQueue<PacketBuffer>,
     pub adapter_manager: AdapterManager,
@@ -86,12 +87,14 @@ impl FastpathWorker {
         let return_q = two_way_queue::ReturnQueue::new();
         let adapter_manager = asm.adapter_manager_factory.make(&return_q);
         let mgmt_dispatch = asm.mgmt_dispatch_factory.make(&return_q);
+        let batch_counters = Default::default();
 
         Self {
             config,
             worker_index,
             asm,
             buffers,
+            batch_counters,
 
             return_q,
             adapter_manager,
@@ -107,7 +110,7 @@ impl FastpathWorker {
         let reason = reason.into();
         debug!(target: DATAPATH, "dropping packet because {reason}");
         self.buffers.push(pkt.destroy());
-        self.asm.counters[reason].increment();
+        self.batch_counters[reason].increment();
     }
 
     pub fn get_fresh_packets(&mut self, n: usize, dest: &mut Vec<Packet>) -> usize {
@@ -166,7 +169,7 @@ impl FastpathWorker {
                 interface_addr,
                 pkt,
             ) {
-                Ok(()) => self.asm.counters[CounterType::DispatchedToMgmt].increment(),
+                Ok(()) => self.batch_counters[CounterType::DispatchedToMgmt].increment(),
                 Err(TryEnqueueError::Full(pkt)) => {
                     self.drop_and_count(pkt, CounterType::QueueBackpressure)
                 }
@@ -197,7 +200,7 @@ impl FastpathWorker {
             // (instead of this silly code to restore it?)
             *pkt.alloc_zeroed_header() = base_hdr;
             match self.mgmt_dispatch.try_dispatch_mgmt_packet_with_link(pkt) {
-                Ok(()) => self.asm.counters[CounterType::DispatchedToMgmt].increment(),
+                Ok(()) => self.batch_counters[CounterType::DispatchedToMgmt].increment(),
                 Err(TryEnqueueError::Full(pkt)) => {
                     self.drop_and_count(pkt, CounterType::QueueBackpressure)
                 }
@@ -224,7 +227,7 @@ impl FastpathWorker {
             self.worker_index,
         ) {
             if old_index != self.worker_index {
-                self.asm.counters[CounterType::ActorPacketsOutOfOrder].increment();
+                self.batch_counters[CounterType::ActorPacketsOutOfOrder].increment();
             }
         }
 
@@ -293,7 +296,7 @@ impl FastpathWorker {
 
                 // issue bind request
                 match self.adapter_manager.try_request_tether_id(pkt) {
-                    Ok(()) => self.asm.counters[CounterType::ActorSlowpath].increment(),
+                    Ok(()) => self.batch_counters[CounterType::ActorSlowpath].increment(),
                     Err(TryEnqueueError::Full(pkt)) => {
                         self.drop_and_count(pkt, CounterType::QueueBackpressure)
                     }
@@ -467,6 +470,11 @@ impl FastpathWorker {
 
     pub fn substrate_egress_packets_queued(&self) -> bool {
         !self.substrate_egress_q.is_empty()
+    }
+
+    pub fn aggregate(&mut self) {
+        self.asm.counters.aggregate(&self.batch_counters);
+        self.batch_counters.clear()
     }
 }
 

--- a/adapter/ph/src/fastpath_io.rs
+++ b/adapter/ph/src/fastpath_io.rs
@@ -137,7 +137,7 @@ impl FastpathIo {
             // we do not want -- only the 5-tuple.  So clear it.
             clear_flowinfo(&mut sender);
 
-            worker.asm.counters.fastpath[FastpathCounterType::InPacksRec].increment();
+            worker.batch_counters[FastpathCounterType::InPacksRec].increment();
             worker.substrate_ingress(&sender, &dest, pkt);
         }
     }
@@ -195,7 +195,7 @@ impl FastpathIo {
                 }
             }
 
-            worker.asm.counters.fastpath[FastpathCounterType::OutPacksRec].increment();
+            worker.batch_counters[FastpathCounterType::OutPacksRec].increment();
             worker.actor_output(pkt);
         }
     }
@@ -207,7 +207,7 @@ impl FastpathIo {
             &mut self.requeue_outq,
             worker.config.batch_size,
             |worker, pkt| {
-                worker.asm.counters.fastpath[FastpathCounterType::RequeuedPacketsReceived]
+                worker.batch_counters[FastpathCounterType::RequeuedPacketsReceived]
                     .increment();
                 worker.actor_output_post_classify(pkt, /* allow_bind_request */ false);
             },
@@ -221,7 +221,7 @@ impl FastpathIo {
             &mut self.mgmt_substrate_outq,
             worker.config.batch_size,
             |worker, pkt| {
-                worker.asm.counters.fastpath[FastpathCounterType::MgmtPacketsSent].increment();
+                worker.batch_counters[FastpathCounterType::MgmtPacketsSent].increment();
                 worker.substrate_egress(pkt);
             },
         );
@@ -276,9 +276,9 @@ impl FastpathIo {
                 Err(err) => panic!("unrecoverable TUN error: {}", err),
             }
         }
-        worker.asm.counters.fastpath[FastpathCounterType::InPacksSent]
+        worker.batch_counters[FastpathCounterType::InPacksSent]
             .increase_by((worker.actor_input_q.len() - dropped) as u64);
-        worker.asm.counters.fastpath[FastpathCounterType::InPacksDrop].increase_by(dropped as u64);
+        worker.batch_counters[FastpathCounterType::InPacksDrop].increase_by(dropped as u64);
 
         // Return buffers to buffer stack.
         worker
@@ -334,9 +334,9 @@ impl FastpathIo {
 
         // Now all un-sent priority packets are at the head of the queue.
 
-        worker.asm.counters.fastpath[FastpathCounterType::OutPacksSent]
+        worker.batch_counters[FastpathCounterType::OutPacksSent]
             .increase_by((worker.substrate_egress_q.len() - dropped - retained) as u64);
-        worker.asm.counters.fastpath[FastpathCounterType::OutPacksDrop].increase_by(dropped as u64);
+        worker.batch_counters[FastpathCounterType::OutPacksDrop].increase_by(dropped as u64);
 
         // Return buffers to buffer stack, except for un-sent priority packets, which are retained for next time.
         worker.buffers.extend(

--- a/adapter/ph/src/fastpath_io.rs
+++ b/adapter/ph/src/fastpath_io.rs
@@ -104,7 +104,7 @@ impl FastpathIo {
         for (pkt, result) in self.packets.drain(..).zip(self.recv_results.drain(..)) {
             let (mut sender, dest) = match result {
                 Ok(res) if res.truncated => {
-                    worker.drop_and_count(pkt, CounterType::DroppedOversize);
+                    worker.drop_and_count(pkt, FastpathCounterType::DroppedOversize);
                     continue;
                 }
 
@@ -137,7 +137,7 @@ impl FastpathIo {
             // we do not want -- only the 5-tuple.  So clear it.
             clear_flowinfo(&mut sender);
 
-            worker.asm.counters[CounterType::InPacksRec].increment();
+            worker.asm.counters.fastpath[FastpathCounterType::InPacksRec].increment();
             worker.substrate_ingress(&sender, &dest, pkt);
         }
     }
@@ -184,18 +184,18 @@ impl FastpathIo {
                 let pi = TunPi::read_pi(&mut pkt);
                 if pi.strip || !is_ip(pi) {
                     // packet was too large or non-IP; drop
-                    worker.drop_and_count(pkt, CounterType::OutPacksDrop);
+                    worker.drop_and_count(pkt, FastpathCounterType::OutPacksDrop);
                     continue;
                 }
             } else {
                 // No packet info, permit IP and IPv6 only (for now?)
                 if pkt.body()[0] >> 4 != 4 && pkt.body()[0] >> 4 != 6 {
-                    worker.drop_and_count(pkt, CounterType::OutPacksDrop);
+                    worker.drop_and_count(pkt, FastpathCounterType::OutPacksDrop);
                     continue;
                 }
             }
 
-            worker.asm.counters[CounterType::OutPacksRec].increment();
+            worker.asm.counters.fastpath[FastpathCounterType::OutPacksRec].increment();
             worker.actor_output(pkt);
         }
     }
@@ -207,7 +207,7 @@ impl FastpathIo {
             &mut self.requeue_outq,
             worker.config.batch_size,
             |worker, pkt| {
-                worker.asm.counters[CounterType::RequeuedPacketsReceived].increment();
+                worker.asm.counters.fastpath[FastpathCounterType::RequeuedPacketsReceived].increment();
                 worker.actor_output_post_classify(pkt, /* allow_bind_request */ false);
             },
         );
@@ -220,7 +220,7 @@ impl FastpathIo {
             &mut self.mgmt_substrate_outq,
             worker.config.batch_size,
             |worker, pkt| {
-                worker.asm.counters[CounterType::MgmtPacketsSent].increment();
+                worker.asm.counters.fastpath[FastpathCounterType::MgmtPacketsSent].increment();
                 worker.substrate_egress(pkt);
             },
         );
@@ -275,9 +275,9 @@ impl FastpathIo {
                 Err(err) => panic!("unrecoverable TUN error: {}", err),
             }
         }
-        worker.asm.counters[CounterType::InPacksSent]
+        worker.asm.counters.fastpath[FastpathCounterType::InPacksSent]
             .increase_by((worker.actor_input_q.len() - dropped) as u64);
-        worker.asm.counters[CounterType::InPacksDrop].increase_by(dropped as u64);
+        worker.asm.counters.fastpath[FastpathCounterType::InPacksDrop].increase_by(dropped as u64);
 
         // Return buffers to buffer stack.
         worker
@@ -333,9 +333,9 @@ impl FastpathIo {
 
         // Now all un-sent priority packets are at the head of the queue.
 
-        worker.asm.counters[CounterType::OutPacksSent]
+        worker.asm.counters.fastpath[FastpathCounterType::OutPacksSent]
             .increase_by((worker.substrate_egress_q.len() - dropped - retained) as u64);
-        worker.asm.counters[CounterType::OutPacksDrop].increase_by(dropped as u64);
+        worker.asm.counters.fastpath[FastpathCounterType::OutPacksDrop].increase_by(dropped as u64);
 
         // Return buffers to buffer stack, except for un-sent priority packets, which are retained for next time.
         worker.buffers.extend(

--- a/adapter/ph/src/fastpath_io.rs
+++ b/adapter/ph/src/fastpath_io.rs
@@ -207,7 +207,8 @@ impl FastpathIo {
             &mut self.requeue_outq,
             worker.config.batch_size,
             |worker, pkt| {
-                worker.asm.counters.fastpath[FastpathCounterType::RequeuedPacketsReceived].increment();
+                worker.asm.counters.fastpath[FastpathCounterType::RequeuedPacketsReceived]
+                    .increment();
                 worker.actor_output_post_classify(pkt, /* allow_bind_request */ false);
             },
         );

--- a/adapter/ph/src/fastpath_io.rs
+++ b/adapter/ph/src/fastpath_io.rs
@@ -207,8 +207,7 @@ impl FastpathIo {
             &mut self.requeue_outq,
             worker.config.batch_size,
             |worker, pkt| {
-                worker.batch_counters[FastpathCounterType::RequeuedPacketsReceived]
-                    .increment();
+                worker.batch_counters[FastpathCounterType::RequeuedPacketsReceived].increment();
                 worker.actor_output_post_classify(pkt, /* allow_bind_request */ false);
             },
         );

--- a/adapter/ph/src/fastpath_worker.rs
+++ b/adapter/ph/src/fastpath_worker.rs
@@ -172,7 +172,6 @@ fn fastpath_main(mut worker: FastpathWorker, mut io: FastpathIo) {
             // read from socket
             io.process_substrate_socket_in(&mut worker);
         }
-
-        worker.aggregate();
+        worker.aggregate()
     }
 }

--- a/adapter/ph/src/fastpath_worker.rs
+++ b/adapter/ph/src/fastpath_worker.rs
@@ -172,5 +172,7 @@ fn fastpath_main(mut worker: FastpathWorker, mut io: FastpathIo) {
             // read from socket
             io.process_substrate_socket_in(&mut worker);
         }
+
+        worker.aggregate();
     }
 }

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1,7 +1,7 @@
 use crate::assembly::Assembly;
 use crate::auth::{self, DecodedBlob, ZdpAuthCodeBlob, ZdpSelfSignedBlob, AUTH_KEY_SIZE_BYTES};
 use crate::config;
-use crate::counters::CounterType;
+use crate::counters::ManagementCounterType;
 use crate::km::ZPIPair;
 use crate::km_multiplexor;
 use crate::logging::targets::LINK_STATE;
@@ -1405,7 +1405,7 @@ impl LinkStateWrapper {
 
     fn process_error_response(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
         let link_id = self.id;
-        asm.counters[CounterType::PeerHandshakeFailure].increment();
+        asm.counters.management[ManagementCounterType::PeerHandshakeFailure].increment();
         warn!(target: LINK_STATE, "Link {link_id} bringup failed at state {:?}",
             self.locked_fsm.lock().unwrap().state);
 
@@ -1700,7 +1700,7 @@ impl LinkStateWrapper {
         let link_id = self.id;
         let task_asm = asm.clone();
         let task_events = self.events.clone();
-        asm.counters[CounterType::PeerHandshakeSuccess].increment();
+        asm.counters.management[ManagementCounterType::PeerHandshakeSuccess].increment();
         debug!(target: LINK_STATE, "Link {link_id} entering active state");
         tokio::task::spawn_local(async move {
             let mut interval = tokio::time::interval(config::DEFAULT_KEEP_ALIVE_PERIOD);

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -5,7 +5,7 @@
 
 use crate::assembly::Assembly;
 use crate::config;
-use crate::counters::CounterType;
+use crate::counters::ManagementCounterType;
 use crate::packet::Packet;
 use crate::seq_nums;
 use crate::zdp;
@@ -26,10 +26,10 @@ pub fn new_heap_packet() -> Packet {
 pub fn count_event(
     asm: &Assembly,
     _pkt: &mut Packet, // for later support of per-packet event recording
-    event: CounterType,
+    event: ManagementCounterType,
 ) {
     debug!(target: crate::logging::targets::MGMT_EVENTS, "packet event {event}");
-    asm.counters[event].increment();
+    asm.counters.management[event].increment();
 }
 
 /// Send a unidirectional non-flow management message on the given link.
@@ -220,7 +220,7 @@ fn match_received(
     match response {
         Some((pkt_type, mut pkt)) => {
             if pkt_type != zdp_response_type {
-                count_event(asm, &mut pkt, CounterType::BadMgmtResponse);
+                count_event(asm, &mut pkt, ManagementCounterType::BadMgmtResponse);
                 return Err(SyncReqError::ProtocolError);
             }
             return Ok(pkt);

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -2,7 +2,7 @@
 
 use super::core;
 use crate::assembly::Assembly;
-use crate::counters::CounterType;
+use crate::counters::ManagementCounterType;
 use crate::km_multiplexor;
 use crate::link_state::LinkType;
 use crate::logging::targets::{KEY_MGMT, ZDP};
@@ -37,7 +37,7 @@ pub fn dispatch_mgmt_packet_with_addr(
                 .start_tether(&peer_sa, &interface_addr, LinkType::NodeToAdapter)
                 .ok()
             else {
-                core::count_event(asm, pkt, CounterType::UnknownPeer);
+                core::count_event(asm, pkt, ManagementCounterType::UnknownPeer);
                 return;
             };
 
@@ -46,7 +46,7 @@ pub fn dispatch_mgmt_packet_with_addr(
             handle_key_management(asm, pkt);
         }
         _ => {
-            core::count_event(asm, pkt, CounterType::UnknownPeer);
+            core::count_event(asm, pkt, ManagementCounterType::UnknownPeer);
             return;
         }
     }
@@ -67,7 +67,7 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
 
         _ => {
             let Some(peer_state) = asm.peer_table.get(pkt.metadata().ingress_link_id) else {
-                core::count_event(asm, pkt, CounterType::PeerRemoved);
+                core::count_event(asm, pkt, ManagementCounterType::PeerRemoved);
                 return;
             };
 
@@ -75,7 +75,7 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
             match peer_state.mgmt_processor.try_enqueue_packet(mgmt_pkt) {
                 Ok(()) => (),
                 Err(queues::TryEnqueueError::Full(_mgmt_pkt)) => {
-                    core::count_event(asm, pkt, CounterType::QueueBackpressure);
+                    core::count_event(asm, pkt, ManagementCounterType::QueueBackpressure);
                     return;
                 }
             }
@@ -85,7 +85,7 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
 
 fn handle_response(asm: &Assembly, pkt: &mut Packet) {
     let Ok(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(pkt) else {
-        core::count_event(asm, pkt, CounterType::BadStructure);
+        core::count_event(asm, pkt, ManagementCounterType::BadStructure);
         return;
     };
 
@@ -100,7 +100,7 @@ fn handle_response(asm: &Assembly, pkt: &mut Packet) {
     // Gets the designated sender, attempts to send the response, if not drops
     // the packet and increments corresponding counter
     let Some(peer_state) = asm.peer_table.get(pkt.metadata().ingress_link_id) else {
-        core::count_event(asm, pkt, CounterType::UnexpectedMgmtResponse);
+        core::count_event(asm, pkt, ManagementCounterType::UnexpectedMgmtResponse);
         return;
     };
 
@@ -111,7 +111,7 @@ fn handle_response(asm: &Assembly, pkt: &mut Packet) {
     {
         Ok(()) => (),
         Err(_mgmt_pkt) => {
-            core::count_event(asm, pkt, CounterType::UnexpectedMgmtResponse);
+            core::count_event(asm, pkt, ManagementCounterType::UnexpectedMgmtResponse);
             return;
         }
     }
@@ -122,7 +122,7 @@ fn handle_response(asm: &Assembly, pkt: &mut Packet) {
 fn handle_key_management(asm: &Arc<Assembly>, pkt: &mut Packet) {
     let Ok(km_hdr) = zdp::ZdpKeyManagementHeader::read_from_buf(pkt) else {
         error!(target: ZDP, "KeyManagement packet arrived with unparseable header");
-        core::count_event(asm, pkt, CounterType::BadStructure);
+        core::count_event(asm, pkt, ManagementCounterType::BadStructure);
         return;
     };
 
@@ -132,14 +132,14 @@ fn handle_key_management(asm: &Arc<Assembly>, pkt: &mut Packet) {
             "KeyManagement packet not using NOISE - type is {}",
             km_hdr.message_type
         );
-        core::count_event(asm, pkt, CounterType::OtherError);
+        core::count_event(asm, pkt, ManagementCounterType::OtherError);
         return;
     }
 
     let km_msg_len = usize::from(km_hdr.message_length);
     if pkt.remaining() < km_msg_len {
         error!(target: KEY_MGMT, "KeyManagement packet arrived with truncated payload");
-        core::count_event(asm, pkt, CounterType::BadStructure);
+        core::count_event(asm, pkt, ManagementCounterType::BadStructure);
         return;
     }
 
@@ -155,7 +155,7 @@ fn handle_key_management(asm: &Arc<Assembly>, pkt: &mut Packet) {
                 "key management handling failed on link {}: {e:?}",
                 pkt.metadata().ingress_link_id,
             );
-            core::count_event(asm, pkt, CounterType::OtherError);
+            core::count_event(asm, pkt, ManagementCounterType::OtherError);
             return;
         }
     };

--- a/adapter/ph/src/mgmt/dock.rs
+++ b/adapter/ph/src/mgmt/dock.rs
@@ -1,5 +1,5 @@
 use crate::assembly::{AddRouteError, Assembly};
-use crate::counters::CounterType;
+use crate::counters::ManagementCounterType;
 use crate::defs::FiveTuple;
 use crate::logging::targets::FLOW_MGMT;
 use crate::visa_mgmt;
@@ -62,7 +62,7 @@ pub async fn bind_actor_address(
                 );
             }
             Err(VisaTableError::ParseError(field)) => {
-                asm.counters[CounterType::VisaRequestError].increment();
+                asm.counters.management[ManagementCounterType::VisaRequestError].increment();
                 error!(target: FLOW_MGMT, "visa request matching error: {field}");
                 return Err(BindActorAddressError::ParseError(field));
             }
@@ -75,7 +75,7 @@ pub async fn bind_actor_address(
                 );
             }
             Err(VisaTableError::DestNotFound(addr)) => {
-                asm.counters[CounterType::VisaRequestError].increment();
+                asm.counters.management[ManagementCounterType::VisaRequestError].increment();
                 error!(target: FLOW_MGMT, "visa request matching error: destination address {addr} not found so no egress link");
                 return Err(BindActorAddressError::ParseError(
                     "destination address not found",
@@ -99,7 +99,7 @@ pub async fn bind_actor_address(
             packet: packet_body.clone(),
         };
 
-        asm.counters[CounterType::VisaRequested].increment();
+        asm.counters.management[ManagementCounterType::VisaRequested].increment();
         match asm.vsconn.as_ref().unwrap().request_visa(visa_req).await {
             Ok(vsapi::VisaResponse {
                 status: Some(vsapi::StatusCode::SUCCESS),
@@ -107,7 +107,7 @@ pub async fn bind_actor_address(
                 ..
             }) => {
                 let Some(visa) = visa else {
-                    asm.counters[CounterType::VisaRequestError].increment();
+                    asm.counters.management[ManagementCounterType::VisaRequestError].increment();
                     error!(target: FLOW_MGMT, "visa request error: Could not parse visa");
                     return Err(BindActorAddressError::ParseError("Could not parse visa"));
                 };
@@ -124,7 +124,7 @@ pub async fn bind_actor_address(
                     egress_link_id,
                     visa_id,
                 });
-                asm.counters[CounterType::VisaRequestSuccess].increment();
+                asm.counters.management[ManagementCounterType::VisaRequestSuccess].increment();
                 debug!(
                     target: FLOW_MGMT,
                     "visa request succeeds, egress_link_id = {egress_link_id}"
@@ -132,13 +132,13 @@ pub async fn bind_actor_address(
             }
 
             Ok(resp) => {
-                asm.counters[CounterType::VisaRequestDenied].increment();
+                asm.counters.management[ManagementCounterType::VisaRequestDenied].increment();
                 debug!(target: FLOW_MGMT, "visa request rejected: {resp:?}");
                 return Err(BindActorAddressError::PolicyError);
             }
 
             Err(err) => {
-                asm.counters[CounterType::VisaRequestError].increment();
+                asm.counters.management[ManagementCounterType::VisaRequestError].increment();
                 error!(target: FLOW_MGMT, "visa request error: {err}");
                 return Err(BindActorAddressError::PolicyError);
             }

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -37,7 +37,7 @@ pub enum HandleMgmtError {
     BadStructure,
 }
 
-impl From<HandleMgmtError> for counters::CounterType {
+impl From<HandleMgmtError> for counters::ManagementCounterType {
     fn from(err: HandleMgmtError) -> Self {
         match err {
             HandleMgmtError::UnknownType(_type) => Self::UnknownType,

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -5,7 +5,7 @@
 #![allow(dead_code)]
 
 use super::core;
-use crate::counters::CounterType;
+use crate::counters::ManagementCounterType;
 use crate::defs::*;
 use crate::logging::targets::ZDP;
 use crate::zdp;
@@ -291,7 +291,7 @@ pub async fn send_bind_actor_address_request(
     match response {
         Ok((tether_id, mut resp)) => {
             let Ok(hdr) = zdp::ZdpBindActorAddressResponseHeader::read_from_buf(&mut resp) else {
-                core::count_event(asm, &mut resp, CounterType::BadStructure);
+                core::count_event(asm, &mut resp, ManagementCounterType::BadStructure);
                 return Err(BindActorAddressError::BadStructure);
             };
 
@@ -300,12 +300,12 @@ pub async fn send_bind_actor_address_request(
 
                 zdp::ResponseCode::Other => {
                     if hdr.info_len as usize > resp.remaining() {
-                        core::count_event(asm, &mut resp, CounterType::BadStructure);
+                        core::count_event(asm, &mut resp, ManagementCounterType::BadStructure);
                         return Err(BindActorAddressError::BadStructure);
                     }
 
                     let Ok(msg) = std::str::from_utf8(&resp.body()[..hdr.info_len as usize]) else {
-                        core::count_event(asm, &mut resp, CounterType::BadStructure);
+                        core::count_event(asm, &mut resp, ManagementCounterType::BadStructure);
                         return Err(BindActorAddressError::BadStructure);
                     };
                     let msg: Box<str> = msg.into();
@@ -314,7 +314,7 @@ pub async fn send_bind_actor_address_request(
                 }
 
                 _ => {
-                    core::count_event(asm, &mut resp, CounterType::BadStructure);
+                    core::count_event(asm, &mut resp, ManagementCounterType::BadStructure);
                     Err(BindActorAddressError::BadStructure)
                 }
             }

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -1,5 +1,5 @@
 use crate::assembly::Assembly;
-use crate::counters::{CounterType, Counters};
+use crate::counters::{ManagementCounterType, ManagementCounters};
 use crate::link_state::LinkEvent;
 use crate::logging::targets::{LINK_STATE, ZDP};
 use crate::mgmt;
@@ -31,7 +31,7 @@ pub async fn launch(
                 // Drop packets which are intended for a link other than the one we are assigned to,
                 // since processing them here will violate concurrency assumptions.
                 if pkt.metadata().ingress_link_id != config.link_id.get() {
-                    mgmt::core::count_event(&asm, &mut pkt, CounterType::InternalRoutingError);
+                    mgmt::core::count_event(&asm, &mut pkt, ManagementCounterType::InternalRoutingError);
                     continue;
                 }
 
@@ -75,13 +75,13 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
         let maybe_seq_num;
         {
             let Some(peer_state) = asm.peer_table.get(pkt.metadata().ingress_link_id) else {
-                mgmt::core::count_event(asm, &mut pkt, CounterType::PeerRemoved);
+                mgmt::core::count_event(asm, &mut pkt, ManagementCounterType::PeerRemoved);
                 return Ok(());
             };
 
             let mut sn_track = peer_state.sn_track.lock().unwrap();
             maybe_seq_num = sn_track.process_seq_num(truncated_seq_num);
-            count_seq_num_tracker_stats(&asm.counters, &mut sn_track);
+            count_seq_num_tracker_stats(&asm.counters.management, &mut sn_track);
         }
 
         let Some(sn) = maybe_seq_num else {
@@ -199,19 +199,19 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
 }
 
 /// Maps a `SeqnumTrackerStat` to a `CounterType`.
-fn seq_num_tracker_stat_to_counter(sn_stat: SeqNumTrackerStat) -> CounterType {
+fn seq_num_tracker_stat_to_counter(sn_stat: SeqNumTrackerStat) -> ManagementCounterType {
     match sn_stat {
-        SeqNumTrackerStat::TooOld => CounterType::DroppedTooOld,
-        SeqNumTrackerStat::Duplicate => CounterType::DroppedDuplicate,
-        SeqNumTrackerStat::Lost => CounterType::LostPacket,
-        SeqNumTrackerStat::OutOfOrder => CounterType::OutOfOrderPacket,
+        SeqNumTrackerStat::TooOld => ManagementCounterType::DroppedTooOld,
+        SeqNumTrackerStat::Duplicate => ManagementCounterType::DroppedDuplicate,
+        SeqNumTrackerStat::Lost => ManagementCounterType::LostPacket,
+        SeqNumTrackerStat::OutOfOrder => ManagementCounterType::OutOfOrderPacket,
     }
 }
 
 /// Pulls stats delta from `SeqNumTracker` and feeds them into the global counters.
-fn count_seq_num_tracker_stats(counters: &Counters, sn_track: &mut SeqNumTracker) {
+fn count_seq_num_tracker_stats(mgmt_counters: &ManagementCounters, sn_track: &mut SeqNumTracker) {
     for stat in SeqNumTrackerStat::iter() {
-        counters[seq_num_tracker_stat_to_counter(stat)]
+        mgmt_counters[seq_num_tracker_stat_to_counter(stat)]
             .increase_by(sn_track.fetch_reset_stat(stat));
     }
 }

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -31,7 +31,11 @@ pub async fn launch(
                 // Drop packets which are intended for a link other than the one we are assigned to,
                 // since processing them here will violate concurrency assumptions.
                 if pkt.metadata().ingress_link_id != config.link_id.get() {
-                    mgmt::core::count_event(&asm, &mut pkt, ManagementCounterType::InternalRoutingError);
+                    mgmt::core::count_event(
+                        &asm,
+                        &mut pkt,
+                        ManagementCounterType::InternalRoutingError,
+                    );
                     continue;
                 }
 

--- a/adapter/ph/src/signal_worker.rs
+++ b/adapter/ph/src/signal_worker.rs
@@ -48,7 +48,10 @@ pub async fn launch(asm: Arc<Assembly>) {
 fn emit_counts(counters: &Counters, uptime: std::time::Duration) {
     println!("{:>42}\n", "*** Counters ***");
     println!("{:>34}: {:?}", "Uptime", uptime);
-    for (key, ref value) in counters {
+    for (key, ref value) in &counters.management {
+        println!("{:>34}: {}", key.name(), value.get_count());
+    }
+    for (key, ref value) in &counters.fastpath {
         println!("{:>34}: {}", key.name(), value.get_count());
     }
 }

--- a/adapter/ph/src/signal_worker.rs
+++ b/adapter/ph/src/signal_worker.rs
@@ -48,11 +48,18 @@ pub async fn launch(asm: Arc<Assembly>) {
 fn emit_counts(counters: &Counters, uptime: std::time::Duration) {
     println!("{:>42}\n", "*** Counters ***");
     println!("{:>34}: {:?}", "Uptime", uptime);
+    println!("\n");
+    println!("{:>42}\n", "*** Management Counters ***");
     for (key, ref value) in &counters.management {
         println!("{:>34}: {}", key.name(), value.get_count());
     }
-    for (key, ref value) in &counters.fastpath {
-        println!("{:>34}: {}", key.name(), value.get_count());
+    for (i, fastpath) in counters.fastpaths.lock().unwrap().iter().enumerate() {
+        println!("\n");
+        let message = format!("*** Fastpath #{} Counters ***", i);
+        println!("{:>42}\n", message);
+        for (key, ref value) in fastpath {
+            println!("{:>34}: {}", key.name(), value.get_count());
+        }
     }
 }
 

--- a/adapter/ph/src/sync_req.rs
+++ b/adapter/ph/src/sync_req.rs
@@ -79,7 +79,7 @@ impl SyncReqState {
         }
     }
 
-    pub async fn acquire_permit(&self) -> Permit {
+    pub async fn acquire_permit(&self) -> Permit<'_> {
         let mut window_state = self.window_state.lock().await;
         let seq_num = window_state.next_seq_num;
         window_state.next_seq_num += 1;

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -1,5 +1,5 @@
 use crate::assembly::Assembly;
-use crate::counters::CounterType;
+use crate::counters::ManagementCounterType;
 use crate::link_state::{LinkEvent, LinkStateError};
 use crate::logging::targets::VISA_MGMT;
 use crate::net_defs::{IpAddress, IPV6_ADDRESS_SIZE};
@@ -183,26 +183,26 @@ pub async fn parse_visa(
     visa: vsapi::VisaHop,
 ) -> Result<(VisaId, NonZero<LinkId>), visa_table::VisaTableError> {
     let Some(visa) = visa.visa else {
-        asm.counters[CounterType::VisaRequestError].increment();
+        asm.counters.management[ManagementCounterType::VisaRequestError].increment();
         error!(target: VISA_MGMT, "visa request error: Could not parse visa");
         return Err(visa_table::VisaTableError::ParseError("all".into()));
     };
     // for now, just pull the destination address tether to set up forwarding
     let Some(octets) = visa.dest.clone() else {
-        asm.counters[CounterType::VisaRequestError].increment();
+        asm.counters.management[ManagementCounterType::VisaRequestError].increment();
         error!(target: VISA_MGMT, "visa request error: Could not parse visa");
         return Err(visa_table::VisaTableError::ParseError(
             "destination address".into(),
         ));
     };
     let Ok(addr) = IpAddress::try_from(octets) else {
-        asm.counters[CounterType::VisaRequestError].increment();
+        asm.counters.management[ManagementCounterType::VisaRequestError].increment();
         return Err(visa_table::VisaTableError::ParseError(
             "destination address".into(),
         ));
     };
     let Some(link_id) = asm.find_egress_link(addr) else {
-        asm.counters[CounterType::VisaRequestError].increment();
+        asm.counters.management[ManagementCounterType::VisaRequestError].increment();
         return Err(visa_table::VisaTableError::DestNotFound(addr));
     };
     let visa_id = asm.visa_table.write().await.insert_visa(visa)?;


### PR DESCRIPTION
More testing needed, and need to change type of `batch_counter` because right now it's wasting a lot of space because the only counters that are explicitly used in `fastpath` are `DispatchedToMgmt`, `ActorPackersOutOfOrder`, and `ActorSlowpath`. Theoretically any packet count could be increased in `drop_and_count` but it seems like a waste of space to automatically have all the counters initialized to 0