### PR TITLE
Created five tuple lookup table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 integration-test/vs-admin
 integration-test/vservice
 integration-test/pregen/zplc
+target/

--- a/adapter/.gitignore
+++ b/adapter/.gitignore
@@ -1,4 +1,4 @@
 build/
 cactl/cmd/cactl/cactl
 target/
-
+*.pcap

--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -821,6 +821,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen_ops"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "304de19db7028420975a296ab0fcbbc8e69438c4ed254a1e41e2a7f37d5f0e0a"
+
+[[package]]
 name = "generator"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,6 +1231,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ip_network_table-deps-treebitmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1449,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1624,7 @@ dependencies = [
  "futures",
  "hdrhistogram",
  "io-uring",
+ "ip_network_table-deps-treebitmap",
  "itertools",
  "libc",
  "libnode",
@@ -1611,6 +1633,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "rand",
+ "range-set-blaze",
  "reqwest",
  "serde",
  "serde_json",
@@ -1742,6 +1765,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "range-set-blaze"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953906b1d974976f882aea72a511bd37c5f633ef17839fd3bf2bd2d18cc101be"
+dependencies = [
+ "gen_ops",
+ "itertools",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -47,6 +47,8 @@ clap_complete = { version = "4.5.57", optional = true}
 cli-proto = { git = "https://github.com/org-zpr/zpr-admin-api-rs.git", tag = "v0.2.0" }
 capnp = { version = "0.21" }
 capnp-rpc = { version = "0.21" }
+ip_network_table-deps-treebitmap = { version = "0.5.0" }
+range-set-blaze = {version = "0.4.1" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-tun = { version = "0.11.5" }

--- a/adapter/ph/src/five_tuple_lookup_table.rs
+++ b/adapter/ph/src/five_tuple_lookup_table.rs
@@ -1,0 +1,886 @@
+use crate::net_defs::{IpAddress, IpProtocol};
+use crate::rcu::RcuBox;
+use crate::visa_table::Visa;
+
+use ip_network_table_deps_treebitmap::IpLookupTable;
+use range_set_blaze::RangeMapBlaze;
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use zpr::{L3Type, VisaId};
+
+pub type FiveTupleLookup = HashMap<
+    IpAddress,
+    IpLookupTable<Ipv6Addr, RangeMapBlaze<u16, RangeMapBlaze<u16, Vec<(IpProtocol, VisaId)>>>>,
+>;
+
+pub struct FiveTupleLookupTable {
+    pub table: RcuBox<FiveTupleLookup>,
+}
+
+impl FiveTupleLookupTable {
+    // TODO change how construction is done once visas move away from being based on a FiveTuples
+    pub fn new(visa_table: HashMap<VisaId, Visa>) -> Self {
+        let mut hash_table: FiveTupleLookup = HashMap::new();
+        for (visa_id, visa) in visa_table.iter() {
+            let five_tuple = match visa.ftuple {
+                Some(ft) => ft,
+                None => continue,
+            };
+
+            // Create array for protocol
+            // 10 elements in the array because there are max 10 ip protocols that the visa could allow
+            let mut arr = Vec::new();
+            arr.push((five_tuple.l4_protocol, *visa_id));
+
+            // Create map for source ports, add array of protocols
+            let mut src_map = RangeMapBlaze::new();
+            if five_tuple.src_port == 0 {
+                src_map.ranges_insert(0..=65535, arr);
+            } else {
+                src_map.insert(five_tuple.src_port, arr);
+            }
+
+            // Create map for dst ports, add map of source ports
+            let mut dst_map = RangeMapBlaze::new();
+            if five_tuple.dst_port == 0 {
+                dst_map.ranges_insert(0..=65535, src_map);
+            } else {
+                dst_map.insert(five_tuple.dst_port, src_map);
+            }
+
+            // Create table of src addresses, add map of destination ports
+            // NOTE how large do we expect each IpLookupTable to be? I.E. how many src addresses for each dst address, typically?
+            let mut ip_table = IpLookupTable::new();
+            match five_tuple.l3_type {
+                // converting v4 to v6 is temporary until a more elegant solution can be determined, currently fine but a waste of space if using ipv4
+                L3Type::Ipv4 => ip_table.insert(
+                    Ipv4Addr::try_from(five_tuple.src_address)
+                        .unwrap()
+                        .to_ipv6_compatible(),
+                    128,
+                    dst_map,
+                ),
+                L3Type::Ipv6 => {
+                    ip_table.insert(Ipv6Addr::from(five_tuple.src_address), 128, dst_map)
+                }
+                _ => None,
+            };
+
+            // Try to add to hash table, if there is a collision, combine the tables, then add the combined table
+            match hash_table.insert(five_tuple.dst_address, ip_table) {
+                None => (),
+                Some(original_src_addrs) => {
+                    let new_src_addrs = hash_table.get_mut(&five_tuple.dst_address).unwrap();
+                    for (og_src_addr, og_mask_len, og_dst_ports) in original_src_addrs.iter() {
+                        // Try to add a source addresses, If the src address is already being used as a key, combine its dst port tables
+                        match new_src_addrs.insert(og_src_addr, og_mask_len, og_dst_ports.clone()) {
+                            None => (),
+                            Some(original_dst_ports) => {
+                                let new_dst_ports = new_src_addrs
+                                    .exact_match_mut(og_src_addr, og_mask_len)
+                                    .unwrap();
+                                // could probably have more efficiency here if we take advantage of some of the other iterators that RangeMapBlaze provides,
+                                // perhaps try initially to iterate over the ranges
+                                for (og_dst_port, og_src_ports) in original_dst_ports.iter() {
+                                    // Try to add a dst port, If the dst port is already being used as a key, combine its src port tables
+                                    match new_dst_ports.insert(og_dst_port, og_src_ports.clone()) {
+                                        None => (),
+                                        Some(mut original_src_ports) => {
+                                            let new_src_ports =
+                                                new_dst_ports.get(og_dst_port).unwrap();
+                                            // have to change the way we have been inserting because RangeMapBlaze does not have a get_mut function
+                                            for (new_src_port, new_protocols) in
+                                                new_src_ports.iter()
+                                            {
+                                                // Try to add a src port, If the src port is already being used as a key, combine its protocol tables
+                                                match original_src_ports
+                                                    .insert(new_src_port, new_protocols.clone())
+                                                {
+                                                    None => (),
+                                                    Some(mut proto_arr) => {
+                                                        for new_proto in new_protocols.iter() {
+                                                            let mut exists = false;
+                                                            for old_proto in proto_arr.iter() {
+                                                                if old_proto.0 == new_proto.0 {
+                                                                    exists = true
+                                                                }
+                                                            }
+                                                            if !exists {
+                                                                proto_arr.push(*new_proto)
+                                                            }
+                                                        }
+                                                        original_src_ports
+                                                            .insert(new_src_port, proto_arr);
+                                                    }
+                                                }
+                                            }
+                                            // original_src_ports now contains the values from original_src_ports and new_src_ports
+                                            // we don't care about the return value because we know it will be Some(new_src_ports)
+                                            new_dst_ports
+                                                .insert(og_dst_port, original_src_ports.clone());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        FiveTupleLookupTable {
+            table: RcuBox::new(hash_table),
+        }
+    }
+}
+
+mod tests {
+    use super::*;
+
+    use crate::defs::FiveTuple;
+    use crate::net_defs::ip_number;
+    use libnode::vsapi;
+
+    #[test]
+    fn test_construction_one_visa() {
+        let src_addr = [1u8; 16];
+        let dst_addr = [2u8; 16];
+
+        let l4proto = vsapi::PEPIndex::TCP;
+        let src_port = 10;
+        let dst_port = 11;
+        let src_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
+        let visa: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let v = Visa::new(visa);
+
+        // let ft = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
+        // assert_eq!(Visa::extract_five_tuple(&v.visa.unwrap()), ft);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(12, v);
+
+        let table = FiveTupleLookupTable::new(hash);
+
+        let un_rcu_table = table.table.get();
+
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .1,
+            12
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .0,
+            ip_number::TCP
+        );
+    }
+
+    #[test]
+    fn test_construction_diff_protos() {
+        let src_addr = [1u8; 16];
+        let dst_addr = [2u8; 16];
+
+        let l4proto1 = vsapi::PEPIndex::TCP;
+        let l4proto2 = vsapi::PEPIndex::UDP;
+        let src_port = 10;
+        let dst_port = 11;
+        let src_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
+        let visa1: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto1,
+            src_dst.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let visa2: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto2,
+            src_dst,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let v1 = Visa::new(visa1);
+        let v2 = Visa::new(visa2);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(12, v1);
+        hash.insert(13, v2);
+
+        let table = FiveTupleLookupTable::new(hash);
+
+        let un_rcu_table = table.table.get();
+
+        let proto_vec = un_rcu_table
+            .get(&IpAddress::from(dst_addr))
+            .unwrap()
+            .exact_match(
+                Ipv6Addr::new(
+                    0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101,
+                ),
+                128,
+            )
+            .unwrap()
+            .get(dst_port as u16)
+            .unwrap()
+            .get(src_port as u16)
+            .unwrap();
+
+        assert_eq!(proto_vec.len(), 2);
+
+        let mut tcp_idx = 0;
+        let mut udp_idx = 0;
+
+        // protovec is not deterministic in terms of ordering, have to figure out which visa is where
+        if proto_vec[0].0 == ip_number::TCP {
+            udp_idx = 1;
+        } else {
+            tcp_idx = 1;
+        }
+
+        assert_eq!(proto_vec[tcp_idx].0, ip_number::TCP);
+        assert_eq!(proto_vec[tcp_idx].1, 12);
+        assert_eq!(proto_vec[udp_idx].0, ip_number::UDP);
+        assert_eq!(proto_vec[udp_idx].1, 13);
+    }
+
+    #[test]
+    fn test_construction_diff_src_ports() {
+        let src_addr = [1u8; 16];
+        let dst_addr = [2u8; 16];
+
+        let l4proto = vsapi::PEPIndex::TCP;
+        let src_port1 = 10;
+        let src_port2 = 14;
+        let dst_port = 11;
+        let src_dst1 =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port1, dst_port, None, None);
+        let src_dst2 =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port2, dst_port, None, None);
+
+        let visa1: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst1,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let visa2: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst2,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let v1 = Visa::new(visa1);
+        let v2 = Visa::new(visa2);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(12, v1);
+        hash.insert(13, v2);
+
+        let table = FiveTupleLookupTable::new(hash);
+
+        let un_rcu_table = table.table.get();
+
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port1 as u16)
+                .unwrap()[0]
+                .1,
+            12
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port1 as u16)
+                .unwrap()[0]
+                .0,
+            ip_number::TCP
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port2 as u16)
+                .unwrap()[0]
+                .1,
+            13
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port2 as u16)
+                .unwrap()[0]
+                .0,
+            ip_number::TCP
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port2 as u16)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_construction_diff_dst_ports() {
+        let src_addr = [1u8; 16];
+        let dst_addr = [2u8; 16];
+
+        let l4proto = vsapi::PEPIndex::TCP;
+        let src_port = 10;
+        let dst_port1 = 11;
+        let dst_port2 = 14;
+        let src_dst1 =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port1, None, None);
+        let src_dst2 =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port2, None, None);
+
+        let visa1: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst1,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let visa2: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst2,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let v1 = Visa::new(visa1);
+        let v2 = Visa::new(visa2);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(12, v1);
+        hash.insert(13, v2);
+
+        let table = FiveTupleLookupTable::new(hash);
+
+        let un_rcu_table = table.table.get();
+
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port1 as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .1,
+            12
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port1 as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .0,
+            ip_number::TCP
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port2 as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .1,
+            13
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port2 as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .0,
+            ip_number::TCP
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port1 as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port1 as u16)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            un_rcu_table.get(&IpAddress::from(dst_addr)).unwrap().len(),
+            1
+        );
+        assert_eq!(un_rcu_table.len(), 1);
+    }
+
+    #[test]
+    fn test_construction_diff_src_addrs() {
+        let src_addr1 = [1u8; 16];
+        let src_addr2 = [3u8; 16];
+        let dst_addr = [2u8; 16];
+
+        let l4proto = vsapi::PEPIndex::TCP;
+        let src_port = 10;
+        let dst_port = 11;
+        let src_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
+        let visa1: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr1.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let visa2: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr2.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let v1 = Visa::new(visa1);
+        let v2 = Visa::new(visa2);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(12, v1);
+        hash.insert(13, v2);
+
+        let table = FiveTupleLookupTable::new(hash);
+
+        let un_rcu_table = table.table.get();
+
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .1,
+            12
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .0,
+            ip_number::TCP
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0303, 0x0303, 0x0303, 0x0303, 0x0303, 0x0303, 0x0303, 0x0303),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .1,
+            13
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0303, 0x0303, 0x0303, 0x0303, 0x0303, 0x0303, 0x0303, 0x0303),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .0,
+            ip_number::TCP
+        );
+        assert_eq!(
+            un_rcu_table.get(&IpAddress::from(dst_addr)).unwrap().len(),
+            2
+        );
+    }
+
+    #[test]
+    fn test_construction_diff_dst_addrs() {
+        let src_addr = [1u8; 16];
+        let dst_addr1 = [2u8; 16];
+        let dst_addr2 = [3u8; 16];
+
+        let l4proto = vsapi::PEPIndex::TCP;
+        let src_port = 10;
+        let dst_port = 11;
+        let src_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
+
+        let visa1: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr1.to_vec(),
+            l4proto,
+            src_dst.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let visa2: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr2.to_vec(),
+            l4proto,
+            src_dst,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let v1 = Visa::new(visa1);
+        let v2 = Visa::new(visa2);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(12, v1);
+        hash.insert(13, v2);
+
+        let table = FiveTupleLookupTable::new(hash);
+
+        let un_rcu_table = table.table.get();
+
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr1))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .1,
+            12
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr1))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .0,
+            ip_number::TCP
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr2))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .1,
+            13
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr2))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(src_port as u16)
+                .unwrap()[0]
+                .0,
+            ip_number::TCP
+        );
+        assert_eq!(un_rcu_table.len(), 2);
+        assert_eq!(
+            un_rcu_table.get(&IpAddress::from(dst_addr2)).unwrap().len(),
+            1
+        );
+    }
+}

