### PR TITLE
bind request non sync work

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -1,4 +1,4 @@
-use crate::adapter_tables::{AltEntry, AltPep};
+use crate::adapter_tables::{self, AltPep};
 use crate::assembly::{Assembly, PhMode};
 use crate::counters::ManagementCounterType;
 use crate::logging::targets::FLOW_MGMT;
@@ -33,28 +33,10 @@ pub async fn launch(
 
 // RFC 6.5 § 6.3.11
 async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
-    let five_tuple = pkt.metadata().five_tuple();
-
-    // if there's already an entry, this is a duplicate request
-    // (NOTE: we should be the only ones modifying this table!)
-    if asm.alt.get(five_tuple).is_some() {
-        mgmt::core::count_event(asm, ManagementCounterType::DroppedAwaitingBind);
-        return;
-    }
+    let dock_link_id = zpr::DOCK_LINK_ID;
 
     // copy out five tuple so we can give away packet
-    let five_tuple = *five_tuple;
-
-    let dock_link_id = match asm.ph_mode {
-        PhMode::Adapter => zpr::DOCK_LINK_ID,
-        PhMode::Node => zpr::LINK_ID_UNKNOWN,
-    };
-
-    if dock_link_id != zpr::LINK_ID_UNKNOWN && !asm.is_link_ready(dock_link_id) {
-        debug!(target: FLOW_MGMT, "Link {dock_link_id} is not ready to receive traffic yet");
-        mgmt::core::count_event(asm, ManagementCounterType::DroppedNoSA);
-        return;
-    }
+    let five_tuple = *pkt.metadata().five_tuple();
 
     if five_tuple.dst_address.is_v6_unicast_link_local()
         || five_tuple.src_address.is_v6_unicast_link_local()
@@ -63,11 +45,42 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
         return;
     }
 
+    let Some(peer_state) = asm.peer_table.get(dock_link_id) else {
+        // Link was dropped
+        return;
+    };
+
+    if !peer_state.link_state_machine.is_ready() {
+        debug!(target: FLOW_MGMT, "Link {dock_link_id} is not ready to receive traffic yet");
+        mgmt::core::count_event(asm, ManagementCounterType::DroppedNoSA);
+        return;
+    }
+
+    // try open a transaction on the link; if we can't due to backpressure, don't wait, just give up
+    let Some(txn) = peer_state.txn_mgr.try_open() else {
+        debug!(target: FLOW_MGMT, "link {dock_link_id}: backpressure on link prevents issuing bind request for {five_tuple}");
+        mgmt::core::count_event(asm, ManagementCounterType::QueueBackpressure);
+        return;
+    };
+
+    // copy out packet body
     let packet_body = pkt.body().to_owned();
 
     // mark ALT entry as pending to attempt to (i.e. racily) prevent
     // fastpath from issuing multiple requests
-    asm.alt.insert(five_tuple, AltEntry::Pending(pkt));
+    match asm.alt.insert_pending(five_tuple, pkt, &txn) {
+        Ok(()) => (),
+
+        Err(adapter_tables::InsertPendingError::AlreadyPending(_pkt)) => {
+            // there's already an entry; this is a duplicate request
+            mgmt::core::count_event(asm, ManagementCounterType::DroppedAwaitingBind);
+            return;
+        }
+
+        Err(adapter_tables::InsertPendingError::DuplicateTransaction(_pkt)) => {
+            panic!("duplicate transaction")
+        }
+    }
 
     debug!(target: FLOW_MGMT, "link {dock_link_id}: Issuing bind request for {five_tuple} (is now set PENDING)");
 
@@ -103,33 +116,19 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
                     .five_tuple()
             {
                 error!(target: FLOW_MGMT, "Bind of {five_tuple} falied: node supplied TC incompatible with initial packet: {tc}");
-                asm.alt.remove(&five_tuple);
+                asm.alt.remove(&five_tuple).unwrap();
                 return;
             }
 
             // Bind succeeded; add to ALT.
             debug!(target: FLOW_MGMT, "Bind of {five_tuple} succeeded: {tether_id}");
 
-            let AltEntry::Pending(initial_packet) = asm
-                .alt
-                .alter(&five_tuple, |entry| {
-                    assert!(
-                        matches!(entry, AltEntry::Pending(_)),
-                        "coding error: race to activate pending ALT entry"
-                    );
-
-                    std::mem::replace(
-                        entry,
-                        AltEntry::Active(AltPep {
-                            compression_mode: tc.compression_mode(),
-                            tether_id,
-                        }),
-                    )
-                })
-                .unwrap()
-            else {
-                unreachable!();
+            let pep = AltPep {
+                compression_mode: tc.compression_mode(),
+                tether_id,
             };
+
+            let initial_packet = asm.alt.set_active(&five_tuple, pep).unwrap();
 
             // now send out initial packet
             match asm.actor_output_requeue.try_enqueue_packet(initial_packet) {
@@ -144,7 +143,7 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
         Err(err) => {
             // Bind failed; remove pending entry from ALT.
             debug!(target: FLOW_MGMT, "Bind of {five_tuple} failed: {err}");
-            asm.alt.remove(&five_tuple);
+            asm.alt.remove(&five_tuple).unwrap();
         }
     }
 }

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -1,11 +1,10 @@
-use crate::adapter_tables::{self, AltPep};
+use crate::adapter_tables;
 use crate::assembly::{Assembly, PhMode};
 use crate::counters::ManagementCounterType;
 use crate::logging::targets::FLOW_MGMT;
 use crate::mgmt;
 use crate::packet::{Packet, PacketBuffer};
