### PR TITLE
use full 8 bytes for sequence numbers on the wire

### DIFF
--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -99,7 +99,7 @@ pub fn send_acknowledgement(asm: &Assembly, link_id: zpr::LinkId, sequence_numbe
     packet.metadata_mut().flags |= packet::flags::CONFIRM;
 
     let mgmt_hdr = packet.alloc_zeroed_header::<zdp::ZdpMgmtHeader>();
-    mgmt_hdr.sequence_number = zdpr::truncate_seq_num(sequence_number).into();
+    mgmt_hdr.sequence_number = sequence_number.into();
 
     let base_hdr = packet.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
     base_hdr.packet_type = zdp::ZdpPacketType::Acknowledgement;
@@ -389,7 +389,7 @@ pub fn build_and_egress_packets<'a>(
             &mut packet.body_mut()[std::mem::size_of::<zdp::ZdpBaseHeader>()..],
         )
         .unwrap();
-        mgmt_hdr.sequence_number = zdpr::truncate_seq_num(seq_num).into();
+        mgmt_hdr.sequence_number = seq_num.into();
 
         // It's possible (but unlikely) the MgmtSubstrateEgress queue fills up.
         // In that case, just ignore the error; act as if the packet was dropped

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -94,7 +94,7 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
 
             // expand sequence number and store in packet metadata
             let mut receiver = peer_state.zdpr_recv.lock().unwrap();
-            let seq_num = receiver.reify_seq_num(mgmt_hdr.sequence_number.get());
+            let seq_num = mgmt_hdr.sequence_number.get();
             pkt.metadata_mut().seq_num = seq_num;
 
             // determine packet disposition per ZDPR mechanism
@@ -132,7 +132,7 @@ fn handle_acknowledgement(asm: &Assembly, pkt: &mut Packet) {
         return;
     };
 
-    let sn = mgmt_hdr.sequence_number.get();
+    let seq_num = mgmt_hdr.sequence_number.get();
     let ingress_link_id = pkt.metadata().ingress_link_id;
 
     let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
@@ -141,7 +141,6 @@ fn handle_acknowledgement(asm: &Assembly, pkt: &mut Packet) {
     };
     let mut sender = peer_state.zdpr_send.lock().unwrap();
 