--- a/adapter/ph/src/five_tuple_lookup_table.rs
+++ b/adapter/ph/src/five_tuple_lookup_table.rs
@@ -73,31 +73,37 @@ impl FiveTupleLookupTable {
             // Try to add to hash table, if there is a collision, combine the tables, then add the combined table
             match hash_table.insert(five_tuple.dst_address, ip_table) {
                 None => (),
-                Some(original_src_addrs) => {
-                    let new_src_addrs = hash_table.get_mut(&five_tuple.dst_address).unwrap();
-                    for (og_src_addr, og_mask_len, og_dst_ports) in original_src_addrs.iter() {
+                Some(removed_src_addrs) => {
+                    let in_table_src_addrs = hash_table.get_mut(&five_tuple.dst_address).unwrap();
+                    for (og_src_addr, og_mask_len, og_dst_ports) in removed_src_addrs.iter() {
                         // Try to add a source addresses, If the src address is already being used as a key, combine its dst port tables
-                        match new_src_addrs.insert(og_src_addr, og_mask_len, og_dst_ports.clone()) {
+                        match in_table_src_addrs.insert(
+                            og_src_addr,
+                            og_mask_len,
+                            og_dst_ports.clone(),
+                        ) {
                             None => (),
-                            Some(original_dst_ports) => {
-                                let new_dst_ports = new_src_addrs
+                            Some(removed_dst_ports) => {
+                                let in_table_dst_ports = in_table_src_addrs
                                     .exact_match_mut(og_src_addr, og_mask_len)
                                     .unwrap();
                                 // could probably have more efficiency here if we take advantage of some of the other iterators that RangeMapBlaze provides,
                                 // perhaps try initially to iterate over the ranges
-                                for (og_dst_port, og_src_ports) in original_dst_ports.iter() {
+                                for (og_dst_port, og_src_ports) in removed_dst_ports.iter() {
                                     // Try to add a dst port, If the dst port is already being used as a key, combine its src port tables
-                                    match new_dst_ports.insert(og_dst_port, og_src_ports.clone()) {
+                                    match in_table_dst_ports
+                                        .insert(og_dst_port, og_src_ports.clone())
+                                    {
                                         None => (),
-                                        Some(mut original_src_ports) => {
-                                            let new_src_ports =
-                                                new_dst_ports.get(og_dst_port).unwrap();
+                                        Some(mut removed_src_ports) => {
+                                            let in_table_src_ports =
+                                                in_table_dst_ports.get(og_dst_port).unwrap();
                                             // have to change the way we have been inserting because RangeMapBlaze does not have a get_mut function
                                             for (new_src_port, new_protocols) in
-                                                new_src_ports.iter()
+                                                in_table_src_ports.iter()
                                             {
                                                 // Try to add a src port, If the src port is already being used as a key, combine its protocol tables
-                                                match original_src_ports
+                                                match removed_src_ports
                                                     .insert(new_src_port, new_protocols.clone())
                                                 {
                                                     None => (),
@@ -113,15 +119,15 @@ impl FiveTupleLookupTable {
                                                                 proto_arr.push(*new_proto)
                                                             }
                                                         }
-                                                        original_src_ports
+                                                        removed_src_ports
                                                             .insert(new_src_port, proto_arr);
                                                     }
                                                 }
                                             }
                                             // original_src_ports now contains the values from original_src_ports and new_src_ports
                                             // we don't care about the return value because we know it will be Some(new_src_ports)
-                                            new_dst_ports
-                                                .insert(og_dst_port, original_src_ports.clone());
+                                            in_table_dst_ports
+                                                .insert(og_dst_port, removed_src_ports.clone());
                                         }
                                     }
                                 }

--- a/adapter/ph/src/five_tuple_lookup_table.rs
+++ b/adapter/ph/src/five_tuple_lookup_table.rs
@@ -1,3 +1,4 @@
+use crate::defs::FiveTuple;
 use crate::net_defs::{IpAddress, IpProtocol};
 use crate::rcu::RcuBox;
 use crate::visa_table::Visa;
@@ -5,9 +6,11 @@ use crate::visa_table::Visa;
 use ip_network_table_deps_treebitmap::IpLookupTable;
 use range_set_blaze::RangeMapBlaze;
 use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{Ipv4Addr, Ipv6Addr};
 use zpr::{L3Type, VisaId};
 
+// TODO wrap inner structures in Arcs, will make re-creation more efficient
+// TODO perhaps change final vec from a vec of tuples to a vec of structs, easier to understand resulting code
 pub type FiveTupleLookup = HashMap<
     IpAddress,
     IpLookupTable<Ipv6Addr, RangeMapBlaze<u16, RangeMapBlaze<u16, Vec<(IpProtocol, VisaId)>>>>,
@@ -66,6 +69,7 @@ impl FiveTupleLookupTable {
                 _ => None,
             };
 
+            // TODO This is quite inefficient, improve
             // Try to add to hash table, if there is a collision, combine the tables, then add the combined table
             match hash_table.insert(five_tuple.dst_address, ip_table) {
                 None => (),
@@ -131,12 +135,36 @@ impl FiveTupleLookupTable {
             table: RcuBox::new(hash_table),
         }
     }
+
+    pub fn find_match(&self, ft: FiveTuple) -> Option<VisaId> {
+        match self.table.get().get(&ft.dst_address) {
+            None => return None,
+            Some(src_addr_table) => {
+                return match src_addr_table.longest_match(Ipv6Addr::from(ft.src_address)) {
+                    None => None,
+                    Some(dst_port_table) => match dst_port_table.2.get(ft.dst_port) {
+                        None => None,
+                        Some(src_port_table) => match src_port_table.get(ft.src_port) {
+                            None => None,
+                            Some(proto_vec) => {
+                                for elem in proto_vec {
+                                    if elem.0 == ft.l4_protocol {
+                                        return Some(elem.1);
+                                    }
+                                }
+                                return None;
+                            }
+                        },
+                    },
+                };
+            }
+        };
+    }
 }
 
 mod tests {
     use super::*;
 
-    use crate::defs::FiveTuple;
     use crate::net_defs::ip_number;
     use libnode::vsapi;
 
@@ -882,5 +910,345 @@ mod tests {
             un_rcu_table.get(&IpAddress::from(dst_addr2)).unwrap().len(),
             1
         );
+    }
+
+    #[test]
+    fn test_exact_match_visa() {
+        let src_addr = [1u8; 16];
+        let dst_addr = [2u8; 16];
+
+        let l4proto = vsapi::PEPIndex::TCP;
+        let src_port = 10;
+        let dst_port = 11;
+        let src_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
+        let visa: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let v = Visa::new(visa);
+
+        let ft = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
+        // assert_eq!(Visa::extract_five_tuple(&v.visa.unwrap()), ft);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(12, v);
+
+        let table = FiveTupleLookupTable::new(hash);
+
+        assert_eq!(table.find_match(ft), Some(12))
+    }
+
+    #[test]
+    fn test_no_visa_match_multiple_visas() {
+        let src_addr = [1u8; 16];
+        let dst_addr = [2u8; 16];
+
+        let l4proto = vsapi::PEPIndex::TCP;
+        let src_port = 10;
+        let dst_port = 11;
+        let src_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
+        
+        let ft = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
+
+        let l4proto_diff = vsapi::PEPIndex::UDP;
+        let src_port_diff = 13;
+        let src_diff_dst = vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port_diff, dst_port, None, None);
+        let dst_port_diff = 14;
+        let src_dst_diff = vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port_diff, None, None);
+        let src_addr_diff = [3u8; 16];
+        let dst_addr_diff = [4u8; 16];
+        
+        let visa_diff_proto: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto_diff,
+            src_dst.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+        let v_diff_proto = Visa::new(visa_diff_proto);
+
+        let visa_diff_src_port: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_diff_dst,
+            None,
+            None,
+            None,
+            None,
+        );
+        let v_diff_src_port = Visa::new(visa_diff_src_port);
+
+        let visa_diff_dst_port: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst_diff,
+            None,
+            None,
+            None,
+            None,
+        );
+        let v_diff_dst_port = Visa::new(visa_diff_dst_port);
+
+        let visa_diff_src_addr: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr_diff.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+        let v_diff_src_addr = Visa::new(visa_diff_src_addr);
+
+        let visa_diff_dst_addr: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr_diff.to_vec(),
+            l4proto,
+            src_dst.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+        let v_diff_dst_addr = Visa::new(visa_diff_dst_addr);
+
+
+        // assert_eq!(Visa::extract_five_tuple(&v.visa.unwrap()), ft);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(15, v_diff_proto);
+        hash.insert(16, v_diff_src_port);
+        hash.insert(17, v_diff_dst_port);
+        hash.insert(18, v_diff_src_addr);
+        hash.insert(19, v_diff_dst_addr);
+
+        let table = FiveTupleLookupTable::new(hash);
+
+        assert_eq!(table.find_match(ft), None);
+    }
+
+    #[test]
+    fn test_no_visa_match_multiple_fts() {
+        let src_addr = [1u8; 16];
+        let dst_addr = [2u8; 16];
+
+        let l4proto = vsapi::PEPIndex::TCP;
+        let src_port = 10;
+        let dst_port = 11;
+        let src_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
+        let visa: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let v = Visa::new(visa);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(15, v);
+        let table = FiveTupleLookupTable::new(hash);
+
+        let src_port_diff = 13;
+        let dst_port_diff = 14;
+        let src_addr_diff = [3u8; 16];
+        let dst_addr_diff = [4u8; 16];
+
+        let ft_diff_proto = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::UDP, src_port as u16, dst_port as u16);
+        let ft_diff_src_port = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port_diff as u16, dst_port as u16);
+        let ft_diff_dst_port = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port_diff as u16);
+        let ft_diff_src_addr = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr_diff), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
+        let ft_diff_dst_addr = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr_diff), ip_number::TCP, src_port as u16, dst_port as u16);
+
+        assert_eq!(table.find_match(ft_diff_proto), None);
+        assert_eq!(table.find_match(ft_diff_src_port), None);
+        assert_eq!(table.find_match(ft_diff_dst_port), None);
+        assert_eq!(table.find_match(ft_diff_src_addr), None);
+        assert_eq!(table.find_match(ft_diff_dst_addr), None);
+    }
+
+    #[test]
+    fn test_match_correct_visa() {
+        let src_addr = [1u8; 16];
+        let dst_addr = [2u8; 16];
+
+        let l4proto = vsapi::PEPIndex::TCP;
+        let src_port = 10;
+        let dst_port = 11;
+        let src_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
+        
+        let ft = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
+
+        let l4proto_diff = vsapi::PEPIndex::UDP;
+        let src_port_diff = 13;
+        let src_diff_dst = vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port_diff, dst_port, None, None);
+        let dst_port_diff = 14;
+        let src_dst_diff = vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port_diff, None, None);
+        let src_addr_diff = [3u8; 16];
+        let dst_addr_diff = [4u8; 16];
+        
+        let visa_diff_proto: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto_diff,
+            src_dst.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+        let v_diff_proto = Visa::new(visa_diff_proto);
+
+        let visa_diff_src_port: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_diff_dst,
+            None,
+            None,
+            None,
+            None,
+        );
+        let v_diff_src_port = Visa::new(visa_diff_src_port);
+
+        let visa_diff_dst_port: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst_diff,
+            None,
+            None,
+            None,
+            None,
+        );
+        let v_diff_dst_port = Visa::new(visa_diff_dst_port);
+
+        let visa_diff_src_addr: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr_diff.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+        let v_diff_src_addr = Visa::new(visa_diff_src_addr);
+
+        let visa_diff_dst_addr: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr_diff.to_vec(),
+            l4proto,
+            src_dst.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+        let v_diff_dst_addr = Visa::new(visa_diff_dst_addr);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(15, v_diff_proto);
+        hash.insert(16, v_diff_src_port);
+        hash.insert(17, v_diff_dst_port);
+        hash.insert(18, v_diff_src_addr);
+        hash.insert(19, v_diff_dst_addr);
+
+        let table = FiveTupleLookupTable::new(hash);
+
+        let ft_diff_proto = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::UDP, src_port as u16, dst_port as u16);
+        let ft_diff_src_port = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port_diff as u16, dst_port as u16);
+        let ft_diff_dst_port = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port_diff as u16);
+        let ft_diff_src_addr = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr_diff), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
+        let ft_diff_dst_addr = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr_diff), ip_number::TCP, src_port as u16, dst_port as u16);
+    
+        assert_eq!(table.find_match(ft_diff_proto), Some(15));
+        assert_eq!(table.find_match(ft_diff_src_port), Some(16));
+        assert_eq!(table.find_match(ft_diff_dst_port), Some(17));
+        assert_eq!(table.find_match(ft_diff_src_addr), Some(18));
+        assert_eq!(table.find_match(ft_diff_dst_addr), Some(19));
+        assert_eq!(table.find_match(ft), None);
+
     }
 }

