### PR TITLE
use ZDPR ACK mechanism as echo response

### DIFF
--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -72,7 +72,7 @@ const DEFAULT_WORKER_CONCURRENCY: usize = 4;
 const DEFAULT_WORKER_CONCURRENCY: usize = 1;
 
 pub const DEFAULT_KEEP_ALIVE_PERIOD: std::time::Duration = std::time::Duration::from_secs(3);
-pub const DEFAULT_KEEP_ALIVE_RETRIES: usize = 3;
+pub const DEFAULT_KEEP_ALIVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
 pub const DEFAULT_LINK_RESTART_HOLDDOWN: std::time::Duration = std::time::Duration::from_secs(5);
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -157,7 +157,6 @@ pub enum LinkEvent {
     AuthenticationSuccess(auth::ZdpAuthCodeBlob), // From an authentication service
     AuthenticationFailure,                        // From an authentication service
 
-    ReceivedEchoResponse,
     ReceivedAuthorizeResponse(IpAddress), // from visa service
     ReceivedKeepAliveResponse,
     ReceivedTerminateRequest(TerminateReason),
@@ -413,12 +412,7 @@ impl LinkStateWrapper {
         asm: &Arc<Assembly>,
         event: LinkEvent,
     ) -> Result<(), LinkStateError> {
-        match event {
-            LinkEvent::ReceivedEchoResponse => {
-                trace!(target: LINK_STATE, "Link {}: *EVENT* {event:?}", self.id)
-            }
-            _ => debug!(target: LINK_STATE, "Link {}: *EVENT* {event:?}", self.id),
-        }
+        debug!(target: LINK_STATE, "Link {}: *EVENT* {event:?}", self.id);
 
         // Enqueue a copy of this event with any concurrent listening state machines.
         // If there are none, avoid trying to do so we don't make a needless copy.
@@ -481,21 +475,15 @@ impl LinkStateWrapper {
             LinkEvent::Error => self.process_error_response(asm),
             LinkEvent::Timeout { logical_clock } => self.process_timeout(asm, logical_clock),
 
+            #[allow(unreachable_patterns)]
             ev => {
                 if listened_for {
                     Ok(())
                 } else {
-                    // TODO: See issue ( https://github.com/org-zpr/zpr-core/issues/930 ).
-                    // In practice this error happens fairly regularly.
-                    if matches!(ev, LinkEvent::ReceivedEchoResponse) {
-                        warn!(target: LINK_STATE, "received echo-response with listened_for=false, continuing...");
-                        Ok(())
-                    } else {
-                        Err(LinkStateError::UnexpectedTransition(
-                            self.locked_fsm.lock().unwrap().state,
-                            ev.into(),
-                        ))
-                    }
+                    Err(LinkStateError::UnexpectedTransition(
+                        self.locked_fsm.lock().unwrap().state,
+                        ev.into(),
+                    ))
                 }
             }
         }
@@ -1789,13 +1777,11 @@ impl LinkStateWrapper {
     pub fn run_active(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
         let link_id = self.id;
         let task_asm = asm.clone();
-        let task_events = self.events.clone();
         asm.counters.management[ManagementCounterType::PeerHandshakeSuccess].increment();
         debug!(target: LINK_STATE, "Link {link_id} entering active state");
         tokio::task::spawn_local(async move {
             let mut interval = tokio::time::interval(config::DEFAULT_KEEP_ALIVE_PERIOD);
             interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-            let mut consecutive_misses = 0;
             while task_asm.is_link_ready(link_id) {
                 interval.tick().await;
                 let start_time = Instant::now();
@@ -1806,36 +1792,13 @@ impl LinkStateWrapper {
                     return;
                 }
 
-                let mut recv = task_events.subscribe();
+                let echo_ack = tokio::time::timeout(
+                    config::DEFAULT_KEEP_ALIVE_TIMEOUT,
+                    mgmt::requests::send_echo_request(&task_asm, link_id).acked(),
+                )
+                .await;
 
-                if mgmt::requests::send_echo_request(&task_asm, link_id)
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-
-                let got_response =
-                    tokio::time::timeout(config::DEFAULT_REQUEST_RETRY_TIMER,
-                        async {
-                            loop {
-                                match recv.recv().await {
-                                    Ok(LinkEvent::ReceivedEchoResponse) => break true,
-
-                                    Ok(_) => (),
-
-                                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                                        debug!(target: LINK_STATE, "Link {link_id} lagged waiting for echo response (unexpected)");
-                                    }
-
-                                    Err(broadcast::error::RecvError::Closed) => {
-                                        break false;  // we'll exit next time through the loop
-                                    }
-                                }
-                            }
-                        }).await.unwrap_or(false);
-
-                drop(recv);
+                let got_response = matches!(echo_ack, Ok(Ok(())));
 
                 let mut link_data = peer.link_state_machine.locked_data.lock().unwrap();
 
@@ -1844,18 +1807,14 @@ impl LinkStateWrapper {
                     link_data
                         .latency_data
                         .add(Instant::now().duration_since(start_time));
-                    consecutive_misses = 0;
                 } else {
                     link_data.echo_timeout += 1;
-                    consecutive_misses += 1;
-                    debug!(target: LINK_STATE, "Link {link_id} did not receive echo response (timeouts {}, with {} consecutive)",
-                        link_data.echo_timeout, consecutive_misses);
                 }
 
                 drop(link_data);
 
-                if consecutive_misses >= config::DEFAULT_KEEP_ALIVE_RETRIES {
-                    error!(target: LINK_STATE, "Link {link_id} failed to respond to keep-alive messages ({} consecutive misses)", consecutive_misses);
+                if !got_response {
+                    error!(target: LINK_STATE, "Link {link_id} failed to respond to keep-alive messages");
                     if task_asm
                         .process_link_state_event(
                             link_id,

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -20,7 +20,6 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 use thiserror::Error;
-use tokio::sync::broadcast;
 use tokio::time::MissedTickBehavior;
 use tracing::*;
 use zpr::{LinkId, ZPI_ENCRYPTED_HEADER_FLAG};
@@ -313,13 +312,10 @@ impl LinkStateMachine {
     }
 }
 
-const LINK_STATE_EVENT_QUEUE_SIZE: usize = 16;
-
 pub struct LinkStateWrapper {
     pub id: LinkId, // set at constructor, never changes.
     link_type: LinkType,
     locked_fsm: Mutex<LinkStateMachine>,
-    events: broadcast::Sender<LinkEvent>,
     pub locked_data: Mutex<LinkData>,
 }
 
@@ -329,7 +325,6 @@ impl LinkStateWrapper {
             id: new_id,
             link_type: new_link_type,
             locked_fsm: Mutex::new(LinkStateMachine::new(new_id)),
-            events: broadcast::Sender::new(LINK_STATE_EVENT_QUEUE_SIZE),
             locked_data: Mutex::new(LinkData::new()),
         }
     }
@@ -414,18 +409,6 @@ impl LinkStateWrapper {
     ) -> Result<(), LinkStateError> {
         debug!(target: LINK_STATE, "Link {}: *EVENT* {event:?}", self.id);
 
-        // Enqueue a copy of this event with any concurrent listening state machines.
-        // If there are none, avoid trying to do so we don't make a needless copy.
-        let listened_for;
-        if self.events.receiver_count() > 0 {
-            match self.events.send(event.clone()) {
-                Ok(n) => listened_for = n > 0,
-                Err(_) => listened_for = false,
-            }
-        } else {
-            listened_for = false;
-        }
-
         match event {
             LinkEvent::Start => self.process_start(asm),
             LinkEvent::KeyingDone => self.process_keying_done(asm),
@@ -474,18 +457,6 @@ impl LinkStateWrapper {
             LinkEvent::CloseDone => Ok(self.complete_close(asm)),
             LinkEvent::Error => self.process_error_response(asm),
             LinkEvent::Timeout { logical_clock } => self.process_timeout(asm, logical_clock),
-
-            #[allow(unreachable_patterns)]
-            ev => {
-                if listened_for {
-                    Ok(())
-                } else {
-                    Err(LinkStateError::UnexpectedTransition(
-                        self.locked_fsm.lock().unwrap().state,
-                        ev.into(),
-                    ))
-                }
-            }
         }
     }
 

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -6,7 +6,7 @@
 use crate::assembly::Assembly;
 use crate::config;
 use crate::counters::ManagementCounterType;
-use crate::packet::Packet;
+use crate::packet::{self, Packet};
 use crate::zdp;
 use crate::zdpr;
 use std::task::{Context, Poll};
@@ -92,10 +92,12 @@ pub fn send_per_flow_mgmt_response(
     )
 }
 
-#[allow(dead_code)]
 pub fn send_acknowledgement(asm: &Assembly, link_id: zpr::LinkId, sequence_number: zpr::SeqNum) {
     // TODO: just allocate this on the stack, pending #985.
     let mut packet = new_tiny_heap_packet();
+
+    // let the OS know we're ACKing data from the peer
+    packet.metadata_mut().flags |= packet::flags::CONFIRM;
 
     let hdr = packet.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
     hdr.packet_type = zdp::ZdpPacketType::Acknowledgement;
@@ -189,7 +191,6 @@ impl<'a> Sent<'a> {
     }
 
     /// Returns a future which waits for this packet to be acked (after it is sent).
-    #[allow(dead_code)]
     pub fn acked(self) -> SentAndAcked<'a> {
         SentAndAcked(self)
     }

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -9,7 +9,6 @@ use crate::defs::*;
 use crate::link_state::{LinkEvent, LinkStateError};
 use crate::logging::targets::{FLOW_MGMT, REPORTING, ZDP};
 use crate::net_defs::{ip_number, IpAddress};
-use crate::packet;
 use crate::packet::Packet;
 use crate::tlv::{self, TlvEncoding};
 use crate::zdp;
@@ -121,29 +120,8 @@ pub async fn handle_discard(_asm: &Arc<Assembly>, pkt: Packet) -> HandleMgmtResu
 }
 
 /// handle an Echo Request message (RFC 6.5 § 6.3.2)
-pub async fn handle_echo_request(asm: &Arc<Assembly>, pkt: Packet) -> HandleMgmtResult {
-    let ingress_link_id = pkt.metadata().ingress_link_id;
-    let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-    rsp_pkt.metadata_mut().flags |= packet::flags::CONFIRM;
-
-    super::core::send_non_flow_mgmt(
-        asm,
-        ingress_link_id,
-        zdp::ZdpPacketType::EchoResponse,
-        rsp_pkt,
-    )
-    .await?;
-
-    Ok(())
-}
-
-pub async fn handle_echo_response(asm: &Arc<Assembly>, pkt: Packet) -> HandleMgmtResult {
-    let _ = dispatch_link_state_event_or_error(
-        asm,
-        pkt.metadata().ingress_link_id,
-        LinkEvent::ReceivedEchoResponse,
-    );
-
+pub async fn handle_echo_request(_asm: &Arc<Assembly>, _pkt: Packet) -> HandleMgmtResult {
+    // we simply rely on the ZDPR ACK
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -59,7 +59,7 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
     let seq_num = pkt.metadata().seq_num;
 
     match base_hdr.packet_type {
-        ZdpPacketType::EchoRequest | ZdpPacketType::EchoResponse => {
+        ZdpPacketType::EchoRequest => {
             trace!(
                 target: ZDP,
                 "Link {}: handling mgmt message type {:?} seq_num {seq_num}",
@@ -105,8 +105,6 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
             ZdpPacketType::Discard => handlers::handle_discard(asm, pkt).await,
 
             ZdpPacketType::EchoRequest => handlers::handle_echo_request(asm, pkt).await,
-
-            ZdpPacketType::EchoResponse => handlers::handle_echo_response(asm, pkt).await,
 
             ZdpPacketType::KeyManagement => {
                 panic!("unexpected Key Management message in mgmt processor")

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -11,7 +11,7 @@ use zpr;
 pub enum ZdpPacketType {
     // Flow-based
     TransitPacket = 0,
-    Unused = 1,
+    Unused1 = 1,
     DestinationUnreachable = 2,
     VisaHeraldRequest = 3,
     VisaHeraldResponse = 4,
@@ -34,7 +34,7 @@ pub enum ZdpPacketType {
     KeyManagement = 129,
     Discard = 130,
     EchoRequest = 131,
-    EchoResponse = 132,
+    Unused132 = 132,
     TerminateLinkRequest = 133,
     TerminateLinkResponse = 134,
     TerminateLinkIndication = 135,


### PR DESCRIPTION
Gets rid of EchoResponses in favor of heeding the ZDPR ACK to an EchoRequest.

Removes the retry mechanism for EchoResponses in favor of ZDPR retries.

Moves the MSG_CONFIRM flag from EchoResponses to ZDPR ACKs.

Removes the LinkEvent mechanism (was used only by echos).