### PR TITLE
fix for new lifetime error in rust 1.89

### DIFF
--- a/adapter/ph/src/sync_req.rs
+++ b/adapter/ph/src/sync_req.rs
@@ -79,7 +79,7 @@ impl SyncReqState {
         }
     }
 
-    pub async fn acquire_permit(&self) -> Permit {
+    pub async fn acquire_permit(&self) -> Permit<'_> {
         let mut window_state = self.window_state.lock().await;
         let seq_num = window_state.next_seq_num;
         window_state.next_seq_num += 1;


### PR DESCRIPTION
I don't fully understand the error, but just implementing the compiler suggested fix gets rid of it.