### PR TITLE
visa_table lock need not be async

### DIFF
--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -71,7 +71,7 @@ pub struct Assembly {
     pub vsconn: Option<libnode::vsconn::VSConnHandle>, // present only on nodes
     pub vs_auth_services: std::sync::RwLock<AuthServicesList>, // present only on nodes, may be empty, managed by visa service
 
-    pub visa_table: tokio::sync::RwLock<visa_table::VisaTable>, // Only for nodes
+    pub visa_table: std::sync::RwLock<visa_table::VisaTable>, // Only for nodes
 
     // Used to intercept packets that are unencrypted but still have ZDP headers
     pub capture_queue: Capture,
@@ -438,7 +438,7 @@ impl Assembly {
         if self
             .visa_table
             .write()
-            .await
+            .unwrap()
             .link_forwarding_entry(
                 visa_id,
                 zpr::ForwardingEntry(ingress_link_id.get(), ingress_tether_id),
@@ -523,7 +523,7 @@ pub mod test {
             .actor_output_requeue
             .unwrap_or_else(|| ActorOutputRequeue::new(Vec::new()));
         let vsconn = builder.vsconn.unwrap_or(None);
-        let visa_table = tokio::sync::RwLock::new(
+        let visa_table = std::sync::RwLock::new(
             builder
                 .visa_table
                 .unwrap_or_else(|| visa_table::VisaTable::new()),

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -545,7 +545,7 @@ fn main() -> ExitCode {
         mgmt_substrate_egress: MgmtSubstrateEgress::new(mgmt_substrate_inq),
         actor_output_requeue: ActorOutputRequeue::new(actor_requeue_inqs),
         vsconn: vsconn.as_ref().map(|c| c.handle()),
-        visa_table: tokio::sync::RwLock::new(visa_table::VisaTable::new_with_vs_visas(
+        visa_table: std::sync::RwLock::new(visa_table::VisaTable::new_with_vs_visas(
             &node_zpr_addr,
         )),
         vs_auth_services: std::sync::RwLock::new(AuthServicesList::default()),

--- a/adapter/ph/src/mgmt/dock.rs
+++ b/adapter/ph/src/mgmt/dock.rs
@@ -43,10 +43,10 @@ pub async fn bind_actor_address(
         "DOCK.bind_actor_address called with five_tuple {five_tuple} from ingress_link_id {ingress_link_id}",
     );
 
-    if let Some(matched) = asm.visa_table.read().await.match_traffic(&five_tuple) {
+    if let Some(matched) = asm.visa_table.read().unwrap().match_traffic(&five_tuple) {
         // We matched a visa we already have.
         let matched_visa_id = matched;
-        let egress_link_id_query = visa_mgmt::get_egress_link_for_visa(asm, matched_visa_id).await;
+        let egress_link_id_query = visa_mgmt::get_egress_link_for_visa(asm, matched_visa_id);
         match egress_link_id_query {
             Ok(link_id) => {
                 forwarding_decision = Some(ForwardingDecision {
@@ -109,14 +109,12 @@ pub async fn bind_actor_address(
                     return Err(BindActorAddressError::ParseError("Could not parse visa"));
                 };
                 let (visa_id, egress_link_id) =
-                    visa_mgmt::parse_visa(asm, visa)
-                        .await
-                        .map_err(|e| match e {
-                            VisaTableError::ParseError(field) => {
-                                BindActorAddressError::ParseError(field)
-                            }
-                            e => panic!("Got unexpected error type {e}"),
-                        })?;
+                    visa_mgmt::parse_visa(asm, visa).map_err(|e| match e {
+                        VisaTableError::ParseError(field) => {
+                            BindActorAddressError::ParseError(field)
+                        }
+                        e => panic!("Got unexpected error type {e}"),
+                    })?;
                 forwarding_decision = Some(ForwardingDecision {
                     egress_link_id,
                     visa_id,

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -178,7 +178,7 @@ pub async fn actor_disconnect(asm: Arc<Assembly>, addr: IpAddress) {
 }
 
 /// Figure out egress link and insert visa into table.
-pub async fn parse_visa(
+pub fn parse_visa(
     asm: &Arc<Assembly>,
     visa: vsapi::VisaHop,
 ) -> Result<(VisaId, NonZero<LinkId>), visa_table::VisaTableError> {
@@ -205,24 +205,24 @@ pub async fn parse_visa(
         asm.counters.management[ManagementCounterType::VisaRequestError].increment();
         return Err(visa_table::VisaTableError::DestNotFound(addr));
     };
-    let visa_id = asm.visa_table.write().await.insert_visa(visa)?;
+    let visa_id = asm.visa_table.write().unwrap().insert_visa(visa)?;
     Ok((visa_id, link_id))
 }
 
 /// Given a visa ID, look up the visa in our table to find the destination address
 /// then use that to find an egress link.
-pub async fn get_egress_link_for_visa(
+pub fn get_egress_link_for_visa(
     asm: &Arc<Assembly>,
     visa_id: VisaId,
 ) -> Result<NonZero<LinkId>, visa_table::VisaTableError> {
-    let addr = asm.visa_table.read().await.get_visa_dest_addr(visa_id)?;
+    let addr = asm.visa_table.read().unwrap().get_visa_dest_addr(visa_id)?;
     let Some(link_id) = asm.find_egress_link(addr) else {
         return Err(visa_table::VisaTableError::DestNotFound(addr));
     };
     Ok(link_id)
 }
 
-pub async fn handle_revocation(
+pub fn handle_revocation(
     asm: &Arc<Assembly>,
     revocation: vsapi::VisaRevocation,
 ) -> Result<(), visa_table::VisaTableError> {
@@ -233,11 +233,11 @@ pub async fn handle_revocation(
 
     asm.visa_table
         .write()
-        .await
+        .unwrap()
         .revoke(&asm.peer_table, visa_id)
 }
 
-pub async fn handle_services_update(
+pub fn handle_services_update(
     asm: &Arc<Assembly>,
     services: vsapi::ServicesList,
 ) -> Result<(), visa_table::VisaTableError> {

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -451,8 +451,8 @@ mod tests {
     use std::num::NonZero;
     use std::sync::Arc;
 
-    #[tokio::test]
-    async fn test_timeouts() {
+    #[test]
+    fn test_timeouts() {
         let mut builder = TestAssemblyBuilder::new();
         builder.visa_table = Some(VisaTable::new());
         let asm = Arc::new(create_assembly(builder));
@@ -461,7 +461,7 @@ mod tests {
         let visa1 = 12345;
         let visa2 = 67890;
         let visa3 = 234;
-        let mut visa_table = asm.visa_table.write().await;
+        let mut visa_table = asm.visa_table.write().unwrap();
         visa_table.insert_id(visa1, DateTime::<Utc>::MIN_UTC); // An element that will timeout immediately
         visa_table.insert_id(visa2, DateTime::<Utc>::MAX_UTC); // An element that won't timeout
         visa_table.insert_id(visa3, Utc::now() + one_second); // An element that will time out in a second
@@ -499,7 +499,7 @@ mod tests {
         assert_eq!(false, visa_table.table.contains_key(&visa3));
     }
 
-    #[tokio::test]
+    #[tokio::test] // must be tokio::test because we create a dummy task in create_dummy_peer_state()
     async fn test_remove_forwarding_entries() {
         let mut builder = TestAssemblyBuilder::new();
         builder.visa_table = Some(VisaTable::new());
@@ -538,7 +538,7 @@ mod tests {
         let tether_id2 = peer_state.pft.insert(pep2).expect("Failed to insert PEP");
         assert_eq!(2, peer_state.pft.len());
 
-        let mut visa_table = asm.visa_table.write().await;
+        let mut visa_table = asm.visa_table.write().unwrap();
         visa_table.insert_id(visa1, DateTime::<Utc>::MAX_UTC); // An element that won't timeout
         visa_table.insert_id(visa2, Utc::now() + one_second); // An element that will time out in a second
         assert!(
@@ -561,13 +561,13 @@ mod tests {
         assert_eq!(0, peer_state.pft.len());
     }
 
-    #[tokio::test]
-    async fn test_match_traffic() {
+    #[test]
+    fn test_match_traffic() {
         let mut builder = TestAssemblyBuilder::new();
         builder.visa_table = Some(VisaTable::new());
         let asm = Arc::new(create_assembly(builder));
 
-        let mut visa_table = asm.visa_table.write().await;
+        let mut visa_table = asm.visa_table.write().unwrap();
 
         let client1_addr: Ipv6Addr = "fd5a:5052:8::1".parse().unwrap();
         let client2_addr: Ipv6Addr = "fd5a:5052:8::2".parse().unwrap();

--- a/adapter/ph/src/vss_worker.rs
+++ b/adapter/ph/src/vss_worker.rs
@@ -12,21 +12,18 @@ pub async fn launch(asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSSMsg>) {
             VSSMsg::PushedVisa(visa) => {
                 let visa_id = visa.issuer_id.unwrap_or_default();
                 debug!(target: VISA_MGMT, "Received pushed visa, id={visa_id}");
-                let result = visa_mgmt::parse_visa(&asm, visa);
-                if let Err(e) = result.await {
+                if let Err(e) = visa_mgmt::parse_visa(&asm, visa) {
                     error!(target: VISA_MGMT, "Error inserting visa {visa_id}: {e}");
                 }
             }
             VSSMsg::PushedRevocation(revocation) => {
                 debug!(target: VISA_MGMT, "Received pushed revocation, id={}", revocation.issuer_id.unwrap());
-                let result = visa_mgmt::handle_revocation(&asm, revocation);
-                if let Err(e) = result.await {
+                if let Err(e) = visa_mgmt::handle_revocation(&asm, revocation) {
                     error!(target: VISA_MGMT, "Error revoking visa: {e}");
                 }
             }
             VSSMsg::PushedServices(services) => {
-                let result = visa_mgmt::handle_services_update(&asm, services);
-                if let Err(e) = result.await {
+                if let Err(e) = visa_mgmt::handle_services_update(&asm, services) {
                     error!(target: VISA_MGMT, "Error processing services update: {e}");
                 }
             }


### PR DESCRIPTION
Since we never hold the lock across an .await or during significant processing there's no benefit to using the async Tokio variant of this mutex.  So switching to the std variant allows us to avoid needing to .await to access the visa table.