### PR TITLE
remove requirement for explicit link noise keys

### DIFF
--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -199,8 +199,6 @@ impl Config {
             config.set_from_adapter(&config_file.adapter, base_dir)?;
             config.set_from_authentication(&config_file.authentication, base_dir)?;
         }
-        // If a noise key is not set, generate one.
-
         Ok(config)
     }
 

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -93,6 +93,10 @@ impl ArgError for str {
 /// use [crate::main_argparse::argparse].
 #[derive(Debug, Clone)]
 pub struct Config {
+    /// Name of this node or adapter. If no signed certificate is available this is used as the CN.
+    /// This has no meaning for nodes.
+    pub name: String,
+
     /// Path to the unix domain socket for the control interface.
     pub control_path: PathBuf,
 
@@ -104,14 +108,14 @@ pub struct Config {
     pub ca_file: PathBuf,
 
     /// Path to a PEM file containing the signed certificate listing the noise public key.
-    pub certificate_file: PathBuf,
+    pub certificate_file: Option<PathBuf>,
 
     /// Path to a PEM file containing the noise private key, if specified.
-    /// One of either `private_key_file` or `private_key_data` must be specified.
+    /// For a node, one of either `private_key_file` or `private_key_data` must be specified.
     pub private_key_file: Option<PathBuf>,
 
     /// The noise private key data, base64 encoded. User has option to set this through an environment variable.
-    /// One of either `private_key_file` or `private_key_data` must be specified.
+    /// For a node, one of either `private_key_file` or `private_key_data` must be specified.
     pub private_key_data: Option<String>,
 
     /// Optionally specify the name of the TUN interface to use. In most cases this
@@ -144,7 +148,8 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn get_noise_private_key_data(&self) -> Result<[u8; NOISE_KEY_LEN], ArgsError> {
+    /// If private noise key is specified through config or args, return it here.
+    pub fn get_noise_private_key_data(&self) -> Result<Option<[u8; NOISE_KEY_LEN]>, ArgsError> {
         if let Some(ref b64data) = self.private_key_data {
             let key_data: [u8; NOISE_KEY_LEN] = match BASE64_STANDARD.decode(b64data) {
                 Ok(data) => data
@@ -156,14 +161,15 @@ impl Config {
                     )))
                 }
             };
-            return Ok(key_data);
+            return Ok(Some(key_data));
         }
         if let Some(ref pkf) = self.private_key_file {
-            return load_noise_private_key(&pkf).map_err(|e| {
+            let pk = load_noise_private_key(&pkf).map_err(|e| {
                 ArgsError::ParseError(format!("failed to load private key from file: {e:?}"))
-            });
+            })?;
+            return Ok(Some(pk));
         }
-        Err("neither private_key_file nor noise_private_key specified".arg_missing())
+        Ok(None)
     }
 
     pub fn noise_private_key_source(&self) -> String {
@@ -193,6 +199,8 @@ impl Config {
             config.set_from_adapter(&config_file.adapter, base_dir)?;
             config.set_from_authentication(&config_file.authentication, base_dir)?;
         }
+        // If a noise key is not set, generate one.
+
         Ok(config)
     }
 
@@ -210,9 +218,13 @@ impl Config {
         Ok(config)
     }
 
-    /// Parse the `certificate_file` (a noise certificate) and return the CN value found within.
+    /// If we have a `certificate_file` use that to figure out our CN.
+    /// Otherwise we return the `global.name` value.
     pub fn get_noise_cn(&self) -> Result<String, ArgsError> {
-        return get_noise_cn(&self.certificate_file);
+        match self.certificate_file.as_ref() {
+            None => Ok(self.name.clone()),
+            Some(f) => get_noise_cn(&f),
+        }
     }
 
     // Check that the required bits are present based on mode.
@@ -232,10 +244,9 @@ impl Config {
             return Err("ca_file".arg_missing());
         }
         check_file_exists("certificate authority file", &self.ca_file)?;
-        if self.certificate_file.to_str().unwrap().is_empty() {
-            return Err("certificate_file".arg_missing());
+        if let Some(ref cf) = self.certificate_file {
+            check_file_exists("certificate file", cf)?;
         }
-        check_file_exists("certificate file", &self.certificate_file)?;
         if let Some(ref pkf) = self.private_key_file {
             if pkf.to_str().unwrap().is_empty() {
                 return Err("private_key_file".arg_missing());
@@ -245,13 +256,17 @@ impl Config {
             if pkd.is_empty() {
                 return Err("private_key_data".arg_missing());
             }
-        } else {
-            return Err("private_key_file or noise_private_key".arg_missing());
         }
         match mode {
             PhMode::Node => {
                 if self.zpr_addr.is_empty() {
                     return Err("zpr_addr".arg_missing());
+                }
+                if self.certificate_file.is_none() {
+                    return Err("certificate_file".arg_missing());
+                }
+                if self.private_key_file.is_none() && self.private_key_data.is_none() {
+                    return Err("private_key_file or noise_private_key".arg_missing());
                 }
             }
             PhMode::Adapter => {
@@ -265,6 +280,15 @@ impl Config {
                         "node public key file",
                         &self.node_public_key_file.as_ref().unwrap(),
                     )?;
+                }
+                if self.private_key_file.is_none()
+                    && self.private_key_data.is_none()
+                    && self.name.is_empty()
+                {
+                    return Err(
+                        "adapter name must be set to CN when not using explicit link keys"
+                            .arg_missing(),
+                    );
                 }
             }
         }
@@ -296,9 +320,9 @@ impl Config {
         }
         if let Some(certificate_file) = &config.certificate_file {
             if certificate_file.is_relative() {
-                self.certificate_file = base_dir.join(certificate_file);
+                self.certificate_file = Some(base_dir.join(certificate_file));
             } else {
-                self.certificate_file = certificate_file.clone();
+                self.certificate_file = Some(certificate_file.clone());
             }
         }
         if let Some(private_key_file) = &config.private_key_file {
@@ -330,6 +354,9 @@ impl Config {
         config: &AdapterConfigSection,
         base_dir: &Path,
     ) -> Result<(), ArgsError> {
+        if let Some(cn) = &config.name {
+            self.name = cn.clone();
+        }
         if let Some(node_addr) = &config.node_addr {
             self.node_addr = Some(*node_addr);
         }
@@ -425,14 +452,15 @@ impl Config {
         if let Some(certificate_file) = &common.certificate_file {
             let cf = PathBuf::from(certificate_file);
             if cf.is_relative() {
-                self.certificate_file = fs::canonicalize(cf).or_else(|e| {
+                let cfile = fs::canonicalize(cf).or_else(|e| {
                     Err(ArgsError::PathError(format!(
                         "path error for certificate_file: {:?}",
                         e
                     )))
                 })?;
+                self.certificate_file = Some(cfile);
             } else {
-                self.certificate_file = cf;
+                self.certificate_file = Some(cf);
             }
         }
         if common.private_key_file.is_some() && common.noise_private_key.is_some() {
@@ -487,10 +515,11 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            name: String::new(),
             control_path: get_data_home().join("control.sock"),
             self_addr: SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)), 0),
             ca_file: PathBuf::from(""),
-            certificate_file: PathBuf::from(""),
+            certificate_file: None,
             private_key_file: None,
             private_key_data: None,
             tun_if: None,
@@ -544,6 +573,7 @@ pub struct GlobalConfigSection {
 // Adapter only bits.
 #[derive(Deserialize, Debug, Clone)]
 pub struct AdapterConfigSection {
+    pub name: Option<String>,
     pub node_addr: Option<SocketAddr>,
     pub node_public_key_file: Option<PathBuf>,
     pub bootstrap_key: Option<PathBuf>,

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -13,7 +13,7 @@ use crate::logging::targets::KEY_MGMT;
 use crate::packet::Packet;
 use crate::zdp::{ZdpBaseHeader, ZdpPacketType, ZdpZpiHeader};
 use bytes::{BufMut, Bytes};
-use openssl::x509::X509;
+use openssl::x509::{X509NameRef, X509};
 use std::fmt;
 use std::fmt::Debug;
 use std::future::Future;
@@ -91,6 +91,30 @@ pub enum DecryptionError {
     DecryptFailed,
 }
 
+/// The key exchange process always swaps certificates, but they may or may not
+/// be signed by our trusted CA. In particular, adapters may create self-signed
+/// certificates.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PeerCertificate {
+    Verified(X509),
+    Unverified(X509),
+}
+
+impl PeerCertificate {
+    pub fn get_cert(&self) -> &X509 {
+        match self {
+            PeerCertificate::Verified(cert) => cert,
+            PeerCertificate::Unverified(cert) => cert,
+        }
+    }
+    pub fn subject_name(&self) -> &X509NameRef {
+        match self {
+            PeerCertificate::Verified(cert) => cert.subject_name(),
+            PeerCertificate::Unverified(cert) => cert.subject_name(),
+        }
+    }
+}
+
 // Copying of off std::io::Result
 pub type KmResult<T> = Result<T, KmError>;
 
@@ -162,8 +186,8 @@ pub struct KmTransportSA {
     /// This is a pointer to the encode/decode functions associated with the current SA.
     pub codec: Arc<dyn Codec>,
 
-    /// If we got (and validated) a certificate from our peer, it is stored here.
-    pub peer_cert: Option<X509>,
+    /// If we got a certificate from our peer, it is stored here.
+    pub peer_cert: Option<PeerCertificate>,
 }
 
 // Does not check the codec.
@@ -651,7 +675,7 @@ impl KmTransportSA {
         send_key: [u8; 32],
         recv_key: [u8; 32],
         codec: Arc<dyn Codec>,
-        peer_cert: Option<X509>,
+        peer_cert: Option<PeerCertificate>,
     ) -> KmTransportSA {
         KmTransportSA {
             sa_id: 0,

--- a/adapter/ph/src/km_cert_exchange.rs
+++ b/adapter/ph/src/km_cert_exchange.rs
@@ -18,13 +18,13 @@
 //!
 
 use openssl::x509::X509;
-use std::path::Path;
-use tracing::error;
+use tracing::{error, warn};
 use zerocopy::byteorder::network_endian::*;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
+use crate::km::PeerCertificate;
 use crate::logging::targets::KEY_MGMT;
-use crate::pki::{load_cert, ParseError};
+use crate::pki::ParseError;
 
 #[derive(Debug)]
 pub enum CertExchangeError {
@@ -61,16 +61,6 @@ impl KmCertExchange {
             local_cert: cert,
             authority_cert,
         }
-    }
-
-    /// Like [KmCertExchange::new] but takes the paths to the various PEM files.
-    pub fn new_from_paths(
-        cert_file: &Path,
-        authority_cert_file: &Path,
-    ) -> Result<Self, ParseError> {
-        let cert = load_cert(cert_file)?;
-        let authority_cert = load_cert(authority_cert_file)?;
-        Ok(KmCertExchange::new(cert, authority_cert))
     }
 
     /// Like [KmCertExchange::new] but takes the contents of the various PEM files.
@@ -118,6 +108,9 @@ impl KmCertExchange {
     }
 
     /// Process a payload from a peer.
+    /// Returns the presented certificate. If we were able to verify the signature against the
+    /// `authority_cert` passed in the constructor, then the returned enum will be [PeerCertificate::Verified],
+    /// otherwise it will be [PeerCertificate::Unverified].
     ///
     /// ## Errors
     /// - [CertExchangeError::ShortPayloadError] - the payload is too short to be valid.
@@ -131,7 +124,7 @@ impl KmCertExchange {
         &self,
         payload: &[u8],
         expected_peer_public_key: &[u8],
-    ) -> Result<X509, CertExchangeError> {
+    ) -> Result<PeerCertificate, CertExchangeError> {
         // Payload should be at minimum: CertExchgHdr
         if payload.len() < std::mem::size_of::<CertExchgHdr>() {
             return Err(CertExchangeError::ShortPayloadError);
@@ -158,17 +151,18 @@ impl KmCertExchange {
             }
         };
 
-        // TODO: Now check that the cert is signed by our authority.
-        {
-            let authority_pkey = self.authority_cert.public_key().unwrap(); // TODO: check this unwrap in ctor
-            match initiator_cert.verify(&authority_pkey) {
-                Ok(_) => (),
-                Err(e) => {
-                    error!(target: KEY_MGMT, "cert verification failed: {e}");
-                    return Err(CertExchangeError::CertificateVerificationError);
-                }
+        let authority_pkey = self.authority_cert.public_key().unwrap(); // TODO: check this unwrap in ctor
+        let is_verified = match initiator_cert.verify(&authority_pkey) {
+            Ok(true) => true,
+            Ok(false) => {
+                warn!(target: KEY_MGMT, "cert failed signature verification");
+                false
             }
-        }
+            Err(e) => {
+                error!(target: KEY_MGMT, "cert verification failed with unexpected error: {e}");
+                return Err(CertExchangeError::CertificateVerificationError);
+            }
+        };
 
         // Extract the public key from the cert and check it against expected
         let initiator_public_key = match initiator_cert.public_key() {
@@ -190,8 +184,12 @@ impl KmCertExchange {
                 return Err(CertExchangeError::KeyError);
             }
         }
-
-        return Ok(initiator_cert);
+        let peer_result = if is_verified {
+            PeerCertificate::Verified(initiator_cert)
+        } else {
+            PeerCertificate::Unverified(initiator_cert)
+        };
+        return Ok(peer_result);
     }
 }
 
@@ -246,7 +244,7 @@ mod test {
 
         // Node emits the initiator cert on success:
         let adapter_cert = X509::from_pem(ADAPTER_CERT_DATA.as_bytes()).unwrap();
-        assert_eq!(adapter_cert, i_cert);
+        assert_eq!(PeerCertificate::Verified(adapter_cert), i_cert);
     }
 
     #[test]

--- a/adapter/ph/src/km_cert_exchange.rs
+++ b/adapter/ph/src/km_cert_exchange.rs
@@ -196,9 +196,9 @@ impl KmCertExchange {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::km_noise::derive_public_key;
+    use crate::km_noise::{derive_public_key, NoiseKeypair};
     use crate::km_testdata::test::*;
-    use crate::pki::NOISE_KEY_LEN;
+    use crate::pki::{generate_self_signed_noise_cert, NOISE_KEY_LEN};
     use base64::prelude::*;
     use bytes::BytesMut;
 
@@ -269,5 +269,42 @@ mod test {
             }
             Err(e) => panic!("unexpected error: {:?}", e),
         };
+    }
+
+    #[test]
+    fn test_km_cert_with_self_signed() {
+        let keypair = NoiseKeypair::generate();
+
+        let self_signed_cert = generate_self_signed_noise_cert("foo.zpl", &keypair).unwrap();
+        let self_signed_cert_pem = self_signed_cert.to_pem().unwrap();
+        let self_signed_cert_pem_str = String::from_utf8(self_signed_cert_pem).unwrap();
+
+        let adapter_exchanger =
+            KmCertExchange::new_from_pem(&self_signed_cert_pem_str, CA_CERT_DATA).unwrap();
+
+        let mut buffer = BytesMut::with_capacity(MSG_BUF_SIZE);
+        //let mut buffer = [0u8; MSG_BUF_SIZE];
+        match adapter_exchanger.write_payload(&mut buffer) {
+            Ok(()) => (),
+            Err(e) => {
+                panic!("Error creating payload: {:?}", e)
+            }
+        };
+        assert!(buffer.len() > 100);
+
+        // Now a node will accept the payload and check the clients cert and signature.
+        // Returning its key fingerprint and a signature.
+        let node_exchanger = KmCertExchange::new_from_pem(NODE_CERT_DATA, CA_CERT_DATA).unwrap();
+
+        let i_cert = match node_exchanger.process_payload(&buffer[..buffer.len()], &keypair.public)
+        {
+            Ok(c) => c,
+            Err(e) => {
+                panic!("Error processing payload: {:?}", e)
+            }
+        };
+
+        // Node emits the initiator cert on success:
+        assert_eq!(PeerCertificate::Unverified(self_signed_cert), i_cert);
     }
 }

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -40,7 +40,6 @@ use base64::prelude::*;
 use bytes::{BufMut, Bytes, BytesMut};
 use curve25519_dalek::montgomery::MontgomeryPoint;
 use openssl::rand::rand_bytes;
-use openssl::x509::X509;
 use std::fmt::{self, Display, Formatter};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -83,7 +82,7 @@ pub struct KmNoise {
     recv_zpis: ZPIPair,
     send_zpis: Option<ZPIPair>,
     certx: KmCertExchange,
-    peer_cert: Option<X509>, // result of key exchange
+    peer_cert: Option<PeerCertificate>, // result of key exchange
 }
 
 /// Holds a noise keypair.
@@ -598,6 +597,7 @@ impl KeyManagerStateMachine for KmNoise {
 mod test {
     use super::*;
 
+    use openssl::x509::X509;
     use tokio::sync::mpsc;
     use tokio::task::yield_now;
     use tokio::time::timeout;
@@ -771,7 +771,10 @@ mod test {
             };
 
             // Responder has initiator's cert
-            assert_eq!(r_transport.peer_cert.unwrap(), actual_i_cert);
+            assert_eq!(
+                r_transport.peer_cert.unwrap(),
+                PeerCertificate::Verified(actual_i_cert)
+            );
         }
 
         {
@@ -783,7 +786,10 @@ mod test {
             };
 
             // Initiator has responder's cert
-            assert_eq!(i_transport.peer_cert.unwrap(), actual_r_cert);
+            assert_eq!(
+                i_transport.peer_cert.unwrap(),
+                PeerCertificate::Verified(actual_r_cert)
+            );
         }
     }
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -2,7 +2,7 @@ use crate::assembly::Assembly;
 use crate::auth::{self, DecodedBlob, ZdpAuthCodeBlob, ZdpSelfSignedBlob, AUTH_KEY_SIZE_BYTES};
 use crate::config;
 use crate::counters::ManagementCounterType;
-use crate::km::ZPIPair;
+use crate::km::{PeerCertificate, ZPIPair};
 use crate::km_multiplexor;
 use crate::logging::targets::LINK_STATE;
 use crate::mgmt;
@@ -581,17 +581,42 @@ impl LinkStateWrapper {
         };
 
         if let Some(ref peer_cert) = sa.peer_cert {
-            info!(target: LINK_STATE, "Link {link_id} has name {:?}", peer_cert.subject_name());
-            // assign special-peer name if this peer is special
-            for name in
-                special_peers::special_peer_names_from_x509_subject_name(peer_cert.subject_name())
-            {
-                match asm.peer_table.assign_special_name(name, link_id) {
-                    Ok(()) => {
-                        info!(target: LINK_STATE, "Link {link_id} assigned special name {name:?}")
+            match peer_cert {
+                PeerCertificate::Unverified(cert) => {
+                    warn!(target: LINK_STATE, "Link {link_id} has unverified name {:?}", cert.subject_name());
+
+                    // Nodes should accept unverified certs from adapters.
+                    // Nodes should not accept unverified certs from other nodes.
+                    // Adapters should not accept unverified certs from nodes.
+                    match self.link_type {
+                        LinkType::AdapterToNode => {
+                            return Err(LinkStateError::InvalidOperation(
+                                "adapter received unverified certificate from node".to_string(),
+                            ))
+                        }
+                        LinkType::NodeToAdapter => (), // OK
+                        LinkType::NodeToNode => {
+                            return Err(LinkStateError::InvalidOperation(
+                                "node received unverified certificate from peer node".to_string(),
+                            ))
+                        }
+                        _ => (),
                     }
-                    Err(_) => {
-                        warn!(target: LINK_STATE, "Unable to assign link {link_id} special name {name:?}")
+                }
+                PeerCertificate::Verified(cert) => {
+                    info!(target: LINK_STATE, "Link {link_id} has verified name {:?}", cert.subject_name());
+                    // assign special-peer name if this peer is special
+                    for name in special_peers::special_peer_names_from_x509_subject_name(
+                        cert.subject_name(),
+                    ) {
+                        match asm.peer_table.assign_special_name(name, link_id) {
+                            Ok(()) => {
+                                info!(target: LINK_STATE, "Link {link_id} assigned special name {name:?}")
+                            }
+                            Err(_) => {
+                                warn!(target: LINK_STATE, "Unable to assign link {link_id} special name {name:?}")
+                            }
+                        }
                     }
                 }
             }
@@ -892,7 +917,7 @@ impl LinkStateWrapper {
             warn!(target: LINK_STATE, "Link {link_id} no peer cert found, cannot validate blob");
             return false;
         };
-        if let Err(e) = ss_blob.verify_blob_challenge(peer_cert, &key) {
+        if let Err(e) = ss_blob.verify_blob_challenge(peer_cert.get_cert(), &key) {
             warn!(target: LINK_STATE, "Link {link_id} challenge verification failed: {e}");
             return false;
         }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -86,7 +86,7 @@ use km_noise::NoiseKeypair;
 use libnode::claims;
 use logging::targets::STARTUP;
 use net_defs::SocketAddrExt;
-use pki::load_noise_public_key;
+use pki::{generate_self_signed_noise_cert, load_cert, load_noise_public_key};
 use queues::*;
 use sys::ZprTun;
 use tun_ctl::TunCtl;
@@ -146,7 +146,7 @@ fn main() -> ExitCode {
     let peer_noise_keypair;
     let certx;
 
-    let private_key = match config.get_noise_private_key_data() {
+    let maybe_private_key = match config.get_noise_private_key_data() {
         Ok(key) => key,
         Err(e) => {
             error!(
@@ -158,8 +158,14 @@ fn main() -> ExitCode {
         }
     };
     if ph_mode == PhMode::Node {
+        // In node mode a private key is required -- since client adapters use the public key to verify the node.
+        let Some(private_key) = maybe_private_key else {
+            // Note that this is already checked in the config code, so this should be redundant.
+            error!(target: STARTUP, "nodes require a noise private key to be specified");
+            return ExitCode::FAILURE;
+        };
         peer_noise_keypair = None;
-        self_noise_keypair = Some(NoiseKeypair::new(private_key));
+        self_noise_keypair = NoiseKeypair::new(private_key);
     } else {
         let public_key = match load_noise_public_key(&Path::new(
             &config.node_public_key_file.clone().unwrap(),
@@ -174,16 +180,41 @@ fn main() -> ExitCode {
             public: public_key,
             private: [0u8; 32], // unknown
         });
-        self_noise_keypair = Some(NoiseKeypair::new(private_key));
+        self_noise_keypair = match maybe_private_key {
+            Some(private_key) => NoiseKeypair::new(private_key),
+            None => NoiseKeypair::generate(),
+        };
     }
 
-    certx = match KmCertExchange::new_from_paths(&config.certificate_file, &config.ca_file) {
-        Ok(certx) => Some(certx),
+    // Set up key exchange.
+    //
+    // If we have a signed certificate, use that.  Otherwise we create a self-signed cert
+    // and insert our CN (`name` from config) and our self_noise_keypair public key.
+
+    let self_cert = match &config.certificate_file {
+        None => match generate_self_signed_noise_cert(&config.name, &self_noise_keypair) {
+            Ok(cert) => cert,
+            Err(e) => {
+                error!(target: STARTUP, "failed to generate self-signed certificate: {e:?}");
+                return ExitCode::FAILURE;
+            }
+        },
+        Some(ref cert_path) => match load_cert(cert_path) {
+            Ok(cert) => cert,
+            Err(e) => {
+                error!(target: STARTUP, "failed to load certificate from {:?}: {e:?}", cert_path);
+                return ExitCode::FAILURE;
+            }
+        },
+    };
+    let ca_cert = match load_cert(&config.ca_file) {
+        Ok(cert) => cert,
         Err(e) => {
-            error!(target: STARTUP, "failed to initialize key exchange: {e:?}");
+            error!(target: STARTUP, "failed to load CA certificate from {:?}: {e:?}", config.ca_file);
             return ExitCode::FAILURE;
         }
     };
+    certx = KmCertExchange::new(self_cert, ca_cert);
 
     //
     // instantiate bounded resources (queues and buffers)
@@ -443,7 +474,8 @@ fn main() -> ExitCode {
     let mut maybe_aaa_pool = None;
 
     if ph_mode == PhMode::Node {
-        let node_name = config::get_noise_cn(&config.certificate_file)
+        // Note that config parsing code ensures that IF node THEN certificate_file is set.
+        let node_name = config::get_noise_cn(config.certificate_file.as_ref().unwrap())
             .expect("unable to determine node name: cannot parse CN");
         info!(target: STARTUP, "node CN is \"{node_name}\"");
 
@@ -477,7 +509,7 @@ fn main() -> ExitCode {
                 node_actor,
                 vs_inq,
                 &SocketAddr::new(zpr::VISA_SERVICE_ADDR, zpr::VISA_SERVICE_PORT).to_string(),
-                &config.certificate_file,
+                config.certificate_file.as_ref().unwrap(),
                 config.zpr_addr[0],
                 None,
             )
@@ -514,9 +546,9 @@ fn main() -> ExitCode {
         mgmt_dispatch_factory: MgmtDispatchFactory::new(md_inq_factory),
         adapter_manager_factory: AdapterManagerFactory::new(am_inq_factory),
         km_state: KmState::new(km_inq, km_sig_inq),
-        self_noise_keypair,
+        self_noise_keypair: Some(self_noise_keypair),
         peer_noise_keypair,
-        certx,
+        certx: Some(certx),
         system_start_time,
         address_pool: std::sync::Mutex::new(maybe_aaa_pool),
         config: rcu::RcuBox::new(config),

--- a/adapter/ph/src/main_argparse.rs
+++ b/adapter/ph/src/main_argparse.rs
@@ -37,6 +37,7 @@ pub fn argparse(args: Option<Vec<&str>>) -> std::result::Result<(PhMode, Config)
 
     match control.command {
         Command::Adapter {
+            name,
             config_file,
             common,
             node_addr,
@@ -60,6 +61,9 @@ pub fn argparse(args: Option<Vec<&str>>) -> std::result::Result<(PhMode, Config)
             config = Config::new_for_adapter(config_file, &common)?;
 
             // fold in the optional, adapter specific command line args:
+            if let Some(cn) = name {
+                config.name = cn;
+            }
             if let Some(node_addr) = node_addr {
                 config.node_addr = Some(node_addr);
             }
@@ -357,7 +361,7 @@ mod test {
             SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(192, 168, 0, 1)), 12345)
         );
         assert_eq!(config.ca_file, ca_file.get_path());
-        assert_eq!(config.certificate_file, cert_file.get_path());
+        assert_eq!(config.certificate_file, Some(cert_file.get_path().into()));
         assert_eq!(
             config.noise_private_key_source(),
             format!("file://{}", pk_file.get_path().display())
@@ -529,7 +533,7 @@ mod test {
             SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(192, 168, 0, 1)), 12345)
         );
         assert_eq!(config.ca_file, ca_file.get_path());
-        assert_eq!(config.certificate_file, cert_file.get_path());
+        assert_eq!(config.certificate_file, Some(cert_file.get_path().into()));
         assert_eq!(
             config.noise_private_key_source(),
             format!("file://{}", pk_file.get_path().display())
@@ -603,7 +607,7 @@ mod test {
             SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)), 0)
         );
         assert_eq!(config.ca_file, ca_file.get_path());
-        assert_eq!(config.certificate_file, cert_file.get_path());
+        assert_eq!(config.certificate_file, Some(cert_file.get_path().into()));
         assert_eq!(
             config.noise_private_key_source(),
             format!("file://{}", pk_file.get_path().display())
@@ -665,7 +669,7 @@ mod test {
             SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)), 0)
         );
         assert_eq!(config.ca_file, ca_file.get_path());
-        assert_eq!(config.certificate_file, cert_file.get_path());
+        assert_eq!(config.certificate_file, Some(cert_file.get_path().into()));
         assert_eq!(
             config.noise_private_key_source(),
             format!("file://{}", pk_file.get_path().display())
@@ -710,7 +714,10 @@ mod test {
             SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)), 0)
         );
         assert_eq!(config.ca_file, PathBuf::from(&ca_file_fname));
-        assert_eq!(config.certificate_file, PathBuf::from(&cert_file_fname));
+        assert_eq!(
+            config.certificate_file,
+            Some(PathBuf::from(&cert_file_fname))
+        );
         assert_eq!(
             config.noise_private_key_source(),
             format!("file://{}", pk_file_fname)

--- a/adapter/ph/src/main_args.rs
+++ b/adapter/ph/src/main_args.rs
@@ -123,6 +123,11 @@ pub enum Command {
     /// Start the handler in adapter mode
     #[command()]
     Adapter {
+        /// Optional unless you are running an adapter without a manually configured noise key. In that
+        /// case this must be set to the desired link key CN value.
+        #[arg(long, value_name = "NAME")]
+        name: Option<String>,
+
         /// Path to adapter configuration file (any options specified on command line will override configuration file)
         #[arg(long, short = 'c', value_name = "PATH")]
         config_file: Option<PathBuf>,

--- a/adapter/ph/src/pki.rs
+++ b/adapter/ph/src/pki.rs
@@ -188,9 +188,6 @@ pub fn generate_self_signed_noise_cert(
 
     // Set the issuer name (for a self-signed cert, this is also the subject)
     let mut name = X509Name::builder()?;
-    name.append_entry_by_text("C", "US")?; // Country
-    name.append_entry_by_text("ST", "MA")?; // State or Province
-    name.append_entry_by_text("O", "ZPR")?; // Organization
     name.append_entry_by_text("CN", cn)?; // Common Name (e.g., domain name or IP)
     let name = name.build();
     builder.set_subject_name(&name)?;
@@ -223,6 +220,7 @@ pub fn generate_self_signed_noise_cert(
 
 #[cfg(test)]
 mod test {
+
     use super::*;
 
     #[test]
@@ -254,5 +252,13 @@ n5ystfC9RDOzkrR8ICLvoWBQ52ctmNH3oWs1p1DT3uL6k3QMnNlejIkUqAY51aI=
         assert!(cns.is_some());
         let cns = cns.unwrap();
         assert_eq!(cns, "bas.zpr.org".to_string());
+    }
+
+    #[test]
+    fn test_that_self_signed_cert_encodes_cn() {
+        let keypair = NoiseKeypair::generate();
+        let self_signed_cert = generate_self_signed_noise_cert("foo.zpr", &keypair).unwrap();
+        let cn = get_cn_from_cert(&self_signed_cert).unwrap();
+        assert_eq!(cn, "foo.zpr".to_string());
     }
 }

--- a/adapter/ph/src/pki.rs
+++ b/adapter/ph/src/pki.rs
@@ -3,11 +3,17 @@
 use std::fs;
 use std::path::Path;
 
-use openssl::pkey::PKey;
-use openssl::x509::X509;
+use openssl::asn1::Asn1Time;
+use openssl::bn::{BigNum, MsbOption};
+use openssl::hash::MessageDigest;
+use openssl::pkey::{Id, PKey};
+use openssl::rsa::Rsa;
+use openssl::x509::{extension::KeyUsage, X509Name, X509};
+
 use thiserror::Error;
 use tracing::error;
 
+use crate::km_noise::NoiseKeypair;
 use crate::logging::targets::KEY_MGMT; // TODO: eliminate logging from this module
 
 const PEM_BEGIN_CERTIFICATE: &str = "-----BEGIN CERTIFICATE-----";
@@ -155,6 +161,64 @@ pub fn get_cn_from_cert(cert: &X509) -> Option<String> {
         }
     }
     None
+}
+
+pub fn generate_self_signed_noise_cert(
+    cn: &str,
+    keypair: &NoiseKeypair,
+) -> Result<X509, Box<dyn std::error::Error>> {
+    if cn.is_empty() {
+        return Err("CN (common name) must be non-empty".into());
+    }
+    // Generate a new RSA private key
+    let rsa = Rsa::generate(2048)?;
+    let pkey = PKey::from_rsa(rsa)?;
+
+    // Create an X509 certificate builder
+    let mut builder = X509::builder()?;
+
+    // Set the version of the certificate (V3)
+    builder.set_version(2)?;
+
+    // Set the serial number
+    let mut serial = BigNum::new()?;
+    serial.rand(128, MsbOption::MAYBE_ZERO, true)?;
+    let serial_asn1 = serial.to_asn1_integer()?;
+    builder.set_serial_number(&serial_asn1)?;
+
+    // Set the issuer name (for a self-signed cert, this is also the subject)
+    let mut name = X509Name::builder()?;
+    name.append_entry_by_text("C", "US")?; // Country
+    name.append_entry_by_text("ST", "MA")?; // State or Province
+    name.append_entry_by_text("O", "ZPR")?; // Organization
+    name.append_entry_by_text("CN", cn)?; // Common Name (e.g., domain name or IP)
+    let name = name.build();
+    builder.set_subject_name(&name)?;
+    builder.set_issuer_name(&name)?; // Self-signed
+
+    // Set the validity period
+    let not_before = Asn1Time::days_from_now(0)?;
+    let not_after = Asn1Time::days_from_now(365)?; // Valid for 1 year
+    builder.set_not_before(&not_before)?;
+    builder.set_not_after(&not_after)?;
+
+    let x_key_usage = KeyUsage::new()
+        .digital_signature()
+        .key_encipherment()
+        .build()?;
+    builder.append_extension(x_key_usage)?;
+
+    // Set the public key
+    let ssl_pubkey = PKey::public_key_from_raw_bytes(&keypair.public, Id::X25519)?;
+    builder.set_pubkey(&ssl_pubkey)?;
+
+    // Sign the certificate with the private key
+    builder.sign(&pkey, MessageDigest::sha256())?;
+
+    // Build the certificate
+    let cert = builder.build();
+
+    Ok(cert)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
A plain old adapter no longer needs to have a configured noise key.  If you drop the `certificate_file` and `private_key_file` configuration args, then the PH will just create a self-signed cert using a randomly generated noise key.

Since we use CNs so much, you do have to set the CN and that is set in the new `adapter.name` config.

Special adapters like "vs.zpr" still need a signed key.  And I've assumed that node<->node links will require signed keys.