### PR TITLE
get rid of unused pkt argument to count_event()

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -31,13 +31,13 @@ pub async fn launch(
 }
 
 // RFC 6.5 § 6.3.11
-async fn do_request_tether_id(asm: &Arc<Assembly>, mut pkt: Packet) {
+async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
     let five_tuple = pkt.metadata().five_tuple();
 
     // if there's already an entry, this is a duplicate request
     // (NOTE: we should be the only ones modifying this table!)
     if asm.alt.get(five_tuple).is_some() {
-        mgmt::core::count_event(asm, &mut pkt, ManagementCounterType::DroppedAwaitingBind);
+        mgmt::core::count_event(asm, ManagementCounterType::DroppedAwaitingBind);
         return;
     }
 
@@ -51,7 +51,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, mut pkt: Packet) {
 
     if dock_link_id != zpr::LINK_ID_UNKNOWN && !asm.is_link_ready(dock_link_id) {
         debug!(target: FLOW_MGMT, "Link {dock_link_id} is not ready to receive traffic yet");
-        mgmt::core::count_event(asm, &mut pkt, ManagementCounterType::DroppedNoSA);
+        mgmt::core::count_event(asm, ManagementCounterType::DroppedNoSA);
         return;
     }
 

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -37,11 +37,7 @@ fn new_tiny_heap_packet() -> Packet {
     )
 }
 
