### PR TITLE
Move internal workflows to v1

### DIFF
--- a/.github/workflows/adapter.yml
+++ b/.github/workflows/adapter.yml
@@ -36,7 +36,7 @@ jobs:
   # Build and upload ph
   build-ph:
     name: PH
-    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@3cb8cffcd752171c2f6c0717abebad3736baa78e
+    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@v1
     with:
       name: 'ph'
       path: './adapter/ph'
@@ -46,7 +46,7 @@ jobs:
   # Build and upload ph-cli
   build-ph-cli:
     name: PH CLI
-    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@3cb8cffcd752171c2f6c0717abebad3736baa78e
+    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@v1
     with:
       name: 'ph-cli'
       path: './adapter/cli'
@@ -59,7 +59,7 @@ jobs:
   test-ph:
     name: PH
     needs: [build-ph]
-    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-test.yml@3cb8cffcd752171c2f6c0717abebad3736baa78e
+    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-test.yml@v1
     with:
       name: 'ph'
       path: './adapter/ph'
@@ -69,7 +69,7 @@ jobs:
   test-ph-cli:
     name: PH CLI
     needs: [build-ph-cli]
-    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-test.yml@3cb8cffcd752171c2f6c0717abebad3736baa78e
+    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-test.yml@v1
     with:
       name: 'ph-cli'
       path: './adapter/cli'
@@ -86,7 +86,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+    - uses: actions/checkout@v4
     # Necessary to run before rust-cache
     - run: rustup toolchain install stable --profile minimal
     - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
@@ -146,7 +146,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+    - uses: actions/checkout@v4
     # Necessary to run before rust-cache
     - run: rustup toolchain install stable --profile minimal
     - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2

--- a/.github/workflows/cbpfrs.yml
+++ b/.github/workflows/cbpfrs.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   cbpf-build:
     name: CBPF
-    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@3cb8cffcd752171c2f6c0717abebad3736baa78e
+    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@v1
     with:
       name: 'CBPF'
       path: './cbpf-rs'

--- a/.github/workflows/cslab.yml
+++ b/.github/workflows/cslab.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   cslab-build:
     name: Cslab
-    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@3cb8cffcd752171c2f6c0717abebad3736baa78e
+    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@v1
     with:
       name: 'Cslab'
       path: './cslab'

--- a/.github/workflows/libnode.yml
+++ b/.github/workflows/libnode.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   libnode-build:
     name: Libnode
-    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-containerized-build-test.yml@3cb8cffcd752171c2f6c0717abebad3736baa78e
+    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-containerized-build-test.yml@v1
     with:
       name: Libnode
       path: ./libnode

--- a/.github/workflows/vs-tools.yml
+++ b/.github/workflows/vs-tools.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         target: [vs-client]
-    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-containerized-build-test.yml@3cb8cffcd752171c2f6c0717abebad3736baa78e
+    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-containerized-build-test.yml@v1
     with:
       name: ${{ matrix.target }}
       path: ./${{ matrix.target }}

--- a/.github/workflows/zprext.yml
+++ b/.github/workflows/zprext.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   zpr-ext:
     name: ZPR Ext
-    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@3cb8cffcd752171c2f6c0717abebad3736baa78e
+    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@v1
     with:
       name: 'ZPR-Ext'
       path: './zpr-ext'


### PR DESCRIPTION
Use version numbers for official GH actions instead of hashes