### PR TITLE
BindEgressStream

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -236,9 +236,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "capnp"

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -9,7 +9,7 @@ aarc = { version = "0.3", optional = true }
 arrayref = { version = "0.3.7" }
 base64 = "0.22.1"
 blake3 = { version = "1.5.4" }
-bytes = { version = "1.7.1" }
+bytes = { version = "1.10" }
 cbpf-rs = { path = "../../cbpf-rs" }
 chrono = "0.4.39"
 clap = { version = "4.5.7", features = ["derive", "env"] }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -426,7 +426,7 @@ impl Assembly {
                     )
                 })?;
         } else {
-            egress_tether_id = mgmt::requests::send_bind_actor_address_request(
+            egress_tether_id = mgmt::requests::send_bind_egress_stream_request(
                 self,
                 egress_link_id.get(),
                 compression_mode,

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -408,7 +408,6 @@ impl Assembly {
         five_tuple: defs::FiveTuple,
         egress_link_id: NonZero<LinkId>,
         compression_mode: zpr::CompressionMode,
-        packet_body: Vec<u8>,
     ) -> Result<zpr::StreamId, AddRouteError> {
         let egress_tether_id;
         if egress_link_id.get() == zpr::LOCAL_ACTOR_LINK_ID {
@@ -431,7 +430,6 @@ impl Assembly {
                 egress_link_id.get(),
                 compression_mode,
                 five_tuple,
-                packet_body,
             )
             .await
             .map_err(|e| AddRouteError::BindFailed(e))?;

--- a/adapter/ph/src/defs.rs
+++ b/adapter/ph/src/defs.rs
@@ -14,7 +14,9 @@ pub enum Direction {
 }
 
 /// IP 5-tuple used for hashing.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, FromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(
+    Copy, Clone, Debug, Default, PartialEq, Eq, Hash, FromBytes, IntoBytes, Immutable, KnownLayout,
+)]
 #[repr(C)]
 pub struct FiveTuple {
     pub src_address: net_defs::IpAddress,

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -58,6 +58,7 @@ mod set_capture_file_worker;
 mod signal_worker;
 mod special_peers;
 mod sys;
+mod tc;
 mod test_packet;
 mod tlv;
 mod tun_ctl;

--- a/adapter/ph/src/mgmt/dock.rs
+++ b/adapter/ph/src/mgmt/dock.rs
@@ -157,7 +157,6 @@ pub async fn bind_actor_address(
             five_tuple,
             decision.egress_link_id,
             compression_mode,
-            packet_body,
         )
         .await;
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -966,7 +966,257 @@ pub async fn handle_bind_actor_address_request(
     Ok(())
 }
 
+pub async fn handle_bind_egress_stream_request(
+    asm: &Arc<Assembly>,
+    txn_id: u16,
+    mut pkt: Packet,
+) -> HandleMgmtResult {
+    let Ok(hdr) = zdp::ZdpBindEgressStreamRequestHeader::read_from_buf(&mut pkt) else {
+        return Err(HandleMgmtError::BadStructure);
+    };
+
+    let classification = match classifier::classify(&mut pkt) {
+        Ok(cls) => cls,
+        Err(_why) => {
+            return Err(HandleMgmtError::BadStructure);
+        }
+    };
+
+    match classification {
+        classifier::ClassifierResult::OK => (),
+        classifier::ClassifierResult::UnclassifiedL4 => {
+            warn!(target: ZDP, "Link {}: unsupported IP protocol {}", pkt.metadata().ingress_link_id, pkt.metadata().get_l4_protocol());
+            return Err(HandleMgmtError::BadStructure);
+        }
+        _ => {
+            return Err(HandleMgmtError::BadStructure);
+        }
+    }
+
+    let five_tuple = *pkt.metadata().five_tuple();
+
+    let packet_body: Vec<u8> = pkt.body().to_vec(); // copy to send to visa service
+
+    let compression_mode = hdr.compression_mode;
+
+    let Some(ingress_link_id) = NonZero::new(pkt.metadata().ingress_link_id) else {
+        // who sent this??
+        error!(target: FLOW_MGMT, "coding error: stray packet from unknown source; dropping");
+        return Ok(());
+    };
+
+    debug!(
+        target: ZDP,
+        "Link {}: handlers.handle_bind_egress_stream_request -- five_tuple {five_tuple}", ingress_link_id.get(),
+    );
+
+    // recycle request buffer for response
+    let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
+
+    let ingress_tether_id;
+
+    match asm.ph_mode {
+        PhMode::Node => {
+            // TODO: errors need more consideration here
+            match super::dock::bind_actor_address(
+                asm,
+                ingress_link_id,
+                compression_mode,
+                five_tuple,
+                packet_body,
+            )
+            .await
+            {
+                Ok(ingress_tid) => {
+                    // success; respond with ingress tether ID
+                    zdp::ZdpBindEgressStreamResponseHeader {
+                        status_code: zdp::ResponseCode::Success,
+                        info_len: 0,
+                    }
+                    .write_to_buf(&mut rsp_pkt)
+                    .unwrap();
+
+                    ingress_tether_id = ingress_tid;
+                }
+
+                Err(super::dock::BindActorAddressError::PolicyError) => {
+                    // send error to requestor
+                    let message = "policy error";
+
+                    zdp::ZdpBindEgressStreamResponseHeader {
+                        status_code: zdp::ResponseCode::Other,
+                        info_len: message.len() as u8,
+                    }
+                    .write_to_buf(&mut rsp_pkt)
+                    .unwrap();
+
+                    rsp_pkt.put(message.as_bytes());
+
+                    ingress_tether_id = 0;
+                }
+
+                Err(super::dock::BindActorAddressError::ParseError(error)) => {
+                    // send error to requestor
+                    zdp::ZdpBindEgressStreamResponseHeader {
+                        status_code: zdp::ResponseCode::Other,
+                        info_len: error.len() as u8,
+                    }
+                    .write_to_buf(&mut rsp_pkt)
+                    .unwrap();
+
+                    rsp_pkt.put(error.as_bytes());
+
+                    ingress_tether_id = 0;
+                }
+
+                Err(super::dock::BindActorAddressError::AddRouteError(
+                    assembly::AddRouteError::PftFull,
+                )) => {
+                    // PFT full; respond with error message
+                    // TODO: maybe tick a counter somewhere?
+                    let message = "PFT full";
+
+                    zdp::ZdpBindEgressStreamResponseHeader {
+                        status_code: zdp::ResponseCode::Other,
+                        info_len: message.len() as u8,
+                    }
+                    .write_to_buf(&mut rsp_pkt)
+                    .unwrap();
+
+                    rsp_pkt.put(message.as_bytes());
+
+                    ingress_tether_id = 0;
+                }
+
+                Err(super::dock::BindActorAddressError::AddRouteError(
+                    assembly::AddRouteError::PeerGone,
+                )) => {
+                    // peer went away; don't bother responding
+                    return Ok(());
+                }
+
+                Err(super::dock::BindActorAddressError::AddRouteError(
+                    assembly::AddRouteError::VisaGone,
+                )) => {
+                    // send error to requestor
+                    let message = "policy error";
+
+                    zdp::ZdpBindEgressStreamResponseHeader {
+                        status_code: zdp::ResponseCode::Other,
+                        info_len: message.len() as u8,
+                    }
+                    .write_to_buf(&mut rsp_pkt)
+                    .unwrap();
+
+                    rsp_pkt.put(message.as_bytes());
+
+                    ingress_tether_id = 0;
+                }
+
+                Err(super::dock::BindActorAddressError::AddRouteError(
+                    assembly::AddRouteError::BindFailed(err),
+                )) => {
+                    // unable to bind next-hop; respond with error message
+                    // TODO: maybe tick a counter somewhere?
+                    let message = format!("unable to bind next-hop: {}", err);
+
+                    zdp::ZdpBindEgressStreamResponseHeader {
+                        status_code: zdp::ResponseCode::Other,
+                        info_len: message.len() as u8,
+                    }
+                    .write_to_buf(&mut rsp_pkt)
+                    .unwrap();
+
+                    rsp_pkt.put(message.as_bytes());
+
+                    ingress_tether_id = 0;
+                }
+            }
+        }
+
+        PhMode::Adapter => {
+            // form PEP
+            let pep = adapter_tables::DltPep {
+                compression_mode,
+                five_tuple,
+            };
+
+            // TODO: reverse path
+
+            // attempt to insert into DLT
+            match asm.dlt.insert(pep) {
+                Ok(tid) => {
+                    // success; respond with tether ID
+                    // TODO: maybe tick a counter somewhere?
+                    zdp::ZdpBindEgressStreamResponseHeader {
+                        status_code: zdp::ResponseCode::Success,
+                        info_len: 0,
+                    }
+                    .write_to_buf(&mut rsp_pkt)
+                    .unwrap();
+
+                    ingress_tether_id = tid;
+                }
+
+                Err(()) => {
+                    // DLT full; respond with error message
+                    // TODO: maybe tick a counter somewhere?
+                    let message = "DLT full";
+
+                    zdp::ZdpBindEgressStreamResponseHeader {
+                        status_code: zdp::ResponseCode::Other,
+                        info_len: message.len() as u8,
+                    }
+                    .write_to_buf(&mut rsp_pkt)
+                    .unwrap();
+
+                    rsp_pkt.put(message.as_bytes());
+
+                    ingress_tether_id = 0;
+                }
+            }
+        }
+    }
+
+    // respond to requestor
+    super::core::send_per_flow_txn_mgmt(
+        asm,
+        ingress_link_id.get(),
+        zdp::ZdpPacketType::BindEgressStreamResponse,
+        ingress_tether_id,
+        txn_id,
+        rsp_pkt,
+    )
+    .await?;
+
+    Ok(())
+}
+
 pub async fn handle_bind_actor_address_response(
+    asm: &Arc<Assembly>,
+    txn_id: u16,
+    pkt: Packet,
+) -> HandleMgmtResult {
+    let link_id = pkt.metadata().ingress_link_id;
+
+    let Some(peer_state) = asm.peer_table.get(link_id) else {
+        return Err(HandleMgmtError::LinkClosed);
+    };
+
+    let Some(txn) = peer_state.txn_mgr.get(txn_id) else {
+        return Err(HandleMgmtError::UnknownTransaction(txn_id));
+    };
+
+    let Some(sender) = peer_state.bind_req_state.lock().unwrap().remove(&txn) else {
+        return Err(HandleMgmtError::UnknownTransaction(txn_id));
+    };
+
+    let _ = sender.send(pkt);
+
+    Ok(())
+}
+
+pub async fn handle_bind_egress_stream_response(
     asm: &Arc<Assembly>,
     txn_id: u16,
     pkt: Packet,

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -909,46 +909,8 @@ pub async fn handle_bind_actor_address_request(
         }
 
         PhMode::Adapter => {
-            // form PEP
-            let pep = adapter_tables::DltPep {
-                compression_mode,
-                five_tuple,
-            };
-
-            // TODO: reverse path
-
-            // attempt to insert into DLT
-            match asm.dlt.insert(pep) {
-                Ok(tid) => {
-                    // success; respond with tether ID
-                    // TODO: maybe tick a counter somewhere?
-                    zdp::ZdpBindActorAddressResponseHeader {
-                        status_code: zdp::ResponseCode::Success,
-                        info_len: 0,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    ingress_tether_id = tid;
-                }
-
-                Err(()) => {
-                    // DLT full; respond with error message
-                    // TODO: maybe tick a counter somewhere?
-                    let message = "DLT full";
-
-                    zdp::ZdpBindActorAddressResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: message.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(message.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-            }
+            error!(target: ZDP, "Link {ingress_link_id}: received BindActorAddress message on adapter");
+            return Err(HandleMgmtError::MessageNotPermitted);
         }
     }
 
@@ -995,8 +957,6 @@ pub async fn handle_bind_egress_stream_request(
 
     let five_tuple = *pkt.metadata().five_tuple();
 
-    let packet_body: Vec<u8> = pkt.body().to_vec(); // copy to send to visa service
-
     let compression_mode = hdr.compression_mode;
 
     let Some(ingress_link_id) = NonZero::new(pkt.metadata().ingress_link_id) else {
@@ -1017,121 +977,8 @@ pub async fn handle_bind_egress_stream_request(
 
     match asm.ph_mode {
         PhMode::Node => {
-            // TODO: errors need more consideration here
-            match super::dock::bind_actor_address(
-                asm,
-                ingress_link_id,
-                compression_mode,
-                five_tuple,
-                packet_body,
-            )
-            .await
-            {
-                Ok(ingress_tid) => {
-                    // success; respond with ingress tether ID
-                    zdp::ZdpBindEgressStreamResponseHeader {
-                        status_code: zdp::ResponseCode::Success,
-                        info_len: 0,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    ingress_tether_id = ingress_tid;
-                }
-
-                Err(super::dock::BindActorAddressError::PolicyError) => {
-                    // send error to requestor
-                    let message = "policy error";
-
-                    zdp::ZdpBindEgressStreamResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: message.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(message.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-
-                Err(super::dock::BindActorAddressError::ParseError(error)) => {
-                    // send error to requestor
-                    zdp::ZdpBindEgressStreamResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: error.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(error.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-
-                Err(super::dock::BindActorAddressError::AddRouteError(
-                    assembly::AddRouteError::PftFull,
-                )) => {
-                    // PFT full; respond with error message
-                    // TODO: maybe tick a counter somewhere?
-                    let message = "PFT full";
-
-                    zdp::ZdpBindEgressStreamResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: message.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(message.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-
-                Err(super::dock::BindActorAddressError::AddRouteError(
-                    assembly::AddRouteError::PeerGone,
-                )) => {
-                    // peer went away; don't bother responding
-                    return Ok(());
-                }
-
-                Err(super::dock::BindActorAddressError::AddRouteError(
-                    assembly::AddRouteError::VisaGone,
-                )) => {
-                    // send error to requestor
-                    let message = "policy error";
-
-                    zdp::ZdpBindEgressStreamResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: message.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(message.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-
-                Err(super::dock::BindActorAddressError::AddRouteError(
-                    assembly::AddRouteError::BindFailed(err),
-                )) => {
-                    // unable to bind next-hop; respond with error message
-                    // TODO: maybe tick a counter somewhere?
-                    let message = format!("unable to bind next-hop: {}", err);
-
-                    zdp::ZdpBindEgressStreamResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: message.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(message.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-            }
+            error!(target: ZDP, "Link {ingress_link_id}: received BindEgressStream message on node");
+            return Err(HandleMgmtError::MessageNotPermitted);
         }
 
         PhMode::Adapter => {

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -10,6 +10,7 @@ use crate::link_state::{LinkEvent, LinkStateError};
 use crate::logging::targets::{FLOW_MGMT, REPORTING, ZDP};
 use crate::net_defs::IpAddress;
 use crate::packet::Packet;
+use crate::tc;
 use crate::tlv::{self, TlvEncoding};
 use crate::zdp;
 use bytes::{Buf, BufMut};
@@ -937,27 +938,14 @@ pub async fn handle_bind_egress_stream_request(
         return Err(HandleMgmtError::BadStructure);
     };
 
-    let classification = match classifier::classify(&mut pkt) {
-        Ok(cls) => cls,
-        Err(_why) => {
-            return Err(HandleMgmtError::BadStructure);
-        }
-    };
-
-    match classification {
-        classifier::ClassifierResult::OK => (),
-        classifier::ClassifierResult::UnclassifiedL4 => {
-            warn!(target: ZDP, "Link {}: unsupported IP protocol {}", pkt.metadata().ingress_link_id, pkt.metadata().get_l4_protocol());
-            return Err(HandleMgmtError::BadStructure);
-        }
-        _ => {
-            return Err(HandleMgmtError::BadStructure);
-        }
+    if hdr.tcst != zpr::Tcst::Ip5Tuple {
+        warn!(target: ZDP, "Link {}: unsupported TCST {}", pkt.metadata().ingress_link_id, hdr.tcst.0);
+        return Err(HandleMgmtError::BadStructure);
     }
 
-    let five_tuple = *pkt.metadata().five_tuple();
-
-    let compression_mode = hdr.compression_mode;
+    let Ok(tc) = tc::Ip5TupleTc::deserialize(&mut pkt) else {
+        return Err(HandleMgmtError::BadStructure);
+    };
 
     let Some(ingress_link_id) = NonZero::new(pkt.metadata().ingress_link_id) else {
         // who sent this??
@@ -967,7 +955,8 @@ pub async fn handle_bind_egress_stream_request(
 
     debug!(
         target: ZDP,
-        "Link {}: handlers.handle_bind_egress_stream_request -- five_tuple {five_tuple}", ingress_link_id.get(),
+        "Link {}: handlers.handle_bind_egress_stream_request -- five_tuple {}",
+        ingress_link_id.get(), tc.five_tuple()
     );
 
     // recycle request buffer for response
@@ -984,8 +973,8 @@ pub async fn handle_bind_egress_stream_request(
         PhMode::Adapter => {
             // form PEP
             let pep = adapter_tables::DltPep {
-                compression_mode,
-                five_tuple,
+                compression_mode: tc.compression_mode(),
+                five_tuple: *tc.five_tuple(),
             };
 
             // TODO: reverse path

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -348,6 +348,83 @@ pub async fn send_bind_actor_address_request(
     }
 }
 
+pub async fn send_bind_egress_stream_request(
+    asm: &Assembly,
+    link_id: zpr::LinkId,
+    compression_mode: zpr::CompressionMode,
+    five_tuple: FiveTuple,
+    packet_body: Vec<u8>,
+) -> Result<zpr::StreamId, BindActorAddressError> {
+    info!(target: ZDP, "Link {link_id}: sending BindEgressStreamRequest for {five_tuple} with compression mode {compression_mode} packet_body size {}", packet_body.len());
+
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+
+    let Some(peer_state) = asm.peer_table.get(link_id) else {
+        return Err(BindActorAddressError::LinkClosed);
+    };
+
+    let txn = peer_state.txn_mgr.open().await;
+    let txn_id = txn.id();
+    peer_state
+        .bind_req_state
+        .lock()
+        .unwrap()
+        .insert(txn, sender);
+
+    drop(peer_state);
+
+    let mut req = core::new_heap_packet();
+    let bind_req_hdr = req.alloc_zeroed_header::<zdp::ZdpBindEgressStreamRequestHeader>();
+    bind_req_hdr.ip_version = five_tuple.l3_type;
+    bind_req_hdr.compression_mode = compression_mode;
+
+    // No longer append source/dest addresses or layer4 protocol; just append the packet body
+    req.put_slice(&packet_body);
+
+    core::send_per_flow_txn_mgmt(
+        asm,
+        link_id,
+        zdp::ZdpPacketType::BindEgressStreamRequest,
+        0,
+        txn_id,
+        req,
+    )
+    .await?;
+
+    let Ok(mut resp) = receiver.await else {
+        return Err(BindActorAddressError::LinkClosed);
+    };
+
+    let Ok(hdr) = zdp::ZdpBindEgressStreamResponseHeader::read_from_buf(&mut resp) else {
+        core::count_event(asm, ManagementCounterType::BadStructure);
+        return Err(BindActorAddressError::BadStructure);
+    };
+
+    match hdr.status_code {
+        zdp::ResponseCode::Success => Ok(resp.metadata().ingress_stream_id),
+
+        zdp::ResponseCode::Other => {
+            if hdr.info_len as usize > resp.remaining() {
+                core::count_event(asm, ManagementCounterType::BadStructure);
+                return Err(BindActorAddressError::BadStructure);
+            }
+
+            let Ok(msg) = std::str::from_utf8(&resp.body()[..hdr.info_len as usize]) else {
+                core::count_event(asm, ManagementCounterType::BadStructure);
+                return Err(BindActorAddressError::BadStructure);
+            };
+            let msg: Box<str> = msg.into();
+
+            Err(BindActorAddressError::BindActorAddressError(msg))
+        }
+
+        _ => {
+            core::count_event(asm, ManagementCounterType::BadStructure);
+            Err(BindActorAddressError::BadStructure)
+        }
+    }
+}
+
 /// send a Report message (RFC 6.5 § 6.3.13)
 pub fn send_report<'a>(asm: &'a Assembly, link_id: zpr::LinkId, report: &'_ str) -> Sent<'a> {
     // TODO this condition will need to be adjusted when we have complete ZPR packets

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -8,6 +8,7 @@ use super::core::{self, Sent};
 use crate::counters::ManagementCounterType;
 use crate::defs::*;
 use crate::logging::targets::ZDP;
+use crate::tc;
 use crate::zdp;
 use crate::{assembly::Assembly, auth};
 
@@ -353,9 +354,10 @@ pub async fn send_bind_egress_stream_request(
     link_id: zpr::LinkId,
     compression_mode: zpr::CompressionMode,
     five_tuple: FiveTuple,
-    packet_body: Vec<u8>,
 ) -> Result<zpr::StreamId, BindActorAddressError> {
-    info!(target: ZDP, "Link {link_id}: sending BindEgressStreamRequest for {five_tuple} with compression mode {compression_mode} packet_body size {}", packet_body.len());
+    info!(target: ZDP, "Link {link_id}: sending BindEgressStreamRequest for {five_tuple} with compression mode {compression_mode}");
+
+    let tc = tc::Ip5TupleTc::new_with_compression_mode(compression_mode, five_tuple);
 
     let (sender, receiver) = tokio::sync::oneshot::channel();
 
@@ -375,11 +377,8 @@ pub async fn send_bind_egress_stream_request(
 
     let mut req = core::new_heap_packet();
     let bind_req_hdr = req.alloc_zeroed_header::<zdp::ZdpBindEgressStreamRequestHeader>();
-    bind_req_hdr.ip_version = five_tuple.l3_type;
-    bind_req_hdr.compression_mode = compression_mode;
-
-    // No longer append source/dest addresses or layer4 protocol; just append the packet body
-    req.put_slice(&packet_body);
+    bind_req_hdr.tcst = zpr::Tcst::Ip5Tuple;
+    tc.serialize(&mut req);
 
     core::send_per_flow_txn_mgmt(
         asm,

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -112,6 +112,26 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
                 .await
             }
 
+            ZdpPacketType::BindEgressStreamRequest => {
+                let Ok(txn_hdr) = ZdpTransactionHeader::read_from_buf(&mut pkt) else {
+                    return Err(HandleMgmtError::BadStructure);
+                };
+                handlers::handle_bind_egress_stream_request(asm, txn_hdr.transaction_id.into(), pkt)
+                    .await
+            }
+
+            ZdpPacketType::BindEgressStreamResponse => {
+                let Ok(txn_hdr) = ZdpTransactionHeader::read_from_buf(&mut pkt) else {
+                    return Err(HandleMgmtError::BadStructure);
+                };
+                handlers::handle_bind_egress_stream_response(
+                    asm,
+                    txn_hdr.transaction_id.into(),
+                    pkt,
+                )
+                .await
+            }
+
             packet_type => Err(HandleMgmtError::UnknownType(packet_type.0)),
         }
     } else {

--- a/adapter/ph/src/net_defs.rs
+++ b/adapter/ph/src/net_defs.rs
@@ -10,12 +10,23 @@ pub mod ethertype {
     pub const IPV6: u16 = 0x86dd;
 }
 
+pub const IPV4_ADDRESS_SIZE: usize = 4;
 pub const IPV6_ADDRESS_SIZE: usize = 16;
 
 /// "Flat" (non-enum) representation of an IPv4 or IPv6 address, used
 /// internally to represent ZPR addresses.
 #[derive(
-    FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned, Copy, Clone, Hash, PartialEq, Eq,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+    Copy,
+    Clone,
+    Default,
+    Hash,
+    PartialEq,
+    Eq,
 )]
 #[repr(transparent)]
 pub struct IpAddress {

--- a/adapter/ph/src/tc.rs
+++ b/adapter/ph/src/tc.rs
@@ -1,0 +1,171 @@
+//! ZPR Traffic Classifiers
+//!
+//! Probably, most of this functionality should live in the zpr crate,
+//! and the serialization/deserialization should move into the zdp module.
+//! For now, it's all here together.
+
+use crate::defs;
+use crate::net_defs;
+use crate::zdp;
+use bytes::{Buf, BufMut};
+use zpr_ext::zerocopy::{FromBytesExt, IntoBytesExt};
+
+/// IP 5-Tuple Traffic Classifier
+pub struct Ip5TupleTc(defs::FiveTuple);
+
+impl Ip5TupleTc {
+    #[allow(dead_code)]
+    /// Interpret a five-tuple as a traffic classifier.  Ports specified as 0
+    /// are interpreted as wildcards.
+    pub fn new(five_tuple: defs::FiveTuple) -> Self {
+        Self(five_tuple)
+    }
+
+    /// TEMPORARY: use compression mode flags to indicate which ports of the five-tuple
+    /// should be masked out and treated as wildcards.
+    pub fn new_with_compression_mode(
+        compression_mode: zpr::CompressionMode,
+        mut five_tuple: defs::FiveTuple,
+    ) -> Self {
+        if compression_mode & zpr::compression_mode::SOURCE_PORT_PRESENT == 0 {
+            five_tuple.src_port = 0;
+        }
+
+        if compression_mode & zpr::compression_mode::DESTINATION_PORT_PRESENT == 0 {
+            five_tuple.dst_port = 0;
+        }
+
+        Self(five_tuple)
+    }
+
+    /// Represent the classifier as a five-tuple.  Wildcard ports are
+    /// represented as 0.
+    pub fn five_tuple(&self) -> &defs::FiveTuple {
+        &self.0
+    }
+
+    /// TEMPORARY: Return compression mode flags indicating whether ports are wildcarded.
+    pub fn compression_mode(&self) -> zpr::CompressionMode {
+        let mut mode: zpr::CompressionMode = 0;
+
+        if self.0.src_port != 0 {
+            mode |= zpr::compression_mode::SOURCE_PORT_PRESENT;
+        }
+
+        if self.0.dst_port != 0 {
+            mode |= zpr::compression_mode::DESTINATION_PORT_PRESENT;
+        }
+
+        mode
+    }
+
+    /// Serialize.
+    pub fn serialize(&self, buf: &mut impl BufMut) {
+        let mut flags = 0;
+
+        match self.0.l3_type {
+            zpr::L3Type::Ipv4 => flags |= zdp::traffic_classifier_flags::IPV4,
+            zpr::L3Type::Ipv6 => (), // default is IPv6
+            _ => panic!("must be IPv4 or IPv6"),
+        }
+
+        if self.0.src_port != 0 {
+            flags |= zdp::traffic_classifier_flags::SOURCE_PORT_PRESENT;
+        }
+
+        if self.0.dst_port != 0 {
+            flags |= zdp::traffic_classifier_flags::DESTINATION_PORT_PRESENT;
+        }
+
+        zdp::ZdpTrafficClassifierHeader {
+            flags,
+            ip_protocol: self.0.l4_protocol,
+        }
+        .write_to_buf(buf)
+        .unwrap();
+
+        match self.0.l3_type {
+            zpr::L3Type::Ipv4 => {
+                buf.put(self.0.src_address.read_as_v4().as_slice());
+                buf.put(self.0.dst_address.read_as_v4().as_slice());
+            }
+
+            zpr::L3Type::Ipv6 => {
+                buf.put(self.0.src_address.v6.as_slice());
+                buf.put(self.0.dst_address.v6.as_slice());
+            }
+
+            _ => panic!("must be IPv4 or IPv6"),
+        }
+
+        if self.0.src_port != 0 {
+            buf.put_u16(self.0.src_port);
+        }
+
+        if self.0.dst_port != 0 {
+            buf.put_u16(self.0.dst_port);
+        }
+    }
+
+    pub fn deserialize(buf: &mut impl Buf) -> Result<Self, ()> {
+        let Ok(hdr) = zdp::ZdpTrafficClassifierHeader::read_from_buf(buf) else {
+            return Err(());
+        };
+
+        let l3_type;
+        let src_address;
+        let dst_address;
+
+        if hdr.flags & zdp::traffic_classifier_flags::IPV4 != 0 {
+            l3_type = zpr::L3Type::Ipv4;
+
+            if buf.remaining() < 2 * net_defs::IPV4_ADDRESS_SIZE {
+                return Err(());
+            }
+
+            src_address = buf_get_ipv4(buf);
+            dst_address = buf_get_ipv4(buf);
+        } else {
+            l3_type = zpr::L3Type::Ipv6;
+
+            if buf.remaining() < 2 * net_defs::IPV6_ADDRESS_SIZE {
+                return Err(());
+            }
+
+            src_address = buf_get_ipv6(buf);
+            dst_address = buf_get_ipv6(buf);
+        }
+
+        let mut src_port = 0;
+        let mut dst_port = 0;
+
+        if hdr.flags & zdp::traffic_classifier_flags::SOURCE_PORT_PRESENT != 0 {
+            src_port = buf.try_get_u16().map_err(|_| ())?;
+        }
+
+        if hdr.flags & zdp::traffic_classifier_flags::DESTINATION_PORT_PRESENT != 0 {
+            dst_port = buf.try_get_u16().map_err(|_| ())?;
+        }
+
+        return Ok(Self(defs::FiveTuple {
+            l3_type,
+            l4_protocol: hdr.ip_protocol,
+            src_address,
+            dst_address,
+            src_port,
+            dst_port,
+        }));
+    }
+}
+
+fn buf_get_ipv4(buf: &mut impl Buf) -> net_defs::IpAddress {
+    <[u8; net_defs::IPV4_ADDRESS_SIZE]>::try_from(&*buf.copy_to_bytes(net_defs::IPV4_ADDRESS_SIZE))
+        .unwrap()
+        .into()
+}
+
+fn buf_get_ipv6(buf: &mut impl Buf) -> net_defs::IpAddress {
+    <[u8; net_defs::IPV6_ADDRESS_SIZE]>::try_from(&*buf.copy_to_bytes(net_defs::IPV6_ADDRESS_SIZE))
+        .unwrap()
+        .into()
+}

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -28,6 +28,8 @@ pub enum ZdpPacketType {
     //AuthenticationRequest = 15,  // unused/deprecated
     SetPathMtu = 16,
     //AuthenticationResponse = 17,  // unused/deprecated
+    BindEgressStreamRequest = 19,  // TODO: add to RFC 17
+    BindEgressStreamResponse = 20, // TODO: add to RFC 17
 
     // Not flow-based
     ZprArp = 128,
@@ -238,6 +240,23 @@ pub struct ZdpBindActorAddressRequestHeader {
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpBindActorAddressResponseHeader {
+    pub status_code: ResponseCode,
+    pub info_len: u8,
+}
+
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(packed)]
+pub struct ZdpBindEgressStreamRequestHeader {
+    pub ip_version: zpr::L3Type,
+    pub compression_mode: zpr::CompressionMode,
+    // Followed in memory by:
+    // - <PACKET BODY starting with IP header>
+    // (source/dest addresses and layer4 protocol must be extracted from the IP header in the packet)
+}
+
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(packed)]
+pub struct ZdpBindEgressStreamResponseHeader {
     pub status_code: ResponseCode,
     pub info_len: u8,
 }

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -247,11 +247,8 @@ pub struct ZdpBindActorAddressResponseHeader {
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpBindEgressStreamRequestHeader {
-    pub ip_version: zpr::L3Type,
-    pub compression_mode: zpr::CompressionMode,
-    // Followed in memory by:
-    // - <PACKET BODY starting with IP header>
-    // (source/dest addresses and layer4 protocol must be extracted from the IP header in the packet)
+    pub tcst: zpr::Tcst,
+    // followed by traffic classifier
 }
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
@@ -291,6 +288,22 @@ impl ZdpKeyManagementHeader {
 #[repr(packed)]
 pub struct ZdpA2aHeader {
     pub a2a_said: zpr::A2aSaid,
+}
+
+#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[repr(packed)]
+pub struct ZdpTrafficClassifierHeader {
+    pub flags: u8,
+    pub ip_protocol: u8,
+    // Followed by source and destination addresses,
+    // then optional source and destination ports.
+}
+
+/// Bitflags for the [ZdpTrafficClassifierHeader] flags field.
+pub mod traffic_classifier_flags {
+    pub const DESTINATION_PORT_PRESENT: u8 = 0x01;
+    pub const SOURCE_PORT_PRESENT: u8 = 0x02;
+    pub const IPV4: u8 = 0x04;
 }
 
 /// Config-specified size of A2A MAC.  Algorithm-specified MAC may be smaller (but not larger).

--- a/zpr/src/lib.rs
+++ b/zpr/src/lib.rs
@@ -77,7 +77,9 @@ pub const KM_ID_NULL: KmId = 0;
 
 /// ZPR actor packet L3 type (RFC 6.5 § 6.3.11)
 #[open_enum]
-#[derive(Copy, Clone, Debug, FromBytes, Hash, IntoBytes, Immutable, KnownLayout, Unaligned)]
+#[derive(
+    Copy, Clone, Debug, Default, FromBytes, Hash, IntoBytes, Immutable, KnownLayout, Unaligned,
+)]
 #[repr(u8)]
 pub enum L3Type {
     Ipv4 = 4,
@@ -120,6 +122,25 @@ pub mod compression_mode {
     pub const DESTINATION_PORT_PRESENT: CompressionMode = 0x20;
     pub const SOURCE_PORT_PRESENT: CompressionMode = 0x40;
     //pub const IP_PROTOCOL_PRESENT: CompressionMode = 0x80; // FIXME: this seems unused; I have a Q out to Frank about it
+}
+
+/// Traffic classification specification type.
+#[open_enum]
+#[derive(
+    Copy, Clone, Debug, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned,
+)]
+#[repr(u8)]
+pub enum Tcst {
+    Ip5Tuple = 0,
+}
+
+impl std::fmt::Display for Tcst {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match *self {
+            Self::Ip5Tuple => write!(f, "IP 5-Tuple"),
+            other => write!(f, "[unknown TCST {}]", other.0),
+        }
+    }
 }
 
 // Well-known DNs.


### PR DESCRIPTION
The BindActorAddress request is currently used both for binding ingress adapter→node and also for node→egress adapter.  We want to do different things for these, and also for node→node.

So to start, this PR splits out the node→adapter functionality into a separate BindEgressStream message, which conveys the compression algorithm to the egress adapter (that is, the TCST and TC, which is a five-tuple).  In the future it will also convey the MICV key.

Reviewing each commit separately may make this easier.