### PR TITLE
zpr: add feature flags limiting capnp dependencies

### DIFF
--- a/.github/workflows/zpr-crate.yml
+++ b/.github/workflows/zpr-crate.yml
@@ -20,9 +20,10 @@ env:
 jobs:
   build-test-check:
     name: zpr_crate
-    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@v1.1
+    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@v1.2
     with:
       name: 'zpr_crate'
       path: './zpr'
       needs-capnp: true
+      features: 'all'
     secrets: inherit

--- a/.github/workflows/zprext.yml
+++ b/.github/workflows/zprext.yml
@@ -21,8 +21,9 @@ env:
 jobs:
   zpr-ext:
     name: ZPR Ext
-    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@v1
+    uses: org-zpr/zpr-dev-tools/.github/workflows/rust-build-test.yml@v1.2
     with:
       name: 'ZPR-Ext'
       path: './zpr-ext'
+      features: 'all'
     secrets: inherit

--- a/adapter/cli/Cargo.lock
+++ b/adapter/cli/Cargo.lock
@@ -89,12 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,12 +366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,12 +468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,12 +494,6 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "log"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -571,25 +547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "objc2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,15 +585,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -914,28 +862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "log",
- "ordered-float",
- "threadpool",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,14 +940,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "vsapi"
-version = "0.4.0"
-source = "git+https://github.com/org-zpr/zpr-vsapi-rs.git?tag=v0.4.1#2e41d0af057268d4b965b026a9b412dbe5483f99"
-dependencies = [
- "thrift",
-]
 
 [[package]]
 name = "wasi"
@@ -1288,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "capnp",
  "capnpc",
@@ -1296,7 +1214,6 @@ dependencies = [
  "strum",
  "thiserror 1.0.69",
  "url",
- "vsapi",
  "zerocopy",
 ]
 

--- a/adapter/cli/Cargo.toml
+++ b/adapter/cli/Cargo.toml
@@ -7,19 +7,19 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+capnp-rpc = { version = "0.23" }
+capnp = { version = "0.23" }
+cbpf-rs = { path = "../../cbpf-rs", features = ['pcap'] }
+clap_complete = { version = "4.5.57", optional = true}
 clap = { version = "4.5.7", features = ["derive"] }
 ctrlc = { version = "3.4.4" }
 pcap = { version = "2.0.0" }
-cbpf-rs = { path = "../../cbpf-rs", features = ['pcap'] }
 shlex = { version = "1.3.0" }
-zpr = { path = "../../zpr" }
-zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "zerocopy"] }
-clap_complete = { version = "4.5.57", optional = true}
-capnp = { version = "0.23" }
-capnp-rpc = { version = "0.23" }
-tokio = { version = "1.37.0", features = ["macros", "rt", "io-util", "time"] }
-tokio-util = { version = "0.7.11", features = ["compat"] }
 thiserror = { version = "2.0.17" }
+tokio-util = { version = "0.7.11", features = ["compat"] }
+tokio = { version = "1.37.0", features = ["macros", "rt", "io-util", "time"] }
+zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "zerocopy"] }
+zpr = { path = "../../zpr", features = ["admin-api"] }
 
 [features]
 complete = ["clap_complete"]
@@ -27,6 +27,7 @@ complete = ["clap_complete"]
 [[bin]]
 name = "ph-cli"
 path = "src/main.rs"
+
 [[bin]]
 name = "generate_completions"
 path = "src/generate_completions.rs"

--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "capnp",
  "capnpc",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -49,7 +49,7 @@ url = "2.5.4"
 zerocopy = { version = "0.8.3", features = ["derive", "std"] }
 zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "socket2", "zerocopy"] }
 zpr-utils = { path = "../../zpr-utils" }
