### PR TITLE
add (but do not enable) lossy-network integration test

### DIFF
--- a/integration-test/common_funcs.sh
+++ b/integration-test/common_funcs.sh
@@ -109,6 +109,14 @@ function create_network() {
   sudo ip -n zpr-c addr add "$C_ZPR_ADDR" peer "$ZPR_SUBNET" dev tun0
 }
 
+function configure_netem() {
+  echo "Configuring netem $@" > /dev/stderr
+  for NIC in vs a b c
+  do
+    sudo tc -n zpr-node qdisc add dev veth-zpr-"$NIC" root netem "$@"
+  done
+}
+
 function destroy_network() {
   sudo ip netns delete zpr-node 2> /dev/null || true
   sudo ip netns delete zpr-vs 2> /dev/null || true

--- a/integration-test/lossy-network-test.sh
+++ b/integration-test/lossy-network-test.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+NETEM_PARAMS="loss random 10%" exec "$(dirname $0)/one-node-test.sh"

--- a/integration-test/one-node-test.sh
+++ b/integration-test/one-node-test.sh
@@ -11,6 +11,10 @@ VS_BIN=$(realpath "$(dirname $0)/vservice")
 VS_ADMIN_BIN=$(realpath "$(dirname $0)/vs-admin")
 PREGEN=$(realpath "$(dirname $0)/pregen")
 
+# netem parameters to configure on all links; e.g. "loss random 10%"
+# blank for no netem
+NETEM_PARAMS=${NETEM_PARAMS:-}
+
 source "$(dirname $0)/common_funcs.sh"
 
 ZPR_USER=$USER
@@ -72,6 +76,9 @@ echo "Setting up network"
 destroy_network
 
 create_network
+if [ -n "$NETEM_PARAMS" ]
+then configure_netem $NETEM_PARAMS  # split on whitespace
+fi
 
 create_ca_key_and_cert ca
 create_actor_key_and_cert ca vs.zpr
@@ -205,12 +212,12 @@ fi
 #
 
 echo "Wait for TUN carrier..."
-wait_for 5 check_carrier zpr-node tun0 || { echo "FAILURE"; exit 1; }
-wait_for 5 check_carrier zpr-vs tun0 || { echo "FAILURE"; exit 1; }
-wait_for 5 check_carrier zpr-a tun0 || { echo "FAILURE"; exit 1; }
-wait_for 5 check_carrier zpr-b tun0 || { echo "FAILURE"; exit 1; }
+wait_for 15 check_carrier zpr-node tun0 || { echo "FAILURE"; exit 1; }
+wait_for 15 check_carrier zpr-vs tun0 || { echo "FAILURE"; exit 1; }
+wait_for 15 check_carrier zpr-a tun0 || { echo "FAILURE"; exit 1; }
+wait_for 15 check_carrier zpr-b tun0 || { echo "FAILURE"; exit 1; }
 if [[ "$NUM_ACTORS" -ge 3 ]]; then
-  wait_for 5 check_carrier zpr-c tun0 || { echo "FAILURE"; exit 1; }
+  wait_for 15 check_carrier zpr-c tun0 || { echo "FAILURE"; exit 1; }
 fi
 echo "Carrier has arrived."
 # This sleep solves a display issue because magic


### PR DESCRIPTION
Adds a test which runs with 10% packet loss to exercise ZDPR functionality.  Has already helped find a bunch of ZDPR bugs.  Unfortunately KM-Noise isn't resilient to packet loss so the test often fails during handshaking.  (See <https://github.com/org-zpr/zpr-core/issues/1055>.)  Hence it's not enabled as part of our checkin suite.