### PR TITLE
ZDPR futures

### DIFF
--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -603,7 +603,7 @@ impl LinkStateWrapper {
 
         // IF this is an adapter, it's expected to issue the hello
         if self.link_type == LinkType::AdapterToNode {
-            mgmt::requests::send_hello_request(asm, self.id);
+            mgmt::requests::send_hello_request(asm, self.id).enqueue();
             self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_RETRY_TIMER);
             debug!(
                 target: LINK_STATE,
@@ -1291,7 +1291,7 @@ impl LinkStateWrapper {
             payload = auth::ZdpInitAuthenticationPayload::default(); // empty
         }
 
-        mgmt::requests::send_init_authentication_request(asm, link_id, flags, payload);
+        mgmt::requests::send_init_authentication_request(asm, link_id, flags, payload).enqueue();
     }
 
     /// Send the Grant message
@@ -1307,7 +1307,8 @@ impl LinkStateWrapper {
             self.id,
             ResponseCode::Success,
             &ipaddrs,
-        );
+        )
+        .enqueue();
     }
 
     /// Run the HTTPS authentication process in a tokio task.
@@ -1408,7 +1409,8 @@ impl LinkStateWrapper {
             self.id,
             requesting_addrs,
             Some(blob.as_bytes()),
-        );
+        )
+        .enqueue();
     }
 
     fn process_error_response(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
@@ -1509,7 +1511,7 @@ impl LinkStateWrapper {
             }
 
             (LinkType::AdapterToNode, LinkState::Helloing) => {
-                mgmt::requests::send_hello_request(asm, self.id);
+                mgmt::requests::send_hello_request(asm, self.id).enqueue();
             }
 
             // Programming error!
@@ -1617,7 +1619,7 @@ impl LinkStateWrapper {
             &mut locked_fsm,
             config::DEFAULT_TERMINATE_RESPONSE_TIMER,
         );
-        mgmt::requests::send_terminate_request(asm, self.id, reason);
+        mgmt::requests::send_terminate_request(asm, self.id, reason).enqueue();
         Ok(())
     }
 
@@ -1738,7 +1740,7 @@ impl LinkStateWrapper {
             .lock()
             .unwrap()
             .set_state(LinkState::Resetting);
-        mgmt::requests::send_terminate_indication(asm, link_id, TerminateReason::Reset);
+        mgmt::requests::send_terminate_indication(asm, link_id, TerminateReason::Reset).enqueue();
         let _ = self.clean_up_link_state(asm).join_all().await;
     }
 
