### PR TITLE
Cslab iterator

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "cslab"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "loom",
 ]

--- a/adapter/ph/src/admin_worker.rs
+++ b/adapter/ph/src/admin_worker.rs
@@ -268,7 +268,13 @@ impl svc::Server for AdminServiceImpl {
     ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
         info!(target: RPC, "Show link summary procedure initiated");
         {
-            let peer_ids = self.asm.peer_ids.lock().unwrap();
+            let mut peer_ids = Vec::new();
+            self.asm.peer_table.for_each(|(id, _)| {
+                if id.get() != zpr::LOCAL_ACTOR_LINK_ID {
+                    peer_ids.push(id.get())
+                }
+            });
+
             let mut results_builder = results.get().init_summary(peer_ids.len() as u32);
 
             for (i, id) in peer_ids.iter().enumerate() {

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -83,7 +83,6 @@ pub struct Assembly {
     pub tun_ctl: Box<dyn TunCtl + Send>,
 
     pub peer_table: peer_table::PeerTable,
-    pub peer_ids: std::sync::Mutex<Vec<zpr::LinkId>>, // HACK until peer_table is enumerable
 
     // Adapter tables
     pub alt: adapter_tables::ActorLookupTable,
@@ -139,20 +138,18 @@ impl Assembly {
         if matches!(self.ph_mode, PhMode::Node) {
             let mut join_set = tokio::task::JoinSet::new();
 
-            // Probably not worth blocking for this
-            let peer_ids = self.peer_ids.lock().unwrap().clone();
-
             let vs_peer = self
                 .peer_table
                 .lookup_special_peer(SpecialPeerName::VisaServiceAdapter);
-            for peer_id in peer_ids {
-                if vs_peer.is_none() || peer_id != vs_peer.unwrap().get() {
+
+            self.peer_table.for_each(|(peer_id, _)| {
+                if Some(peer_id) != vs_peer && peer_id.get() != zpr::LOCAL_ACTOR_LINK_ID {
                     // This should be a short block and must be blocked on,
                     // otherwise the messages won't get sent
                     let spawn_self = self.clone();
-                    join_set.spawn_local(async move { spawn_self.reset_peer(peer_id).await });
+                    join_set.spawn_local(async move { spawn_self.reset_peer(peer_id.get()).await });
                 }
-            }
+            });
 
             join_set.join_all().await;
 
@@ -166,33 +163,33 @@ impl Assembly {
     async fn shutdown_adapter(self: &Arc<Self>) {
         let mut join_set = tokio::task::JoinSet::new();
 
-        // Probably not worth blocking for this
-        let peer_ids = self.peer_ids.lock().unwrap().clone();
-
-        for peer_id in peer_ids {
-            if let Some(peer) = self.peer_table.get(peer_id) {
-                if let Err(e) = peer
-                    .link_state_machine
-                    .process_event(self, LinkEvent::Close(TerminateReason::Shutdown))
-                {
-                    error!(target: PEER_MGMT, "Failed to nicely close peer {peer_id}: {e}");
-                    // So try harder...
-                    let spawn_self = self.clone();
-                    join_set.spawn_local(async move { spawn_self.reset_peer(peer_id).await });
-                }
+        self.peer_table.for_each(|(peer_id, peer)| {
+            if peer_id.get() == zpr::LOCAL_ACTOR_LINK_ID {
+                return;
             }
-        }
+
+            if let Err(e) = peer
+                .link_state_machine
+                .process_event(self, LinkEvent::Close(TerminateReason::Shutdown))
+            {
+                error!(target: PEER_MGMT, "Failed to nicely close peer {peer_id}: {e}");
+                // So try harder...
+                let spawn_self = self.clone();
+                join_set.spawn_local(async move { spawn_self.reset_peer(peer_id.get()).await });
+            }
+        });
         join_set.join_all().await;
 
-        let mut peer_ids = self.peer_ids.lock().unwrap().clone();
+        let mut npeers = self.peer_table.len() - 1; // - 1 accounts for local actor
         info!(
+            target: PEER_MGMT,
             "Waiting for {} peer{} to disconnect...",
-            peer_ids.len(),
-            if peer_ids.len() == 1 { "" } else { "s" }
+            npeers,
+            if npeers == 1 { "" } else { "s" }
         );
-        while !peer_ids.is_empty() {
+        while npeers > 0 {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            peer_ids = self.peer_ids.lock().unwrap().clone();
+            npeers = self.peer_table.len() - 1; // - 1 accounts for local actor
         }
     }
 
@@ -310,7 +307,6 @@ impl Assembly {
             debug!(target: PEER_MGMT, "Removing peer {link_id}");
         }
         self.peer_table.remove(link_id);
-        self.peer_ids.lock().unwrap().retain(|id| *id != link_id);
         info!(target: PEER_MGMT, "Removed peer {link_id}");
     }
 
@@ -349,7 +345,6 @@ impl Assembly {
         assert!(link_type != LinkType::NodeToNode);
         debug!(target: PEER_MGMT, "Starting tether with {adapter_addr} connected to {interface_addr}");
         let peer_id = self.add_peer(link_type, adapter_addr, interface_addr)?;
-        self.peer_ids.lock().unwrap().push(peer_id.get());
 
         let Some(peer) = self.peer_table.get(peer_id.get()) else {
             // Peer is gone already
@@ -375,27 +370,25 @@ impl Assembly {
     /// Temporary? function to find a link based on the actor address
     pub fn find_egress_link(&self, actor_addr: IpAddress) -> Option<NonZero<LinkId>> {
         // First check the local actor addresses to see if it's a locally-destined packet
-        for addr in self.config.get().zpr_addr.iter() {
-            if actor_addr == (*addr).into() {
-                return Some(NonZero::new(zpr::LOCAL_ACTOR_LINK_ID).unwrap());
-            }
+        if self
+            .config
+            .get()
+            .zpr_addr
+            .iter()
+            .any(|addr| IpAddress::new_from_std(addr) == actor_addr)
+        {
+            return Some(NonZero::new(zpr::LOCAL_ACTOR_LINK_ID).unwrap());
         }
-
-        let ids = self.peer_ids.lock().unwrap().clone();
 
         // Check peer actor addresses to see if one of them matches
-        for id in ids.iter() {
-            let peer = self
-                .peer_table
-                .get(*id)
-                .expect("Peer IDs out of sync with peer table");
-            for addr in peer.link_state_machine.get_actor_addresses() {
-                if addr == actor_addr {
-                    return Some(NonZero::new(*id).unwrap());
-                }
-            }
-        }
-        None
+        self.peer_table
+            .find(|(_id, peer)| {
+                peer.link_state_machine
+                    .get_actor_addresses()
+                    .iter()
+                    .any(|addr| *addr == actor_addr)
+            })
+            .map(|(id, _peer)| id)
     }
 
     pub async fn add_route(
@@ -494,7 +487,6 @@ pub mod test {
         pub counters: Option<Counters>,
         pub tun_ctl: Option<Box<dyn TunCtl + Send>>,
         pub peer_table: Option<peer_table::PeerTable>,
-        pub peer_ids: Option<Vec<zpr::LinkId>>,
         pub alt: Option<adapter_tables::ActorLookupTable>,
         pub dlt: Option<adapter_tables::DockLookupTable>,
         pub mgmt_dispatch_factory: Option<MgmtDispatchFactory>,
@@ -556,7 +548,6 @@ pub mod test {
         let peer_table = builder
             .peer_table
             .unwrap_or_else(|| peer_table::PeerTable::new());
-        let peer_ids = std::sync::Mutex::new(builder.peer_ids.unwrap_or_default());
         let alt = builder
             .alt
             .unwrap_or_else(|| adapter_tables::ActorLookupTable::new());
@@ -603,7 +594,6 @@ pub mod test {
             counters,
             tun_ctl,
             peer_table,
-            peer_ids,
             alt,
             dlt,
             mgmt_dispatch_factory,

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -28,7 +28,6 @@ use km_noise::NoiseKeypair;
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::num::NonZero;
-use std::panic;
 use std::result::Result;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
@@ -137,10 +136,12 @@ impl Assembly {
 
     // The node quickly sends Terminate Indications
     async fn shutdown_node(self: &Arc<Self>) {
-        // Probably not worth blocking for this
-        let peer_ids = self.peer_ids.lock().unwrap().clone();
+        if matches!(self.ph_mode, PhMode::Node) {
+            let mut join_set = tokio::task::JoinSet::new();
 
-        if self.ph_mode == PhMode::Node {
+            // Probably not worth blocking for this
+            let peer_ids = self.peer_ids.lock().unwrap().clone();
+
             let vs_peer = self
                 .peer_table
                 .lookup_special_peer(SpecialPeerName::VisaServiceAdapter);
@@ -148,9 +149,13 @@ impl Assembly {
                 if vs_peer.is_none() || peer_id != vs_peer.unwrap().get() {
                     // This should be a short block and must be blocked on,
                     // otherwise the messages won't get sent
-                    self.reset_peer(peer_id).await;
+                    let spawn_self = self.clone();
+                    join_set.spawn_local(async move { spawn_self.reset_peer(peer_id).await });
                 }
             }
+
+            join_set.join_all().await;
+
             if let Some(vs_peer) = vs_peer {
                 self.reset_peer(vs_peer.get()).await;
             }
@@ -172,30 +177,22 @@ impl Assembly {
                 {
                     error!(target: PEER_MGMT, "Failed to nicely close peer {peer_id}: {e}");
                     // So try harder...
-                    self.reset_peer(peer_id).await;
+                    let spawn_self = self.clone();
+                    join_set.spawn_local(async move { spawn_self.reset_peer(peer_id).await });
                 }
             }
         }
-        let spawn_self = self.clone();
-        join_set.spawn_local(async move {
-            let mut peer_ids = spawn_self.peer_ids.lock().unwrap().clone();
-            info!(
-                "Waiting for {} peer{} to disconnect...",
-                peer_ids.len(),
-                if peer_ids.len() == 1 { "" } else { "s" }
-            );
-            while !peer_ids.is_empty() {
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                peer_ids = spawn_self.peer_ids.lock().unwrap().clone();
-            }
-        });
+        join_set.join_all().await;
 
-        while let Some(res) = join_set.join_next().await {
-            match res {
-                Ok(_) => (),
-                Err(err) if err.is_panic() => panic::resume_unwind(err.into_panic()),
-                Err(e) => error!("unexpected error during shutdown: {e}"),
-            }
+        let mut peer_ids = self.peer_ids.lock().unwrap().clone();
+        info!(
+            "Waiting for {} peer{} to disconnect...",
+            peer_ids.len(),
+            if peer_ids.len() == 1 { "" } else { "s" }
+        );
+        while !peer_ids.is_empty() {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            peer_ids = self.peer_ids.lock().unwrap().clone();
         }
     }
 

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -554,7 +554,6 @@ fn main() -> ExitCode {
         counters: Default::default(),
         tun_ctl,
         peer_table: peer_table::PeerTable::new(),
-        peer_ids: Default::default(),
         alt: adapter_tables::ActorLookupTable::new(),
         dlt: adapter_tables::DockLookupTable::new(),
         mgmt_dispatch_factory: MgmtDispatchFactory::new(md_inq_factory),

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -255,6 +255,30 @@ impl PeerTable {
             .get_guarded((link_id as usize).wrapping_sub(1))
     }
 
+    /// Apply the given function to all peers.
+    pub fn for_each(&self, mut f: impl FnMut((NonZero<LinkId>, &PeerState))) {
+        self.peer_slab_reader.inspect(|r| {
+            r.iter()
+                .for_each(|(idx, peer)| f((NonZero::new((idx + 1) as LinkId).unwrap(), peer)))
+        })
+    }
+
+    /// Find and return the first peer matching the given predicate, if any.
+    pub fn find(
+        &self,
+        mut predicate: impl FnMut((NonZero<LinkId>, &PeerState)) -> bool,
+    ) -> Option<(NonZero<LinkId>, PeerTableEntryGuard<'_>)> {
+        let (idx, guard) = self.peer_slab_reader.find_guarded(|(idx, peer)| {
+            predicate((NonZero::new((idx + 1) as LinkId).unwrap(), peer))
+        })?;
+        Some((NonZero::new((idx + 1) as LinkId).unwrap(), guard))
+    }
+
+    /// Gets the number of peers; synchronizes with insert/remove.
+    pub fn len(&self) -> usize {
+        self.peer_slab.lock().unwrap().len()
+    }
+
     /// Sets an established security association on the link.
     pub fn set_security_association(
         &self,

--- a/adapter/ph/src/rcu.rs
+++ b/adapter/ph/src/rcu.rs
@@ -416,6 +416,15 @@ impl<T> RcuBox<cslab::RcuCslabReader<T>> {
             None
         }
     }
+
+    pub fn find_guarded(
+        &self,
+        predicate: impl FnMut(&(usize, &T)) -> bool,
+    ) -> Option<(usize, RcuCslabEntryGuard<'_, T>)> {
+        let guard = self.get();
+        let key = guard.iter().find(predicate)?.0;
+        Some((key, RcuCslabEntryGuard { guard, key }))
+    }
 }
 
 #[cfg(test)]

--- a/cslab/Cargo.lock
+++ b/cslab/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cslab"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "loom",
 ]

--- a/cslab/Cargo.toml
+++ b/cslab/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cslab"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/cslab/src/lib.rs
+++ b/cslab/src/lib.rs
@@ -123,6 +123,27 @@ use sync::{
 // remove [R] operations to readers.  The `Cslab` data structure does not
 // provide this.  Instead, the `RcuCslab` data structure builds upon `Cslab`
 // to provide this functionality.  It is described below.
+//
+// Finally, iteration [S] is performed simply by scanning the bitmap
+// in-order.  However, this would naively force us to scan a potentially
+// very large table even if it was never used.  So to optimize this, we also
+// track the maximum index which was ever marked in the bitmap (the
+// "frontier").  This is updated (increased) [Im] on insert [I] prior to
+// marking the entry in the bitmap [Ib], so that if a get [G] ever succeeds,
+// the ordering of [Ib] ⇒ [Gb] ensures that a subsequent load of the
+// maximum index [Sm] will also see this item.
+//
+// It is also possible to decrease the frontier on remove [R], though we
+// don't currently, since it's questionable whether this actually is a
+// performance help: indexes aren't guaranteed to be released in order, so
+// we often simply _can't_ decrease it, and the zero-pages are already
+// physically manifested and almost certain nonzero so we can't even return
+// them to the OS.  However, if we did want to perform this operation, then
+// we would update (decrease) [Rm] this value with release ordering after
+// clearing the index in the bitmap [Rb], and [Sm] should be modified to have
+// acquire ordering, so that [Rm] ⇒ [Sm] ensures that any get [G] which occurs
+// after having seen the item hidden by the decreased frontier also sees
+// the item actually marked for removal.
 
 union Entry<T> {
     next_free: isize, // offset to next empty; neighbor is 0 so zero-alloced array is initialized
@@ -132,10 +153,14 @@ union Entry<T> {
 type CslabTable<T> = [UnsafeCell<Entry<T>>];
 type CslabBitmap = [AtomicUsize];
 
-// `CslabStorage` "glues together" the table and bitmap allocations into one.
-// This allows us to write a `Drop` implementation which uses both of them.
+/// `CslabStorage` "glues together" the table and bitmap allocations into one.
+/// This allows us to write a `Drop` implementation which uses both of them.
 struct CslabStorage<T> {
+    /// total number of indexes
     size: usize,
+    /// maximum used index (marked in bitmap) plus 1
+    /// (used to decouple performance of scanning from size of table)
+    frontier: AtomicUsize,
     ptr: *mut u8,
     bitmap_offset: usize,
     phantom: std::marker::PhantomData<T>,
@@ -182,6 +207,7 @@ impl<T> CslabStorage<T> {
 
         Self {
             size,
+            frontier: AtomicUsize::new(0),
             ptr,
             bitmap_offset,
             phantom: std::marker::PhantomData,
@@ -190,6 +216,10 @@ impl<T> CslabStorage<T> {
 
     pub fn len(&self) -> usize {
         self.size
+    }
+
+    pub fn frontier(&self) -> &AtomicUsize {
+        &self.frontier
     }
 
     pub fn table(&self) -> &CslabTable<T> {
@@ -207,6 +237,7 @@ impl<T> CslabStorage<T> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn parts_mut(&mut self) -> (&mut CslabTable<T>, &mut CslabBitmap) {
         // SAFETY: we've correctly allocated memory
         (
@@ -223,27 +254,12 @@ impl<T> CslabStorage<T> {
 
 impl<T> Drop for CslabStorage<T> {
     fn drop(&mut self) {
-        // FIXME: this is inefficient for very large tables
-        // NOTE: we can (a) use bitscanning, and (b) keep a count of how many values remaining
-
-        let size = self.size;
-        let (table, bitmap) = self.parts_mut();
-
-        for (i, bme) in bitmap.iter().enumerate() {
-            let x = bme.load(Ordering::Relaxed);
-            for j in 0..usize::BITS as usize {
-                let idx = (i * usize::BITS as usize) + j;
-                if idx >= size {
-                    break;
-                }
-                if (x >> j) & 1 != 0 {
-                    // SAFETY: we know an element is present from the bit being set
-                    // and our requirement that `finalize_remove()` be called
-                    // for every `mark_removed()`
-                    unsafe { ManuallyDrop::drop(&mut (*table[idx].get()).item) }
-                }
-            }
-        }
+        Iter::new(self).for_each(|(_, item)|
+            // SAFETY: we know an element is present from the bit being set
+            // and our requirement that `finalize_remove()` be called
+            // for every `mark_removed()`
+            // SAFETY: we know we have exclusive access to this item
+            unsafe { std::ptr::drop_in_place((item as *const T) as *mut T) });
 
         let (layout, _) = Self::storage_layout(self.size);
         // SAFETY: we are dropping; no-one else has a pointer to this
@@ -287,6 +303,160 @@ unsafe fn get_unchecked_impl<T>(storage: &CslabStorage<T>, idx: usize) -> &T {
     unsafe { &(*storage.table()[idx].get()).item } /* [Gi] */
 }
 
+/// Iterator over a `CslabReader`.
+pub struct Iter<'a, T> {
+    storage: &'a CslabStorage<T>,
+    head: usize, // inclusive
+    tail: usize, // exclusive
+}
+
+impl<'a, T> Iter<'a, T> {
+    fn new(storage: &'a CslabStorage<T>) -> Self {
+        let frontier = storage.frontier().load(Ordering::Relaxed) /* [Sm] */;
+        debug_assert!(frontier <= storage.size);
+
+        Self {
+            storage,
+            head: 0,
+            tail: frontier,
+        }
+    }
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = (usize, &'a T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // needed to avoid possibly loading past the end
+        if self.head >= self.tail {
+            return None;
+        }
+
+        loop {
+            let bme = self.storage.bitmap()[self.head / usize::BITS as usize].load(Ordering::Acquire) /* [Gb] */
+                    >> (self.head % usize::BITS as usize);
+
+            // compute distance from head to next item, or next bitmap entry
+            let d;
+            if bme == 0 {
+                d = usize::BITS as usize - (self.head % usize::BITS as usize);
+            } else {
+                d = bme.trailing_zeros() as usize;
+            }
+
+            if d >= self.tail - self.head {
+                // if we've reached the end, finish
+                self.head = self.tail;
+                return None;
+            }
+
+            // move to next item, or next bitmap entry
+            self.head += d;
+
+            if bme != 0 {
+                // if we did find an item, return it!
+                let idx = self.head;
+                self.head += 1;
+                // SAFETY: the bitmap has told us there is an item
+                return Some((idx, unsafe { get_unchecked_impl(self.storage, idx) }));
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.tail - self.head))
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        // needed to avoid possibly loading past the beginning
+        if self.tail <= self.head {
+            return None;
+        }
+
+        loop {
+            let bme = self.storage.bitmap()[(self.tail - 1) / usize::BITS as usize].load(Ordering::Acquire) /* [Gb] */
+                    << (usize::BITS as usize - (((self.tail - 1) % usize::BITS as usize) + 1));
+
+            // compute distance from tail to previous item, or previous bitmap entry
+            let d;
+            if bme == 0 {
+                d = ((self.tail - 1) % usize::BITS as usize) + 1;
+            } else {
+                d = bme.leading_zeros() as usize;
+            }
+
+            if d >= self.tail - self.head {
+                // if we've reached the beginning, finish
+                self.tail = self.head;
+                return None;
+            }
+
+            // move to previous item, or previous bitmap entry
+            self.tail -= d;
+
+            if bme != 0 {
+                // if we did find an item, return it!
+                self.tail -= 1;
+                // SAFETY: the bitmap has told us there is an item
+                return Some((self.tail, unsafe {
+                    get_unchecked_impl(self.storage, self.tail)
+                }));
+            }
+        }
+    }
+}
+
+impl<'a, T> std::iter::FusedIterator for Iter<'a, T> {}
+
+/// Iterator over a `Cslab`.
+pub struct ExclIter<'a, T> {
+    iter: Iter<'a, T>,
+    in_use: usize,
+}
+
+impl<'a, T> ExclIter<'a, T> {
+    fn new(storage: &'a CslabStorage<T>, in_use: usize) -> Self {
+        Self {
+            iter: Iter::new(storage),
+            in_use,
+        }
+    }
+}
+
+impl<'a, T> Iterator for ExclIter<'a, T> {
+    type Item = <Iter<'a, T> as Iterator>::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.in_use, Some(self.in_use))
+    }
+
+    fn count(self) -> usize {
+        self.in_use
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for ExclIter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
+    }
+}
+
+impl<'a, T> ExactSizeIterator for ExclIter<'a, T> {}
+
+impl<'a, T> std::iter::FusedIterator for ExclIter<'a, T> {}
+
+impl<'a, T> From<ExclIter<'a, T>> for Iter<'a, T> {
+    fn from(value: ExclIter<'a, T>) -> Self {
+        value.iter
+    }
+}
+
 /// Cloneable read-only handle to a `Cslab`.
 pub struct CslabReader<T>(Arc<CslabStorage<T>>);
 
@@ -301,12 +471,12 @@ impl<T> CslabReader<T> {
     /// have been marked for removal by the writer thread.  (The item
     /// returned is however still valid.)
     pub fn get(&self, idx: usize) -> Option<&T> {
-        get_impl(&*self.0, idx)
+        get_impl(&self.0, idx)
     }
 
     /// Like `get()`, but simply returns whether an item is present or not.
     pub fn contains_key(&self, idx: usize) -> bool {
-        contains_key_impl(&*self.0, idx)
+        contains_key_impl(&self.0, idx)
     }
 
     /// Gets an item known not to have been finalized.  (I.e., the item must be
@@ -318,7 +488,14 @@ impl<T> CslabReader<T> {
     /// that an item is present at this index, and `finalize_remove()`
     /// has not been called on this index in the interim.
     pub unsafe fn get_unchecked(&self, idx: usize) -> &T {
-        unsafe { get_unchecked_impl(&*self.0, idx) }
+        unsafe { get_unchecked_impl(&self.0, idx) }
+    }
+
+    /// Returns an iterator over the slab.
+    ///
+    /// Items added during the iterator's lifetime may or may not be visible.
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter::new(&self.0)
     }
 }
 
@@ -383,7 +560,15 @@ impl<T> Cslab<T> {
     /// Unlike `CslabReader::get()`, it is _not_ possible for this method to
     /// return items which have been marked for removal.
     pub fn get(&self, idx: usize) -> Option<&T> {
-        get_impl(&*self.storage, idx)
+        get_impl(&self.storage, idx)
+    }
+
+    /// Returns an iterator over the slab.
+    ///
+    /// Unlike `CslabReader::iter()`, it is not possible for items to be
+    /// concurrently added (and therefore be nondeterministically visible).
+    pub fn iter(&self) -> ExclIter<'_, T> {
+        ExclIter::new(&self.storage, self.in_use)
     }
 
     /// Return a clonable read-only handle to the slab.
@@ -414,6 +599,13 @@ impl<T> Cslab<T> {
         // store item
         // SAFETY: any index in the freelist has no item
         unsafe { (*self.storage.table()[idx].get()).item = ManuallyDrop::new(item) } /* [Ii] */;
+
+        // update highest-used index
+        // note, we are the only writer, so we don't need to use `fetch_max`
+        let old_frontier = self.storage.frontier().load(Ordering::Relaxed);
+        if idx >= old_frontier {
+            self.storage.frontier().store(idx + 1, Ordering::Relaxed) /* [Im] */;
+        }
 
         // mark in bitmap
         let mask = self.storage.bitmap()[idx / usize::BITS as usize].load(Ordering::Relaxed);
@@ -641,6 +833,83 @@ mod tests {
         std::mem::drop(slab);
         assert!(j_dropped.get());
     }
+
+    #[test]
+    fn iter_test() {
+        let mut slab = Cslab::with_fixed_capacity(4);
+        assert_eq!(slab.iter().len(), 0);
+        assert!(slab.iter().collect::<Vec::<_>>().is_empty());
+
+        let i = slab.insert(123).unwrap();
+        let j = slab.insert(456).unwrap();
+        let k = slab.insert(789).unwrap();
+        assert_eq!(slab.iter().len(), 3);
+        assert_eq!(
+            slab.iter().collect::<Vec::<_>>(),
+            vec![(i, &123), (j, &456), (k, &789)]
+        );
+        assert_eq!(
+            slab.iter().rev().collect::<Vec::<_>>(),
+            vec![(k, &789), (j, &456), (i, &123)]
+        );
+
+        unsafe {
+            slab.mark_removed(j);
+        }
+
+        assert_eq!(slab.iter().len(), 2);
+        assert_eq!(
+            slab.iter().collect::<Vec::<_>>(),
+            vec![(i, &123), (k, &789)]
+        );
+        assert_eq!(
+            slab.iter().rev().collect::<Vec::<_>>(),
+            vec![(k, &789), (i, &123)]
+        );
+    }
+
+    #[test]
+    fn iter_bidi_test() {
+        let mut slab = Cslab::with_fixed_capacity(4);
+
+        let i = slab.insert(123).unwrap();
+        let j = slab.insert(456).unwrap();
+        let k = slab.insert(789).unwrap();
+
+        let mut it = slab.iter();
+        assert_eq!(it.next(), Some((i, &123)));
+        assert_eq!(it.next_back(), Some((k, &789)));
+        assert_eq!(it.next(), Some((j, &456)));
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+
+        // test fusing also
+        assert_eq!(it.next(), None);
+        assert_eq!(it.next_back(), None);
+    }
+
+    #[test]
+    fn iter_large_test() {
+        let mut slab = Cslab::with_fixed_capacity(128);
+
+        let mut items = Vec::new();
+
+        for i in 0..128 {
+            items.push(slab.insert(100 + i).unwrap());
+        }
+
+        let mut it = slab.iter();
+        for i in 0..128 {
+            assert_eq!(it.next(), Some((items[i], &(100 + i))));
+        }
+        assert!(it.next().is_none());
+
+        let mut it = slab.iter();
+        for i in 0..128 {
+            assert_eq!(it.next_back(), Some((items[127 - i], &(100 + (127 - i)))));
+        }
+        assert!(it.next_back().is_none());
+    }
 }
 
 #[cfg(all(test, loom))]
@@ -839,6 +1108,13 @@ impl<T> RcuCslabReader<T> {
         // which prevents any removal of this item from being finalized
         unsafe { self.reader.get_unchecked(idx) }
     }
+
+    /// Returns an iterator over the slab.
+    ///
+    /// Items added during the iterator's lifetime may or may not be visible.
+    pub fn iter(&self) -> Iter<'_, T> {
+        self.reader.iter()
+    }
 }
 
 impl<T> Clone for RcuCslabReader<T> {
@@ -869,10 +1145,10 @@ impl<T> Clone for RcuCslabReader<T> {
 ///
 ///   for idx in 0..10 {
 ///     let reader = reader_reader_box.lock().unwrap().clone();
-///      match reader.get(idx) {
-///        Some(value) => (),
-///        None => (),
-///      }
+///     match reader.get(idx) {
+///       Some(value) => (),
+///       None => (),
+///     }
 ///   }
 /// );
 ///
@@ -962,6 +1238,14 @@ impl<T> RcuCslab<T> {
     /// return items which have been marked for removal.
     pub fn get(&self, idx: usize) -> Option<&T> {
         self.reader.get(idx)
+    }
+
+    /// Returns an iterator over the slab.
+    ///
+    /// Unlike `RcuCslabReader::iter()`, it is not possible for items to be
+    /// concurrently added (and therefore be nondeterministically visible).
+    pub fn iter(&self) -> ExclIter<'_, T> {
+        ExclIter::new(&self.reader.0, self.len())
     }
 
     /// Return a clonable read-only handle to the slab, associated with the


### PR DESCRIPTION
Adds iterator functionality to the Cslab / RcuCslab and PeerTable.  This replaces our ad-hoc list of peer IDs we maintained under a Mutex.

The iterator implementation simply scans the bitmap of allocated entries (using bitcounting for performance).  To avoid walking/paging in the entire bitmap if (as is almost always the case) only a small prefix has been used, we also track the maximum entry which has ever been allocated (the "frontier") and stop there.  The frontier is updated prior to marking the entry as in-use to ensure consistency if a scan is performed after a lookup (explained in-depth in the comments).  The frontier is never decreased (reasoning also given in the comments).

Also simplified some of the logic in `assembly` regarding iterating over peers.

I can't figure out a good way to export an iterator from the peer table, so it just has `for_each()` and `find()` methods directly on it for now.  (I suspect I'd need to add a `MappedRcuGuard` type but that would be blocked on [`MappedRwLockReadGuard`](https://doc.rust-lang.org/std/sync/struct.MappedRwLockReadGuard.html).)

Closes #435.