### PR TITLE
rework BindActorAddress to mostly match RFC

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -5,6 +5,7 @@ use crate::logging::targets::FLOW_MGMT;
 use crate::mgmt;
 use crate::packet::{Packet, PacketBuffer};
 use crate::queues::{AdapterManagerMessage, TryEnqueueError};
+use crate::tc;
 use crate::two_way_queue;
 use std::num::NonZero;
 use std::sync::Arc;
@@ -62,14 +63,11 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
         return;
     }
 
-    let packet_body: Vec<u8> = pkt.body().into();
+    let packet_body = pkt.body().to_owned();
 
     // mark ALT entry as pending to attempt to (i.e. racily) prevent
     // fastpath from issuing multiple requests
     asm.alt.insert(five_tuple, AltEntry::Pending(pkt));
-
-    // compress only IP addresses for now
-    let compression_mode: zpr::CompressionMode = 0;
 
     debug!(target: FLOW_MGMT, "link {dock_link_id}: Issuing bind request for {five_tuple} (is now set PENDING)");
 
@@ -78,9 +76,8 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
             mgmt::requests::send_bind_actor_address_request(
                 asm,
                 dock_link_id,
-                compression_mode,
-                five_tuple,
-                packet_body,
+                &five_tuple,
+                &packet_body,
             )
             .await
         }