@@ -1806,7 +1808,12 @@ impl LinkStateWrapper {
 
                 let mut recv = task_events.subscribe();
 
-                mgmt::requests::send_echo_request(&task_asm, link_id);
+                if mgmt::requests::send_echo_request(&task_asm, link_id)
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
 
                 let got_response =
                     tokio::time::timeout(config::DEFAULT_REQUEST_RETRY_TIMER,

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -109,6 +109,10 @@ pub fn send_acknowledgement(asm: &Assembly, link_id: zpr::LinkId, sequence_numbe
         .try_enqueue_packet(link_id, &mut packet);
 }
 
+pub enum MgmtSendError {
+    LinkClosed,
+}
+
 #[allow(dead_code)]
 enum PacketId {
     Sent(zpr::SeqNum),
@@ -198,7 +202,7 @@ impl<'a> Drop for Sent<'a> {
 }
 
 impl<'a> std::future::Future for Sent<'a> {
-    type Output = Result<Acked<'a>, ()>;
+    type Output = Result<Acked<'a>, MgmtSendError>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.packet_id {
@@ -210,7 +214,7 @@ impl<'a> std::future::Future for Sent<'a> {
 
             PacketId::Queued(packet_id) => {
                 let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
-                    return Poll::Ready(Err(()));
+                    return Poll::Ready(Err(MgmtSendError::LinkClosed));
                 };
 
                 let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
@@ -240,7 +244,7 @@ pub struct Acked<'a> {
 }
 
 impl<'a> std::future::Future for Acked<'a> {
-    type Output = Result<(), ()>;
+    type Output = Result<(), MgmtSendError>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let Some(seq_num) = self.seq_num else {
@@ -248,7 +252,7 @@ impl<'a> std::future::Future for Acked<'a> {
         };
 
         let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
-            return Poll::Ready(Err(()));
+            return Poll::Ready(Err(MgmtSendError::LinkClosed));
         };
 
         let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
@@ -281,11 +285,11 @@ impl<'a> SentAndAcked<'a> {
 }
 
 impl<'a> std::future::Future for SentAndAcked<'a> {
-    type Output = Result<(), ()>;
+    type Output = Result<(), MgmtSendError>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let Some(peer_state) = self.0.asm.peer_table.get(self.0.link_id) else {
-            return Poll::Ready(Err(()));
+            return Poll::Ready(Err(MgmtSendError::LinkClosed));
         };
 
         let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -57,7 +57,7 @@ pub fn send_non_flow_mgmt(
     link_id: zpr::LinkId,
     packet_type: zdp::ZdpPacketType,
     packet: Packet,
-) {
+) -> Sent<'_> {
     send_mgmt_helper(asm, link_id, packet_type, None, None, packet)
 }
 
@@ -70,7 +70,7 @@ pub fn send_per_flow_mgmt(
     packet_type: zdp::ZdpPacketType,
     stream_id: zpr::StreamId,
     packet: Packet,
-) {
+) -> Sent<'_> {
     send_mgmt_helper(asm, link_id, packet_type, Some(stream_id), None, packet)
 }
 
@@ -81,7 +81,7 @@ pub fn send_per_flow_mgmt_response(
     stream_id: zpr::StreamId,
     txn_id: u16,
     packet: Packet,
-) {
+) -> Sent<'_> {
     send_mgmt_helper(
         asm,
         link_id,
@@ -170,7 +170,7 @@ impl<'a> Sent<'a> {
                 let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
                     return Err(Acked {
                         asm: self.asm,
-                        link_id: zpr::LINK_ID_UNKNOWN, // guard against memory order shenanigans
+                        link_id: zpr::LINK_ID_UNKNOWN,
                         seq_num: None,
                     });
                 };
@@ -310,7 +310,7 @@ fn send_mgmt_helper(
     stream_id: Option<zpr::StreamId>,
     txn_id: Option<u16>,
     mut packet: Packet,
-) {
+) -> Sent<'_> {
     assert_ne!(packet_type, zdp::ZdpPacketType::KeyManagement);
     assert_eq!(stream_id.is_some(), packet_type.is_per_flow());
 
@@ -330,7 +330,11 @@ fn send_mgmt_helper(
     hdr.packet_type = packet_type;
 
     let Some(peer_state) = asm.peer_table.get(link_id) else {
-        return;
+        return Sent {
+            asm,
+            link_id: zpr::LINK_ID_UNKNOWN,
+            packet_id: PacketId::Queued(0), // will not be used due to unknown link ID
+        };
     };
     let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
 
@@ -348,9 +352,19 @@ fn send_mgmt_helper(
                 // This packet should activate / restart our retry timer.
                 peer_state.zdpr_retry_timer_reset.notify_one();
             }
+
+            Sent {
+                asm,
+                link_id,
+                packet_id: PacketId::Sent(seq_num),
+            }
         }
 
-        zdpr::EnqueueResult::Queued(_packet_id) => (),
+        zdpr::EnqueueResult::Queued(packet_id) => Sent {
+            asm,
+            link_id,
+            packet_id: PacketId::Queued(packet_id),
+        },
     }
 }
 
@@ -429,6 +443,14 @@ pub enum SyncReqError {
     Timeout,
 }
 
+impl From<super::core::MgmtSendError> for SyncReqError {
+    fn from(err: super::core::MgmtSendError) -> Self {
+        match err {
+            super::core::MgmtSendError::LinkClosed => SyncReqError::LinkClosed,
+        }
+    }
+}
+
 /// Helper for send management request function
 /// Requires the type of ZDP packet being sent as well as the type of the
 /// expected response packet. The Option determines whether the function is helping the per-flow or
@@ -462,7 +484,8 @@ async fn send_sync_req_helper(
             stream_id,
             Some(permit.seq_num() as u16),
             packet,
-        );
+        )
+        .await?;
 
         tokio::select! {
             response = &mut response_future => {

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -36,6 +36,9 @@ pub enum HandleMgmtError {
 
     #[error("bad packet structure")]
     BadStructure,
+
+    #[error("link closed")]
+    LinkClosed,
 }
 
 impl From<HandleMgmtError> for counters::ManagementCounterType {
@@ -44,6 +47,15 @@ impl From<HandleMgmtError> for counters::ManagementCounterType {
             HandleMgmtError::UnknownType(_type) => Self::UnknownType,
             HandleMgmtError::BadStructure => Self::BadStructure,
             HandleMgmtError::MessageNotPermitted => Self::OtherError,
+            HandleMgmtError::LinkClosed => Self::OtherError,
+        }
+    }
+}
+
+impl From<super::core::MgmtSendError> for HandleMgmtError {
+    fn from(err: super::core::MgmtSendError) -> Self {
+        match err {
+            super::core::MgmtSendError::LinkClosed => HandleMgmtError::LinkClosed,
         }
     }
 }
@@ -119,7 +131,8 @@ pub async fn handle_echo_request(asm: &Arc<Assembly>, pkt: Packet) -> HandleMgmt
         ingress_link_id,
         zdp::ZdpPacketType::EchoResponse,
         rsp_pkt,
-    );
+    )
+    .await?;
 
     Ok(())
 }