-pub fn count_event(
-    asm: &Assembly,
-    _pkt: &mut Packet, // for later support of per-packet event recording
-    event: ManagementCounterType,
-) {
+pub fn count_event(asm: &Assembly, event: ManagementCounterType) {
     debug!(target: crate::logging::targets::MGMT_EVENTS, "packet event {event}");
     asm.counters.management[event].increment();
 }
@@ -490,9 +486,9 @@ fn match_received(
     zdp_response_type: zdp::ZdpPacketType,
 ) -> Result<Packet, SyncReqError> {
     match response {
-        Some((pkt_type, mut pkt)) => {
+        Some((pkt_type, pkt)) => {
             if pkt_type != zdp_response_type {
-                count_event(asm, &mut pkt, ManagementCounterType::BadMgmtResponse);
+                count_event(asm, ManagementCounterType::BadMgmtResponse);
                 return Err(SyncReqError::ProtocolError);
             }
             return Ok(pkt);

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -39,7 +39,7 @@ pub fn dispatch_mgmt_packet_with_addr(
                 .start_tether(&peer_sa, &interface_addr, LinkType::NodeToAdapter)
                 .ok()
             else {
-                core::count_event(asm, pkt, ManagementCounterType::UnknownPeer);
+                core::count_event(asm, ManagementCounterType::UnknownPeer);
                 return;
             };
 
@@ -48,7 +48,7 @@ pub fn dispatch_mgmt_packet_with_addr(
             handle_key_management(asm, pkt);
         }
         _ => {
-            core::count_event(asm, pkt, ManagementCounterType::UnknownPeer);
+            core::count_event(asm, ManagementCounterType::UnknownPeer);
             return;
         }
     }
@@ -71,7 +71,7 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
 
         Ok((base_hdr, _)) => {
             let Some(peer_state) = asm.peer_table.get(pkt.metadata().ingress_link_id) else {
-                core::count_event(asm, pkt, ManagementCounterType::PeerRemoved);
+                core::count_event(asm, ManagementCounterType::PeerRemoved);
                 return;
             };
 
@@ -99,7 +99,7 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
                     match peer_state.mgmt_processor.try_enqueue_packet(mgmt_pkt) {
                         Ok(()) => (),
                         Err(queues::TryEnqueueError::Full(_mgmt_pkt)) => {
-                            core::count_event(asm, pkt, ManagementCounterType::QueueBackpressure);
+                            core::count_event(asm, ManagementCounterType::QueueBackpressure);
                             return;
                         }
                     }
@@ -107,13 +107,13 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
             }
         }
 
-        Err(_) => core::count_event(asm, pkt, ManagementCounterType::BadStructure),
+        Err(_) => core::count_event(asm, ManagementCounterType::BadStructure),
     }
 }
 
 fn handle_acknowledgement(asm: &Assembly, pkt: &mut Packet) {
     let Ok(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(pkt) else {
-        core::count_event(asm, pkt, ManagementCounterType::BadStructure);
+        core::count_event(asm, ManagementCounterType::BadStructure);
         return;
     };
 
@@ -121,7 +121,7 @@ fn handle_acknowledgement(asm: &Assembly, pkt: &mut Packet) {
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
     let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
-        core::count_event(asm, pkt, ManagementCounterType::PeerRemoved);
+        core::count_event(asm, ManagementCounterType::PeerRemoved);
         return;
     };
     let mut sender = peer_state.zdpr_send.lock().unwrap();
@@ -150,14 +150,14 @@ fn handle_acknowledgement(asm: &Assembly, pkt: &mut Packet) {
 
 fn handle_response(asm: &Assembly, pkt: &mut Packet) {
     let Ok(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(pkt) else {
-        core::count_event(asm, pkt, ManagementCounterType::BadStructure);
+        core::count_event(asm, ManagementCounterType::BadStructure);
         return;
     };
 
     let packet_type = base_hdr.packet_type;
 
     let Ok(txn_hdr) = zdp::ZdpTransactionHeader::read_from_buf(pkt) else {
-        core::count_event(asm, pkt, ManagementCounterType::BadStructure);
+        core::count_event(asm, ManagementCounterType::BadStructure);
         return;
     };
     let txn_id = txn_hdr.transaction_id.get();
@@ -170,7 +170,7 @@ fn handle_response(asm: &Assembly, pkt: &mut Packet) {
     // Gets the designated sender, attempts to send the response, if not drops
     // the packet and increments corresponding counter
     let Some(peer_state) = asm.peer_table.get(pkt.metadata().ingress_link_id) else {
-        core::count_event(asm, pkt, ManagementCounterType::UnexpectedMgmtResponse);
+        core::count_event(asm, ManagementCounterType::UnexpectedMgmtResponse);
         return;
     };
 
@@ -181,7 +181,7 @@ fn handle_response(asm: &Assembly, pkt: &mut Packet) {
     {
         Ok(()) => (),
         Err(_mgmt_pkt) => {
-            core::count_event(asm, pkt, ManagementCounterType::UnexpectedMgmtResponse);
+            core::count_event(asm, ManagementCounterType::UnexpectedMgmtResponse);
             return;
         }
     }
@@ -192,7 +192,7 @@ fn handle_response(asm: &Assembly, pkt: &mut Packet) {
 fn handle_key_management(asm: &Arc<Assembly>, pkt: &mut Packet) {
     let Ok(km_hdr) = zdp::ZdpKeyManagementHeader::read_from_buf(pkt) else {
         error!(target: ZDP, "KeyManagement packet arrived with unparseable header");
-        core::count_event(asm, pkt, ManagementCounterType::BadStructure);
+        core::count_event(asm, ManagementCounterType::BadStructure);
         return;
     };
 
@@ -204,14 +204,14 @@ fn handle_key_management(asm: &Arc<Assembly>, pkt: &mut Packet) {
             "KeyManagement packet type does not match KM implementation - type is {}",
             km_hdr.message_type
         );
-        core::count_event(asm, pkt, ManagementCounterType::OtherError);
+        core::count_event(asm, ManagementCounterType::OtherError);
         return;
     }
 
     let km_msg_len = usize::from(km_hdr.message_length);
     if pkt.remaining() < km_msg_len {
         error!(target: KEY_MGMT, "KeyManagement packet arrived with truncated payload");
-        core::count_event(asm, pkt, ManagementCounterType::BadStructure);
+        core::count_event(asm, ManagementCounterType::BadStructure);
         return;
     }
 
@@ -227,7 +227,7 @@ fn handle_key_management(asm: &Arc<Assembly>, pkt: &mut Packet) {
                 "key management handling failed on link {}: {e:?}",
                 pkt.metadata().ingress_link_id,
             );
-            core::count_event(asm, pkt, ManagementCounterType::OtherError);
+            core::count_event(asm, ManagementCounterType::OtherError);
             return;
         }
     };

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -48,7 +48,7 @@ impl From<HandleMgmtError> for counters::ManagementCounterType {
     }
 }
 
-pub type HandleMgmtResult = Result<(), (HandleMgmtError, Packet)>;
+pub type HandleMgmtResult = Result<(), HandleMgmtError>;
 
 /// Fire an event into the given link state machine. If there is an event handler error
 /// it will be returned but only after we try to send in an ERROR event which should
@@ -80,7 +80,7 @@ fn dispatch_link_state_event_or_error(
 /// handle a Report message (RFC 6.5 § 6.3.13)
 pub async fn handle_report(_asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpReportHeader::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     };
 
     // TODO handle protocol errors i.e. if the body is shorter
@@ -146,7 +146,7 @@ pub async fn handle_init_authentication_request(
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
     let Ok(hdr) = zdp::ZdpInitAuthenticationRequestHeader::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     };
     let is_bootstrap = hdr.flags & zdp::init_authentication_flags::BOOTSTRAP_SUPPORT != 0;
 
@@ -155,20 +155,20 @@ pub async fn handle_init_authentication_request(
     if is_bootstrap {
         if hdr.data_len == 0 {
             warn!(target: ZDP, "Received Init Authentication with bootstrap support but no payload");
-            return Err((HandleMgmtError::BadStructure, pkt));
+            return Err(HandleMgmtError::BadStructure);
         }
         if hdr.data_len < size_of::<auth::ZdpInitAuthenticationPayload>() as u16 {
             warn!(target: ZDP, "Received Init Authentication with unexpected payload size {}", hdr.data_len);
-            return Err((HandleMgmtError::BadStructure, pkt));
+            return Err(HandleMgmtError::BadStructure);
         }
         if pkt.remaining() < usize::from(hdr.data_len) {
             warn!(target: ZDP, "packet too short for payload");
-            return Err((HandleMgmtError::BadStructure, pkt));
+            return Err(HandleMgmtError::BadStructure);
         }
         debug!(target: ZDP, "Received Init Authentication +bootstrap for link {ingress_link_id}");
 
         let Ok(payload) = auth::ZdpInitAuthenticationPayload::read_from_buf(&mut pkt) else {
-            return Err((HandleMgmtError::BadStructure, pkt));
+            return Err(HandleMgmtError::BadStructure);
         };
         challenge_opt = Some(payload);
     } else {
@@ -203,7 +203,7 @@ pub async fn handle_init_authentication_response(
     mut pkt: Packet,
 ) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpInitAuthenticationResponse::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     };
 
     let link_id = pkt.metadata().ingress_link_id;
@@ -225,7 +225,7 @@ pub async fn handle_init_authentication_response(
 pub async fn handle_terminate_request(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
     let Ok(hdr) = zdp::ZdpTerminateLinkRequestHeader::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     };
 
     info!(target: ZDP, "Received Terminate Request for link {ingress_link_id}");
@@ -257,7 +257,7 @@ pub async fn handle_terminate_request(asm: &Arc<Assembly>, mut pkt: Packet) -> H
 
 pub async fn handle_terminate_response(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpTerminateLinkResponseHeader::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     };
 
     let link_id = pkt.metadata().ingress_link_id;
@@ -274,7 +274,7 @@ pub async fn handle_terminate_response(asm: &Arc<Assembly>, mut pkt: Packet) -> 
 pub async fn handle_terminate_indication(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
     let Ok(hdr) = zdp::ZdpTerminateLinkIndicationHeader::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     };
 
     debug!(target: ZDP, "Received Terminate Indication for link {ingress_link_id}");
@@ -293,7 +293,7 @@ pub async fn handle_hello_request(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
     let ingress_link_id = pkt.metadata().ingress_link_id;
     if asm.ph_mode != PhMode::Node {
         warn!(target: ZDP, "Link {ingress_link_id} received Hello Request but not in node mode");
-        return Err((HandleMgmtError::MessageNotPermitted, pkt));
+        return Err(HandleMgmtError::MessageNotPermitted);
     }
     debug!(target: ZDP, "Received Hello Request for link {ingress_link_id}");
 
@@ -301,7 +301,7 @@ pub async fn handle_hello_request(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
         Ok(data) => data,
         Err(_) => {
             error!(target: ZDP, "Link {ingress_link_id}: Failed to parse HelloRequest TLV data");
-            return Err((HandleMgmtError::BadStructure, pkt));
+            return Err(HandleMgmtError::BadStructure);
         }
     };
 
@@ -411,7 +411,7 @@ pub async fn handle_hello_request(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
 
 pub async fn handle_hello_response(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpHelloResponseHeader::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     };
 
     let link_id = pkt.metadata().ingress_link_id;
@@ -424,7 +424,7 @@ pub async fn handle_hello_response(asm: &Arc<Assembly>, mut pkt: Packet) -> Hand
         Ok(data) => data,
         Err(e) => {
             error!(target: ZDP, "Link {link_id}: HelloResponse - failed to parse TLVs: {:?}", e);
-            return Err((HandleMgmtError::BadStructure, pkt));
+            return Err(HandleMgmtError::BadStructure);
         }
     };
 
@@ -449,7 +449,7 @@ pub async fn handle_hello_response(asm: &Arc<Assembly>, mut pkt: Packet) -> Hand
                         }
                         _ => {
                             warn!(target: ZDP, "Link {link_id}: HelloResponse ASA value type is wrong: {asa_entry:?}");
-                            return Err((HandleMgmtError::BadStructure, pkt));
+                            return Err(HandleMgmtError::BadStructure);
                         }
                     }
                 }
@@ -458,7 +458,7 @@ pub async fn handle_hello_response(asm: &Arc<Assembly>, mut pkt: Packet) -> Hand
                 for aaa_entry in tlv_value {
                     if aaa_address.is_some() {
                         warn!(target: ZDP, "Link {link_id}: HelloResponse includes multiple AAA addresses");
-                        return Err((HandleMgmtError::BadStructure, pkt));
+                        return Err(HandleMgmtError::BadStructure);
                     }
                     match aaa_entry {
                         tlv::TlvValue::Ipv4Addr(ipa) => {
@@ -471,7 +471,7 @@ pub async fn handle_hello_response(asm: &Arc<Assembly>, mut pkt: Packet) -> Hand
                         }
                         _ => {
                             warn!(target: ZDP, "Link {link_id}: HelloResponse AAA value type is wrong: {aaa_entry:?}");
-                            return Err((HandleMgmtError::BadStructure, pkt));
+                            return Err(HandleMgmtError::BadStructure);
                         }
                     }
                 }
@@ -485,7 +485,7 @@ pub async fn handle_hello_response(asm: &Arc<Assembly>, mut pkt: Packet) -> Hand
     // AAA is required.
     if aaa_address.is_none() {
         warn!(target: ZDP, "Link {link_id}: HelloResponse did not include AAA");
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     }
 
     let maybe_asa_addrs = if asa_addresses.is_empty() {
@@ -573,7 +573,7 @@ pub async fn handle_acquire_zpr_address_response(
     mut pkt: Packet,
 ) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpAcquireZprAddressResponse::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     };
 
     let link_id = pkt.metadata().ingress_link_id;
@@ -651,7 +651,7 @@ pub async fn handle_grant_zpr_address_response(
     mut pkt: Packet,
 ) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpGrantZprAddressResponse::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     };
 
     let link_id = pkt.metadata().ingress_link_id;
@@ -812,7 +812,7 @@ pub async fn handle_bind_actor_address_request(
     mut pkt: Packet,
 ) -> HandleMgmtResult {
     let Ok(hdr) = zdp::ZdpBindActorAddressRequestHeader::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     };
 
     // The packet body now immediately follows the header
@@ -823,7 +823,7 @@ pub async fn handle_bind_actor_address_request(
     let (src_address, dst_address, ip_protocol) = match hdr.ip_version {
         zpr::L3Type::Ipv4 => {
             if body.len() < 20 {
-                return Err((HandleMgmtError::BadStructure, pkt));
+                return Err(HandleMgmtError::BadStructure);
             }
             // IPv4 header: src @ 12..16, dst @ 16..20, protocol @ 9
             let src_address = IpAddress::new_from_v4([body[12], body[13], body[14], body[15]]);
@@ -833,7 +833,7 @@ pub async fn handle_bind_actor_address_request(
         }
         zpr::L3Type::Ipv6 => {
             if body.len() < 40 {
-                return Err((HandleMgmtError::BadStructure, pkt));
+                return Err(HandleMgmtError::BadStructure);
             }
             // IPv6 header: src @ 8..24, dst @ 24..40, next_header @ 6
             let src_address = IpAddress {
@@ -846,7 +846,7 @@ pub async fn handle_bind_actor_address_request(
             (src_address, dst_address, ip_protocol)
         }
         _ => {
-            return Err((HandleMgmtError::BadStructure, pkt));
+            return Err(HandleMgmtError::BadStructure);
         }
     };
 
@@ -865,28 +865,28 @@ pub async fn handle_bind_actor_address_request(
         zpr::L3Type::Ipv4 => {
             if pkt.remaining() < 20 {
                 // minimum IPv4 header size
-                return Err((HandleMgmtError::BadStructure, pkt));
+                return Err(HandleMgmtError::BadStructure);
             }
             let ihl = pkt.body()[0] & 0x0f; // Internet Header Length
             if ihl < 5 {
-                return Err((HandleMgmtError::BadStructure, pkt));
+                return Err(HandleMgmtError::BadStructure);
             }
             let hdrlen = (ihl as usize) * 4; // header length in bytes
             if pkt.remaining() < hdrlen {
-                return Err((HandleMgmtError::BadStructure, pkt));
+                return Err(HandleMgmtError::BadStructure);
             }
             pkt.advance(hdrlen); // skip IPv4 header
         }
         zpr::L3Type::Ipv6 => {
             if pkt.remaining() < 40 {
                 // IPv6 header size
-                return Err((HandleMgmtError::BadStructure, pkt));
+                return Err(HandleMgmtError::BadStructure);
             }
             pkt.advance(40); // skip IPv6 header
         }
         _ => {
             warn!(target: ZDP, "Link {}: unsupported ip_version value {}", pkt.metadata().ingress_link_id, hdr.ip_version);
-            return Err((HandleMgmtError::BadStructure, pkt));
+            return Err(HandleMgmtError::BadStructure);
         }
     }
     // At this point our packet buffer is set to the start of whatever is after the
@@ -895,7 +895,7 @@ pub async fn handle_bind_actor_address_request(
         ip_number::TCP | ip_number::UDP => {
             // read TCP/UDP header
             if pkt.remaining() < 4 {
-                return Err((HandleMgmtError::BadStructure, pkt));
+                return Err(HandleMgmtError::BadStructure);
             }
             src_port = pkt.get_u16();
             dst_port = pkt.get_u16();
@@ -903,7 +903,7 @@ pub async fn handle_bind_actor_address_request(
         ip_number::ICMP | ip_number::IPV6_ICMP => {
             // Just stuff the TYPE value into both source and dest.
             if pkt.remaining() < 2 {
-                return Err((HandleMgmtError::BadStructure, pkt));
+                return Err(HandleMgmtError::BadStructure);
             }
             let icmp_type = pkt.get_u8();
             src_port = icmp_type.into();
@@ -911,7 +911,7 @@ pub async fn handle_bind_actor_address_request(
         }
         _ => {
             warn!(target: ZDP, "Link {}: unsupported IP protocol {}", pkt.metadata().ingress_link_id, ip_protocol);
-            return Err((HandleMgmtError::BadStructure, pkt));
+            return Err(HandleMgmtError::BadStructure);
         }
     }
 

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -292,7 +292,7 @@ pub async fn send_bind_actor_address_request(
     match response {
         Ok((tether_id, mut resp)) => {
             let Ok(hdr) = zdp::ZdpBindActorAddressResponseHeader::read_from_buf(&mut resp) else {
-                core::count_event(asm, &mut resp, ManagementCounterType::BadStructure);
+                core::count_event(asm, ManagementCounterType::BadStructure);
                 return Err(BindActorAddressError::BadStructure);
             };
 
@@ -301,12 +301,12 @@ pub async fn send_bind_actor_address_request(
 
                 zdp::ResponseCode::Other => {
                     if hdr.info_len as usize > resp.remaining() {
-                        core::count_event(asm, &mut resp, ManagementCounterType::BadStructure);
+                        core::count_event(asm, ManagementCounterType::BadStructure);
                         return Err(BindActorAddressError::BadStructure);
                     }
 
                     let Ok(msg) = std::str::from_utf8(&resp.body()[..hdr.info_len as usize]) else {
-                        core::count_event(asm, &mut resp, ManagementCounterType::BadStructure);
+                        core::count_event(asm, ManagementCounterType::BadStructure);
                         return Err(BindActorAddressError::BadStructure);
                     };
                     let msg: Box<str> = msg.into();
@@ -315,7 +315,7 @@ pub async fn send_bind_actor_address_request(
                 }
 
                 _ => {
-                    core::count_event(asm, &mut resp, ManagementCounterType::BadStructure);
+                    core::count_event(asm, ManagementCounterType::BadStructure);
                     Err(BindActorAddressError::BadStructure)
                 }
             }

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -25,27 +25,23 @@ pub async fn launch(
 ) {
     while let Some(msg) = queue.recv().await {
         match msg {
-            MgmtProcessorMessage::Packet(mut pkt) => {
+            MgmtProcessorMessage::Packet(pkt) => {
                 // Drop packets which are intended for a link other than the one we are assigned to,
                 // since processing them here will violate concurrency assumptions.
                 if pkt.metadata().ingress_link_id != config.link_id.get() {
-                    mgmt::core::count_event(
-                        &asm,
-                        &mut pkt,
-                        ManagementCounterType::InternalRoutingError,
-                    );
+                    mgmt::core::count_event(&asm, ManagementCounterType::InternalRoutingError);
                     continue;
                 }
 
                 match handle_packet(&asm, pkt).await {
                     Ok(()) => (),
-                    Err((err, mut pkt)) => {
+                    Err(err) => {
                         let link_id = config.link_id.get();
                         error!(target: ZDP, "Error handling packet received on link {link_id}: {err}");
                         if let Err(e) = asm.process_link_state_event(link_id, LinkEvent::Error) {
                             error!(target: LINK_STATE, "Error handling link error on link {link_id}: {e}");
                         }
-                        mgmt::core::count_event(&asm, &mut pkt, err.into());
+                        mgmt::core::count_event(&asm, err.into());
                     }
                 }
             }
@@ -57,7 +53,7 @@ pub async fn launch(
 
 async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
     let Ok(base_hdr) = ZdpBaseHeader::read_from_buf(&mut pkt) else {
-        return Err((HandleMgmtError::BadStructure, pkt));
+        return Err(HandleMgmtError::BadStructure);
     };
 
     let seq_num = pkt.metadata().seq_num;
@@ -84,7 +80,7 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
 
     if base_hdr.packet_type.is_per_flow() {
         let Ok(per_flow_hdr) = ZdpPerFlowHeader::read_from_buf(&mut pkt) else {
-            return Err((HandleMgmtError::BadStructure, pkt));
+            return Err(HandleMgmtError::BadStructure);
         };
 
         pkt.metadata_mut().ingress_stream_id = per_flow_hdr.stream_id.into();
@@ -94,13 +90,13 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
 
             ZdpPacketType::BindActorAddressRequest => {
                 let Ok(txn_hdr) = ZdpTransactionHeader::read_from_buf(&mut pkt) else {
-                    return Err((HandleMgmtError::BadStructure, pkt));
+                    return Err(HandleMgmtError::BadStructure);
                 };
                 handlers::handle_bind_actor_address_request(asm, txn_hdr.transaction_id.into(), pkt)
                     .await
             }
 
-            packet_type => Err((HandleMgmtError::UnknownType(packet_type.0), pkt)),
+            packet_type => Err(HandleMgmtError::UnknownType(packet_type.0)),
         }
     } else {
         match base_hdr.packet_type {
@@ -158,7 +154,7 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
 
             packet_type => {
                 warn!("unhandled mgmt packet type {:?}", packet_type);
-                Err((HandleMgmtError::UnknownType(packet_type.0), pkt))
+                Err(HandleMgmtError::UnknownType(packet_type.0))
             }
         }
     }


### PR DESCRIPTION
We don't use this argument and it makes an upcoming PR clunky (preventing easy use of the `?` operator to propagate send failures).