### PR TITLE
ZDPR futures (and a couple bugfixes)

### DIFF
--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -10,6 +10,7 @@ use crate::packet::Packet;
 use crate::seq_nums;
 use crate::zdp;
 use crate::zdpr;
+use std::task::{Context, Poll};
 use thiserror::Error;
 use tokio::time::sleep;
 use tracing::*;
@@ -113,6 +114,196 @@ pub fn send_acknowledgement(asm: &Assembly, link_id: zpr::LinkId, sequence_numbe
     let _ = asm
         .mgmt_substrate_egress
         .try_enqueue_packet(link_id, packet);
+}
+
+#[allow(dead_code)]
+enum PacketId {
+    Sent(zpr::SeqNum),
+    Queued(zdpr::QueuedPacketId),
+}
+
+/// Future which represents a packet waiting to be sent on the link.
+///
+/// Dropping this future cancels delivery of the packet if
+/// it has not already been sent.
+///
+/// Note that completion of this future does not indicate whether the peer
+/// has actually received the packet!  It merely indicates that we have
+/// committed to delivering the packet.
+///
+/// Resolves to another future which may be waited upon for acknowledgement
+/// by the remote peer.  Resolves to an error if the link was terminated (and
+/// therefore the packet was never sent).
+#[must_use = "dropping a sent packet may cancel it"]
+pub struct Sent<'a> {
+    asm: &'a Assembly,
+    link_id: zpr::LinkId,
+    packet_id: PacketId,
+    // NOTE: if we add anything without a trivial destructor,
+    // modify `enqueue()` appropriately!
+}
+
+impl<'a> Sent<'a> {
+    /// If sending would block, queue this packet instead.
+    pub fn enqueue(self) {
+        // Note that in fact, if we are blocked, we already are in the
+        // queue.  So we just need to prevent running our Drop impl which
+        // would take us _out_ of the queue.  `forget()` is the simplest way
+        // to do that.  (This do not leak anything because we have no
+        // members with nontrivial destructors.)
+        std::mem::forget(self)
+    }
+
+    /// Explicitly try to cancel the packet, returning the packet if successful,
+    /// or an `Acked` future if unsuccessful (meaning the packet was already sent).
+    #[allow(dead_code)]
+    pub fn try_cancel(mut self) -> Result<Packet, Acked<'a>> {
+        self.try_cancel_internal()
+    }
+
+    fn try_cancel_internal(&mut self) -> Result<Packet, Acked<'a>> {
+        match self.packet_id {
+            PacketId::Sent(seq_num) => Err(Acked {
+                asm: self.asm,
+                link_id: self.link_id,
+                seq_num: Some(seq_num),
+            }),
+
+            PacketId::Queued(packet_id) => {
+                let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
+                    return Err(Acked {
+                        asm: self.asm,
+                        link_id: zpr::LINK_ID_UNKNOWN, // guard against memory order shenanigans
+                        seq_num: None,
+                    });
+                };
+                let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+                if let Some(pkt) = zdpr_send.cancel_packet(packet_id) {
+                    Ok(pkt)
+                } else {
+                    Err(Acked {
+                        asm: self.asm,
+                        link_id: self.link_id,
+                        seq_num: zdpr_send.lookup_seq_num(packet_id),
+                    })
+                }
+            }
+        }
+    }
+
+    /// Returns a future which waits for this packet to be acked (after it is sent).
+    #[allow(dead_code)]
+    pub fn acked(self) -> SentAndAcked<'a> {
+        SentAndAcked(self)
+    }
+}
+
+impl<'a> Drop for Sent<'a> {
+    fn drop(&mut self) {
+        drop(self.try_cancel_internal())
+    }
+}
+
+impl<'a> std::future::Future for Sent<'a> {
+    type Output = Result<Acked<'a>, ()>;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.packet_id {
+            PacketId::Sent(seq_num) => Poll::Ready(Ok(Acked {
+                asm: self.asm,
+                link_id: self.link_id,
+                seq_num: Some(seq_num),
+            })),
+
+            PacketId::Queued(packet_id) => {
+                let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
+                    return Poll::Ready(Err(()));
+                };
+
+                let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+                zdpr_send.poll_send(cx, packet_id).map(|seq_num| {
+                    Ok(Acked {
+                        asm: self.asm,
+                        link_id: self.link_id,
+                        seq_num,
+                    })
+                })
+            }
+        }
+    }
+}
+
+/// Future which represents the acknowledgement of a packet
+/// by the link peer.  (Does _not_ indicate that the peer has
+/// necessarily done anything useful with the packet!  Just that
+/// we've made forward progress in communicating the packet.)
+///
+/// Resolves to an error if the link was terminated (and therefore
+/// it is unknown whether the peer ever received the packet).
+pub struct Acked<'a> {
+    asm: &'a Assembly,
+    link_id: zpr::LinkId,
+    seq_num: Option<zpr::SeqNum>, // None indicates acked before we knew the sequenece number
+}
+
+impl<'a> std::future::Future for Acked<'a> {
+    type Output = Result<(), ()>;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let Some(seq_num) = self.seq_num else {
+            return Poll::Ready(Ok(()));
+        };
+
+        let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
+            return Poll::Ready(Err(()));
+        };
+
+        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+        zdpr_send.poll_ack(cx, seq_num).map(|()| Ok(()))
+    }
+}
+
+/// Future which waits for a packet to be both sent and acknowledged.
+///
+/// Dropping this future cancels delivery of the packet if
+/// it has not already been sent.
+///
+/// Resolves to an error if the link was terminated (and therefore
+/// it is unknown whether the peer ever received the packet).
+#[must_use = "dropping a sent packet may cancel it"]
+pub struct SentAndAcked<'a>(Sent<'a>);
+
+#[allow(dead_code)]
+impl<'a> SentAndAcked<'a> {
+    /// if sending would block, queue this packet instead
+    pub fn enqueue(self) {
+        self.0.enqueue()
+    }
+
+    /// explicitly try to cancel the packet, returning the packet if successful,
+    /// or an `Acked` future if unsuccessful
+    pub fn try_cancel(self) -> Result<Packet, Acked<'a>> {
+        self.0.try_cancel()
+    }
+}
+
+impl<'a> std::future::Future for SentAndAcked<'a> {
+    type Output = Result<(), ()>;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let Some(peer_state) = self.0.asm.peer_table.get(self.0.link_id) else {
+            return Poll::Ready(Err(()));
+        };
+
+        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+
+        match self.0.packet_id {
+            PacketId::Sent(seq_num) => zdpr_send.poll_ack(cx, seq_num).map(|()| Ok(())),
+            PacketId::Queued(packet_id) => {
+                zdpr_send.poll_send_and_ack(cx, packet_id).map(|()| Ok(()))
+            }
+        }
+    }
 }
 
 fn send_mgmt_helper(

--- a/adapter/ph/src/zdpr.rs
+++ b/adapter/ph/src/zdpr.rs
@@ -327,32 +327,20 @@ impl<Pkt> Sender<Pkt> {
 
         if -offset >= self.blocked.len() as i64 {
             // already sent
-
-            if -offset >= (self.blocked.len() + self.sent.len()) as i64 {
-                let idx =
-                    (self.blocked.len() as i64 + self.sent.len() as i64 + offset - 1) as usize;
-                self.sent[idx] = None;
-                if idx == 0 {
-                    self.clean_sent_queue();
-                }
-            }
-
-            None
-        } else {
-            // still blocked
-
-            let idx = (self.blocked.len() as i64 + offset - 1) as usize;
-
-            let (pkt, waker) = self.blocked[idx].take()?;
-
-            if idx == 0 {
-                self.clean_blocked_queue();
-            }
-
-            // TODO: move wake up to caller? to minimize time under lock
-            waker.wake();
-            Some(pkt)
+            return None;
         }
+
+        let idx = (self.blocked.len() as i64 + offset - 1) as usize;
+
+        let (pkt, waker) = self.blocked[idx].take()?;
+
+        if idx == 0 {
+            self.clean_blocked_queue();
+        }
+
+        // TODO: move wake up to caller? to minimize time under lock
+        waker.wake();
+        Some(pkt)
     }
 
     /// Expand a truncated sequence number to a full sequence number,
@@ -375,7 +363,7 @@ impl<Pkt> Sender<Pkt> {
             return None;
         }
 
-        self.sent[(-offset) as usize]
+        self.sent[(self.sent.len() as i64 + offset - 1) as usize]
     }
 
     /// Process a received acknowledgement of the given sequence number.


