### PR TITLE
update auxiliary crates to Rust 2024

### DIFF
--- a/cbpf-rs/Cargo.toml
+++ b/cbpf-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cbpf-rs"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/cbpf-rs/fuzz/Cargo.toml
+++ b/cbpf-rs/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cbpf-rs-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [package.metadata]

--- a/cslab/Cargo.toml
+++ b/cslab/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cslab"
 version = "0.1.1"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/cslab/src/lib.rs
+++ b/cslab/src/lib.rs
@@ -14,8 +14,8 @@ use std::mem::ManuallyDrop;
 #[cfg(not(loom))]
 use std::sync;
 use sync::{
-    atomic::{AtomicUsize, Ordering},
     Arc, Mutex, MutexGuard,
+    atomic::{AtomicUsize, Ordering},
 };
 
 // DESIGN NOTES
@@ -318,7 +318,7 @@ impl<T> CslabReader<T> {
     /// that an item is present at this index, and `finalize_remove()`
     /// has not been called on this index in the interim.
     pub unsafe fn get_unchecked(&self, idx: usize) -> &T {
-        get_unchecked_impl(&*self.0, idx)
+        unsafe { get_unchecked_impl(&*self.0, idx) }
     }
 }
 
@@ -499,7 +499,7 @@ impl<T> Cslab<T> {
 
         // drop item
         // SAFETY: we know only we can access this item from our safety requirement
-        let entry = &mut *self.storage.table()[idx].get();
+        let entry = unsafe { &mut *self.storage.table()[idx].get() };
         // SAFETY: we know there is an item from our safety requirement
         let item = unsafe { ManuallyDrop::take(&mut entry.item) } /* [Ri] */;
 
@@ -799,7 +799,7 @@ pub struct RcuCslabReader<T> {
     // a reference to the generation we were created in; we don't actually
     // use the value, but keeping this reference is necessary to prevent
     // finalization of the generation
-    gen: Arc<RcuCslabGen<T>>,
+    r#gen: Arc<RcuCslabGen<T>>,
 }
 
 impl<T> RcuCslabReader<T> {
@@ -845,7 +845,7 @@ impl<T> Clone for RcuCslabReader<T> {
     fn clone(&self) -> Self {
         Self {
             reader: self.reader.clone(),
-            gen: self.gen.clone(),
+            r#gen: self.r#gen.clone(),
         }
     }
 }
@@ -975,7 +975,7 @@ impl<T> RcuCslab<T> {
     pub fn reader(&self) -> RcuCslabReader<T> {
         RcuCslabReader {
             reader: self.reader.clone(),
-            gen: self.cur_gen.clone(),
+            r#gen: self.cur_gen.clone(),
         }
     }
 

--- a/libnode/Cargo.toml
+++ b/libnode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libnode"
 version = "0.4.1"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -416,7 +416,7 @@ s5JVZ48=
                 .unwrap()
                 .as_millis();
             let dir = env::temp_dir();
-            let num: u32 = rng.gen();
+            let num: u32 = rng.r#gen();
             let path = dir.join(format!("org_zpr_node_vs_test_{}_{}.pem", num, tstamp));
             fs::write(&path, contents).expect("Unable to write file");
             TempFile {

--- a/vs-client/Cargo.toml
+++ b/vs-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vs-client"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/vs-client/src/main.rs
+++ b/vs-client/src/main.rs
@@ -4,7 +4,7 @@ pub mod traffic_parser;
 pub mod vsclient;
 mod vssd;
 
-use crate::traffic_parser::{parse_traffic, Protocol};
+use crate::traffic_parser::{Protocol, parse_traffic};
 
 const DEFAULT_SERVICE: &str = "[fd5a:5052::1]:5002";
 const DEFAULT_VSS_PORT: u16 = 8183;
@@ -234,9 +234,13 @@ fn main() {
             println!();
             println!("   - IPv6 addresses should be enclosed in square brackets.");
             println!("   - Flags are optional, and can be 'S' for SYN, 'A' for ACK, or both.");
-            println!("   - Source port is optional, and if omitted a high number port is randomly chosen.");
+            println!(
+                "   - Source port is optional, and if omitted a high number port is randomly chosen."
+            );
             println!();
-            println!("   Note that the protocol is set by using the --tcp or --udp arg in the requestvisa command.");
+            println!(
+                "   Note that the protocol is set by using the --tcp or --udp arg in the requestvisa command."
+            );
             println!();
             println!("   Examples:");
             println!();

--- a/vs-client/src/traffic_parser.rs
+++ b/vs-client/src/traffic_parser.rs
@@ -98,7 +98,7 @@ pub fn parse_traffic(input: &str, prot: Protocol) -> Result<TrafficDesc, std::io
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "Invalid source address",
-            ))
+            ));
         }
     };
     let dst_addr = match capts.get(3).unwrap().as_str().parse::<IpAddr>() {
@@ -107,7 +107,7 @@ pub fn parse_traffic(input: &str, prot: Protocol) -> Result<TrafficDesc, std::io
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "Invalid destination address",
-            ))
+            ));
         }
     };
 
