### PR TITLE
Mk/update vsapi 0.8.0

### DIFF
--- a/zpr/src/vsapi_types/visa.rs
+++ b/zpr/src/vsapi_types/visa.rs
@@ -322,7 +322,7 @@ impl TryFrom<v1::dock_pep::Reader<'_>> for DockPep {
                 let tcp_udp_pep_reader = tcp_udp_pep_result?;
                 let source_port = tcp_udp_pep_reader.get_source_port();
                 let dest_port = tcp_udp_pep_reader.get_dest_port();
-                let endpoint = match tcp_udp_pep_reader.get_enpoint()? {
+                let endpoint = match tcp_udp_pep_reader.get_endpoint()? {
                     v1::EndpointT::Any => EndpointT::Any,
                     v1::EndpointT::Server => EndpointT::Server,
                     v1::EndpointT::Client => EndpointT::Client,
@@ -334,7 +334,7 @@ impl TryFrom<v1::dock_pep::Reader<'_>> for DockPep {
                 let tcp_udp_pep_reader = tcp_udp_pep_result?;
                 let source_port = tcp_udp_pep_reader.get_source_port();
                 let dest_port = tcp_udp_pep_reader.get_dest_port();
-                let endpoint = match tcp_udp_pep_reader.get_enpoint()? {
+                let endpoint = match tcp_udp_pep_reader.get_endpoint()? {
                     v1::EndpointT::Any => EndpointT::Any,
                     v1::EndpointT::Server => EndpointT::Server,
                     v1::EndpointT::Client => EndpointT::Client,

--- a/zpr/src/vsapi_types_writers.rs
+++ b/zpr/src/vsapi_types_writers.rs
@@ -64,9 +64,9 @@ impl WriteTo<v1::dock_pep_tcp_udp::Builder<'_>> for TcpUdpPep {
         bldr.set_source_port(self.source_port);
         bldr.set_dest_port(self.dest_port);
         match self.endpoint {
-            EndpointT::Any => bldr.set_enpoint(v1::EndpointT::Any),
-            EndpointT::Server => bldr.set_enpoint(v1::EndpointT::Server),
-            EndpointT::Client => bldr.set_enpoint(v1::EndpointT::Client),
+            EndpointT::Any => bldr.set_endpoint(v1::EndpointT::Any),
+            EndpointT::Server => bldr.set_endpoint(v1::EndpointT::Server),
+            EndpointT::Client => bldr.set_endpoint(v1::EndpointT::Client),
         }
     }
 }


### PR DESCRIPTION
Previously updated zpr-vsapi to fix a typo.

I have gone in here and changed HEAD of the submodule (I think).
And then changed the old references to the typo.

Once this goes through we can add a new zpr-xxx tag and use it from other crates.