### PR TITLE
arc-swap backend for Rcu

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -135,6 +135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1610,7 @@ name = "ph"
 version = "0.6.0"
 dependencies = [
  "aarc",
+ "arc-swap",
  "arrayref",
  "base64 0.22.1",
  "blake3",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 aarc = { version = "0.3", optional = true }
+arc-swap = { version = "1.7", optional = true }
 arrayref = { version = "0.3.7" }
 base64 = "0.22.1"
 blake3 = { version = "1.5.4" }
@@ -63,10 +64,11 @@ tokio = { version = "1.37.0", features = ["test-util"] }
 [features]
 default = ["io-uring", "rcu-crossbeam-epoch"]
 ci = []
-rcu-rwlock = []
-rcu-mutex-arc = []
-rcu-crossbeam-epoch = ["dep:crossbeam-epoch"]
 rcu-aarc = ["dep:aarc"]
+rcu-arc-swap = ["dep:arc-swap"]
+rcu-crossbeam-epoch = ["dep:crossbeam-epoch"]
+rcu-mutex-arc = []
+rcu-rwlock = []
 complete = ["clap_complete"]
 
 [profile.dev]

--- a/adapter/ph/src/rcu.rs
+++ b/adapter/ph/src/rcu.rs
@@ -297,18 +297,20 @@ mod rcu_impl {
             }
         }
 
-        pub fn write(&self, new_value: T) {
+        fn write_nonlocked(&self, new_value: T) {
             // NOTE: it's not clear from aarc docs in which threads GC is allowed;
             // if in `load()` threads, this would be a deal-breaker
             self.0.store(Some(&aarc::Arc::new(new_value)))
         }
 
+        pub fn write(&self, new_value: T) {
+            let _guard = self.1.lock().unwrap();
+            self.write_nonlocked(new_value);
+        }
+
         pub fn update(&self, f: impl Fn(&T) -> Option<T>) -> Result<(), ()> {
             let _guard = self.1.lock().unwrap();
-            let Some(new_value) = self.inspect(f) else {
-                return Err(());
-            };
-            self.write(new_value);
+            self.write_nonlocked(self.inspect(f).ok_or(())?);
             Ok(())
         }
     }

--- a/adapter/ph/src/rcu.rs
+++ b/adapter/ph/src/rcu.rs
@@ -18,18 +18,20 @@
 #![allow(dead_code)]
 
 #[cfg(all(
-    feature = "rcu-rwlock",
-    feature = "rcu-mutex-arc",
+    feature = "rcu-aarc",
+    feature = "rcu-arc-swap",
     feature = "rcu-crossbeam-epoch",
-    feature = "rcu-aarc"
+    feature = "rcu-mutex-arc",
+    feature = "rcu-rwlock",
 ))]
 compile_error!("exactly one rcu-* feature must be selected");
 
 #[cfg(not(any(
-    feature = "rcu-rwlock",
-    feature = "rcu-mutex-arc",
+    feature = "rcu-aarc",
+    feature = "rcu-arc-swap",
     feature = "rcu-crossbeam-epoch",
-    feature = "rcu-aarc"
+    feature = "rcu-mutex-arc",
+    feature = "rcu-rwlock",
 )))]
 compile_error!("exactly one rcu-* feature must be selected");
 
@@ -309,6 +311,63 @@ mod rcu_impl {
         }
 
         pub fn update(&self, f: impl Fn(&T) -> Option<T>) -> Result<(), ()> {
+            let _guard = self.1.lock().unwrap();
+            self.write_nonlocked(self.inspect(f).ok_or(())?);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(all(feature = "rcu-arc-swap", not(doc)))]
+mod rcu_impl {
+    use std::sync::{Arc, Mutex};
+
+    pub struct RcuBox<T: 'static>(arc_swap::ArcSwapAny<Arc<T>>, Mutex<()>);
+
+    pub struct RcuGuard<'a, T: 'static> {
+        guard: arc_swap::Guard<Arc<T>>,
+        phantom: std::marker::PhantomData<&'a T>,
+    }
+
+    impl<T> std::ops::Deref for RcuGuard<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            self.guard.deref()
+        }
+    }
+
+    impl<T> RcuBox<T> {
+        pub fn new(value: T) -> Self {
+            Self(arc_swap::ArcSwap::new(Arc::new(value)), Mutex::new(()))
+        }
+
+        pub fn inspect<U>(&self, f: impl FnOnce(&T) -> U) -> U {
+            f(&self.0.load())
+        }
+
+        pub fn get(&self) -> RcuGuard<'_, T> {
+            RcuGuard {
+                guard: self.0.load(),
+                phantom: std::marker::PhantomData,
+            }
+        }
+
+        fn write_nonlocked(&self, new_value: T) {
+            self.0.store(Arc::new(new_value))
+        }
+
+        pub fn write(&self, new_value: T) {
+            let _guard = self.1.lock().unwrap();
+            self.write_nonlocked(new_value);
+        }
+
+        pub fn update(&self, f: impl Fn(&T) -> Option<T>) -> Result<(), ()> {
+            // Despite that ArcSwap::rcu() is very nearly this function,
+            // (modulo giving `f` the option to bail out of a write),
+            // we prefer to use a locking technique to serialize updates
+            // since (a) they're not performance sensitive and (b)
+            // it ensures fairness.
             let _guard = self.1.lock().unwrap();
             self.write_nonlocked(self.inspect(f).ok_or(())?);
             Ok(())


### PR DESCRIPTION
Adds arc-swap as a backend for Rcu.  (I hadn't found it in my initial survey of the landscape!)

Also includes a bugfix for a locking oversight I noticed in the aarc backend (which is not currently used).  Unfortunately I don't know a good way to unit-test this.