-zpr = { path = "../../zpr" }
+zpr = { path = "../../zpr", features = ["admin-api", "vsapi"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7.4", optional = true }

--- a/libnode/Cargo.lock
+++ b/libnode/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "capnp",
  "capnpc",

--- a/libnode2/Cargo.lock
+++ b/libnode2/Cargo.lock
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "capnp",
  "capnpc",

--- a/libnode2/Cargo.toml
+++ b/libnode2/Cargo.toml
@@ -5,18 +5,18 @@ edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]
-capnp-rpc = "0.23.0"
 capnp = "0.23.0"
-thiserror = "2.0.17"
-tracing = "0.1.41"
-tokio = { version = "1.48.0", features = ["full"] }
-tokio-util = { version = "0.7.17", features = ["rt", "compat"] }
-openssl = "0.10.74"
+capnp-rpc = "0.23.0"
 clap = { version = "4.5.23", features = ["derive"], optional = true } # lnt
-tracing-subscriber = { version = "0.3.20", optional = true } # lnt
 ipnet = "2.11.0"
-zpr = { path = "../zpr" }
+openssl = "0.10.74"
 rustyline = { version = "17.0.2", optional = true } #lnt
+thiserror = "2.0.17"
+tokio-util = { version = "0.7.17", features = ["rt", "compat"] }
+tokio = { version = "1.48.0", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", optional = true } # lnt
+zpr = { path = "../zpr", features = ["vsapi"]}
 
 [features]
 build-lnt = ["clap", "tracing-subscriber", "rustyline"]
@@ -25,5 +25,3 @@ build-lnt = ["clap", "tracing-subscriber", "rustyline"]
 name = "lntest"
 path = "src/bin/lntest.rs"
 required-features = ["build-lnt"]
-
-

--- a/zpr-ext/src/tokio.rs
+++ b/zpr-ext/src/tokio.rs
@@ -15,7 +15,7 @@ pub mod net {
 
     pub trait UdpSocketExt {
         fn mtu(&self) -> io::Result<u32>;
-        #[cfg(any(doc, target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         fn attach_reuse_port_cbpf(&self, filter: &[libc::sock_filter]) -> io::Result<()>;
     }
 
@@ -37,7 +37,7 @@ pub mod net {
             return Ok(1400);
         }
 
-        #[cfg(any(doc, target_os = "android", target_os = "linux"))]
+        #[cfg(any(target_os = "android", target_os = "linux"))]
         fn attach_reuse_port_cbpf(&self, filter: &[libc::sock_filter]) -> io::Result<()> {
             let fprog = libc::sock_fprog {
                 len: filter.len() as u16,

--- a/zpr-utils/Cargo.lock
+++ b/zpr-utils/Cargo.lock
@@ -33,10 +33,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "embedded-io"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "heck"
@@ -51,6 +71,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,15 +180,21 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "num-traits"
@@ -117,6 +245,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +282,48 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strum"
@@ -171,6 +356,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -216,10 +412,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vsapi"
@@ -227,6 +451,35 @@ version = "0.4.0"
 source = "git+https://github.com/org-zpr/zpr-vsapi-rs.git?tag=v0.4.1#2e41d0af057268d4b965b026a9b412dbe5483f99"
 dependencies = [
  "thrift",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -250,14 +503,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zpr"
-version = "0.1.4"
+version = "0.4.0"
 dependencies = [
  "capnp",
  "capnpc",
  "open-enum",
  "strum",
  "thiserror",
+ "url",
  "vsapi",
  "zerocopy",
 ]

--- a/zpr-utils/Cargo.toml
+++ b/zpr-utils/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 
 [dependencies]
 zerocopy = { version = "0.8.3", features = ["derive", "std"] }
-zpr = { path = "../zpr" }
+zpr = { path = "../zpr", features = ["vsapi"] }

--- a/zpr/Cargo.lock
+++ b/zpr/Cargo.lock
@@ -180,9 +180,9 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "litemap"
@@ -192,9 +192,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "num-traits"
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.2.1"
+version = "0.4.0"
 dependencies = [
  "capnp",
  "capnpc",

--- a/zpr/Cargo.toml
+++ b/zpr/Cargo.toml
@@ -1,17 +1,23 @@
 [package]
 name = "zpr"
-version = "0.2.1"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]
-capnp = "0.23"
+capnp = { version = "0.23", optional = true }
 open-enum = { version = "0.5" }
 strum = { version = "0.26", features = ["derive"] }
 zerocopy = { version = "0.8", features = ["derive"] }
 thiserror = "1.0.65"
-vsapi = { git = "https://github.com/org-zpr/zpr-vsapi-rs.git", tag = "v0.4.1" }
+vsapi = { git = "https://github.com/org-zpr/zpr-vsapi-rs.git", tag = "v0.4.1", optional = true }
 url = "2.5.4"
 
 [build-dependencies]
 capnpc = "0.23"
+
+[features]
+admin-api = ["capnp"]
+policy = ["capnp"]
+vsapi = ["capnp", "dep:vsapi"]
+all = ["admin-api", "policy", "vsapi"]

--- a/zpr/src/lib.rs
+++ b/zpr/src/lib.rs
@@ -4,20 +4,28 @@ pub mod addrs;
 pub mod dn;
 pub mod packet_info;
 pub mod rpc_commands;
+#[cfg(feature = "vsapi")]
 pub mod vsapi_types;
+#[cfg(feature = "vsapi")]
 pub mod vsapi_types_writers;
 
+#[cfg(feature = "admin-api")]
 capnp::generated_code!(pub mod cli_capnp);
+#[cfg(feature = "admin-api")]
 pub mod admin_api {
     pub use super::cli_capnp as v1;
 }
 
+#[cfg(feature = "policy")]
 capnp::generated_code!(pub mod policy_capnp);
+#[cfg(feature = "policy")]
 pub mod policy {
     pub use super::policy_capnp as v1;
 }
 
+#[cfg(feature = "vsapi")]
 capnp::generated_code!(pub mod vs_capnp);
+#[cfg(feature = "vsapi")]
 pub mod vsapi {
     pub use super::vs_capnp as v1;
 }


### PR DESCRIPTION
These feature flags (all off by default) allow a developer to control whether the capnproto compiler and submodules are required.

Major version bump (0.3.0→0.4.0) for zpr.  (Note, we had tagged zpr-0.3.0, but not updated the Cargo.toml.)

Also sorted some dependency lists.

Pending org-zpr/zpr-dev-tools#32, to use new workflow capability to test build with additional feature flags.

Will tag zpr-0.4.0 after push.