@@ -185,7 +198,8 @@ pub async fn handle_init_authentication_request(
         ingress_link_id,
         zdp::ZdpPacketType::InitAuthenticationResponse,
         rsp_pkt,
-    );
+    )
+    .await?;
 
     let _ = dispatch_link_state_event_or_error(
         asm,
@@ -247,7 +261,8 @@ pub async fn handle_terminate_request(asm: &Arc<Assembly>, mut pkt: Packet) -> H
         ingress_link_id,
         zdp::ZdpPacketType::TerminateLinkResponse,
         rsp_pkt,
-    );
+    )
+    .await?;
 
     // Tell state machine we sent a TerminateLinkResponse. This will trigger `clean_up_link_state`.
     let _ = asm.process_link_state_event(ingress_link_id, LinkEvent::SentTerminate);
@@ -380,7 +395,8 @@ pub async fn handle_hello_request(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
         ingress_link_id,
         zdp::ZdpPacketType::HelloResponse,
         rsp_pkt,
-    );
+    )
+    .await?;
 
     let close_link = if response_status == zdp::ResponseCode::Success {
         match asm.process_link_state_event(ingress_link_id, LinkEvent::SentHelloResponse) {
@@ -546,7 +562,8 @@ pub async fn handle_acquire_zpr_address_request(
         ingress_link_id,
         zdp::ZdpPacketType::AcquireZprAddressResponse,
         rsp_pkt,
-    );
+    )
+    .await?;
 
     // Now we can do our async prcessing of the acquire which will involve talking to
     // the visa service.
@@ -631,7 +648,8 @@ pub async fn handle_grant_zpr_address_request(
         ingress_link_id,
         zdp::ZdpPacketType::GrantZprAddressResponse,
         rsp_pkt,
-    );
+    )
+    .await?;
 
     let processing_result = asm.process_link_state_event(
         ingress_link_id,
@@ -1113,7 +1131,8 @@ pub async fn handle_bind_actor_address_request(
         ingress_tether_id,
         txn_id,
         rsp_pkt,
-    );
+    )
+    .await?;
 
     Ok(())
 }

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -4,7 +4,7 @@
 
 #![allow(dead_code)]
 
-use super::core;
+use super::core::{self, Sent};
 use crate::counters::ManagementCounterType;
 use crate::defs::*;
 use crate::logging::targets::ZDP;
@@ -38,13 +38,13 @@ pub fn send_key_management(asm: &Assembly, link_id: zpr::LinkId, km_id: zpr::KmI
 }
 
 /// send a Discard message (RFC 6.5 § 6.3.1)
-pub fn send_discard(asm: &Assembly, link_id: zpr::LinkId) {
+pub fn send_discard(asm: &Assembly, link_id: zpr::LinkId) -> Sent<'_> {
     let pkt = core::new_heap_packet();
     core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::Discard, pkt)
 }
 
 /// send an Echo Request (RFC 6.5 § 6.3.2)
-pub fn send_echo_request(asm: &Assembly, link_id: zpr::LinkId) {
+pub fn send_echo_request(asm: &Assembly, link_id: zpr::LinkId) -> Sent<'_> {
     let mut pkt = core::new_heap_packet();
     pkt.alloc_zeroed_header::<zdp::ZdpEchoHeader>();
     core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::EchoRequest, pkt)