@@ -88,9 +85,8 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
         PhMode::Node => mgmt::dock::bind_actor_address(
             asm,
             NonZero::new(zpr::LOCAL_ACTOR_LINK_ID).unwrap(),
-            compression_mode,
-            five_tuple,
-            packet_body,
+            &five_tuple,
+            &packet_body,
         )
         .await
         .map_err(|err| {
@@ -99,7 +95,18 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
     };
 
     match bind_result {
-        Ok(tether_id) => {
+        Ok((tether_id, tc)) => {
+            // Confirm this TC matches our initial packet.
+            // TODO: use the TC itself to do this, once we have that code in place.
+            if tc.five_tuple()
+                != tc::Ip5TupleTc::new_with_compression_mode(tc.compression_mode(), five_tuple)
+                    .five_tuple()
+            {
+                error!(target: FLOW_MGMT, "Bind of {five_tuple} falied: node supplied TC incompatible with initial packet: {tc}");
+                asm.alt.remove(&five_tuple);
+                return;
+            }
+
             // Bind succeeded; add to ALT.
             debug!(target: FLOW_MGMT, "Bind of {five_tuple} succeeded: {tether_id}");
 
@@ -114,7 +121,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
                     std::mem::replace(
                         entry,
                         AltEntry::Active(AltPep {
-                            compression_mode,
+                            compression_mode: tc.compression_mode(),
                             tether_id,
                         }),
                     )

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -3,7 +3,6 @@ use crate::address_pool::AddressPool;
 use crate::capture_worker::CaptureWorker;
 use crate::config;
 use crate::counters::*;
-use crate::defs;
 use crate::flow_control::FlowControl;
 use crate::forwarding_tables;
 use crate::km_cert_exchange::KmCertExchange;
@@ -19,6 +18,7 @@ use crate::peer_table::PeerInsertError;
 use crate::queues::*;
 use crate::rcu;
 use crate::special_peers::SpecialPeerName;
+use crate::tc;
 use crate::tun_ctl::TunCtl;
 use crate::visa_table;
 use crate::vs_types::AuthServicesList;
@@ -110,7 +110,7 @@ pub struct Assembly {
 #[derive(Debug, Error)]
 pub enum AddRouteError {
     #[error("bind failed: {0}")]
-    BindFailed(mgmt::requests::BindActorAddressError),
+    BindFailed(#[from] mgmt::requests::BindActorAddressError),
     #[error("peer gone")]
     PeerGone,
     #[error("PFT full")]
@@ -391,21 +391,21 @@ impl Assembly {
             .map(|(id, _peer)| id)
     }
 
+    // CTP TODO: so much to fix here as we properly implement classification & forwarding
     pub async fn add_route(
         &self,
         ingress_link_id: NonZero<LinkId>,
         visa_id: VisaId,
-        five_tuple: defs::FiveTuple,
+        tc: tc::Ip5TupleTc,
         egress_link_id: NonZero<LinkId>,
-        compression_mode: zpr::CompressionMode,
     ) -> Result<zpr::StreamId, AddRouteError> {
         let egress_tether_id;
         if egress_link_id.get() == zpr::LOCAL_ACTOR_LINK_ID {
             egress_tether_id = self
                 .dlt
                 .insert(adapter_tables::DltPep {
-                    compression_mode,
-                    five_tuple,
+                    compression_mode: tc.compression_mode(),
+                    five_tuple: *tc.five_tuple(),
                 })
                 .map_err(|()| {
                     AddRouteError::BindFailed(
@@ -415,14 +415,9 @@ impl Assembly {
                     )
                 })?;
         } else {
-            egress_tether_id = mgmt::requests::send_bind_egress_stream_request(
-                self,
-                egress_link_id.get(),
-                compression_mode,
-                five_tuple,
-            )
-            .await
-            .map_err(|e| AddRouteError::BindFailed(e))?;
+            egress_tether_id =
+                mgmt::requests::send_bind_egress_stream_request(self, egress_link_id.get(), tc)
+                    .await?;
         }
 
         // form PEP

--- a/adapter/ph/src/classifier.rs
+++ b/adapter/ph/src/classifier.rs
@@ -88,25 +88,46 @@ struct ICMPHeader {
     pub checksum: [u8; 2],
 }
 
+#[derive(Clone, Default)]
+pub struct ClassifierOptions {
+    ignore_truncated_packets: bool,
+}
+
+impl ClassifierOptions {
+    pub fn ignore_truncated_packets(mut self, value: bool) -> Self {
+        self.ignore_truncated_packets = value;
+        self
+    }
+}
+
 pub fn get_ip_version(body: &[u8]) -> u8 {
     (body[0] & IP_VERSION_MASK) >> 4
 }
 
 pub fn classify(packet: &mut packet::Packet) -> Result<ClassifierResult, &'static str> {
+    classify_with_options(packet, &ClassifierOptions::default())
+}
+
+pub fn classify_with_options(
+    packet: &mut packet::Packet,
+    options: &ClassifierOptions,
+) -> Result<ClassifierResult, &'static str> {
     let (metadata, body) = packet.metadata_mut_and_body_mut();
-    classify_zdp(metadata, body)
+    classify_zdp(metadata, body, options)
 }
 
 fn classify_zdp(
     metadata: &mut packet::PacketMetadata,
     body: &[u8],
+    options: &ClassifierOptions,
 ) -> Result<ClassifierResult, &'static str> {
-    classify_l3(metadata, body)
+    classify_l3(metadata, body, options)
 }
 
 fn classify_l3(
     metadata: &mut packet::PacketMetadata,
     body: &[u8],
+    options: &ClassifierOptions,
 ) -> Result<ClassifierResult, &'static str> {
     if body.is_empty() {
         return Err("Packet length error");
@@ -115,8 +136,8 @@ fn classify_l3(
     let ip_version = get_ip_version(body);
 
     match ip_version {
-        4 => classify_ipv4(metadata, body),
-        6 => classify_ipv6(metadata, body),
+        4 => classify_ipv4(metadata, body, options),
+        6 => classify_ipv6(metadata, body, options),
         _ => return Ok(ClassifierResult::NonIP),
     }
 }
@@ -124,6 +145,7 @@ fn classify_l3(
 fn classify_ipv4(
     metadata: &mut packet::PacketMetadata,
     body: &[u8],
+    options: &ClassifierOptions,
 ) -> Result<ClassifierResult, &'static str> {
     metadata.set_l3_type(L3Type::Ipv4);
 
@@ -137,9 +159,10 @@ fn classify_ipv4(
 
     let header_length = ipv4_header.vhl & IPV4_HEADER_LENGTH_MASK;
     let total_length = ipv4_header.total_length.get();
-    if total_length as usize != body.len()
+    if (!options.ignore_truncated_packets && body.len() < total_length as usize)
+        || body.len() > total_length as usize
         || header_length < 5
-        || u16::from(header_length * 4) > total_length
+        || (header_length as usize) * 4 > body.len()
     {
         return Err("Packet length error");
     }
@@ -170,6 +193,7 @@ fn classify_ipv4(
 fn classify_ipv6(
     metadata: &mut packet::PacketMetadata,
     body: &[u8],
+    options: &ClassifierOptions,
 ) -> Result<ClassifierResult, &'static str> {
     metadata.set_l3_type(L3Type::Ipv6);
 
@@ -196,7 +220,10 @@ fn classify_ipv6(
         // RFC 2675 § 3
         return Err("IPv6 jumbograms not supported");
     }
-    if payload_length as usize != body.len() - size_of::<IPv6Header>() {
+    if (!options.ignore_truncated_packets
+        && body.len() - size_of::<IPv6Header>() < payload_length as usize)
+        || body.len() - size_of::<IPv6Header>() > payload_length as usize
+    {
         return Err("Packet length error");
     }
 

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -74,6 +74,13 @@ pub const DEFAULT_KEEP_ALIVE_TIMEOUT: std::time::Duration = std::time::Duration:
 
 pub const DEFAULT_LINK_RESTART_HOLDDOWN: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// Maximum length of payload to include in a Bind Request.
+///
+/// 256 octects is more than enough to capture the longest common headers
+/// (e.g. QUIC, which is over 64) without bumping up against IPv4 min-max
+/// length of 576.
+pub const BIND_REQUEST_MAX_PAYLOAD_LENGTH: usize = 256;
+
 // Little trait to make creating "missing argument" errors easier.
 trait ArgError {
     fn arg_missing(&self) -> ArgsError;

--- a/adapter/ph/src/mgmt/dock.rs
+++ b/adapter/ph/src/mgmt/dock.rs
@@ -2,6 +2,7 @@ use crate::assembly::{AddRouteError, Assembly};
 use crate::counters::ManagementCounterType;
 use crate::defs::FiveTuple;
 use crate::logging::targets::FLOW_MGMT;
+use crate::tc;
 use crate::visa_mgmt;
 use crate::visa_table::VisaTableError;
 
@@ -19,7 +20,7 @@ pub enum BindActorAddressError {
     #[error("parse error: {0}")]
     ParseError(&'static str),
     #[error("adding route failed: {0}")]
-    AddRouteError(AddRouteError),
+    AddRouteError(#[from] AddRouteError),
 }
 
 pub struct ForwardingDecision {
@@ -32,10 +33,9 @@ pub struct ForwardingDecision {
 pub async fn bind_actor_address(
     asm: &Arc<Assembly>,
     ingress_link_id: NonZero<LinkId>,
-    compression_mode: zpr::CompressionMode,
-    five_tuple: FiveTuple,
-    packet_body: Vec<u8>,
-) -> Result<StreamId, BindActorAddressError> {
+    five_tuple: &FiveTuple,
+    packet_body: &[u8],
+) -> Result<(StreamId, tc::Ip5TupleTc), BindActorAddressError> {
     let mut forwarding_decision: Option<ForwardingDecision> = None;
 
     debug!(
@@ -93,7 +93,7 @@ pub async fn bind_actor_address(
         let visa_req = vsconn::VisaRequest {
             source_tether_addr: five_tuple.src_address.into(),
             l3_type: five_tuple.l3_type,
-            packet: packet_body.clone(),
+            packet: packet_body.to_vec(),
         };
 
         asm.counters.management[ManagementCounterType::VisaRequested].increment();
@@ -142,6 +142,9 @@ pub async fn bind_actor_address(
         }
     }
 
+    // TODO: get this from the Visa Service
+    let tc = tc::Ip5TupleTc::new_with_compression_mode(0, *five_tuple);
+
     // Now way to get here without forwarding_decision being set.
     let decision = forwarding_decision.unwrap();
     debug!(target: FLOW_MGMT, "now routing {five_tuple} from {ingress_link_id} to {}",
@@ -151,14 +154,15 @@ pub async fn bind_actor_address(
         .add_route(
             ingress_link_id,
             decision.visa_id,
-            five_tuple,
+            tc.clone(),
             decision.egress_link_id,
-            compression_mode,
         )
         .await;
 
     // TODO: reverse ingress TID needs to be sent to next-hop;
     // this is blocked on switching to new-style bind requests
 
-    route_result.map_err(BindActorAddressError::AddRouteError)
+    let ingress_stream_id = route_result?;
+
+    Ok((ingress_stream_id, tc))
 }

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -750,9 +750,21 @@ pub async fn handle_bind_actor_address_request(
         return Err(HandleMgmtError::BadStructure);
     };
 
-    let classification = match classifier::classify(&mut pkt) {
+    let endpoint_packet_length = hdr.endpoint_packet_length.get() as usize;
+    if endpoint_packet_length > pkt.len() {
+        return Err(HandleMgmtError::BadStructure);
+    }
+
+    // drop any garbage after the packet body
+    pkt.shrink_by(pkt.len() - endpoint_packet_length);
+
+    // CTP TODO: this should be done by Visa Service
+    let classifier_options =
+        classifier::ClassifierOptions::default().ignore_truncated_packets(true);
+    let classification = match classifier::classify_with_options(&mut pkt, &classifier_options) {
         Ok(cls) => cls,
         Err(_why) => {
+            warn!(target: ZDP, "Link {}: bind request: could not parse initial packet", pkt.metadata().ingress_link_id);
             return Err(HandleMgmtError::BadStructure);
         }
     };
@@ -760,7 +772,7 @@ pub async fn handle_bind_actor_address_request(
     match classification {
         classifier::ClassifierResult::OK => (),
         classifier::ClassifierResult::UnclassifiedL4 => {
-            warn!(target: ZDP, "Link {}: unsupported IP protocol {}", pkt.metadata().ingress_link_id, pkt.metadata().get_l4_protocol());
+            warn!(target: ZDP, "Link {}: bind request: unsupported IP protocol {}", pkt.metadata().ingress_link_id, pkt.metadata().get_l4_protocol());
             return Err(HandleMgmtError::BadStructure);
         }
         _ => {
@@ -771,8 +783,6 @@ pub async fn handle_bind_actor_address_request(
     let five_tuple = *pkt.metadata().five_tuple();
 
     let packet_body: Vec<u8> = pkt.body().to_vec(); // copy to send to visa service
-
-    let compression_mode = hdr.compression_mode;
 
     let Some(ingress_link_id) = NonZero::new(pkt.metadata().ingress_link_id) else {
         // who sent this??
@@ -793,16 +803,10 @@ pub async fn handle_bind_actor_address_request(
     match asm.ph_mode {
         PhMode::Node => {
             // TODO: errors need more consideration here
-            match super::dock::bind_actor_address(
-                asm,
-                ingress_link_id,
-                compression_mode,
-                five_tuple,
-                packet_body,
-            )
-            .await
+            match super::dock::bind_actor_address(asm, ingress_link_id, &five_tuple, &packet_body)
+                .await
             {
-                Ok(ingress_tid) => {
+                Ok((ingress_tid, tc)) => {
                     // success; respond with ingress tether ID
                     zdp::ZdpBindActorAddressResponseHeader {
                         status_code: zdp::ResponseCode::Success,
@@ -810,6 +814,9 @@ pub async fn handle_bind_actor_address_request(
                     }
                     .write_to_buf(&mut rsp_pkt)
                     .unwrap();
+
+                    zpr::Tcst::Ip5Tuple.write_to_buf(&mut rsp_pkt).unwrap();
+                    tc.serialize(&mut rsp_pkt);
 
                     ingress_tether_id = ingress_tid;
                 }
@@ -938,7 +945,7 @@ pub async fn handle_bind_egress_stream_request(
         return Err(HandleMgmtError::BadStructure);
     };
 
-    if hdr.tcst != zpr::Tcst::Ip5Tuple {
+    if !matches!(hdr.tcst, zpr::Tcst::Ip5Tuple) {
         warn!(target: ZDP, "Link {}: unsupported TCST {}", pkt.metadata().ingress_link_id, hdr.tcst.0);
         return Err(HandleMgmtError::BadStructure);
     }

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -5,6 +5,7 @@
 #![allow(dead_code)]
 
 use super::core::{self, Sent};
+use crate::config;
 use crate::counters::ManagementCounterType;
 use crate::defs::*;
 use crate::logging::targets::ZDP;
@@ -275,11 +276,10 @@ impl From<core::MgmtSendError> for BindActorAddressError {
 pub async fn send_bind_actor_address_request(
     asm: &Assembly,
     link_id: zpr::LinkId,
-    compression_mode: zpr::CompressionMode,
-    five_tuple: FiveTuple,
-    packet_body: Vec<u8>,
-) -> Result<zpr::StreamId, BindActorAddressError> {
-    info!(target: ZDP, "Link {link_id}: sending BindActorAddressRequest for {five_tuple} with compression mode {compression_mode} packet_body size {}", packet_body.len());
+    five_tuple: &FiveTuple,
+    packet_body: &[u8],
+) -> Result<(zpr::StreamId, tc::Ip5TupleTc), BindActorAddressError> {
+    info!(target: ZDP, "Link {link_id}: sending BindActorAddressRequest for {five_tuple} with packet_body size {}", packet_body.len());
 
     let (sender, receiver) = tokio::sync::oneshot::channel();
 
@@ -299,11 +299,12 @@ pub async fn send_bind_actor_address_request(
 
     let mut req = core::new_heap_packet();
     let bind_req_hdr = req.alloc_zeroed_header::<zdp::ZdpBindActorAddressRequestHeader>();
-    bind_req_hdr.ip_version = five_tuple.l3_type;
-    bind_req_hdr.compression_mode = compression_mode;
-
-    // No longer append source/dest addresses or layer4 protocol; just append the packet body
-    req.put_slice(&packet_body);
+    let endpoint_packet_length =
+        std::cmp::min(config::BIND_REQUEST_MAX_PAYLOAD_LENGTH, packet_body.len());
+    bind_req_hdr
+        .endpoint_packet_length
+        .set(endpoint_packet_length as u16);
+    req.put_slice(&packet_body[..endpoint_packet_length]);
 
     core::send_per_flow_txn_mgmt(
         asm,
@@ -325,7 +326,24 @@ pub async fn send_bind_actor_address_request(
     };
 
     match hdr.status_code {
-        zdp::ResponseCode::Success => Ok(resp.metadata().ingress_stream_id),
+        zdp::ResponseCode::Success => {
+            let stream_id = resp.metadata().ingress_stream_id;
+
+            let Ok(tcst) = zpr::Tcst::read_from_buf(&mut resp) else {
+                return Err(BindActorAddressError::BadStructure);
+            };
+
+            if !matches!(tcst, zpr::Tcst::Ip5Tuple) {
+                warn!(target: ZDP, "Link {}: unsupported TCST {}", resp.metadata().ingress_link_id, tcst.0);
+                return Err(BindActorAddressError::BadStructure);
+            }
+
+            let Ok(tc) = tc::Ip5TupleTc::deserialize(&mut resp) else {
+                return Err(BindActorAddressError::BadStructure);
+            };
+
+            return Ok((stream_id, tc));
+        }
 
         zdp::ResponseCode::Other => {
             if hdr.info_len as usize > resp.remaining() {
@@ -352,12 +370,9 @@ pub async fn send_bind_actor_address_request(
 pub async fn send_bind_egress_stream_request(
     asm: &Assembly,
     link_id: zpr::LinkId,
-    compression_mode: zpr::CompressionMode,
-    five_tuple: FiveTuple,
+    tc: tc::Ip5TupleTc,
 ) -> Result<zpr::StreamId, BindActorAddressError> {
-    info!(target: ZDP, "Link {link_id}: sending BindEgressStreamRequest for {five_tuple} with compression mode {compression_mode}");
-
-    let tc = tc::Ip5TupleTc::new_with_compression_mode(compression_mode, five_tuple);
+    info!(target: ZDP, "Link {link_id}: sending BindEgressStreamRequest for {tc}");
 
     let (sender, receiver) = tokio::sync::oneshot::channel();
 

--- a/adapter/ph/src/tc.rs
+++ b/adapter/ph/src/tc.rs
@@ -11,7 +11,10 @@ use bytes::{Buf, BufMut};
 use zpr_ext::zerocopy::{FromBytesExt, IntoBytesExt};
 
 /// IP 5-Tuple Traffic Classifier
+#[derive(Clone)]
 pub struct Ip5TupleTc(defs::FiveTuple);
+
+// TODO: actually add traffic classification code here
 
 impl Ip5TupleTc {
     #[allow(dead_code)]
@@ -155,6 +158,12 @@ impl Ip5TupleTc {
             src_port,
             dst_port,
         }));
+    }
+}
+
+impl std::fmt::Display for Ip5TupleTc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -229,8 +229,7 @@ pub struct ZdpTerminateLinkResponseHeader {
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpBindActorAddressRequestHeader {
-    pub ip_version: zpr::L3Type,
-    pub compression_mode: zpr::CompressionMode,
+    pub endpoint_packet_length: U16,
     // Followed in memory by:
     // - <PACKET BODY starting with IP header>
     // (source/dest addresses and layer4 protocol must be extracted from the IP header in the packet)
@@ -242,6 +241,9 @@ pub struct ZdpBindActorAddressRequestHeader {
 pub struct ZdpBindActorAddressResponseHeader {
     pub status_code: ResponseCode,
     pub info_len: u8,
+    // followed by `info_len` octets of Optional Additional Status Information
+    // followed by 8-bit TCST
+    // followed by traffic classifier
 }
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]


### PR DESCRIPTION
"Mostly" in that the Packet Count field is missing.  I've left that out for now because (a) we don't support it, and (b) personally there's some changes I'd like to make to that (e.g. simply supporting packing multiple ZDP messages into a single packet generally).

However, now we live in a word where the adapter simply sends the packet body, and the node/VS selects the compression algorithm and returns it.  There's still some reorganizing of code I'd like to do (namely, pushing the "traffic classifier" concept through to the adapter & dock tables) but that will wait for now.

Also adds an option to the classifier to ignore truncated packets.  We only use this temporarily, as the node currently classifies the initial packet fragment into a 5-tuple, whereas we should have the VS do this.  But the VS we'll want to share the code for the classifier anyway.

Closes #433.