-    let seq_num = sender.reify_seq_num(sn);
     sender.process_ack(seq_num);
 
     // If at this point (after processing the ACK) we should not have our

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -107,7 +107,7 @@ pub struct ZdpBaseHeader {
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpMgmtHeader {
-    pub sequence_number: U16,
+    pub sequence_number: U64,
 }
 
 /// Offset into ZDP packet where [ZdpBaseHeader] starts.
@@ -291,5 +291,5 @@ pub const ZDP_A2A_MAC_SIZE: usize = 8;
 pub const ZDP_PACKET_MAC_SIZE: usize = 8;
 
 const _: () = assert!(core::mem::size_of::<ZdpBaseHeader>() == 2);
-const _: () = assert!(core::mem::size_of::<ZdpMgmtHeader>() == 2);
+const _: () = assert!(core::mem::size_of::<ZdpMgmtHeader>() == 8);
 const _: () = assert!(core::mem::size_of::<ZdpPerFlowHeader>() == 4);

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -76,7 +76,7 @@ impl ZdpPacketType {
     ///
     /// "Management" packets are everything except transit, ARP, and KM packets.
     pub fn is_mgmt(self) -> bool {
-        matches!(
+        !matches!(
             self,
             Self::TransitPacket | Self::ZprArp | Self::KeyManagement
         )

--- a/adapter/ph/src/zdpr.rs
+++ b/adapter/ph/src/zdpr.rs
@@ -221,7 +221,7 @@ impl<Pkt> Sender<Pkt> {
             None => panic!("poll of cancelled packet"),
 
             Some((_, ref mut waker)) => {
-                *waker = cx.waker().clone();
+                waker.clone_from(cx.waker());
                 Poll::Pending
             }
         }
@@ -242,7 +242,7 @@ impl<Pkt> Sender<Pkt> {
             None => Poll::Ready(()),
 
             Some((_, ref mut waker)) => {
-                *waker = cx.waker().clone();
+                waker.clone_from(cx.waker());
                 Poll::Pending
             }
         }

--- a/adapter/ph/src/zdpr.rs
+++ b/adapter/ph/src/zdpr.rs
@@ -16,28 +16,6 @@ use std::collections::VecDeque;
 use std::task::{ready, Context, Poll, Waker};
 use zpr::SeqNum;
 
-/// Reify the truncated sequence number relative to the reference sequence
-/// number, under the assumption that it is within a window centered on the
-/// highest seen value thus far.
-fn reify_seq_num(reference: SeqNum, sn: u16) -> SeqNum {
-    // We operate under the assumption that the difference between the
-    // true sequence number and `reference` is in the range [-2^15, 2^15).
-
-    // Under that assumption, we can subtract the truncated versions
-    // of both to produce a 16-bit 2s-complement value representing
-    // this difference.
-    let diff = sn.wrapping_sub(reference as u16);
-
-    // Convert the 16-bit 2s-complement value into a 64-bit signed value
-    // and add back to the reference.
-    reference.wrapping_add_signed((diff as i16) as i64)
-}
-
-/// Truncate a sequence number to 16 bits for sending over the ether.
-pub fn truncate_seq_num(sn: SeqNum) -> u16 {
-    (sn & 0xFFFF) as u16
-}
-
 /// ID of a packet which was queued for sending (but maybe not yet sent).
 pub type QueuedPacketId = u64;
 
@@ -345,12 +323,6 @@ impl<Pkt> Sender<Pkt> {
         Some(pkt)
     }
 
-    /// Expand a truncated sequence number to a full sequence number,
-    /// with reference to the most recently sent packet.
-    pub fn reify_seq_num(&self, sn: u16) -> SeqNum {
-        reify_seq_num(self.last_sent, sn)
-    }
-
     /// Lookup the sequence number of a packet which had been queued
     /// and has now been sent.
     ///
@@ -632,11 +604,6 @@ impl Receiver {
         }
     }
 
-    /// Reify the truncated sequence number into a full sequence number.
-    pub fn reify_seq_num(&self, sn: u16) -> SeqNum {
-        reify_seq_num(self.highest_seen, sn)
-    }
-
     fn oldest_unrecvd_offset(&self) -> i64 {
         -(WindowBitset::BITS as i64) + (self.recvd.leading_ones() as i64) + 1
     }
@@ -687,34 +654,6 @@ impl Receiver {
 
     pub fn window_size(&self) -> usize {
         self.window_size
-    }
-}
-
-#[cfg(test)]
-mod global_tests {
-    use super::reify_seq_num;
-
-    #[test]
-    fn test_reify() {
-        assert_eq!(reify_seq_num(0x12342000, 0x2000), 0x12342000);
-        assert_eq!(reify_seq_num(0x12342000, 0x2001), 0x12342001);
-        assert_eq!(reify_seq_num(0x12342000, 0x1FFF), 0x12341FFF);
-        assert_eq!(reify_seq_num(0x12342000, 0x3000), 0x12343000);
-        assert_eq!(reify_seq_num(0x12342000, 0x1000), 0x12341000);
-        assert_eq!(reify_seq_num(0x12342000, 0x9000), 0x12349000);
-        assert_eq!(reify_seq_num(0x12342000, 0xF000), 0x1233F000);
-        assert_eq!(reify_seq_num(0x12342000, 0xB000), 0x1233B000);
-        assert_eq!(reify_seq_num(0x12342000, 0xA000), 0x1233A000);
-
-        assert_eq!(reify_seq_num(0x1234E000, 0xE000), 0x1234E000);
-        assert_eq!(reify_seq_num(0x1234E000, 0xDFFF), 0x1234DFFF);
-        assert_eq!(reify_seq_num(0x1234E000, 0xE001), 0x1234E001);
-        assert_eq!(reify_seq_num(0x1234E000, 0xD000), 0x1234D000);
-        assert_eq!(reify_seq_num(0x1234E000, 0xF000), 0x1234F000);
-        assert_eq!(reify_seq_num(0x1234E000, 0x7000), 0x12347000);
-        assert_eq!(reify_seq_num(0x1234E000, 0x1000), 0x12351000);
-        assert_eq!(reify_seq_num(0x1234E000, 0x5000), 0x12355000);
-        assert_eq!(reify_seq_num(0x1234E000, 0x6000), 0x12346000);
     }
 }
 


### PR DESCRIPTION
In order to prevent replay attacks, we need to incorporate the full sequence number of ZDPR packets into the AEAD data somehow.  Since the sequence number is now only present on mgmt packets, Sarah suggested simply including the full sequence number in the packet body and doing away with the truncated sequence number mechanism.  Since management packets are mostly small (and the large ones are very large), this doesn't cause any problems and is architecturally simple, so this patch does that.

Note that this is a deviation from RFC 6/17.

Also a drive-by micro performance enhancement in ZDPR as suggested in <https://doc.rust-lang.org/std/task/struct.Waker.html#impl-Clone-for-Waker>.