@@ -55,7 +55,7 @@ pub fn send_echo_request(asm: &Assembly, link_id: zpr::LinkId) {
 /// Originally this was used to send the pre-configured ZPR address of the
 /// remote adapter into the node.  This is no longer necessary.
 ///
-pub fn send_hello_request(asm: &Assembly, link_id: zpr::LinkId) {
+pub fn send_hello_request(asm: &Assembly, link_id: zpr::LinkId) -> Sent<'_> {
     let req = core::new_heap_packet();
     core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::HelloRequest, req)
 }
@@ -76,7 +76,7 @@ pub fn send_init_authentication_request(
     link_id: zpr::LinkId,
     flags: u8,
     payload: auth::ZdpInitAuthenticationPayload,
-) {
+) -> Sent<'_> {
     debug!(target: ZDP, "Link {link_id}: sending InitAuthenticationRequest, flags: {flags:x?}");
 
     let mut req = core::new_heap_packet();
@@ -109,12 +109,12 @@ pub fn send_init_authentication_request(
 ///
 /// ## Panics
 /// - Panics if all requested addresses are not the same IP version.
-pub fn send_acquire_zpr_address_request(
-    asm: &Assembly,
+pub fn send_acquire_zpr_address_request<'a>(
+    asm: &'a Assembly,
     link_id: zpr::LinkId,
-    actor_addrs: &[IpAddr],
-    blob: Option<&[u8]>,
-) {
+    actor_addrs: &'_ [IpAddr],
+    blob: Option<&'_ [u8]>,
+) -> Sent<'a> {
     let blob = blob.unwrap_or_default();
 
     let mut req = core::new_heap_packet();
@@ -169,12 +169,12 @@ pub fn send_acquire_zpr_address_request(
 ///
 /// ## Panics
 /// - Panics if all granted addresses are not the same IP version.
-pub fn send_grant_zpr_address_request(
-    asm: &Assembly,
+pub fn send_grant_zpr_address_request<'a>(
+    asm: &'a Assembly,
     link_id: zpr::LinkId,
     status_code: zdp::ResponseCode,
-    actor_addrs: &[IpAddr],
-) {
+    actor_addrs: &'_ [IpAddr],
+) -> Sent<'a> {
     info!(target: ZDP, "Link {link_id} - sending GrantZprAddressRequest, status: {status_code:?}");
 
     let mut req = core::new_heap_packet();
@@ -224,7 +224,7 @@ pub fn send_terminate_request<'a, 'pktbuf>(
     asm: &Assembly,
     link_id: zpr::LinkId,
     reason: zdp::TerminateReason,
-) {
+) -> Sent<'_> {
     let mut pkt = core::new_heap_packet();
     pkt.push_header(&zdp::ZdpTerminateLinkRequestHeader {
         reason_code: reason,
@@ -238,7 +238,7 @@ pub fn send_terminate_indication<'a, 'pktbuf>(
     asm: &Assembly,
     link_id: zpr::LinkId,
     reason: zdp::TerminateReason,
-) {
+) -> Sent<'_> {
     let mut pkt = core::new_heap_packet();
     let hdr = pkt.alloc_zeroed_header::<zdp::ZdpTerminateLinkIndicationHeader>();
     hdr.reason_code = reason;
@@ -326,7 +326,7 @@ pub async fn send_bind_actor_address_request(
 }
 
 /// send a Report message (RFC 6.5 § 6.3.13)
-pub fn send_report(asm: &Assembly, link_id: zpr::LinkId, report: &str) {
+pub fn send_report<'a>(asm: &'a Assembly, link_id: zpr::LinkId, report: &'_ str) -> Sent<'a> {
     // TODO this condition will need to be adjusted when we have complete ZPR packets
     // with the information at the end of the packet at well
     /*if packet::PACKET_BUFFER_MAX_BODY_SIZE - config::DEFAULT_MESSAGE_HEADROOM < report.len() {


### PR DESCRIPTION
Now we can finally use the futures we built as returns from calls to the core mgmt send functions.

This change does that, and litters the rest of the codebase with `.await` and `.enqueue()` calls as appropriate to the context (async or non-async).

Also I replaced the unit error type of the futures with a new `MgmtSendResult` which allows for easy error propagation via `?`.  (The only error which can occur is link closure.)

Also removed a misleading comment about memory order races which can not in fact occur.