### PR TITLE
fixed set_program function

### DIFF
--- a/integration-test/capture-test.sh
+++ b/integration-test/capture-test.sh
@@ -33,11 +33,15 @@ if [ ! -e "$VS_BIN" ]; then
 fi
 
 NODE_SOCK=node.sock
-NODE_CAP_SOCK=cap.sock
 VS_SOCK=vs.sock
 ADAPTER1_SOCK=adapter1.sock
 ADAPTER2_SOCK=adapter2.sock
 ADAPTER3_SOCK=adapter3.sock
+NODE_CAP_SOCK=node_cap.sock
+VS_CAP_SOCK=vs_cap.sock
+ADAPTER1_CAP_SOCK=adapter1_cap.sock
+ADAPTER2_CAP_SOCK=adapter2_cap.sock
+ADAPTER3_CAP_SOCK=adapter3_cap.sock
 
 SHOW_CAPTURE="${ZPR_TEST_VERBOSE:-no}"
 
@@ -49,10 +53,11 @@ function set_program() {
   SOCKET=$1
   FILE_NAME=$2
   PROGRAM=$3
-  "$PH_DEBUG_BIN" -p "$SOCKET" -c "$NODE_CAP_SOCK" capture set-file "$FILE_NAME"
+  CAP_SOCK=$4
+  "$PH_DEBUG_BIN" -p "$SOCKET" -c "$CAP_SOCK" capture set-file "$FILE_NAME"
 
   if [ "$PROGRAM" != "None" ]; then
-    "$PH_DEBUG_BIN" -p "$SOCKET" -c "$NODE_CAP_SOCK" capture set-program "$PROGRAM"
+    "$PH_DEBUG_BIN" -p "$SOCKET" -c "$CAP_SOCK" capture set-program "$PROGRAM"
   fi
 }
 
@@ -126,6 +131,7 @@ sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --logging "$DEBUG_TARGETS" \
   --control-path "$VS_SOCK" \
+  --capture-path "$VS_CAP_SOCK" \
   --self-addr "$VS_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
   --certificate-file vs.zpr.crt \
@@ -142,6 +148,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --logging "$DEBUG_TARGETS" \
   --control-path "$ADAPTER1_SOCK" \
+  --capture-path "$ADAPTER1_CAP_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
   --certificate-file adapter1.crt \
@@ -156,6 +163,7 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --logging "$DEBUG_TARGETS" \
   --control-path "$ADAPTER2_SOCK" \
+  --capture-path "$ADAPTER2_CAP_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
   --certificate-file adapter2.crt \
@@ -171,6 +179,7 @@ if [[ "$NUM_ACTORS" -ge 3 ]]; then
     adapter \
     --logging "$DEBUG_TARGETS" \
     --control-path "$ADAPTER3_SOCK" \
+    --capture-path "$ADAPTER3_CAP_SOCK" \
     --self-addr "$C_SUBSTRATE_ADDR":0 \
     --ca-file ca.crt \
     --certificate-file adapter3.crt \
@@ -183,7 +192,7 @@ if [[ "$NUM_ACTORS" -ge 3 ]]; then
 fi
 
 sleep 1 # FIXME: I think we need this b/c DTLS doesn't deal with dropped initial packet well
-set_program "$ADAPTER1_SOCK" "$TMPDIR/cap_test1.pcap" 'link[0] == 1'
+set_program "$ADAPTER1_SOCK" "$TMPDIR/cap_test1.pcap" 'link[0] == 1' "$ADAPTER1_CAP_SOCK"
 
 #
 # Wait for connectivity
@@ -215,7 +224,7 @@ stty sane || true
 # Run test
 #
 
-set_program "$ADAPTER2_SOCK" "$TMPDIR/cap_test2.pcap" None
+set_program "$ADAPTER2_SOCK" "$TMPDIR/cap_test2.pcap" None "$ADAPTER2_CAP_SOCK"
 
 echo "starting PING test..."
 

--- a/integration-test/capture-test.sh
+++ b/integration-test/capture-test.sh
@@ -127,6 +127,8 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --tun-if tun0 \
   --zpr-addr "$NODE_ZPR_ADDR" 2>&1 | tee node.log | prefix_log zpr-node &
 
+sleep 2
+
 sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --logging "$DEBUG_TARGETS" \
@@ -142,7 +144,7 @@ sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --node-public-key-file node.pubkey \
   --zpr-addr "$VS_ZPR_ADDR" 2>&1 | tee adapter-vs.log | prefix_log zpr-vs &
 
-sleep 2
+sleep 5
 
 sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \

--- a/integration-test/one-node-test.sh
+++ b/integration-test/one-node-test.sh
@@ -47,12 +47,15 @@ if [ ! -e "$VS_ADMIN_BIN" ]; then
 fi
 
 NODE_SOCK=node.sock
-CAP_SOCK=cap.sock
 VS_SOCK=vs.sock
 ADAPTER1_SOCK=adapter1.sock
 ADAPTER2_SOCK=adapter2.sock
 ADAPTER3_SOCK=adapter3.sock
 NODE_CAP_SOCK=node_cap.sock
+VS_CAP_SOCK=vs_cap.sock
+ADAPTER1_CAP_SOCK=adapter1_cap.sock
+ADAPTER2_CAP_SOCK=adapter2_cap.sock
+ADAPTER3_CAP_SOCK=adapter3_cap.sock
 
 function counters() {
   SOCKET=$1
@@ -77,6 +80,7 @@ echo "Setting up network"
 destroy_network
 
 create_network
+
 if [ -n "$NETEM_PARAMS" ]
 then configure_netem $NETEM_PARAMS  # split on whitespace
 fi
@@ -139,7 +143,7 @@ sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --logging "$DEBUG_TARGETS" \
   --control-path "$VS_SOCK" \
-  --capture-path "$CAP_SOCK" \
+  --capture-path "$VS_CAP_SOCK" \
   --self-addr "$VS_SUBSTRATE_ADDR" \
   --ca-file ca.crt \
   --certificate-file vs.zpr.crt \
@@ -158,7 +162,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --logging "$DEBUG_TARGETS" \
   --control-path "$ADAPTER1_SOCK" \
-  --capture-path "$CAP_SOCK" \
+  --capture-path "$ADAPTER1_CAP_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR" \
   --ca-file ca.crt \
   --certificate-file adapter1.crt \
@@ -175,7 +179,7 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
   --logging "$DEBUG_TARGETS" \
   --control-path "$ADAPTER2_SOCK" \
-  --capture-path "$CAP_SOCK" \
+  --capture-path "$ADAPTER2_CAP_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR" \
   --ca-file ca.crt \
   --certificate-file adapter2.crt \
@@ -195,7 +199,7 @@ if [[ "$NUM_ACTORS" -ge 3 ]]; then
     adapter \
     --logging "$DEBUG_TARGETS" \
     --control-path "$ADAPTER3_SOCK" \
-    --capture-path "$CAP_SOCK" \
+    --capture-path "$ADAPTER3_CAP_SOCK" \
     --self-addr "$C_SUBSTRATE_ADDR" \
     --ca-file ca.crt \
     --certificate-file adapter3.crt \


### PR DESCRIPTION
Not 100% sure this will fix all the problems with the capture worker running, but I ran it locally many times and it did not fail. Regardless, it will fix a logic problem with the set_program function and ensure there is  no overlap in capture sockets.

I also added in a sleep and extended another one to align with the one node test, not sure if this is necessary.