@@ -127,10 +127,10 @@ pub fn parse_traffic(input: &str, prot: Protocol) -> Result<TrafficDesc, std::io
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     "Invalid source port",
-                ))
+                ));
             }
         },
-        None => rng.gen(),
+        None => rng.r#gen(),
     };
 
     let dst_port: u16 = match capts.get(4).unwrap().as_str().parse::<u16>() {
@@ -139,7 +139,7 @@ pub fn parse_traffic(input: &str, prot: Protocol) -> Result<TrafficDesc, std::io
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "Invalid destination port",
-            ))
+            ));
         }
     };
 
@@ -154,7 +154,7 @@ pub fn parse_traffic(input: &str, prot: Protocol) -> Result<TrafficDesc, std::io
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::Other,
                         "Invalid flags",
-                    ))
+                    ));
                 }
             }
         }
@@ -281,7 +281,10 @@ mod test {
         for input in questionable_input {
             let res = parse_traffic(input, Protocol::TCP);
             if res.is_err() {
-                println!("parse has been improved!  Hazzah! Now patch this test!  used to succeed on ==> '{}', Error: {:?}", input, res);
+                println!(
+                    "parse has been improved!  Hazzah! Now patch this test!  used to succeed on ==> '{}', Error: {:?}",
+                    input, res
+                );
                 assert!(false)
             }
         }

--- a/zpr-ext/Cargo.toml
+++ b/zpr-ext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zpr-ext"
 version = "0.5.3"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]
@@ -18,6 +18,7 @@ tokio = { version = "1.37.0", features = ["macros", "time", "rt"] }
 [features]
 # Each feature flag is the name of a library the user is already using
 # and would like to have "extended".
+all = ["bytes", "socket2", "tokio", "zerocopy"]
 bytes = ["dep:bytes"]
 socket2 = ["dep:socket2"]
 tokio = ["dep:tokio"]

--- a/zpr-ext/src/tokio.rs
+++ b/zpr-ext/src/tokio.rs
@@ -1,6 +1,6 @@
 pub mod net {
     use crate::std::os::unix::net::{
-        uds_recv_vectored_with_ancillary, uds_send_vectored_with_ancillary, SocketAncillary,
+        SocketAncillary, uds_recv_vectored_with_ancillary, uds_send_vectored_with_ancillary,
     };
     use std::io::{self, IoSlice, IoSliceMut};
     use std::os::fd::AsFd;

--- a/zpr/Cargo.toml
+++ b/zpr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zpr"
 version = "0.1.2"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/zpr/src/rpc_commands.rs
+++ b/zpr/src/rpc_commands.rs
@@ -20,5 +20,5 @@ pub enum RpcCommands {
     StartLink,
     StopLink,
     ResetLink,
-    SetLogging
+    SetLogging,
 }


### PR DESCRIPTION
Beside formatting changes, had to update a few `gen` -> `r#gen`, and add a couple unsafe blocks inside of unsafe functions.