### PR TITLE
remove authentication ACK messages

### DIFF
--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -145,7 +145,7 @@ pub enum LinkEvent {
     SentHelloResponse,
 
     ReceivedInitAuth((bool, Option<auth::ZdpInitAuthenticationPayload>)), // (bootstrap_flag, challenge)
-    ReceivedInitAuthResponse(ResponseCode),
+    ReceivedInitAuthAck,
 
     ReceivedAcquireZprAddressRequest(Option<Vec<IpAddress>>, String), // (requested_addrs, auth_blob)
     ReceivedAcquireResponse(ResponseCode),
@@ -348,7 +348,6 @@ impl LinkStateWrapper {
     ///
     /// The timeout may be cancelled manually using `LinkStateMachine::cancel_timeout()`.
     /// It will be cancelled atomically.
-    #[allow(dead_code)]
     fn set_timeout(
         &self,
         asm: &Arc<Assembly>,
@@ -429,7 +428,7 @@ impl LinkStateWrapper {
                 self.process_init_auth(asm, bootstrap_flag, challenge)
             }
 
-            LinkEvent::ReceivedInitAuthResponse(code) => self.process_init_auth_response(asm, code),
+            LinkEvent::ReceivedInitAuthAck => self.process_init_auth_ack(asm),
 
             LinkEvent::ReceivedGrantZprAddressRequest(addrs) => {
                 self.process_grant_zpr_address_request(asm, addrs)
@@ -653,8 +652,9 @@ impl LinkStateWrapper {
             // Node->Adapter - we are in helloing state until we have fired off our
             // HelloResponse.  At that point we can send an init-auth request.
             (LinkType::NodeToAdapter, LinkState::Helloing) => {
-                locked_fsm.set_state(LinkState::WaitForInitAuth);
+                locked_fsm.set_state(LinkState::WaitForAcquireZprAddress);
                 self.send_init_authentication_request(asm);
+                // short timeout until we at least get the ACK
                 self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_TIMEOUT);
                 debug!(
                     target: LINK_STATE,
@@ -1202,36 +1202,25 @@ impl LinkStateWrapper {
         Ok(())
     }
 
-    /// The node sends init-authentication to the adapter, the response only serves to
-    /// clear our retry timer.  The adapter will in the meantime take care of doing
+    /// The node sends init-authentication to the adapter, we await the ACK to
+    /// clear our timeout.  The adapter will in the meantime take care of doing
     /// whatever authentication it needs to and will eventually send us an acquire-zpr-address
     /// message with the authentication results (blob).
-    fn process_init_auth_response(
-        &self,
-        asm: &Arc<Assembly>,
-        response_code: ResponseCode,
-    ) -> Result<(), LinkStateError> {
+    fn process_init_auth_ack(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         match (self.link_type, locked_fsm.state) {
-            (LinkType::NodeToAdapter, LinkState::WaitForInitAuth) => {
-                debug!(target: LINK_STATE, "Link {} received init auth response with code {:?}", self.id, response_code);
-                if response_code == ResponseCode::Success {
-                    locked_fsm.set_state(LinkState::WaitForAcquireZprAddress);
-                    // In this state we are waiting on the adapter to perform authentication and
-                    // that may involve external services and could be quite slow relative to a
-                    // straightforward ZDP response.  So, we set a longer timeout.  We do not retransmit
-                    // anything... if we do not get auth within a reasonable amount of time we shut down
-                    // the link.
-                    self.set_timeout(asm, &mut locked_fsm, config::ACTOR_AUTHENTICATION_TIMEOUT);
-                    Ok(())
-                } else {
-                    error!(target: LINK_STATE, "Link {} received init auth response with non-success response {:?}", self.id, response_code);
-                    drop(locked_fsm);
-                    self.initiate_close(asm, TerminateReason::Other)
-                }
+            (LinkType::NodeToAdapter, LinkState::WaitForAcquireZprAddress) => {
+                debug!(target: LINK_STATE, "Link {} received init auth ack", self.id);
+                // Now we are waiting on the adapter to perform authentication and
+                // that may involve external services and could be quite slow relative to a
+                // straightforward ZDP response.  So, we set a longer timeout.  We do not retransmit
+                // anything... if we do not get auth within a reasonable amount of time we shut down
+                // the link.
+                self.set_timeout(asm, &mut locked_fsm, config::ACTOR_AUTHENTICATION_TIMEOUT);
+                Ok(())
             }
             (_, _) => Err(LinkStateError::InvalidOperation(
-                "Discarded unsolicited init auth response".to_string(),
+                "Discarded unsolicited init auth ack".to_string(),
             )),
         }
     }
@@ -1275,7 +1264,20 @@ impl LinkStateWrapper {
             payload = auth::ZdpInitAuthenticationPayload::default(); // empty
         }
 
-        mgmt::requests::send_init_authentication_request(asm, link_id, flags, payload).enqueue();
+        let task_asm = asm.clone();
+        tokio::task::spawn_local(async move {
+            if mgmt::requests::send_init_authentication_request(&task_asm, link_id, flags, payload)
+                .acked()
+                .await
+                .is_err()
+            {
+                // link was terminated
+                return;
+            }
+            // ignore error here, it just means we've moved on to another state and got the ACK (very) late
+            let _ = task_asm.process_link_state_event(link_id, LinkEvent::ReceivedInitAuthAck);
+            return;
+        });
     }
 
     /// Send the Grant message
@@ -1421,7 +1423,6 @@ impl LinkStateWrapper {
         match (self.link_type, locked_fsm.state) {
             (LinkType::AdapterToNode, LinkState::RegisterAA)
             | (LinkType::NodeToAdapter, LinkState::RegisterAA)
-            | (LinkType::NodeToAdapter, LinkState::WaitForInitAuth)
             | (LinkType::AdapterToNode, LinkState::Helloing)
             | (LinkType::NodeToAdapter, LinkState::WaitForAcquireZprAddress) => {
                 // Timeout here means we give up on the link.

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -150,7 +150,6 @@ pub enum LinkEvent {
     ReceivedAcquireZprAddressRequest(Option<Vec<IpAddress>>, String), // (requested_addrs, auth_blob)
 
     ReceivedGrantZprAddressRequest(Option<Vec<IpAddress>>), // granted_addrs, None means failure.
-    ReceivedGrantResponse(ResponseCode),
 
     AuthenticationSuccess(auth::ZdpAuthCodeBlob), // From an authentication service
     AuthenticationFailure,                        // From an authentication service
@@ -431,8 +430,6 @@ impl LinkStateWrapper {
             LinkEvent::ReceivedGrantZprAddressRequest(addrs) => {
                 self.process_grant_zpr_address_request(asm, addrs)
             }
-            LinkEvent::ReceivedGrantResponse(code) => self.process_grant_response(asm, code),
-
             LinkEvent::AuthenticationFailure => self.process_authentication_failure(asm),
 
             LinkEvent::AuthenticationSuccess(blob) => {
@@ -881,41 +878,6 @@ impl LinkStateWrapper {
         true
     }
 
-    /// A grant response is just an ACK of a ZPR address grant message.
-    /// For now only expected from an adapter to a a node.
-    /// If status is OK means the link is addressed and up on sender side.
-    fn process_grant_response(
-        &self,
-        asm: &Arc<Assembly>,
-        code: ResponseCode,
-    ) -> Result<(), LinkStateError> {
-        let link_id = self.id;
-        let mut locked_fsm = self.locked_fsm.lock().unwrap();
-        match (self.link_type, locked_fsm.state) {
-            (LinkType::NodeToAdapter, LinkState::RegisterAA) => {
-                if code == ResponseCode::Success {
-                    locked_fsm.set_state(LinkState::Active);
-                    debug!(target: LINK_STATE, "Link {link_id} has ACKd the grant.  Becoming active");
-                    drop(locked_fsm);
-                    self.run_active(&asm)
-                } else {
-                    warn!(target: LINK_STATE, "Link {link_id} did not ACK the grant. Shutting down");
-                    locked_fsm.set_state(LinkState::Error);
-                    drop(locked_fsm);
-                    self.initiate_close(asm, TerminateReason::Other)
-                }
-            }
-            (LinkType::NodeToAdapter, LinkState::Active) => {
-                // Assume this is just a retransmit.
-                debug!(target: LINK_STATE, "Link {link_id} received unsolicited grant response while already in active, ignoring");
-                Ok(())
-            }
-            (_, _) => Err(LinkStateError::InvalidOperation(
-                "Discarded unsolicited grant response".to_string(),
-            )),
-        }
-    }
-
     /// Grant ZPR Address message is from a node to an adapter and includes the
     /// result of authentication verification.
     ///
@@ -1009,11 +971,11 @@ impl LinkStateWrapper {
     /// This is the event handler fro the return path from the visa service AUTHORIZE operation.
     /// This needs to trigger sending of the Grant Address message.
     ///
-    /// This is happengin on a NODE.
+    /// This is happening on a NODE.
     ///
     /// This is only called for SUCCESSFUL responses (unsuccessful responses trigger a link error).
     ///
-    /// Does not change state. Remains in [LinkState::RegisterAA].
+    /// Transitions to [LinkState::Active].  (Adapter will terminate the link if it doesn't like our grant.)
     ///
     fn process_authorize_response(
         &self,
@@ -1022,8 +984,6 @@ impl LinkStateWrapper {
     ) -> Result<(), LinkStateError> {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
 
-        locked_fsm.actor_addresses.clear();
-        locked_fsm.actor_addresses.push(zpr_addr);
         info!(target: LINK_STATE, "Link {} received authorize response with ZPR address {}", self.id, zpr_addr);
 
         match (self.link_type, locked_fsm.state) {
@@ -1035,13 +995,18 @@ impl LinkStateWrapper {
             }
         }
 
+        locked_fsm.actor_addresses.clear();
+        locked_fsm.actor_addresses.push(zpr_addr);
+
         // Send a Grant message, consume the response and then send in an event
         // indicating we got it (ReceivedGrantResponse).
 
         // Will call back via ReceivedGrantResponse event if successful.
         self.send_grant_zpr_address_request(asm, &locked_fsm.actor_addresses);
+        locked_fsm.set_state(LinkState::Active);
         self.set_timeout(asm, &mut locked_fsm, config::GRANT_REQUEST_TIMEOUT);
-        Ok(())
+        debug!(target: LINK_STATE, "Link {} has ACKd the grant.  Becoming active", self.id);
+        self.run_active(&asm)
     }
 
     /// Handle an init-auth message from sender.
@@ -1330,7 +1295,7 @@ impl LinkStateWrapper {
 
     /// Callback via the AuthenticationSuccess event.
     ///
-    /// We exepect to be in the RegisterAA state.
+    /// We expect to be in the RegisterAA state.
     ///
     /// TODO: Should we have a state to represent waiting-for-authentication?
     fn process_authentication_success(
@@ -1397,7 +1362,6 @@ impl LinkStateWrapper {
         // handle the timeout...
         match (self.link_type, locked_fsm.state) {
             (LinkType::AdapterToNode, LinkState::RegisterAA)
-            | (LinkType::NodeToAdapter, LinkState::RegisterAA)
             | (LinkType::AdapterToNode, LinkState::Helloing)
             | (LinkType::NodeToAdapter, LinkState::WaitForAcquireZprAddress) => {
                 // Timeout here means we give up on the link.

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -148,7 +148,6 @@ pub enum LinkEvent {
     ReceivedInitAuthAck,
 
     ReceivedAcquireZprAddressRequest(Option<Vec<IpAddress>>, String), // (requested_addrs, auth_blob)
-    ReceivedAcquireResponse(ResponseCode),
 
     ReceivedGrantZprAddressRequest(Option<Vec<IpAddress>>), // granted_addrs, None means failure.
     ReceivedGrantResponse(ResponseCode),
@@ -422,7 +421,6 @@ impl LinkStateWrapper {
             LinkEvent::ReceivedAcquireZprAddressRequest(addrs, blob) => {
                 self.process_acquire_zpr_address_request(asm, addrs, blob)
             }
-            LinkEvent::ReceivedAcquireResponse(code) => self.process_acquire_response(asm, code),
 
             LinkEvent::ReceivedInitAuth((bootstrap_flag, challenge)) => {
                 self.process_init_auth(asm, bootstrap_flag, challenge)
@@ -881,29 +879,6 @@ impl LinkStateWrapper {
             return false;
         }
         true
-    }
-
-    /// AcquireResponse is sent from a node to the adapter after adapter sends
-    /// in the acquire zpr address message (which is essentially an auth message).
-    /// The ACK of this means we are now waiting for a Grant message.
-    ///
-    /// No state change. No messages.
-    fn process_acquire_response(
-        &self,
-        _asm: &Arc<Assembly>,
-        code: ResponseCode,
-    ) -> Result<(), LinkStateError> {
-        let link_id = self.id;
-        let locked_fsm = self.locked_fsm.lock().unwrap();
-        match (self.link_type, locked_fsm.state) {
-            (LinkType::AdapterToNode, LinkState::RegisterAA) => {
-                debug!(target: LINK_STATE, "link {link_id} acquire ZDP address response (ACK) message received, code {:?}", code);
-                Ok(())
-            }
-            (_, _) => Err(LinkStateError::InvalidOperation(
-                "Discarded unsolicited acquire zpr address response".to_string(),
-            )),
-        }
     }
 
     /// A grant response is just an ACK of a ZPR address grant message.

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -167,45 +167,12 @@ pub async fn handle_init_authentication_request(
         challenge_opt = None;
     }
 
-    let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpInitAuthenticationResponse>();
-    hdr.status_code = zdp::ResponseCode::Success;
-
-    super::core::send_non_flow_mgmt(
-        asm,
-        ingress_link_id,
-        zdp::ZdpPacketType::InitAuthenticationResponse,
-        rsp_pkt,
-    )
-    .await?;
-
     let _ = dispatch_link_state_event_or_error(
         asm,
         ingress_link_id,
         LinkEvent::ReceivedInitAuth((is_bootstrap, challenge_opt)),
     );
 
-    Ok(())
-}
-
-/// Process the InitAuthenticationResponse message.
-/// Just inform the link_state that we got this.
-pub async fn handle_init_authentication_response(
-    asm: &Arc<Assembly>,
-    mut pkt: Packet,
-) -> HandleMgmtResult {
-    let Ok(hdr) = zdp::ZdpInitAuthenticationResponse::read_from_buf(&mut pkt) else {
-        return Err(HandleMgmtError::BadStructure);
-    };
-
-    let link_id = pkt.metadata().ingress_link_id;
-    let status = hdr.status_code;
-    debug!(target: ZDP, "Link {link_id}: Received InitAuthenticationResponse, status: {status:?}");
-    let _ = dispatch_link_state_event_or_error(
-        asm,
-        link_id,
-        LinkEvent::ReceivedInitAuthResponse(status),
-    );
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -488,37 +488,14 @@ pub async fn handle_acquire_zpr_address_request(
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
-    let mut status_code = zdp::ResponseCode::Other;
-
-    let parse_res = parse_acquire_zpr_address_request(&mut pkt);
-    if parse_res.is_ok() {
-        status_code = zdp::ResponseCode::Success; // parse OK
-    } else {
-        warn!(target: ZDP, "Link {ingress_link_id} Failed to parse Acquire Zpr Address Request message");
-    }
-
-    // Send an ACK.
-    let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpAcquireZprAddressResponse>();
-    hdr.status_code = status_code;
-
-    super::core::send_non_flow_mgmt(
-        asm,
-        ingress_link_id,
-        zdp::ZdpPacketType::AcquireZprAddressResponse,
-        rsp_pkt,
-    )
-    .await?;
+    let Ok((actor_addresses, blob)) = parse_acquire_zpr_address_request(&mut pkt) else {
+        error!(target: ZDP, "Link {ingress_link_id} Failed to parse Acquire Zpr Address Request message");
+        return Err(HandleMgmtError::BadStructure);
+    };
 
     // Now we can do our async prcessing of the acquire which will involve talking to
     // the visa service.
 
-    let (actor_addresses, blob) = match parse_res {
-        Ok((actor_addresses, blob)) => (actor_addresses, blob),
-        Err(_) => {
-            return Ok(()); // this only happens if we fail to parse the blob above
-        }
-    };
     debug!(target: ZDP, "Link {}: received Acquire ZPR Address Request for link with addresses {:?}", ingress_link_id, actor_addresses);
 
     let _ = dispatch_link_state_event_or_error(
@@ -527,25 +504,6 @@ pub async fn handle_acquire_zpr_address_request(
         LinkEvent::ReceivedAcquireZprAddressRequest(actor_addresses, blob),
     );
 
-    Ok(())
-}
-
-pub async fn handle_acquire_zpr_address_response(
-    asm: &Arc<Assembly>,
-    mut pkt: Packet,
-) -> HandleMgmtResult {
-    let Ok(hdr) = zdp::ZdpAcquireZprAddressResponse::read_from_buf(&mut pkt) else {
-        return Err(HandleMgmtError::BadStructure);
-    };
-
-    let link_id = pkt.metadata().ingress_link_id;
-    let resp_code = hdr.status_code;
-    debug!("Link {link_id} Received AcquireZprAddressResponse, status: {resp_code:?}");
-    let _ = dispatch_link_state_event_or_error(
-        asm,
-        link_id,
-        LinkEvent::ReceivedAcquireResponse(resp_code),
-    );
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -520,39 +520,27 @@ pub async fn handle_grant_zpr_address_request(
 ) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
-    let (grant_event_payload, status_code) = match parse_grant_zpr_address_request(&mut pkt) {
+    let grant_event_payload;
+    match parse_grant_zpr_address_request(&mut pkt) {
         Ok(Ok(actor_addresses)) => {
             if actor_addresses.is_empty() {
                 error!(target: ZDP, "Received Grant Zpr Address Request with no addresses");
-                (None, zdp::ResponseCode::Other)
+                return Err(HandleMgmtError::BadStructure);
             } else {
                 info!(target: ZDP,
                     "Received Grant Zpr Address Request for link {} with addresses {:?}", ingress_link_id, actor_addresses);
-                (Some(actor_addresses), zdp::ResponseCode::Success)
+                grant_event_payload = Some(actor_addresses);
             }
         }
         Ok(Err(c)) => {
             info!(target: ZDP, "Grant request indicates non-success; code: {:?}", c);
-            (None, zdp::ResponseCode::Success)
+            grant_event_payload = None;
         }
         Err(_) => {
             error!(target: ZDP, "Failed to parse Grant Zpr Address Request message, grant fails.");
-            (None, zdp::ResponseCode::Other)
+            return Err(HandleMgmtError::BadStructure);
         }
     };
-
-    // Since processing the grant is time consuming, send an ACK now.
-    let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpGrantZprAddressResponse>();
-    hdr.status_code = status_code;
-
-    super::core::send_non_flow_mgmt(
-        asm,
-        ingress_link_id,
-        zdp::ZdpPacketType::GrantZprAddressResponse,
-        rsp_pkt,
-    )
-    .await?;
 
     let processing_result = asm.process_link_state_event(
         ingress_link_id,
@@ -564,26 +552,6 @@ pub async fn handle_grant_zpr_address_request(
         error!(target: ZDP, "Link {ingress_link_id}: Failed to process GrantZprAddressRequest event: {:?}", e);
         let _ignore_errors = asm.process_link_state_event(ingress_link_id, LinkEvent::Error);
     }
-    Ok(())
-}
-
-pub async fn handle_grant_zpr_address_response(
-    asm: &Arc<Assembly>,
-    mut pkt: Packet,
-) -> HandleMgmtResult {
-    let Ok(hdr) = zdp::ZdpGrantZprAddressResponse::read_from_buf(&mut pkt) else {
-        return Err(HandleMgmtError::BadStructure);
-    };
-
-    let link_id = pkt.metadata().ingress_link_id;
-    let resp_code = hdr.status_code;
-    debug!(target: ZDP, "Link {link_id}: received GrantZprAddressResponse, status: {resp_code:?}");
-    let _ = dispatch_link_state_event_or_error(
-        asm,
-        link_id,
-        LinkEvent::ReceivedGrantResponse(resp_code),
-    );
-
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -130,10 +130,6 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
                 handlers::handle_init_authentication_request(asm, pkt).await
             }
 
-            ZdpPacketType::InitAuthenticationResponse => {
-                handlers::handle_init_authentication_response(asm, pkt).await
-            }
-
             ZdpPacketType::AcquireZprAddressRequest => {
                 handlers::handle_acquire_zpr_address_request(asm, pkt).await
             }

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -138,10 +138,6 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
                 handlers::handle_grant_zpr_address_request(asm, pkt).await
             }
 
-            ZdpPacketType::GrantZprAddressResponse => {
-                handlers::handle_grant_zpr_address_response(asm, pkt).await
-            }
-
             packet_type => {
                 warn!("unhandled mgmt packet type {:?}", packet_type);
                 Err(HandleMgmtError::UnknownType(packet_type.0))

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -134,10 +134,6 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
                 handlers::handle_acquire_zpr_address_request(asm, pkt).await
             }
 
-            ZdpPacketType::AcquireZprAddressResponse => {
-                handlers::handle_acquire_zpr_address_response(asm, pkt).await
-            }
-
             ZdpPacketType::GrantZprAddressRequest => {
                 handlers::handle_grant_zpr_address_request(asm, pkt).await
             }

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -49,8 +49,8 @@ pub enum ZdpPacketType {
     Report = 145,
     InitAuthenticationRequest = 146, // TODO: add to RFC 6
     Unused147 = 147,
-    GrantZprAddressRequest = 148,  // TODO: add to RFC 6
-    GrantZprAddressResponse = 149, // TODO: add to RFC 6
+    GrantZprAddressRequest = 148, // TODO: add to RFC 6
+    Unused149 = 149,
 
     Acknowledgement = 255,
 }
@@ -171,12 +171,6 @@ pub struct ZdpGrantZprAddressRequestHeader {
     pub addr_count: u8,
     // Followed in memory by:
     //  - IP addresses (addr_count * IP address size bytes)
-}
-
-#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
-#[repr(packed)]
-pub struct ZdpGrantZprAddressResponse {
-    pub status_code: ResponseCode,
 }
 
 #[open_enum]

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -47,10 +47,10 @@ pub enum ZdpPacketType {
     UnregisterActorAddressRequest = 143,
     UnregisterActorAddressResponse = 144,
     Report = 145,
-    InitAuthenticationRequest = 146,  // TODO: add to RFC 6
-    InitAuthenticationResponse = 147, // TODO: add to RFC 6
-    GrantZprAddressRequest = 148,     // TODO: add to RFC 6
-    GrantZprAddressResponse = 149,    // TODO: add to RFC 6
+    InitAuthenticationRequest = 146, // TODO: add to RFC 6
+    Unused147 = 147,
+    GrantZprAddressRequest = 148,  // TODO: add to RFC 6
+    GrantZprAddressResponse = 149, // TODO: add to RFC 6
 
     Acknowledgement = 255,
 }
@@ -150,12 +150,6 @@ pub struct ZdpInitAuthenticationRequestHeader {
     pub flags: u8,
     pub data_len: U16,
     // Followed by challenge payload, eg ZdpInitAuthenticationPayload below.
-}
-
-#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
-#[repr(packed)]
-pub struct ZdpInitAuthenticationResponse {
-    pub status_code: ResponseCode,
 }
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -42,8 +42,8 @@ pub enum ZdpPacketType {
     HelloResponse = 137,
     ConfigurationRequest = 138,
     ConfigurationResponse = 139,
-    AcquireZprAddressRequest = 140,  // TODO: add to RFC 6
-    AcquireZprAddressResponse = 142, // TODO: add to RFC 6
+    AcquireZprAddressRequest = 140, // TODO: add to RFC 6
+    Unused142 = 142,
     UnregisterActorAddressRequest = 143,
     UnregisterActorAddressResponse = 144,
     Report = 145,
@@ -165,12 +165,6 @@ pub struct ZdpAcquireZprAddressRequestHeader {
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
-pub struct ZdpAcquireZprAddressResponse {
-    pub status_code: ResponseCode,
-}
-
-#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
-#[repr(packed)]
 pub struct ZdpGrantZprAddressRequestHeader {
     pub status_code: ResponseCode,
     pub ip_version: zpr::L3Type, // Length of address determined by IP type
@@ -190,7 +184,7 @@ pub struct ZdpGrantZprAddressResponse {
 #[repr(u8)]
 pub enum TerminateReason {
     Other = 0,
-    BadSequenceNumber = 1,
+    Unused1 = 1,
     RequestTimedOut = 2,
     Reset = 3,
     Shutdown = 4, // quell any restart behavior


### PR DESCRIPTION
Finally, addressing what first inspired ZDPR!

These three commits (maybe helpful to view separately) remove the explicit acknowledgement messages associated with the three authentication messages.  In detail:

* `InitAuthenticationResponse` goes away.  It always carried a successful status so we don't need to change anything there.  The node no longer transitions into `WaitForInitAuth`; instead it goes directly to `WaitForAcquireZprAddress`.  However, since that may be a long time, and it is useful that we provide quick feedback if the link is actually dead, we still set a short initial timeout, which is reset to a longer timeout upon receiving a ZDPR ACK for `InitAuthenticationRequest`.  (This mirrors the behavior of `WaitForInitAuth` without the extra machinery of actually transitioning to and from that state.)

* `AcquireZprAddressResponse` goes away.  It carried an error status in the case the node couldn't parse the corresponding request, which in turn caused the adapter to bring the link down.  Instead now, the node simply brings the link down itself.

* `GrantZprAddressResponse` goes away.  It carried an error status in the case the adapter couldn't parse the corresponding request, which in turn caused the node to bring the link down.   Instead now, the adapter simply brings the link down itself.  (The node therefore now also now transitions to `Active` from `RegisterAA` as soon as the visa service authorizes the connection, rather than waiting further for the adapter to acknowledge the grant.)

Also a couple trivial cleanups mixed in.