### PR TITLE
ZDPR retries

### DIFF
--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -23,6 +23,7 @@ use crate::tun_ctl::TunCtl;
 use crate::visa_table;
 use crate::vs_types::AuthServicesList;
 use crate::zdp::TerminateReason;
+use crate::zdpr_worker;
 use km_noise::NoiseKeypair;
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -294,7 +295,11 @@ impl Assembly {
                 mgmt_processor_worker::launch(worker_config, self.clone(), q)
             });
 
-        Ok(entry.insert(peer_state))
+        let link_id = entry.insert(peer_state);
+
+        tokio::task::spawn_local(zdpr_worker::launch(self.clone(), link_id.get()));
+
+        Ok(link_id)
     }
 
     /// Caled from `LinkStateWrapper::complete_close`.`

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -41,7 +41,7 @@ pub const TINY_MESSAGE_HEADROOM: usize = 64;
 pub const DEFAULT_ZDPR_RECEIVE_WINDOW_SIZE: usize = 32;
 
 pub const DEFAULT_REQUEST_RETRY_COUNT: usize = 3;
-pub const DEFAULT_REQUEST_RETRY_TIMER: std::time::Duration = std::time::Duration::from_secs(1);
+pub const DEFAULT_REQUEST_RETRY_TIMER: std::time::Duration = std::time::Duration::from_millis(400);
 pub const DEFAULT_TERMINATE_RESPONSE_TIMER: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// Slightly longer -- asking visa service to grant an address

