### PR TITLE
skip setting linux address if not specified.

### DIFF
--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -245,7 +245,12 @@ fn main() -> ExitCode {
             None
         }
     } else {
-        Some(zpr::ZPR_TEMP_LOCAL_ADDRESS.into())
+        // TODO: If linux then do not bother setting the temp address since it will fail because ipv6.
+        if cfg!(target_os = "linux") {
+            None
+        } else {
+            Some(zpr::ZPR_TEMP_LOCAL_ADDRESS.into())
+        }
     };
 
     let tun_devs: Vec<_> = match ZprTun::new_mq(


### PR DESCRIPTION
I have this change in mk/m4 for use int he demo.  Basically, this lets us fire up a linux adapter without setting a local zpr address first.  On linux, the driver cannot handle IPv6 so using our fake temp address does not work.  However, it is totally fine with NO address, so that's what this does.