--- a/adapter/ph/src/five_tuple_lookup_table.rs
+++ b/adapter/ph/src/five_tuple_lookup_table.rs
@@ -1345,4 +1345,228 @@ mod tests {
         assert_eq!(table.find_match(ft_diff_dst_addr), Some(19));
         assert_eq!(table.find_match(ft), None);
     }
+
+    #[test]
+    fn test_wildcarded_src_ports() {
+        let src_addr = [1u8; 16];
+        let dst_addr = [2u8; 16];
+
+        let l4proto = vsapi::PEPIndex::TCP;
+        let src_port = 0;
+        let dst_port = 11;
+        let src_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
+        let visa: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let v = Visa::new(visa);
+
+        // let ft = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
+        // assert_eq!(Visa::extract_five_tuple(&v.visa.unwrap()), ft);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(12, v);
+
+        let table = FiveTupleLookupTable::new(&hash);
+
+        let ft1 = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            3423,
+            dst_port as u16,
+        );
+        let ft2 = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            1,
+            dst_port as u16,
+        );
+        let ft3 = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            65535,
+            dst_port as u16,
+        );
+        let ft4 = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            43211,
+            dst_port as u16,
+        );
+        assert_eq!(table.find_match(ft1), Some(12));
+        assert_eq!(table.find_match(ft2), Some(12));
+        assert_eq!(table.find_match(ft3), Some(12));
+        assert_eq!(table.find_match(ft4), Some(12));
+        let un_rcu_table = table.table.get();
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .len(),
+            65536
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(dst_port as u16)
+                .unwrap()
+                .get(5411).unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_wildcarded_dst_ports() {
+        let src_addr = [1u8; 16];
+        let dst_addr = [2u8; 16];
+
+        let l4proto = vsapi::PEPIndex::TCP;
+        let src_port = 10;
+        let dst_port = 0;
+        let src_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
+        let visa: vsapi::Visa = vsapi::Visa::new(
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            src_addr.to_vec(),
+            dst_addr.to_vec(),
+            l4proto,
+            src_dst,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let v = Visa::new(visa);
+
+        // let ft = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
+        // assert_eq!(Visa::extract_five_tuple(&v.visa.unwrap()), ft);
+
+        let mut hash: HashMap<VisaId, Visa> = HashMap::new();
+        hash.insert(12, v);
+
+        let table = FiveTupleLookupTable::new(&hash);
+
+        let ft1 = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port as u16,
+            3423,
+        );
+        let ft2 = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port as u16,
+            1,
+        );
+        let ft3 = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port as u16,
+            65535,
+        );
+        let ft4 = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port as u16,
+            43211,
+        );
+        assert_eq!(table.find_match(ft1), Some(12));
+        assert_eq!(table.find_match(ft2), Some(12));
+        assert_eq!(table.find_match(ft3), Some(12));
+        assert_eq!(table.find_match(ft4), Some(12));
+        let un_rcu_table = table.table.get();
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .len(),
+            65536
+        );
+        assert_eq!(
+            un_rcu_table
+                .get(&IpAddress::from(dst_addr))
+                .unwrap()
+                .exact_match(
+                    Ipv6Addr::new(0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101, 0x0101),
+                    128
+                )
+                .unwrap()
+                .get(4321)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
 }

