### PR TITLE
remove sequence_number field from non-mgmt packets

### DIFF
--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -1129,7 +1129,6 @@ mod test {
         let hdr = ZdpBaseHeader {
             packet_type: ZdpPacketType::EchoRequest,
             excess_length: 0u8,
-            sequence_number: 0u16.into(),
         };
         let buf = Box::new([0u8; PACKET_BUFFER_SIZE]);
         let mut pkt = Packet::new(buf, 64);
@@ -1159,7 +1158,6 @@ mod test {
 
         assert!(encr_hdr.packet_type == hdr.packet_type);
         assert!(encr_hdr.excess_length == hdr.excess_length);
-        assert!(encr_hdr.sequence_number == hdr.sequence_number);
     }
 
     #[tokio::test]
@@ -1172,7 +1170,6 @@ mod test {
         let hdr = ZdpBaseHeader {
             packet_type: ZdpPacketType::EchoRequest,
             excess_length: 0u8,
-            sequence_number: 0u16.into(),
         };
         //let hbytes = hdr.as_bytes();
         //pkt.body_mut()[0..hbytes.len()].copy_from_slice(&hbytes);
@@ -1208,6 +1205,5 @@ mod test {
 
         assert!(encr_hdr.packet_type == hdr.packet_type);
         assert!(encr_hdr.excess_length == hdr.excess_length);
-        assert!(encr_hdr.sequence_number == hdr.sequence_number);
     }
 }

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -98,9 +98,11 @@ pub fn send_acknowledgement(asm: &Assembly, link_id: zpr::LinkId, sequence_numbe
     // let the OS know we're ACKing data from the peer
     packet.metadata_mut().flags |= packet::flags::CONFIRM;
 
-    let hdr = packet.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
-    hdr.packet_type = zdp::ZdpPacketType::Acknowledgement;
-    hdr.sequence_number = zdpr::truncate_seq_num(sequence_number).into();
+    let mgmt_hdr = packet.alloc_zeroed_header::<zdp::ZdpMgmtHeader>();
+    mgmt_hdr.sequence_number = zdpr::truncate_seq_num(sequence_number).into();
+
+    let base_hdr = packet.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
+    base_hdr.packet_type = zdp::ZdpPacketType::Acknowledgement;
 
     // It's possible (but unlikely) the MgmtSubstrateEgress queue fills up.
     // In that case, just ignore the error; act as if the packet was dropped
@@ -326,8 +328,11 @@ fn send_mgmt_helper(
         txn_hdr.transaction_id = txn_id.into();
     }
 
-    let hdr = packet.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
-    hdr.packet_type = packet_type;
+    let _mgmt_hdr = packet.alloc_zeroed_header::<zdp::ZdpMgmtHeader>();
+    // sequence_number is chosen and filled in upon egress, if the packet is not cancelled
+
+    let base_hdr = packet.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
+    base_hdr.packet_type = packet_type;
 
     let Some(peer_state) = asm.peer_table.get(link_id) else {
         return Sent {
@@ -380,8 +385,11 @@ pub fn build_and_egress_packets<'a>(
     let mut dropped_backpressure = 0;
 
     packets.for_each(|(seq_num, packet)| {
-        let (hdr, _) = zdp::ZdpBaseHeader::mut_from_prefix(packet.body_mut()).unwrap();
-        hdr.sequence_number = zdpr::truncate_seq_num(seq_num).into();
+        let (mgmt_hdr, _) = zdp::ZdpMgmtHeader::mut_from_prefix(
+            &mut packet.body_mut()[std::mem::size_of::<zdp::ZdpBaseHeader>()..],
+        )
+        .unwrap();
+        mgmt_hdr.sequence_number = zdpr::truncate_seq_num(seq_num).into();
 
         // It's possible (but unlikely) the MgmtSubstrateEgress queue fills up.
         // In that case, just ignore the error; act as if the packet was dropped
@@ -457,8 +465,8 @@ impl From<super::core::MgmtSendError> for SyncReqError {
 /// expected response packet. The Option determines whether the function is helping the per-flow or
 /// non-per flow sender.
 /// pkt_fn allows the function to create the proper body of the ZDP packet to send
-/// Returns the received packet without the ZdpBaseHeader, but still any other Zdp header information
-/// not included in the ZdpBaseHeader, or an error
+/// Returns the received packet without the ZdpBaseHeader or ZdpMgmtHeader, but still any other
+/// Zdp header information not included in these headers, or an error
 async fn send_sync_req_helper(
     asm: &Assembly,
     link_id: zpr::LinkId,

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -78,10 +78,13 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
         }
 
         Ok((base_hdr, _)) if base_hdr.packet_type == zdp::ZdpPacketType::Acknowledgement => {
+            pkt.advance(std::mem::size_of::<zdp::ZdpBaseHeader>());
             handle_acknowledgement(asm, pkt)
         }
 
-        Ok((base_hdr, _)) => {
+        Ok((base_hdr, rest)) => {
+            let (mgmt_hdr, _) = zdp::ZdpMgmtHeader::ref_from_prefix(rest).unwrap();
+
             let Some(peer_state) = asm.peer_table.get(pkt.metadata().ingress_link_id) else {
                 core::count_event(asm, ManagementCounterType::PeerRemoved);
                 return;
@@ -91,7 +94,7 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
 
             // expand sequence number and store in packet metadata
             let mut receiver = peer_state.zdpr_recv.lock().unwrap();
-            let seq_num = receiver.reify_seq_num(base_hdr.sequence_number.get());
+            let seq_num = receiver.reify_seq_num(mgmt_hdr.sequence_number.get());
             pkt.metadata_mut().seq_num = seq_num;
 
             // determine packet disposition per ZDPR mechanism
@@ -124,12 +127,12 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
 }
 
 fn handle_acknowledgement(asm: &Assembly, pkt: &mut Packet) {
-    let Ok(base_hdr) = zdp::ZdpBaseHeader::read_from_buf(pkt) else {
+    let Ok(mgmt_hdr) = zdp::ZdpMgmtHeader::read_from_buf(pkt) else {
         core::count_event(asm, ManagementCounterType::BadStructure);
         return;
     };
 
-    let sn = base_hdr.sequence_number.get();
+    let sn = mgmt_hdr.sequence_number.get();
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
     let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
@@ -167,6 +170,11 @@ fn handle_response(asm: &Assembly, pkt: &mut Packet) {
     };
 
     let packet_type = base_hdr.packet_type;
+
+    let Ok(_mgmt_hdr) = zdp::ZdpMgmtHeader::read_from_buf(pkt) else {
+        core::count_event(asm, ManagementCounterType::BadStructure);
+        return;
+    };
 
     let Ok(txn_hdr) = zdp::ZdpTransactionHeader::read_from_buf(pkt) else {
         core::count_event(asm, ManagementCounterType::BadStructure);
@@ -291,14 +299,12 @@ mod test {
         // write ZDP base header
         let hdr = pkt1.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
         hdr.packet_type = zdp::ZdpPacketType::KeyManagement;
-        hdr.sequence_number = 1u16.into();
 
         let buf2 = Box::new([0u8; PACKET_BUFFER_SIZE]);
         let mut pkt2 = Packet::new(buf2, 64);
 
         let hdr = pkt2.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
         hdr.packet_type = zdp::ZdpPacketType::KeyManagement;
-        hdr.sequence_number = 1u16.into();
 
         let peer_sa = zpr::SubstrateAddr::from(([127, 0, 0, 1], 1234));
         let int_addr = net_defs::ScopedIpAddr::V4(Ipv4Addr::new(127, 0, 0, 1).into());

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -56,6 +56,10 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
         return Err(HandleMgmtError::BadStructure);
     };
 
+    let Ok(_mgmt_hdr) = ZdpMgmtHeader::read_from_buf(&mut pkt) else {
+        return Err(HandleMgmtError::BadStructure);
+    };
+
     let seq_num = pkt.metadata().seq_num;
 
     match base_hdr.packet_type {

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -128,11 +128,14 @@ use zpr::L3Type;
 ///     let msg_len = payload.len() as u16;
 ///     report_hdr.report_data_length = msg_len.into();
 ///
-///     // Next the ZdpHeader. No need to set values that are zero since
+///     // Next the ZdpMgmtHeader.
+///     let mgmt_hdr = pkt.alloc_zeroed_header::<ZdpMgmtHeader>();
+///     mgmt_hdr.sequence_number = 22.into();
+///
+///     // Next the ZdpBaseHeader. No need to set values that are zero since
 ///     // the `alloc` function returns zero'd memory.
-///     let zdp_hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
-///     zdp_hdr.packet_type = ZdpPacketType::Report;
-///     zdp_hdr.sequence_number = 22.into();
+///     let base_hdr = pkt.alloc_zeroed_header::<ZdpBaseHeader>();
+///     base_hdr.packet_type = ZdpPacketType::Report;
 ///
 ///     // Finally the ZpiHeader
 ///     let zpi_hdr = pkt.alloc_zeroed_header::<ZdpZpiHeader>().zpi = 5;

--- a/adapter/ph/src/packet_steering.rs
+++ b/adapter/ph/src/packet_steering.rs
@@ -71,7 +71,7 @@ mod os_impl {
                 // eBPF programs (see <https://github.com/torvalds/linux/blob/master/net/core/sock_reuseport.c#L595-L598>).
                 // (`[SKF_AD_RXHASH]` just reads as 0!)
 
-                // [0] load ZPI and packet type
+                // [0] load ZPI (upper 8 bits) and packet type (lower 8 bits)
                 sf {
                     code: LD | H | ABS,
                     jt: 0,
@@ -81,12 +81,12 @@ mod os_impl {
                 // [1] if packet is encrypted, or packet is non-flow, fall back to hash
                 sf {
                     code: JMP | JSET | K,
-                    jt: 3,
+                    jt: 5,
                     jf: 0,
                     k: ((zpr::ZPI_ENCRYPTED_HEADER_FLAG as u32) << 8)
                         | zdp::ZDP_PACKET_TYPE_NON_FLOW_FLAG as u32,
                 },
-                // [2] load stream ID
+                // [2] load stream ID, assuming this is a transit packet (no MgmtHeader)
                 sf {
                     code: LD | W | ABS,
                     jt: 0,
@@ -96,21 +96,39 @@ mod os_impl {
                         + offset_of!(zdp::ZdpPerFlowHeader, stream_id))
                         as u32,
                 },
-                // [3] modulo # of queues
+                // [3] if this is in fact a transit packet, we're good, else...
+                sf {
+                    code: JMP | JEQ | K,
+                    jt: 1,
+                    jf: 0,
+                    k: zdp::ZdpPacketType::TransitPacket.0 as u32,
+                },
+                // [4] this is a mgmt packet, reload stream ID from the correct location (after MgmtHeader)
+                sf {
+                    code: LD | W | ABS,
+                    jt: 0,
+                    jf: 0,
+                    k: (size_of::<zdp::ZdpZpiHeader>()
+                        + size_of::<zdp::ZdpBaseHeader>()
+                        + size_of::<zdp::ZdpMgmtHeader>()
+                        + offset_of!(zdp::ZdpPerFlowHeader, stream_id))
+                        as u32,
+                },
+                // [5] modulo # of queues
                 sf {
                     code: ALU | MOD | K,
                     jt: 0,
                     jf: 0,
                     k: num_queues as u32,
                 },
-                // [4] return as selected queue #
+                // [6] return as selected queue #
                 sf {
                     code: RET | A,
                     jt: 0,
                     jf: 0,
                     k: 0,
                 },
-                // [5] return huge value to force fallback to hash-based steering
+                // [7] return huge value to force fallback to hash-based steering
                 sf {
                     code: RET | K,
                     jt: 0,

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -71,6 +71,16 @@ impl ZdpPacketType {
             _ => false,
         }
     }
+
+    /// Only "management" packets have a `ZdpMgmtHeader`.
+    ///
+    /// "Management" packets are everything except transit, ARP, and KM packets.
+    pub fn is_mgmt(self) -> bool {
+        matches!(
+            self,
+            Self::TransitPacket | Self::ZprArp | Self::KeyManagement
+        )
+    }
 }
 
 #[open_enum]
@@ -92,6 +102,11 @@ pub struct ZdpZpiHeader {
 pub struct ZdpBaseHeader {
     pub packet_type: ZdpPacketType,
     pub excess_length: u8,
+}
+
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(packed)]
+pub struct ZdpMgmtHeader {
     pub sequence_number: U16,
 }
 
@@ -275,5 +290,6 @@ pub const ZDP_A2A_MAC_SIZE: usize = 8;
 /// This HMAC is tacked on to the end of the packet (following the A2A HMAC).
 pub const ZDP_PACKET_MAC_SIZE: usize = 8;
 
-const _: () = assert!(core::mem::size_of::<ZdpBaseHeader>() == 4);
+const _: () = assert!(core::mem::size_of::<ZdpBaseHeader>() == 2);
+const _: () = assert!(core::mem::size_of::<ZdpMgmtHeader>() == 2);
 const _: () = assert!(core::mem::size_of::<ZdpPerFlowHeader>() == 4);


### PR DESCRIPTION
This field is unused for transit, KM, and ARP packets.  Let's get rid of it.

(Note, this is a deviation from the RFC!)