### PR TITLE
ZDPR loose ends

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -1580,7 +1580,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "ph"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aarc",
  "arrayref",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ph"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -49,9 +49,6 @@ pub const DEFAULT_TERMINATE_TIMEOUT: std::time::Duration = std::time::Duration::
 /// means it may have to do a lot of work to verify auth.
 pub const VS_GRANT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
-/// Grant requires reconfiguring TUN, so longer.
-pub const GRANT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
-
 /// How long to wait for an actor to finish out of band authentication.
 pub const ACTOR_AUTHENTICATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1004,7 +1004,6 @@ impl LinkStateWrapper {
         // Will call back via ReceivedGrantResponse event if successful.
         self.send_grant_zpr_address_request(asm, &locked_fsm.actor_addresses);
         locked_fsm.set_state(LinkState::Active);
-        self.set_timeout(asm, &mut locked_fsm, config::GRANT_REQUEST_TIMEOUT);
         debug!(target: LINK_STATE, "Link {} has ACKd the grant.  Becoming active", self.id);
         self.run_active(&asm)
     }

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -117,7 +117,6 @@ pub struct ZdpTransactionHeader {
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpEchoHeader {
-    pub sequence_number: U16, // Only used for the response
     pub additional_length: U16,
 }
 


### PR DESCRIPTION
Tiny ZDPR things I've missed.

`GRANT_REQUEST_TIMEOUT` is no longer used (since nodes now immediately transition to Active at that point) and in fact causes error logs when it eventually goes off with no-one handling it.

I keep forgetting to bump the PH version to reflect these protocol changes, so here we go.

Echos no longer need the sequence number field.  It was only used in echo responses, and we don't have those anymore.