--- a/adapter/ph/src/five_tuple_lookup_table.rs
+++ b/adapter/ph/src/five_tuple_lookup_table.rs
@@ -17,12 +17,12 @@ pub type FiveTupleLookup = HashMap<
 >;
 
 pub struct FiveTupleLookupTable {
-    pub table: RcuBox<FiveTupleLookup>,
+    table: RcuBox<FiveTupleLookup>,
 }
 
 impl FiveTupleLookupTable {
     // TODO change how construction is done once visas move away from being based on a FiveTuples
-    pub fn new(visa_table: HashMap<VisaId, Visa>) -> Self {
+    pub fn new(visa_table: &HashMap<VisaId, Visa>) -> Self {
         let mut hash_table: FiveTupleLookup = HashMap::new();
         for (visa_id, visa) in visa_table.iter() {
             let five_tuple = match visa.ftuple {
@@ -131,7 +131,7 @@ impl FiveTupleLookupTable {
                 }
             }
         }
-        FiveTupleLookupTable {
+        Self {
             table: RcuBox::new(hash_table),
         }
     }
@@ -162,6 +162,7 @@ impl FiveTupleLookupTable {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -202,7 +203,7 @@ mod tests {
         let mut hash: HashMap<VisaId, Visa> = HashMap::new();
         hash.insert(12, v);
 
-        let table = FiveTupleLookupTable::new(hash);
+        let table = FiveTupleLookupTable::new(&hash);
 
         let un_rcu_table = table.table.get();
 
@@ -290,7 +291,7 @@ mod tests {
         hash.insert(12, v1);
         hash.insert(13, v2);
 
-        let table = FiveTupleLookupTable::new(hash);
+        let table = FiveTupleLookupTable::new(&hash);
 
         let un_rcu_table = table.table.get();
 
@@ -380,7 +381,7 @@ mod tests {
         hash.insert(12, v1);
         hash.insert(13, v2);
 
-        let table = FiveTupleLookupTable::new(hash);
+        let table = FiveTupleLookupTable::new(&hash);
 
         let un_rcu_table = table.table.get();
 
@@ -545,7 +546,7 @@ mod tests {
         hash.insert(12, v1);
         hash.insert(13, v2);
 
-        let table = FiveTupleLookupTable::new(hash);
+        let table = FiveTupleLookupTable::new(&hash);
 
         let un_rcu_table = table.table.get();
 
@@ -712,7 +713,7 @@ mod tests {
         hash.insert(12, v1);
         hash.insert(13, v2);
 
-        let table = FiveTupleLookupTable::new(hash);
+        let table = FiveTupleLookupTable::new(&hash);
 
         let un_rcu_table = table.table.get();
 
@@ -837,7 +838,7 @@ mod tests {
         hash.insert(12, v1);
         hash.insert(13, v2);
 
-        let table = FiveTupleLookupTable::new(hash);
+        let table = FiveTupleLookupTable::new(&hash);
 
         let un_rcu_table = table.table.get();
 
@@ -940,13 +941,20 @@ mod tests {
 
         let v = Visa::new(visa);
 
-        let ft = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
+        let ft = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port as u16,
+            dst_port as u16,
+        );
         // assert_eq!(Visa::extract_five_tuple(&v.visa.unwrap()), ft);
 
         let mut hash: HashMap<VisaId, Visa> = HashMap::new();
         hash.insert(12, v);
 
-        let table = FiveTupleLookupTable::new(hash);
+        let table = FiveTupleLookupTable::new(&hash);
 
         assert_eq!(table.find_match(ft), Some(12))
     }
@@ -961,17 +969,26 @@ mod tests {
         let dst_port = 11;
         let src_dst =
             vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
-        
-        let ft = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
+
+        let ft = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port as u16,
+            dst_port as u16,
+        );
 
         let l4proto_diff = vsapi::PEPIndex::UDP;
         let src_port_diff = 13;
-        let src_diff_dst = vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port_diff, dst_port, None, None);
+        let src_diff_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port_diff, dst_port, None, None);
         let dst_port_diff = 14;
-        let src_dst_diff = vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port_diff, None, None);
+        let src_dst_diff =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port_diff, None, None);
         let src_addr_diff = [3u8; 16];
         let dst_addr_diff = [4u8; 16];
-        
+
         let visa_diff_proto: vsapi::Visa = vsapi::Visa::new(
             0,
             0,
@@ -1057,7 +1074,6 @@ mod tests {
         );
         let v_diff_dst_addr = Visa::new(visa_diff_dst_addr);
 
-
         // assert_eq!(Visa::extract_five_tuple(&v.visa.unwrap()), ft);
 
         let mut hash: HashMap<VisaId, Visa> = HashMap::new();
@@ -1067,7 +1083,7 @@ mod tests {
         hash.insert(18, v_diff_src_addr);
         hash.insert(19, v_diff_dst_addr);
 
-        let table = FiveTupleLookupTable::new(hash);
+        let table = FiveTupleLookupTable::new(&hash);
 
         assert_eq!(table.find_match(ft), None);
     }
@@ -1102,18 +1118,53 @@ mod tests {
 
         let mut hash: HashMap<VisaId, Visa> = HashMap::new();
         hash.insert(15, v);
-        let table = FiveTupleLookupTable::new(hash);
+        let table = FiveTupleLookupTable::new(&hash);
 
         let src_port_diff = 13;
         let dst_port_diff = 14;
         let src_addr_diff = [3u8; 16];
         let dst_addr_diff = [4u8; 16];
 
-        let ft_diff_proto = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::UDP, src_port as u16, dst_port as u16);
-        let ft_diff_src_port = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port_diff as u16, dst_port as u16);
-        let ft_diff_dst_port = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port_diff as u16);
-        let ft_diff_src_addr = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr_diff), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
-        let ft_diff_dst_addr = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr_diff), ip_number::TCP, src_port as u16, dst_port as u16);
+        let ft_diff_proto = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::UDP,
+            src_port as u16,
+            dst_port as u16,
+        );
+        let ft_diff_src_port = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port_diff as u16,
+            dst_port as u16,
+        );
+        let ft_diff_dst_port = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port as u16,
+            dst_port_diff as u16,
+        );
+        let ft_diff_src_addr = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr_diff),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port as u16,
+            dst_port as u16,
+        );
+        let ft_diff_dst_addr = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr_diff),
+            ip_number::TCP,
+            src_port as u16,
+            dst_port as u16,
+        );
 
         assert_eq!(table.find_match(ft_diff_proto), None);
         assert_eq!(table.find_match(ft_diff_src_port), None);