-use crate::queues::{AdapterManagerMessage, TryEnqueueError};
-use crate::tc;
+use crate::queues::AdapterManagerMessage;
 use crate::two_way_queue;
 use std::num::NonZero;
 use std::sync::Arc;
@@ -66,6 +65,8 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
     // copy out packet body
     let packet_body = pkt.body().to_owned();
 
+    let txn_id = txn.id();
+
     // mark ALT entry as pending to attempt to (i.e. racily) prevent
     // fastpath from issuing multiple requests
     match asm.alt.insert_pending(five_tuple, pkt, &txn) {
@@ -84,66 +85,38 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
 
     debug!(target: FLOW_MGMT, "link {dock_link_id}: Issuing bind request for {five_tuple} (is now set PENDING)");
 
-    let bind_result = match asm.ph_mode {
+    match asm.ph_mode {
         PhMode::Adapter => {
             mgmt::requests::send_bind_actor_address_request(
                 asm,
                 dock_link_id,
+                txn_id,
                 &five_tuple,
                 &packet_body,
             )
-            .await
+            .enqueue();
         }
 
-        PhMode::Node => mgmt::dock::bind_actor_address(
-            asm,
-            NonZero::new(zpr::LOCAL_ACTOR_LINK_ID).unwrap(),
-            &five_tuple,
-            &packet_body,
-        )
-        .await
-        .map_err(|err| {
-            mgmt::requests::BindActorAddressError::BindActorAddressError(err.to_string().into())
-        }),
-    };
+        PhMode::Node => {
+            let bind_result = mgmt::dock::bind_actor_address(
+                asm,
+                NonZero::new(zpr::LOCAL_ACTOR_LINK_ID).unwrap(),
+                &five_tuple,
+                &packet_body,
+            )
+            .await;
 
-    match bind_result {
-        Ok((tether_id, tc)) => {
-            // Confirm this TC matches our initial packet.
-            // TODO: use the TC itself to do this, once we have that code in place.
-            if tc.five_tuple()
-                != tc::Ip5TupleTc::new_with_compression_mode(tc.compression_mode(), five_tuple)
-                    .five_tuple()
-            {
-                error!(target: FLOW_MGMT, "Bind of {five_tuple} falied: node supplied TC incompatible with initial packet: {tc}");
-                asm.alt.remove(&five_tuple).unwrap();
-                return;
-            }
+            match bind_result {
+                Ok((tether_id, tc)) => {
+                    mgmt::adapter::install_tether(asm, &txn, tether_id, tc).unwrap()
+                }
 
-            // Bind succeeded; add to ALT.
-            debug!(target: FLOW_MGMT, "Bind of {five_tuple} succeeded: {tether_id}");
-
-            let pep = AltPep {
-                compression_mode: tc.compression_mode(),
-                tether_id,
-            };
-
-            let initial_packet = asm.alt.set_active(&five_tuple, pep).unwrap();
-
-            // now send out initial packet
-            match asm.actor_output_requeue.try_enqueue_packet(initial_packet) {
-                Ok(()) => (),
-                Err(TryEnqueueError::Full(_pkt)) => {
-                    debug!(target: FLOW_MGMT, "Requeue backpressure on bind of {five_tuple}, dropping initial packet");
-                    asm.counters.management[ManagementCounterType::QueueBackpressure].increment();
+                Err(err) => {
+                    // Bind failed; remove pending entry from ALT.
+                    debug!(target: FLOW_MGMT, "Bind of {five_tuple} failed: {err}");
+                    asm.alt.remove(&five_tuple).unwrap();
                 }
             }
-        }
-
-        Err(err) => {
-            // Bind failed; remove pending entry from ALT.
-            debug!(target: FLOW_MGMT, "Bind of {five_tuple} failed: {err}");
-            asm.alt.remove(&five_tuple).unwrap();
         }
     }
 }

--- a/adapter/ph/src/adapter_tables.rs
+++ b/adapter/ph/src/adapter_tables.rs
@@ -1,5 +1,7 @@
 //! Adapter lookup tables
 //!
+//! These tables hold the state of all tethers on an adapter, outbound (ALT) or inbound (DLT).
+//!
 //! RFC 6.5 § 5.1
 
 #![allow(dead_code)]
@@ -24,10 +26,16 @@ pub struct AltPep {
 }
 
 pub enum AltEntry {
+    /// We've requested a tether ID for this flow, but haven't received one yet.
     Pending(Packet, TxnHandle),
+    /// There is currently a tether allocated for this flow.
     Active(AltPep),
 }
 
+/// The Actor Lookup Table (ALT) holds all state of outbound tethers.
+///
+/// It is used to map five-tuples (from the endpoint) to compression
+/// specifications and tether IDs (for the dock).
 pub struct ActorLookupTable {
     table: DashMap<FiveTuple, AltEntry>,
     pending: DashMap<TxnHandle, FiveTuple>,
@@ -173,6 +181,10 @@ pub struct DltPep {
     pub five_tuple: FiveTuple,
 }
 
+/// The Dock Lookup Table (DLT) holds all state of inbound tethers.
+///
+/// It is used to map tether IDs (from the dock) to decompression
+/// specifications and five-tuples (for the endpoint).
 pub struct DockLookupTable {
     table: Mutex<RcuCslab<DltPep>>,
     reader: RcuBox<RcuCslabReader<DltPep>>,

--- a/adapter/ph/src/adapter_tables.rs
+++ b/adapter/ph/src/adapter_tables.rs
@@ -5,10 +5,12 @@
 #![allow(dead_code)]
 
 use crate::defs::FiveTuple;
+use crate::mgmt::txn_mgr::TxnHandle;
 use crate::packet::Packet;
 use crate::rcu::{RcuBox, RcuCslabEntryGuard};
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::DashMap;
+use dashmap::mapref::entry::Entry as DashMapEntry;
 use dashmap::mapref::one::Ref as DashMapRef;
 use std::sync::Mutex;
 use zpr::{CompressionMode, StreamId};
@@ -22,12 +24,13 @@ pub struct AltPep {
 }
 
 pub enum AltEntry {
+    Pending(Packet, TxnHandle),
     Active(AltPep),
-    Pending(Packet),
 }
 
 pub struct ActorLookupTable {
     table: DashMap<FiveTuple, AltEntry>,
+    pending: DashMap<TxnHandle, FiveTuple>,
 }
 
 pub struct AltEntryGuard<'a>(DashMapRef<'a, FiveTuple, AltEntry>);
@@ -40,11 +43,101 @@ impl std::ops::Deref for AltEntryGuard<'_> {
     }
 }
 
+pub enum InsertPendingError {
+    AlreadyPending(Packet),
+    DuplicateTransaction(Packet),
+}
+
+impl std::fmt::Debug for InsertPendingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            Self::AlreadyPending(_) => write!(f, "AlreadyPending"),
+            Self::DuplicateTransaction(_) => write!(f, "DuplicateTransaction"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum LookupPendingError {
+    NotFound,
+    NotPending,
+}
+
+#[derive(Debug)]
+pub enum RemoveError {
+    NotFound,
+}
+
+pub enum SetActiveError {
+    NotFound(AltPep),
+    NotPending(AltPep),
+}
+
+impl std::fmt::Debug for SetActiveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self {
+            Self::NotFound(_) => write!(f, "NotFound"),
+            Self::NotPending(_) => write!(f, "NotPending"),
+        }
+    }
+}
+
 impl ActorLookupTable {
     pub fn new() -> Self {
         Self {
             table: DashMap::new(),
+            pending: DashMap::new(),
         }
+    }
+
+    pub fn insert_pending(
+        &self,
+        five_tuple: FiveTuple,
+        init_packet: Packet,
+        txn: &TxnHandle,
+    ) -> Result<(), InsertPendingError> {
+        match self.table.entry(five_tuple) {
+            DashMapEntry::Occupied(_) => Err(InsertPendingError::AlreadyPending(init_packet)),
+
+            DashMapEntry::Vacant(entry) => {
+                if self.pending.insert(txn.clone(), five_tuple).is_some() {
+                    return Err(InsertPendingError::DuplicateTransaction(init_packet));
+                }
+                entry.insert(AltEntry::Pending(init_packet, txn.clone()));
+                Ok(())
+            }
+        }
+    }
+
+    pub fn lookup_pending(&self, txn: &TxnHandle) -> Result<FiveTuple, LookupPendingError> {
+        Ok(*self.pending.get(txn).ok_or(LookupPendingError::NotFound)?)
+    }
+
+    pub fn set_active(
+        &self,
+        five_tuple: &FiveTuple,
+        pep: AltPep,
+    ) -> Result<Packet, SetActiveError> {
+        let Some(mut entry) = self.table.get_mut(five_tuple) else {
+            return Err(SetActiveError::NotFound(pep));
+        };
+
+        if !matches!(entry.value(), AltEntry::Pending(..)) {
+            return Err(SetActiveError::NotPending(pep));
+        }
+
+        let AltEntry::Pending(packet, txn) =
+            std::mem::replace(entry.value_mut(), AltEntry::Active(pep))
+        else {
+            unreachable!();
+        };
+
+        assert!(
+            matches!(self.pending.remove(&txn), Some((_txn, ft)) if &ft == five_tuple),
+            "ALT consistency error"
+        );
+
+        Ok(packet)
     }
 
     // TODO: figure out whether we want to perform partial matching
@@ -60,29 +153,18 @@ impl ActorLookupTable {
         self.table.get(five_tuple).map(AltEntryGuard)
     }
 
-    // FIXME: ideally we want `try_insert()` but dashmap doesn't support that…
-    pub fn insert(&self, five_tuple: FiveTuple, entry: AltEntry) {
-        self.table.insert(five_tuple, entry);
-    }
+    pub fn remove(&self, five_tuple: &FiveTuple) -> Result<AltEntry, RemoveError> {
+        let (_, entry) = self.table.remove(five_tuple).ok_or(RemoveError::NotFound)?;
 
-    /// Alter an ALT entry according to the provided function.
-    ///
-    /// If the entry exists, returns the alterer function's result.
-    ///
-    /// If the entry doesn't exist, returns `Err`.
-    pub fn alter<T>(
-        &self,
-        five_tuple: &FiveTuple,
-        alterer: impl FnOnce(&mut AltEntry) -> T,
-    ) -> Result<T, ()> {
-        match self.table.get_mut(five_tuple) {
-            Some(mut ref_) => Ok(alterer(ref_.value_mut())),
-            None => Err(()),
+        match &entry {
+            AltEntry::Pending(_, txn) => assert!(
+                matches!(self.pending.remove(&txn), Some((_txn, ft)) if &ft == five_tuple),
+                "ALT consistency error"
+            ),
+            AltEntry::Active(_) => (),
         }
-    }
 
-    pub fn remove(&self, five_tuple: &FiveTuple) {
-        self.table.remove(five_tuple);
+        Ok(entry)
     }
 }
 

--- a/adapter/ph/src/admin_worker.rs
+++ b/adapter/ph/src/admin_worker.rs
@@ -260,8 +260,8 @@ impl svc::Server for AdminServiceImpl {
         info!(target: RPC, "Show link summary procedure initiated");
         {
             let mut peer_ids = Vec::new();
-            self.asm.peer_table.for_each(|(id, _)| {
-                if id.get() != zpr::LOCAL_ACTOR_LINK_ID {
+            self.asm.peer_table.for_each(|(id, peer)| {
+                if !peer.is_internal() {
                     peer_ids.push(id.get())
                 }
             });

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -12,7 +12,7 @@ use crate::link_state::{LinkEvent, LinkStateError, LinkType};
 use crate::logging::targets::PEER_MGMT;
 use crate::mgmt;
 use crate::mgmt_processor_worker;
-use crate::net_defs::{self, IpAddress, ScopedIpAddr};
+use crate::net_defs::{IpAddress, ScopedIpAddr};
 use crate::peer_table;
 use crate::peer_table::PeerInsertError;
 use crate::queues::*;
@@ -126,10 +126,9 @@ impl Assembly {
 
     /// Graceful shutdown routine.  Not guaranteed to be called
     pub async fn shutdown(self: &Arc<Self>) {
-        if self.ph_mode == PhMode::Node {
-            self.shutdown_node().await
-        } else {
-            self.shutdown_adapter().await
+        match self.ph_mode {
+            PhMode::Node => self.shutdown_node().await,
+            PhMode::Adapter => self.shutdown_adapter().await,
         }
     }
 
@@ -142,8 +141,8 @@ impl Assembly {
                 .peer_table
                 .lookup_special_peer(SpecialPeerName::VisaServiceAdapter);
 
-            self.peer_table.for_each(|(peer_id, _)| {
-                if Some(peer_id) != vs_peer && peer_id.get() != zpr::LOCAL_ACTOR_LINK_ID {
+            self.peer_table.for_each(|(peer_id, peer)| {
+                if Some(peer_id) != vs_peer && !peer.is_internal() {
                     // This should be a short block and must be blocked on,
                     // otherwise the messages won't get sent
                     let spawn_self = self.clone();
@@ -164,7 +163,7 @@ impl Assembly {
         let mut join_set = tokio::task::JoinSet::new();
 
         self.peer_table.for_each(|(peer_id, peer)| {
-            if peer_id.get() == zpr::LOCAL_ACTOR_LINK_ID {
+            if peer.is_internal() {
                 return;
             }
 
@@ -250,26 +249,6 @@ impl Assembly {
             return Err(LinkStateError::NotFound(id));
         };
         peer.link_state_machine.process_event(self, event)
-    }
-
-    /// Populates the Peer Table with the "fake" internal peer used to hold
-    /// state relating to the local actor / internal dock.
-    ///
-    /// Must be called prior to adding any other peers; panics otherwise.
-    pub fn add_local_actor_peer(&self) {
-        let entry = self.peer_table.vacant_entry().unwrap();
-
-        assert_eq!(entry.key().get(), zpr::LOCAL_ACTOR_LINK_ID);
-
-        let peer_state = peer_table::PeerState::new(
-            entry.key(),
-            LinkType::Internal,
-            std::net::SocketAddrV6::new(std::net::Ipv6Addr::from_bits(0), 0, 0, 0).into(),
-            net_defs::ScopedIpv6Addr::new(std::net::Ipv6Addr::from_bits(0), 0).into(),
-            |_| std::future::pending(),
-        );
-
-        entry.insert(peer_state);
     }
 
     fn add_peer(

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -347,7 +347,7 @@ impl FastpathWorker {
                     true
                 }
 
-                AltEntry::Pending(_) => {
+                AltEntry::Pending(..) => {
                     // do not forward
                     false
                 }

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -319,12 +319,24 @@ pub struct LinkStateWrapper {
 
 impl LinkStateWrapper {
     pub fn new(new_id: LinkId, new_link_type: LinkType) -> Self {
+        let mut lsm = LinkStateMachine::new(new_id);
+
+        if matches!(new_link_type, LinkType::Internal) {
+            // Internal links are always up and active, that is, `is_ready()`.
+            lsm.state = LinkState::Active;
+            lsm.status = LinkStatus::Up;
+        }
+
         Self {
             id: new_id,
             link_type: new_link_type,
-            locked_fsm: Mutex::new(LinkStateMachine::new(new_id)),
+            locked_fsm: Mutex::new(lsm),
             locked_data: Mutex::new(LinkData::new()),
         }
+    }
+
+    pub fn is_internal(&self) -> bool {
+        matches!(self.link_type, LinkType::Internal)
     }
 
     /// Get the link's current state

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -581,23 +581,34 @@ fn main() -> ExitCode {
     // instantiate the "fake" local actor link
     //
 
-    asm.add_local_actor_peer();
+    assert_eq!(
+        asm.peer_table.insert_internal_peer().get(),
+        zpr::LOCAL_ACTOR_LINK_ID
+    );
 
     //
-    // instantiate tether if we're an adapter
+    // instantiate tether if we're an adapter,
+    // or "fake" internal dock link if we're a node
     // NOTE: must occur before we start any other workers!
     //
 
-    if ph_mode == PhMode::Adapter {
-        let dsid = asm
-            .start_tether(
-                asm.config.get().node_addr.as_ref().unwrap(),
-                &asm.config.get().self_addr.scoped_ip(),
-                link_state::LinkType::AdapterToNode,
-            )
-            .unwrap();
+    match ph_mode {
+        PhMode::Adapter => {
+            let dsid = asm
+                .start_tether(
+                    asm.config.get().node_addr.as_ref().unwrap(),
+                    &asm.config.get().self_addr.scoped_ip(),
+                    link_state::LinkType::AdapterToNode,
+                )
+                .unwrap();
 
-        assert_eq!(dsid.get(), zpr::DOCK_LINK_ID);
+            assert_eq!(dsid.get(), zpr::DOCK_LINK_ID);
+        }
+
+        PhMode::Node => assert_eq!(
+            asm.peer_table.insert_internal_peer().get(),
+            zpr::DOCK_LINK_ID
+        ),
     }
 
     //

--- a/adapter/ph/src/mgmt.rs
+++ b/adapter/ph/src/mgmt.rs
@@ -1,5 +1,6 @@
 //! Management packet functions.
 
+pub mod adapter;
 pub mod core;
 pub mod dispatch;
 pub mod dock;

--- a/adapter/ph/src/mgmt/adapter.rs
+++ b/adapter/ph/src/mgmt/adapter.rs
@@ -48,6 +48,15 @@ pub fn install_tether(
     };
 
     let Ok(initial_packet) = asm.alt.set_active(&five_tuple, pep) else {
+        // The only way for a transaction to have exited pending (i.e.,
+        // either error from set_active()) at this point (after our earlier
+        // lookup of the 5t) is because we got some other response to this
+        // same transaction which caused this code to be run twice
+        // concurrently.  So from a serialization perspective, the first
+        // response ended the transaction, and now this 2nd response is for
+        // a non-existent transaction.  For logging, we infer that a duplicate
+        // response must be the cause.
+
         warn!(target: FLOW_MGMT, "Duplicate bind response for {five_tuple}, ignoring");
         return Err(InstallTetherError::NoSuchTransaction);
     };

--- a/adapter/ph/src/mgmt/adapter.rs
+++ b/adapter/ph/src/mgmt/adapter.rs
@@ -1,0 +1,95 @@
+use super::txn_mgr;
+use crate::adapter_tables::AltPep;
+use crate::assembly::Assembly;
+use crate::counters::ManagementCounterType;
+use crate::logging::targets::FLOW_MGMT;
+use crate::queues;
+use crate::tc;
+use tracing::*;
+use zpr::StreamId;
+
+#[derive(Debug)]
+pub enum InstallTetherError {
+    NoSuchTransaction,
+}
+
+/// Install the given tether into the ALT.
+///
+/// Completes the indicated transaction.
+///
+/// Returns an error only if the transaction is invalid.
+pub fn install_tether(
+    asm: &Assembly,
+    txn: &txn_mgr::TxnHandle,
+    tether_id: StreamId,
+    tc: tc::Ip5TupleTc,
+) -> Result<(), InstallTetherError> {
+    let five_tuple = asm
+        .alt
+        .lookup_pending(txn)
+        .map_err(|_| InstallTetherError::NoSuchTransaction)?;
+
+    // Confirm this TC matches our initial packet.
+    // TODO: use the TC itself to do this, once we have that code in place.
+    if tc.five_tuple()
+        != tc::Ip5TupleTc::new_with_compression_mode(tc.compression_mode(), five_tuple).five_tuple()
+    {
+        error!(target: FLOW_MGMT, "Bind of {five_tuple} falied: node supplied TC incompatible with initial packet: {tc}");
+        asm.alt.remove(&five_tuple).unwrap();
+        return Ok(());
+    }
+
+    // Bind succeeded; add to ALT.
+    debug!(target: FLOW_MGMT, "Bind of {five_tuple} succeeded: {tether_id}");
+
+    let pep = AltPep {
+        compression_mode: tc.compression_mode(),
+        tether_id,
+    };
+
+    let Ok(initial_packet) = asm.alt.set_active(&five_tuple, pep) else {
+        warn!(target: FLOW_MGMT, "Duplicate bind response for {five_tuple}, ignoring");
+        return Err(InstallTetherError::NoSuchTransaction);
+    };
+
+    // now send out initial packet
+    match asm.actor_output_requeue.try_enqueue_packet(initial_packet) {
+        Ok(()) => (),
+        Err(queues::TryEnqueueError::Full(_pkt)) => {
+            debug!(target: FLOW_MGMT, "Requeue backpressure on bind of {five_tuple}, dropping initial packet");
+            asm.counters.management[ManagementCounterType::QueueBackpressure].increment();
+        }
+    }
+
+    Ok(())
+}
+
+/// Deny the given tether request.
+///
+/// Completes the indicated transaction.
+pub fn deny_tether(
+    asm: &Assembly,
+    txn: &txn_mgr::TxnHandle,
+    reason: &str,
+) -> Result<(), InstallTetherError> {
+    let five_tuple = asm
+        .alt
+        .lookup_pending(txn)
+        .map_err(|_| InstallTetherError::NoSuchTransaction)?;
+
+    debug!(target: FLOW_MGMT, "Bind of {five_tuple} failed: {reason}");
+
+    // TODO FIXME:
+    //
+    // We could have a weird race where a second (buggy) response for the same
+    // transaction comes in, we process it concurrently (which we don't right now),
+    // it wins the race and removes the 5t and txn, a _new_ bind request for the
+    // _same_ 5t enters the table, and _then_ we remove that one erroneously.
+    //
+    // We ignore that possibility.
+
+    match asm.alt.remove(&five_tuple) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(InstallTetherError::NoSuchTransaction),
+    }
+}

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -1,5 +1,6 @@
 //! Handlers for management requests.
 
+use super::adapter;
 use crate::adapter_tables;
 use crate::assembly::{self, Assembly, PhMode, VERSION};
 use crate::auth;
@@ -1044,7 +1045,7 @@ pub async fn handle_bind_egress_stream_request(
 pub async fn handle_bind_actor_address_response(
     asm: &Arc<Assembly>,
     txn_id: u16,
-    pkt: Packet,
+    mut pkt: Packet,
 ) -> HandleMgmtResult {
     let link_id = pkt.metadata().ingress_link_id;
 
@@ -1056,13 +1057,54 @@ pub async fn handle_bind_actor_address_response(
         return Err(HandleMgmtError::UnknownTransaction(txn_id));
     };
 
-    let Some(sender) = peer_state.bind_req_state.lock().unwrap().remove(&txn) else {
-        return Err(HandleMgmtError::UnknownTransaction(txn_id));
+    let Ok(hdr) = zdp::ZdpBindActorAddressResponseHeader::read_from_buf(&mut pkt) else {
+        return Err(HandleMgmtError::BadStructure);
     };
 
-    let _ = sender.send(pkt);
+    match hdr.status_code {
+        zdp::ResponseCode::Success => {
+            let stream_id = pkt.metadata().ingress_stream_id;
 
-    Ok(())
+            let Ok(tcst) = zpr::Tcst::read_from_buf(&mut pkt) else {
+                return Err(HandleMgmtError::BadStructure);
+            };
+
+            if !matches!(tcst, zpr::Tcst::Ip5Tuple) {
+                warn!(target: ZDP, "Link {}: unsupported TCST {}", pkt.metadata().ingress_link_id, tcst.0);
+                return Err(HandleMgmtError::BadStructure);
+            }
+
+            let Ok(tc) = tc::Ip5TupleTc::deserialize(&mut pkt) else {
+                return Err(HandleMgmtError::BadStructure);
+            };
+
+            let txn_id = txn.id();
+
+            adapter::install_tether(&asm, &txn, stream_id, tc).map_err(
+                |adapter::InstallTetherError::NoSuchTransaction| {
+                    HandleMgmtError::UnknownTransaction(txn_id)
+                },
+            )
+        }
+
+        zdp::ResponseCode::Other => {
+            if hdr.info_len as usize > pkt.remaining() {
+                return Err(HandleMgmtError::BadStructure);
+            }
+
+            let Ok(msg) = std::str::from_utf8(&pkt.body()[..hdr.info_len as usize]) else {
+                return Err(HandleMgmtError::BadStructure);
+            };
+
+            adapter::deny_tether(&asm, &txn, msg).map_err(
+                |adapter::InstallTetherError::NoSuchTransaction| {
+                    HandleMgmtError::UnknownTransaction(txn_id)
+                },
+            )
+        }
+
+        _ => Err(HandleMgmtError::BadStructure),
+    }
 }
 
 pub async fn handle_bind_egress_stream_response(

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -5,6 +5,7 @@
 #![allow(dead_code)]
 
 use super::core::{self, Sent};
+use super::txn_mgr::TxnId;
 use crate::config;
 use crate::counters::ManagementCounterType;
 use crate::defs::*;
@@ -259,7 +260,7 @@ pub enum BindActorAddressError {
     #[error("bad structure")]
     BadStructure,
     #[error("{0}")]
-    BindActorAddressError(Box<str>),
+    BindActorAddressError(String),
     #[error("link closed")]
     LinkClosed,
 }
@@ -273,29 +274,14 @@ impl From<core::MgmtSendError> for BindActorAddressError {
 }
 
 /// send a Bind Actor Address Request and wait for the Response (RFC 6.5 § 6.3.11)
-pub async fn send_bind_actor_address_request(
-    asm: &Assembly,
+pub fn send_bind_actor_address_request<'a>(
+    asm: &'a Assembly,
     link_id: zpr::LinkId,
+    txn_id: TxnId,
     five_tuple: &FiveTuple,
     packet_body: &[u8],
-) -> Result<(zpr::StreamId, tc::Ip5TupleTc), BindActorAddressError> {
+) -> Sent<'a> {
     info!(target: ZDP, "Link {link_id}: sending BindActorAddressRequest for {five_tuple} with packet_body size {}", packet_body.len());
-
-    let (sender, receiver) = tokio::sync::oneshot::channel();
-
-    let Some(peer_state) = asm.peer_table.get(link_id) else {
-        return Err(BindActorAddressError::LinkClosed);
-    };
-
-    let txn = peer_state.txn_mgr.open().await;
-    let txn_id = txn.id();
-    peer_state
-        .bind_req_state
-        .lock()
-        .unwrap()
-        .insert(txn, sender);
-
-    drop(peer_state);
 
     let mut req = core::new_heap_packet();
     let bind_req_hdr = req.alloc_zeroed_header::<zdp::ZdpBindActorAddressRequestHeader>();
@@ -314,57 +300,6 @@ pub async fn send_bind_actor_address_request(
         txn_id,
         req,
     )
-    .await?;
-
-    let Ok(mut resp) = receiver.await else {
-        return Err(BindActorAddressError::LinkClosed);
-    };
-
-    let Ok(hdr) = zdp::ZdpBindActorAddressResponseHeader::read_from_buf(&mut resp) else {
-        core::count_event(asm, ManagementCounterType::BadStructure);
-        return Err(BindActorAddressError::BadStructure);
-    };
-
-    match hdr.status_code {
-        zdp::ResponseCode::Success => {
-            let stream_id = resp.metadata().ingress_stream_id;
-
-            let Ok(tcst) = zpr::Tcst::read_from_buf(&mut resp) else {
-                return Err(BindActorAddressError::BadStructure);
-            };
-
-            if !matches!(tcst, zpr::Tcst::Ip5Tuple) {
-                warn!(target: ZDP, "Link {}: unsupported TCST {}", resp.metadata().ingress_link_id, tcst.0);
-                return Err(BindActorAddressError::BadStructure);
-            }
-
-            let Ok(tc) = tc::Ip5TupleTc::deserialize(&mut resp) else {
-                return Err(BindActorAddressError::BadStructure);
-            };
-
-            return Ok((stream_id, tc));
-        }
-
-        zdp::ResponseCode::Other => {
-            if hdr.info_len as usize > resp.remaining() {
-                core::count_event(asm, ManagementCounterType::BadStructure);
-                return Err(BindActorAddressError::BadStructure);
-            }
-
-            let Ok(msg) = std::str::from_utf8(&resp.body()[..hdr.info_len as usize]) else {
-                core::count_event(asm, ManagementCounterType::BadStructure);
-                return Err(BindActorAddressError::BadStructure);
-            };
-            let msg: Box<str> = msg.into();
-
-            Err(BindActorAddressError::BindActorAddressError(msg))
-        }
-
-        _ => {
-            core::count_event(asm, ManagementCounterType::BadStructure);
-            Err(BindActorAddressError::BadStructure)
-        }
-    }
 }
 
 pub async fn send_bind_egress_stream_request(
@@ -427,9 +362,8 @@ pub async fn send_bind_egress_stream_request(
                 core::count_event(asm, ManagementCounterType::BadStructure);
                 return Err(BindActorAddressError::BadStructure);
             };
-            let msg: Box<str> = msg.into();
 
-            Err(BindActorAddressError::BindActorAddressError(msg))
+            Err(BindActorAddressError::BindActorAddressError(msg.to_owned()))
         }
 
         _ => {

--- a/adapter/ph/src/mgmt/txn_mgr.rs
+++ b/adapter/ph/src/mgmt/txn_mgr.rs
@@ -92,6 +92,21 @@ struct TxnMgrInner {
     open: BTreeMap<TxnId, usize>,
 }
 
+impl TxnMgrInner {
+    fn try_open_raw(&mut self) -> Option<TxnId> {
+        let next_free = self.next_free;
+        // If the ID we want is not in use,
+        if let btree_map::Entry::Vacant(entry) = self.open.entry(next_free) {
+            // mark it as in-use and return it
+            entry.insert(0);
+            self.next_free = self.next_free.wrapping_add(1);
+            return Some(next_free);
+        }
+
+        None
+    }
+}
+
 /// ZDP transaction manager.
 ///
 /// See module-level documentation for theory of use.
@@ -130,6 +145,18 @@ impl TxnMgr {
         }
     }
 
+    /// Try to open a new transaction.
+    ///
+    /// Returns a handle to the transaction if one was available;
+    /// `None` if there are no free transactions.
+    pub fn try_open(self: &Arc<Self>) -> Option<TxnHandle> {
+        let id = self.try_open_raw()?;
+        Some(TxnHandle {
+            mgr: Arc::downgrade(self),
+            id,
+        })
+    }
+
     /// Get a handle to an existing transaction.
     ///
     /// This is primarily useful when looking up the transaction
@@ -150,13 +177,9 @@ impl TxnMgr {
             // grab the lock
             let mut inner = self.inner.lock().unwrap();
 
-            let next_free = inner.next_free;
-            // If the ID we want is not in use,
-            if let btree_map::Entry::Vacant(entry) = inner.open.entry(next_free) {
-                // mark it as in-use and return it
-                entry.insert(0);
-                inner.next_free = inner.next_free.wrapping_add(1);
-                return next_free;
+            // try to open a new transaction, return it if successful
+            if let Some(id) = inner.try_open_raw() {
+                return id;
             }
 
             // else, register to receive a notification when this changes
@@ -179,6 +202,11 @@ impl TxnMgr {
             // repeatedly lose the contention race yet more so, so we don't
             // worry about this)
         }
+    }
+
+    /// Try to open a new transaction, returning the raw ID.
+    fn try_open_raw(&self) -> Option<TxnId> {
+        self.inner.lock().unwrap().try_open_raw()
     }
 
     /// Increment the refcount of an open transaction.

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -5,7 +5,7 @@ use crate::forwarding_tables::PeerForwardingTable;
 use crate::km::{KeyManager, KmTransportSA};
 use crate::link_state::{LinkStateWrapper, LinkType};
 use crate::mgmt::txn_mgr;
-use crate::net_defs::ScopedIpAddr;
+use crate::net_defs::{ScopedIpAddr, ScopedIpv6Addr};
 use crate::queues;
 use crate::rcu::{RcuBox, RcuCslabEntryGuard, RcuOptionGuard};
 use crate::special_peers::*;
@@ -122,6 +122,21 @@ impl PeerState {
     ) -> Option<RcuOptionGuard<'_, KmTransportSA>> {
         self.km_state.transport_sa.get().into()
     }
+
+    /// Creates a "dummy" peer for referencing internal links.
+    pub fn new_internal_peer(link_id: NonZero<LinkId>) -> Self {
+        PeerState::new(
+            link_id,
+            LinkType::Internal,
+            std::net::SocketAddrV6::new(std::net::Ipv6Addr::from_bits(0), 0, 0, 0).into(),
+            ScopedIpv6Addr::new(std::net::Ipv6Addr::from_bits(0), 0).into(),
+            |_| std::future::pending(),
+        )
+    }
+
+    pub fn is_internal(&self) -> bool {
+        self.link_state_machine.is_internal()
+    }
 }
 
 type AtomicLinkId = atomic::AtomicU32;
@@ -162,8 +177,14 @@ impl PeerTable {
         }
     }
 
-    pub fn insert(&self, peer_state: PeerState) -> Result<NonZero<LinkId>, PeerInsertError> {
-        Ok(self.vacant_entry()?.insert(peer_state))
+    /// Adds a "dummy" peer with the expected link ID for referencing internal links.
+    ///
+    /// Panics if there is no room in the table.  (This is intended to only be invoked
+    /// at startup, before dynamic entries have been added.)
+    pub fn insert_internal_peer(&self) -> NonZero<LinkId> {
+        let entry = self.vacant_entry().unwrap();
+        let peer = PeerState::new_internal_peer(entry.key());
+        entry.insert(peer)
     }
 
     pub fn vacant_entry(&self) -> Result<VacantPeerTableEntry<'_>, PeerInsertError> {
@@ -418,14 +439,16 @@ impl VacantPeerTableEntry<'_> {
         // the "reverse" table with Acquire ordering
         atomic::fence(Ordering::Release);
 
-        if let Some(other) = self.sa_to_link_ref.insert(
-            (peer_state_ref.substrate_addr, peer_state_ref.interface_addr),
-            link_id,
-        ) {
-            panic!(
-                "duplicate peer substrate address: {link_id} and {other} share {} on dock {}",
-                peer_state_ref.substrate_addr, peer_state_ref.interface_addr,
-            );
+        if !peer_state_ref.substrate_addr.ip().is_unspecified() {
+            if let Some(other) = self.sa_to_link_ref.insert(
+                (peer_state_ref.substrate_addr, peer_state_ref.interface_addr),
+                link_id,
+            ) {
+                panic!(
+                    "duplicate peer substrate address: {link_id} and {other} share {} on dock {}",
+                    peer_state_ref.substrate_addr, peer_state_ref.interface_addr,
+                );
+            }
         }
 
         link_id

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -461,7 +461,6 @@ mod tests {
     use crate::net_defs;
     use crate::peer_table::test::create_dummy_peer_state;
     use std::net::{IpAddr, Ipv4Addr};
-    use std::num::NonZero;
     use std::sync::Arc;
 
     #[test]
@@ -517,15 +516,15 @@ mod tests {
         let mut builder = TestAssemblyBuilder::new();
         builder.visa_table = Some(VisaTable::new());
         let asm = Arc::new(create_assembly(builder));
-        let link_id = asm
-            .peer_table
+        let entry = asm.peer_table.vacant_entry().unwrap();
+        let entry_key = entry.key();
+        let link_id = entry
             .insert(create_dummy_peer_state(
-                NonZero::new(zpr::LOCAL_ACTOR_LINK_ID).unwrap(),
+                entry_key,
                 LinkType::Internal,
                 zpr::SubstrateAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 443),
                 net_defs::ScopedIpAddr::V4(Ipv4Addr::new(1, 2, 3, 5)),
             ))
-            .unwrap()
             .get();
 
         let one_second = std::time::Duration::from_secs(1);

--- a/zpr/src/lib.rs
+++ b/zpr/src/lib.rs
@@ -38,7 +38,8 @@ pub const LINK_ID_UNKNOWN: LinkId = 0;
 /// Link ID used to refer to a node or adapter's local actor.
 pub const LOCAL_ACTOR_LINK_ID: LinkId = 1;
 
-/// Link ID used on an adapter to refer to the dock to which it's connected.
+/// Link ID used on an adapter to refer to the dock to which it's connected,
+/// or on a node to refer to the node's internal dock.
 pub const DOCK_LINK_ID: LinkId = 2;
 
 /// Stream ID
@@ -127,9 +128,7 @@ pub mod compression_mode {
 
 /// Traffic classification specification type.
 #[open_enum]
-#[derive(
-    Copy, Clone, Debug, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned,
-)]
+#[derive(Copy, Clone, Debug, FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(u8)]
 pub enum Tcst {
     Ip5Tuple = 0,


### PR DESCRIPTION
This is the first step of the final phase of work to move away from the async-request model for bind requests (#906), and toward an explicit state-machine model.  The changes herein are:

* We add a dummy link representing the internal dock on nodes.  We use the same fixed ID (2) we use on adapters to represent the dock link.  This is needed so that the internal adapter of a node can open a transaction to request a bind of the internal dock same as a standalone adapter connected to the external dock.  The transaction ID is the key to reference the state of an outstanding bind request in the adapter tables.
* We add a means to try to open a transaction without blocking.  This is useful when initiating a bind request, since we never want to wait for a free transaction; we always just want to drop the initial packet and give up if there's no free transaction.
* Tracking of pending bind requests moves from the peer state to the ALT.  (We still use the peer state to track egress tether requests, see TODO below.)
* Adapter-initiated bind requests are no longer async functions.  They now open a transaction, add it to the ALT, send a message, and return immediately.  Later, the bind response then looks up the state in the ALT by transaction ID, and installs the tether at that point.

The benefits of the explicit state-machine model are:
* better match to the unidirectional message model of ZDP
* no longer a need for every transaction to make temporary "one-shot" channels for waiting for results
* much easier to get insight into a running system to see what state everything is in (rather than just a giant bag of opaque Tokio-tasks)

Maybe easier to review commit-by-commit.

Work for future PRs includes:
* Either adding a wrapper layer so bind requests from internal adapters can also be state-machine-based, or reworking the internal dock bind code (which is currently called directly) so that they are so.  (This will then allow bind requests to be issued concurrently)
* Breaking up egress tether requests similarly.  (This will then allow us to remove the global transaction→one-shot-channel table.)

THEN we'll finally be able to tackle implementing the full routing flow correctly!