### PR TITLE
ZDPR retry timer should be 600 ms, not 400 ms

### DIFF
--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -40,7 +40,7 @@ pub const TINY_MESSAGE_HEADROOM: usize = 64;
 
 pub const DEFAULT_ZDPR_RECEIVE_WINDOW_SIZE: usize = 32;
 
-pub const DEFAULT_ZDPR_RETRY_TIMER: std::time::Duration = std::time::Duration::from_millis(400);
+pub const DEFAULT_ZDPR_RETRY_TIMER: std::time::Duration = std::time::Duration::from_millis(600);
 
 pub const DEFAULT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 pub const DEFAULT_TERMINATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);


### PR DESCRIPTION
Per observation from Frank.  Somehow I misremembered the Reliable UDP timeout as 400 ms, when it is in fact 600 ms (which is required for satellite operations).