@@ -1132,17 +1183,26 @@ mod tests {
         let dst_port = 11;
         let src_dst =
             vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
-        
-        let ft = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
+
+        let ft = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port as u16,
+            dst_port as u16,
+        );
 
         let l4proto_diff = vsapi::PEPIndex::UDP;
         let src_port_diff = 13;
-        let src_diff_dst = vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port_diff, dst_port, None, None);
+        let src_diff_dst =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port_diff, dst_port, None, None);
         let dst_port_diff = 14;
-        let src_dst_diff = vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port_diff, None, None);
+        let src_dst_diff =
+            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port_diff, None, None);
         let src_addr_diff = [3u8; 16];
         let dst_addr_diff = [4u8; 16];
-        
+
         let visa_diff_proto: vsapi::Visa = vsapi::Visa::new(
             0,
             0,
@@ -1235,20 +1295,54 @@ mod tests {
         hash.insert(18, v_diff_src_addr);
         hash.insert(19, v_diff_dst_addr);
 
-        let table = FiveTupleLookupTable::new(hash);
+        let table = FiveTupleLookupTable::new(&hash);
 
-        let ft_diff_proto = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::UDP, src_port as u16, dst_port as u16);
-        let ft_diff_src_port = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port_diff as u16, dst_port as u16);
-        let ft_diff_dst_port = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port_diff as u16);
-        let ft_diff_src_addr = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr_diff), IpAddress::from(dst_addr), ip_number::TCP, src_port as u16, dst_port as u16);
-        let ft_diff_dst_addr = FiveTuple::new(L3Type::Ipv6, IpAddress::from(src_addr), IpAddress::from(dst_addr_diff), ip_number::TCP, src_port as u16, dst_port as u16);
-    
+        let ft_diff_proto = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::UDP,
+            src_port as u16,
+            dst_port as u16,
+        );
+        let ft_diff_src_port = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port_diff as u16,
+            dst_port as u16,
+        );
+        let ft_diff_dst_port = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port as u16,
+            dst_port_diff as u16,
+        );
+        let ft_diff_src_addr = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr_diff),
+            IpAddress::from(dst_addr),
+            ip_number::TCP,
+            src_port as u16,
+            dst_port as u16,
+        );
+        let ft_diff_dst_addr = FiveTuple::new(
+            L3Type::Ipv6,
+            IpAddress::from(src_addr),
+            IpAddress::from(dst_addr_diff),
+            ip_number::TCP,
+            src_port as u16,
+            dst_port as u16,
+        );
+
         assert_eq!(table.find_match(ft_diff_proto), Some(15));
         assert_eq!(table.find_match(ft_diff_src_port), Some(16));
         assert_eq!(table.find_match(ft_diff_dst_port), Some(17));
         assert_eq!(table.find_match(ft_diff_src_addr), Some(18));
         assert_eq!(table.find_match(ft_diff_dst_addr), Some(19));
         assert_eq!(table.find_match(ft), None);
