### PR TITLE
ZDPR Acknowledgement packet type

### DIFF
--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -24,8 +24,19 @@ pub const MAX_ACTIVE_LINKS: usize = 1024;
 /// Size of a packet buffer.
 pub const PACKET_BUFFER_SIZE: usize = 4096 * 3;
 
+/// Size of a "small" packet buffer, suitable for most outbound management traffic.
+pub const SMALL_PACKET_BUFFER_SIZE: usize = 2048;
+
+/// Size of a "tiny" packet buffer, suitable for packets with no bodies (e.g. acks).
+/// Note, this is not large enough for `DEFAULT_MESSAGE_HEADROOM`; use
+/// with `TINY_MESSAGE_HEADROOM` instead.
+pub const TINY_PACKET_BUFFER_SIZE: usize = 256;
+
 /// Size of headroom necessary for most messages.
 pub const DEFAULT_MESSAGE_HEADROOM: usize = 256;
+
+/// Size of headroom suitable for "tiny" (bodyless) messages.
+pub const TINY_MESSAGE_HEADROOM: usize = 64;
 
 pub const DEFAULT_ZDPR_RECEIVE_WINDOW_SIZE: usize = 32;
 
@@ -76,8 +87,6 @@ impl ArgError for str {
         ArgsError::Missing(self.to_string())
     }
 }
-
-// CTP WORKING: move engine-select into here
 
 /// This config struct is loaded up from the command line args and used by the
 /// ph system to configure itself.  Do not create this directly,

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -9,6 +9,7 @@ use crate::counters::ManagementCounterType;
 use crate::packet::Packet;
 use crate::seq_nums;
 use crate::zdp;
+use crate::zdpr;
 use thiserror::Error;
 use tokio::time::sleep;
 use tracing::*;
@@ -16,10 +17,22 @@ use zpr;
 use zpr_ext::zerocopy::FromBytesExt;
 
 /// Helper to allocate a new Packet with default parameters from the heap.
+/// The packet is sized to fit most outbound management traffic, but
+/// is not necessarily large enough to fit any arbitrary jumbo packet.
 pub fn new_heap_packet() -> Packet {
     Packet::new(
-        Box::new([0u8; config::PACKET_BUFFER_SIZE]),
+        Box::new([0u8; config::SMALL_PACKET_BUFFER_SIZE]),
         config::DEFAULT_MESSAGE_HEADROOM,
+    )
+}
+
+/// Helper to allocate a new Packet suitable only for bodyless messages.
+/// Since the only such messages right now are ACKs, and those are only
+/// generated from within this module, this is private for now.
+fn new_tiny_heap_packet() -> Packet {
+    Packet::new(
+        Box::new([0u8; config::TINY_PACKET_BUFFER_SIZE]),
+        config::TINY_MESSAGE_HEADROOM,
     )
 }
 
@@ -83,6 +96,23 @@ pub fn send_per_flow_mgmt_response(
         Some(sequence_number),
         packet,
     )
+}
+
+#[allow(dead_code)]
+pub fn send_acknowledgement(asm: &Assembly, link_id: zpr::LinkId, sequence_number: zpr::SeqNum) {
+    // TODO: just allocate this on the stack, pending #985.
+    let mut packet = new_tiny_heap_packet();
+
+    let hdr = packet.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
+    hdr.packet_type = zdp::ZdpPacketType::Acknowledgement;
+    hdr.sequence_number = zdpr::truncate_seq_num(sequence_number).into();
+
+    // It's possible (but unlikely) the MgmtSubstrateEgress queue fills up.
+    // In that case, just ignore the error; act as if the packet was dropped
+    // by the substrate due to congestion.
+    let _ = asm
+        .mgmt_substrate_egress
+        .try_enqueue_packet(link_id, packet);
 }
 
 fn send_mgmt_helper(

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -28,6 +28,7 @@ pub enum ZdpPacketType {
     //AuthenticationRequest = 15,  // unused/deprecated
     SetPathMtu = 16,
     //AuthenticationResponse = 17,  // unused/deprecated
+
     // Not flow-based
     ZprArp = 128,
     KeyManagement = 129,
@@ -50,6 +51,8 @@ pub enum ZdpPacketType {
     InitAuthenticationResponse = 147, // TODO: add to RFC 6
     GrantZprAddressRequest = 148,     // TODO: add to RFC 6
     GrantZprAddressResponse = 149,    // TODO: add to RFC 6
+
+    Acknowledgement = 255,
 }
 
 pub const ZDP_PACKET_TYPE_NON_FLOW_FLAG: u8 = 0x80;


### PR DESCRIPTION
Adds the Acknowledgement packet type needed by ZDPR.  Also adds the notion of a "tiny packet" which we use for sending Acknowledgements (since they are so tiny), and a "small packet" which we use for all other management packets (since they are not large), in order to reduce pressure on the memory allocator of allocating 3 pages for every management packet.