### PR TITLE
added verbose logging option

### DIFF
--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -109,6 +109,9 @@ pub struct Config {
     /// Enable debug logging for specified targets, or ALL
     pub debug: Vec<String>,
 
+    /// Enable trace logging for targets specified by the debug flag
+    pub verbose: bool,
+
     /// Disable info & warnings for specified targets, or ALL
     pub quiet: Vec<String>,
 
@@ -305,6 +308,9 @@ impl Config {
         if let Some(debug) = &config.debug {
             self.debug.extend(debug.into_iter().cloned());
         }
+        if let Some(verbose) = &config.verbose {
+            self.verbose = verbose.clone();
+        }
         if let Some(quiet) = &config.quiet {
             self.quiet.extend(quiet.into_iter().cloned());
         }
@@ -460,6 +466,8 @@ impl Config {
         self.debug.extend(common.debug.iter().cloned());
         self.quiet.extend(common.quiet.iter().cloned());
 
+        self.verbose = common.verbose.clone();
+
         self.batch_io_engine = common.io_engine.clone();
 
         Ok(())
@@ -477,6 +485,7 @@ impl Default for Config {
             private_key_data: None,
             tun_if: None,
             debug: Vec::new(),
+            verbose: false,
             quiet: Vec::new(),
             node_addr: None,
             zpr_addr: Vec::new(),
@@ -520,6 +529,7 @@ pub struct GlobalConfigSection {
     pub tun_if: Option<String>,
     pub zpr_addr: Option<Vec<IpAddr>>,
     pub debug: Option<Vec<String>>,
+    pub verbose: Option<bool>,
     pub quiet: Option<Vec<String>>,
     pub io_engine: Option<String>,
 }

--- a/adapter/ph/src/logging.rs
+++ b/adapter/ph/src/logging.rs
@@ -65,6 +65,7 @@ pub mod targets {
 fn create_target_filter<T>(
     debug: impl IntoIterator<Item = T>,
     quiet: impl IntoIterator<Item = T>,
+    verbose: &bool,
 ) -> Targets
 where
     String: From<T>,
@@ -74,14 +75,31 @@ where
 
     targets = targets.with_default(Level::INFO);
 
+    let lvl = match verbose {
+        false => Level::DEBUG,
+        true => Level::TRACE,
+    };
+
+    let mut empty = true;
+
     for target in debug.into_iter() {
+        empty = false;
         if target == targets::ALL {
-            targets = targets.with_default(Level::DEBUG);
+            targets = targets.with_default(lvl);
         } else if target == targets::NONE {
-            targets = targets.with_default(Level::INFO);
+            if lvl == Level::TRACE {
+                targets = targets.with_default(lvl);
+            } else {
+                targets = targets.with_default(Level::INFO);
+            }
         } else {
-            targets = targets.with_target(target, Level::DEBUG);
+            targets = targets.with_target(target, lvl);
         }
+    }
+
+    // Prints trace level debugging even if user did not use --debug flag
+    if empty && lvl == Level::TRACE {
+        targets = targets.with_default(lvl);
     }
 
     let debugged_targets = targets.clone();
@@ -102,6 +120,10 @@ where
 pub fn initialize(config: &config::Config) {
     tracing_subscriber::registry()
         .with(fmt::layer())
-        .with(create_target_filter(&config.debug, &config.quiet))
+        .with(create_target_filter(
+            &config.debug,
+            &config.quiet,
+            &config.verbose,
+        ))
         .init();
 }

--- a/adapter/ph/src/main_args.rs
+++ b/adapter/ph/src/main_args.rs
@@ -95,6 +95,10 @@ pub struct CommonArgs {
     #[arg(long, short = 'd', value_parser = clap::builder::PossibleValuesParser::new(ALL_TARGETS))]
     pub debug: Vec<String>,
 
+    /// Enable verbose logging which includes trace values
+    #[arg(long, short = 'v')]
+    pub verbose: bool,
+
     /// Disable info & warnings for specified targets
     #[arg(long, short = 'q', value_parser = clap::builder::PossibleValuesParser::new(ALL_TARGETS))]
     pub quiet: Vec<String>,


### PR DESCRIPTION
If the user uses --verbose, they will enable TRACE level messages to be logged. If the user does not use the --debug flag or they use --debug all, the log will print both DEBUG and TRACE for all targets. If the user specifies specific targets with the --debug flag and they also use the --verbose flag, both DEBUG and TRACE for those targets will be printed. The debug flag still functions as previously if the verbose flag is not used. The --debug none and --verbose are incompatible and will function the same as --debug all with the verbose flag.