-
     }
 }

--- a/adapter/ph/src/five_tuple_lookup_table.rs
+++ b/adapter/ph/src/five_tuple_lookup_table.rs
@@ -1456,7 +1456,8 @@ mod tests {
                 .unwrap()
                 .get(dst_port as u16)
                 .unwrap()
-                .get(5411).unwrap()
+                .get(5411)
+                .unwrap()
                 .len(),
             1
         );
@@ -1536,10 +1537,7 @@ mod tests {
         assert_eq!(table.find_match(ft4), Some(12));
         let un_rcu_table = table.table.get();
         assert_eq!(
-            un_rcu_table
-                .get(&IpAddress::from(dst_addr))
-                .unwrap()
-                .len(),
+            un_rcu_table.get(&IpAddress::from(dst_addr)).unwrap().len(),
             1
         );
         assert_eq!(

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -31,6 +31,7 @@ mod defs;
 mod fastpath;
 mod fastpath_io;
 mod fastpath_worker;
+mod five_tuple_lookup_table;
 mod flow_control;
 mod forwarding_tables;
 mod km;

--- a/adapter/ph/src/mgmt/dock.rs
+++ b/adapter/ph/src/mgmt/dock.rs
@@ -45,10 +45,7 @@ pub async fn bind_actor_address(
 
     if let Some(matched) = asm.visa_table.read().await.match_traffic(&five_tuple) {
         // We matched a visa we already have.
-        if matched.len() > 1 {
-            warn!(target: FLOW_MGMT, "multiple visas matched for {five_tuple}, using the first one ({matched:?})");
-        }
-        let matched_visa_id = matched[0];
+        let matched_visa_id = matched;
         let egress_link_id_query = visa_mgmt::get_egress_link_for_visa(asm, matched_visa_id).await;
         match egress_link_id_query {
             Ok(link_id) => {

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -39,9 +39,9 @@ pub enum VisaTableError {
 /// Struct that holds an instance of a visa local to a Node
 #[derive(Default)]
 pub struct Visa {
-    visa: Option<vsapi::Visa>,
+    pub visa: Option<vsapi::Visa>,
     streams: Vec<ForwardingEntry>,
-    ftuple: Option<FiveTuple>,
+    pub ftuple: Option<FiveTuple>,
 }
 
 /// Struct for the visa timeout queue
@@ -209,8 +209,9 @@ impl Visa {
 }
 
 pub struct VisaTable {
-    table: HashMap<VisaId, Visa>,
-    timeout_queue: BinaryHeap<VisaTimeout>,
+    pub table: HashMap<VisaId, Visa>,
+    pub timeout_queue: BinaryHeap<VisaTimeout>,
+    // pub lookup_table: FiveTupleLookupTable,
 }
 
 impl VisaTable {
@@ -218,6 +219,7 @@ impl VisaTable {
         Self {
             table: HashMap::new(),
             timeout_queue: BinaryHeap::new(),
+            // lookup_table: FiveTupleLookupTable::new(HashMap::new()),
         }
     }
 

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -332,20 +332,7 @@ impl VisaTable {
     }
 
     /// Match traffic to a visa. Returns all matching visa IDs.
-    ///
-    /// TODO: This is linear search through all our visas -- we should create an index.
     pub fn match_traffic(&self, five_tuple: &FiveTuple) -> Option<VisaId> {
-        // let mut matching_visas = Vec::new();
-        // for (visa_id, visa) in self.table.iter() {
-        //     if visa.match_traffic(five_tuple) {
-        //         matching_visas.push(*visa_id);
-        //     }
-        // }
-        // if matching_visas.is_empty() {
-        //     None
-        // } else {
-        //     Some(matching_visas)
-        // }
         self.lookup_table.find_match(*five_tuple)
     }
 

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 
 use crate::defs::FiveTuple;
+use crate::five_tuple_lookup_table::FiveTupleLookupTable;
 use crate::logging::targets::VISA_MGMT;
 use crate::net_defs::{ip_number, IpAddress};
 use crate::peer_table;
@@ -39,6 +40,7 @@ pub enum VisaTableError {
 /// Struct that holds an instance of a visa local to a Node
 #[derive(Default)]
 pub struct Visa {
+    // TODO add methods so that these don't have to be made pub
     pub visa: Option<vsapi::Visa>,
     streams: Vec<ForwardingEntry>,
     pub ftuple: Option<FiveTuple>,
@@ -211,7 +213,7 @@ impl Visa {
 pub struct VisaTable {
     pub table: HashMap<VisaId, Visa>,
     pub timeout_queue: BinaryHeap<VisaTimeout>,
-    // pub lookup_table: FiveTupleLookupTable,
+    pub lookup_table: FiveTupleLookupTable,
 }
 
 impl VisaTable {
@@ -219,7 +221,7 @@ impl VisaTable {
         Self {
             table: HashMap::new(),
             timeout_queue: BinaryHeap::new(),
-            // lookup_table: FiveTupleLookupTable::new(HashMap::new()),
+            lookup_table: FiveTupleLookupTable::new(&HashMap::new()),
         }
     }
 
@@ -277,6 +279,8 @@ impl VisaTable {
             .insert_visa(vs2node)
             .expect("Failed to insert visa->node visa into table");
 
+        visa_table.lookup_table = FiveTupleLookupTable::new(&visa_table.table);
+
         visa_table
     }
 
@@ -293,6 +297,8 @@ impl VisaTable {
         };
         let _ = self.table.insert(visa_id, visa);
         self.timeout_queue.push(timeout);
+
+        self.lookup_table = FiveTupleLookupTable::new(&self.table);
     }
 
     /// Insert a visa from the Visa Service into the Visa Table
@@ -319,24 +325,28 @@ impl VisaTable {
         };
         let _ = self.table.insert(visa_id, visa);
         self.timeout_queue.push(timeout);
+
+        self.lookup_table = FiveTupleLookupTable::new(&self.table);
+
         Ok(visa_id)
     }
 
     /// Match traffic to a visa. Returns all matching visa IDs.
     ///
     /// TODO: This is linear search through all our visas -- we should create an index.
-    pub fn match_traffic(&self, five_tuple: &FiveTuple) -> Option<Vec<VisaId>> {
-        let mut matching_visas = Vec::new();
-        for (visa_id, visa) in self.table.iter() {
-            if visa.match_traffic(five_tuple) {
-                matching_visas.push(*visa_id);
-            }
-        }
-        if matching_visas.is_empty() {
-            None
-        } else {
-            Some(matching_visas)
-        }
+    pub fn match_traffic(&self, five_tuple: &FiveTuple) -> Option<VisaId> {
+        // let mut matching_visas = Vec::new();
+        // for (visa_id, visa) in self.table.iter() {
+        //     if visa.match_traffic(five_tuple) {
+        //         matching_visas.push(*visa_id);
+        //     }
+        // }
+        // if matching_visas.is_empty() {
+        //     None
+        // } else {
+        //     Some(matching_visas)
+        // }
+        self.lookup_table.find_match(*five_tuple)
     }
 
     /// Link a forwarding entry to a given visa
@@ -365,6 +375,8 @@ impl VisaTable {
         };
         visa.remove_forwarding_entries(peer_table);
         info!(target: VISA_MGMT, "Revoked visa {visa_id}");
+        self.lookup_table = FiveTupleLookupTable::new(&self.table);
+
         Ok(())
     }
 
@@ -380,6 +392,7 @@ impl VisaTable {
             // Ignore if the visa was not found, since it might have been previously revoked
             let _ = self.revoke(peer_table, timeout_entry.id);
         }
+        self.lookup_table = FiveTupleLookupTable::new(&self.table);
     }
 
     /// Given a visa ID, look up the visa and return the destination address.
@@ -593,6 +606,6 @@ mod tests {
         };
         let matched = visa_table.match_traffic(&traffic);
         assert!(matched.is_some());
-        assert_eq!(matched.unwrap(), vec![1000]);
+        assert_eq!(matched.unwrap(), 1000);
     }
 }


### PR DESCRIPTION
I think the best way to review this will be commit by commit, which are

1. the first commit is about constructing the table and all of the tests associated with that
2. the second commit adds the lookup function that takes in a five tuple and returns a visa, if it is in the table
3. the third commit integrates the `FiveTupleLookupTable` into the visa_table - makes `visa_table::match_traffic` essentially a wrapper for `FiveTupleLookupTable::find_match`

Major TODO is to add a better way to update the lookup table. Currently every time a visa is added or removed, the whole table is remade from scratch. That is fine currently because the visa table is relatively small, but will become problematic quickly.

The first improvement will likely use some sort of cloning and `Arc`s, as suggested by Chris. The step after that would be some more specific editing.

Editing the table also is likely easier right now because of the lack of wildcards, lists, etc, will become more complicated as allowed values increase. 