### PR TITLE
updated error message in km_noise::tick

### DIFF
--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -540,7 +540,7 @@ impl KeyManagerStateMachine for KmNoise {
             && self.hs_sent_t.is_some()
             && Instant::now().duration_since(self.hs_sent_t.unwrap()) > HANDSHAKE_TIMEOUT
         {
-            error!(target: KEY_MGMT, "noise: handshake timeout");
+            error!(target: KEY_MGMT, "noise: handshake timeout - node-adapter connection failed");
             self.hs_state = None;
             self.hs_sent_t = None;
             self.state = KmSMState::Error;


### PR DESCRIPTION
Here is the new error, the only thing I changed was adding the portion about node-adapter connection failure.

<img width="1386" height="334" alt="image" src="https://github.com/user-attachments/assets/40a1069f-3ee5-4c8d-9402-f18b7927d1f6" />

I'm not quite sure if this was what you had in mind. I don't know if there is a way to tell if the node actually never made a successful connection to the node versus a node that made a connection and then lost it. 