### PR DESCRIPTION
These futures allow mgmt code to asynchronously wait on the stages of a ZDPR packet.  Requesting a mgmt packet to be sent (e.g. via `send_non_flow_mgmt()`) will return a `Sent` future, representing that the packet has been entered into the ZDPR machinery.

The caller can do one of four things with `Sent`.  Either:
1) `.await` it.  This completes only when the packet has made its way into the send window (and therefore actually sent on the wire).  This enables callers to participate in basic flow control by preventing the caller from queueing up more than a single packet while the window is full.  On completion, this returns an `Acked` future (see below).
2) Drop the future, or `.try_cancel()` it.  If the packet is currently in the blocked queue, it is cancelled (and returned in the case of `.try_cancel()`).  This allows callers to choose to no longer wait in the blocked queue (e.g. because of a timeout).  (If the packet was already sent, an `Acked` future is returned instead.)
3) `.enqueue()` it.  This returns immediately, leaving the packet on the blocked queue (if it was still/ever there).  This allows non-async code (such as the link state machine) to send mgmt packets, in exchange for taking on the burden of ensuring that they do not flood the blocked queue.
4) Call `.acked()` to transform this into a `SentAndAcked` future (see below) which waits for the packet to be acknowledged.

When `Sent` completes, an `Acked` future is returned.  (Or, an error is returned if the link died.)   This future can only be `.await`ed on, indicating that the remote peer acknowledged receipt of the packet.  (Dropping an `Acked` does nothing; the packet continues to participate in ZDPR until it is acknowledged.)

A `SentAndAcked` future (as returned by `Sent::acked()`) combines the stages of waiting for sending and acking into one.  This is helpful in contexts such as `select!()` statements which cannot handle the "chained" futures of Sent->Acked.  It provides the same affordances as a `Sent` future, except that completion indicates the packet has been acknowledged by the peer.  (Notably, we'll use this for echo requests.)

An upcoming PR will switch over the `mgmt::core` methods such as `send_non_flow_mgmt()` to use ZDPR and return these futures.  For now they are just dead code.

------

ALSO, this PR contains a couple bugfixes to `zdpr`.  First, cancellation is fixed not to remove the packet from the sent queue (this was an optimization I had made which breaks an assumption used by these futures, namely that we can continue to refer to a packet which we tried and failed to cancel).  Second, there was an arithmetic error in packet ID -> sequence number lookup.  (This is my reminder to get unit tests in place!)