--- a/adapter/ph/src/counters.rs
+++ b/adapter/ph/src/counters.rs
@@ -126,6 +126,7 @@ pub enum ManagementCounterType {
     UnexpectedMgmtResponse,
     LostPacket,       // lost management packet detected
     OutOfOrderPacket, // out-of-order management packet detected (and processed)
+    ResentPacket,
 
     UnknownPeer,
     PeerRemoved,
@@ -211,6 +212,7 @@ impl ManagementCounterType {
             Self::UnexpectedMgmtResponse => "Unexpected Management Response",
             Self::LostPacket => "Lost Packet",
             Self::OutOfOrderPacket => "Out Of Order Packet",
+            Self::ResentPacket => "Resent Packet",
 
             // Peer operation failures
             Self::UnknownPeer => "Management Unknown Peer",

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -71,6 +71,7 @@ mod vss_worker;
 mod zdp;
 mod zdp_ll;
 mod zdpr;
+mod zdpr_worker;
 mod zprtun;
 
 #[cfg(test)]

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -14,6 +14,7 @@ use std::task::{Context, Poll};
 use thiserror::Error;
 use tokio::time::sleep;
 use tracing::*;
+use zerocopy::FromBytes;
 use zpr;
 use zpr_ext::zerocopy::FromBytesExt;
 
@@ -44,6 +45,14 @@ pub fn count_event(
 ) {
     debug!(target: crate::logging::targets::MGMT_EVENTS, "packet event {event}");
     asm.counters.management[event].increment();
+}
+
+pub fn count_events(asm: &Assembly, event: ManagementCounterType, count: u64) {
+    if count == 0 {
+        return;
+    }
+    debug!(target: crate::logging::targets::MGMT_EVENTS, "packet event {event} ({count})");
+    asm.counters.management[event].increase_by(count);
 }
 
 /// Send a unidirectional non-flow management message on the given link.
@@ -113,7 +122,7 @@ pub fn send_acknowledgement(asm: &Assembly, link_id: zpr::LinkId, sequence_numbe
     // by the substrate due to congestion.
     let _ = asm
         .mgmt_substrate_egress
-        .try_enqueue_packet(link_id, packet);
+        .try_enqueue_packet(link_id, &mut packet);
 }
 
 #[allow(dead_code)]
@@ -333,7 +342,29 @@ fn send_mgmt_helper(
     // by the substrate due to congestion.
     let _ = asm
         .mgmt_substrate_egress
-        .try_enqueue_packet(link_id, packet);
+        .try_enqueue_packet(link_id, &mut packet);
+}
+
+/// Used to send packets as instructed by ZDPR mechanism.
+///
+/// Simply fills in the assigned sequence number (which is
+/// a no-op for retries), and forwards to the fastpath.
+pub fn build_and_egress_packets<'a>(
+    asm: &Assembly,
+    link_id: zpr::LinkId,
+    packets: impl Iterator<Item = (zpr::SeqNum, &'a mut Packet)>,
+) {
+    packets.for_each(|(seq_num, packet)| {
+        let (hdr, _) = zdp::ZdpBaseHeader::mut_from_prefix(packet.body_mut()).unwrap();
+        hdr.sequence_number = zdpr::truncate_seq_num(seq_num).into();
+
+        // It's possible (but unlikely) the MgmtSubstrateEgress queue fills up.
+        // In that case, just ignore the error; act as if the packet was dropped
+        // by the substrate due to congestion.
+        let _ = asm
+            .mgmt_substrate_egress
+            .try_enqueue_packet(link_id, packet);
+    });
 }
 
 /// Sender function for per flow request management packet.

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -87,21 +87,21 @@ impl MgmtSubstrateEgress {
     /// The packet is marked PRIORITY, which instructs the fastpath to
     /// ensure it eventually gets queued with the OS.
     #[allow(dead_code)]
-    pub async fn enqueue_packet(&self, link_id: zpr::LinkId, mut packet: Packet) {
+    pub async fn enqueue_packet(&self, link_id: zpr::LinkId, packet: &mut Packet) {
         packet.metadata_mut().egress_link_id = link_id;
         packet.metadata_mut().flags |= packet::flags::PRIORITY;
         self.queue
-            .send(&packet)
+            .send(packet)
             .await
             .expect("unrecoverable I/O error");
     }
 
     /// Try to enqueue the given packet to be egressed on the substrate.
-    /// Returns said packet if there is no room in the queue.
+    /// Returns `false` if there is no room in the queue.
     /// Unlike `enqueue_packet()`, the packet is not marked for any special processing.
-    pub fn try_enqueue_packet(&self, link_id: zpr::LinkId, mut packet: Packet) -> bool {
+    pub fn try_enqueue_packet(&self, link_id: zpr::LinkId, packet: &mut Packet) -> bool {
         packet.metadata_mut().egress_link_id = link_id;
-        match self.queue.try_send(&packet) {
+        match self.queue.try_send(packet) {
             Ok(()) => true,
             Err(packet_queue::TrySendError::Full) => false,
             Err(err) => panic!("unrecoverable I/O error: {err:?}"),

--- a/adapter/ph/src/zdpr_worker.rs
+++ b/adapter/ph/src/zdpr_worker.rs
@@ -1,0 +1,36 @@
+//! Code which handles active aspects of ZDPR (namely, retries).
+
+use crate::assembly::Assembly;
+use crate::config;
+use crate::counters;
+use crate::mgmt;
+use std::sync::Arc;
+use tokio::select;
+use tokio::time;
+
+pub async fn launch(asm: Arc<Assembly>, link_id: zpr::LinkId) {
+    let mut retry_interval = time::interval(config::DEFAULT_REQUEST_RETRY_TIMER);
+    retry_interval.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+
+    loop {
+        let Some(peer_state) = asm.peer_table.get(link_id) else {
+            // peer removed; we're done
+            break;
+        };
+
+        let retry_needed = peer_state.zdpr_send.lock().unwrap().retry_needed();
+
+        select! {
+            _ = retry_interval.tick(), if retry_needed => {
+                let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+                let mut count = 0;
+                let packets = zdpr_send.retry_packets();
+                let packets = packets.inspect(|_| count += 1);
+                mgmt::core::build_and_egress_packets(&asm, link_id, packets);
+                mgmt::core::count_events(&asm, counters::ManagementCounterType::ResentPacket, count);
+            }
+
+            () = peer_state.zdpr_retry_timer_reset.notified() => retry_interval.reset(),
+        };
+    }
+}


### PR DESCRIPTION
Here is the first "active" part of ZDPR.  It is a per-link worker whose sole job is to retry unacknowledged ZDPR packets.

Its logic is very simple.  Every 400 ms, if there are any unacknowledged packets in the ZDPR sender state, it retransmits them.

When notified by the ZDPR retry-timer-reset `Notify`, it resets the timer to execute in 400 ms (and every 400 ms repeatedly after that).  This notification will be sent (in a future PR) whenever the ZDPR sender state transitions from having "no" unacknowledged packets to "some" unacknowledged packets.  The net effect is that the first packet sent in a "burst" starts the timer, which runs continually until there are no outstanding unacknowledged packets.

This matches the behavior of the [Reliable UDP](https://datatracker.ietf.org/doc/html/draft-ietf-sigtran-reliable-udp-00/) proposal.