### PR TITLE
Ort/remove panic from zpr

### DIFF
--- a/zpr/src/vsapi_types/error.rs
+++ b/zpr/src/vsapi_types/error.rs
@@ -1,3 +1,5 @@
+use std::net::AddrParseError;
+
 use thiserror::Error;
 
 /// Error type
@@ -17,4 +19,6 @@ pub enum VsapiTypeError {
     CodedError(crate::vsapi_types::ErrorCode),
     #[error("IP address conversion error: {0}")]
     TryFromSliceError(#[from] std::array::TryFromSliceError),
+    #[error("Addr Parse Error")]
+    AddrParseError(#[from] AddrParseError),
 }

--- a/zpr/src/vsapi_types/services.rs
+++ b/zpr/src/vsapi_types/services.rs
@@ -76,13 +76,13 @@ impl TryFrom<vsapi::ServicesList> for AuthServicesList {
     /// Returns err if a ServiceDescriptor is badly formatted
     fn try_from(services_list: vsapi::ServicesList) -> Result<Self, Self::Error> {
         let mut expiration = None;
-        if services_list.expiration.is_some() {
+        if let Some(exp) = services_list.expiration {
             expiration =
-                Some(UNIX_EPOCH + Duration::from_secs(services_list.expiration.unwrap() as u64));
+                Some(UNIX_EPOCH + Duration::from_secs(exp as u64));
         }
         let mut services = Vec::new();
-        if services_list.services.is_some() {
-            for svc in services_list.services.unwrap() {
+        if let Some(svc_list) = services_list.services {
+            for svc in svc_list {
                 services.push(ServiceDescriptor::try_from(svc)?);
             }
         }
@@ -103,17 +103,17 @@ impl TryFrom<vsapi::ServiceDescriptor> for ServiceDescriptor {
                 "vsapi::ServiceDescriptor is not of type ACTOR_AUTHENTICATION",
             ));
         }
-        if value.address.is_none() {
-            return Err(VsapiTypeError::DeserializationError(
+        let zpr_addr = match value.address {
+            Some(address) => ip_addr_from_vec(address)?,
+            None => return Err(VsapiTypeError::DeserializationError(
                 "vsapi::ServiceDescriptor addr is empty",
-            ));
-        }
-        let zpraddr = ip_addr_from_vec(value.address.unwrap())?;
+            ))
+        };
 
         Ok(ServiceDescriptor {
             service_id: value.service_id.unwrap_or_default(),
             service_uri: value.uri.unwrap_or_default(),
-            zpr_addr: zpraddr,
+            zpr_addr,
         })
     }
 }

--- a/zpr/src/vsapi_types/services.rs
+++ b/zpr/src/vsapi_types/services.rs
@@ -77,8 +77,7 @@ impl TryFrom<vsapi::ServicesList> for AuthServicesList {
     fn try_from(services_list: vsapi::ServicesList) -> Result<Self, Self::Error> {
         let mut expiration = None;
         if let Some(exp) = services_list.expiration {
-            expiration =
-                Some(UNIX_EPOCH + Duration::from_secs(exp as u64));
+            expiration = Some(UNIX_EPOCH + Duration::from_secs(exp as u64));
         }
         let mut services = Vec::new();
         if let Some(svc_list) = services_list.services {
@@ -105,9 +104,11 @@ impl TryFrom<vsapi::ServiceDescriptor> for ServiceDescriptor {
         }
         let zpr_addr = match value.address {
             Some(address) => ip_addr_from_vec(address)?,
-            None => return Err(VsapiTypeError::DeserializationError(
-                "vsapi::ServiceDescriptor addr is empty",
-            ))
+            None => {
+                return Err(VsapiTypeError::DeserializationError(
+                    "vsapi::ServiceDescriptor addr is empty",
+                ));
+            }
         };
 
         Ok(ServiceDescriptor {

--- a/zpr/src/vsapi_types/visa.rs
+++ b/zpr/src/vsapi_types/visa.rs
@@ -185,10 +185,10 @@ impl TryFrom<v1::visa::Reader<'_>> for Visa {
         };
         let dest_addr = match reader.get_dest_addr()?.which()? {
             v1::ip_addr::Which::V4(data) => {
-                IpAddr::from(<[u8; 4]>::try_from(data.unwrap()).unwrap())
+                IpAddr::from(<[u8; 4]>::try_from(data?)?)
             }
             v1::ip_addr::Which::V6(data) => {
-                IpAddr::from(<[u8; 16]>::try_from(data.unwrap()).unwrap())
+                IpAddr::from(<[u8; 16]>::try_from(data?)?)
             }
         };
 

--- a/zpr/src/vsapi_types/visa.rs
+++ b/zpr/src/vsapi_types/visa.rs
@@ -184,12 +184,8 @@ impl TryFrom<v1::visa::Reader<'_>> for Visa {
             v1::ip_addr::Which::V6(data) => IpAddr::from(<[u8; 16]>::try_from(data?)?),
         };
         let dest_addr = match reader.get_dest_addr()?.which()? {
-            v1::ip_addr::Which::V4(data) => {
-                IpAddr::from(<[u8; 4]>::try_from(data?)?)
-            }
-            v1::ip_addr::Which::V6(data) => {
-                IpAddr::from(<[u8; 16]>::try_from(data?)?)
-            }
+            v1::ip_addr::Which::V4(data) => IpAddr::from(<[u8; 4]>::try_from(data?)?),
+            v1::ip_addr::Which::V6(data) => IpAddr::from(<[u8; 16]>::try_from(data?)?),
         };
 
         let dock_pep = DockPep::try_from(reader.get_dock_pep()?)?;


### PR DESCRIPTION
Removed all unwraps from zpr, other than the unwraps in the unit tests in mod, because we necessarily know the result (and would want the test to panic if for some reason we were wrong).

I removed unwraps that were unchecked and could have potentially caused a panic, and I also removed unwraps that came after `if val.is_some()` and replaced with either with an `if let`, or a `match` just to avoid any confusion when scanning the code that there may be an unchecked unwrap.

TODO: rebase -i once #1157 has been approved and merged to eliminate unnecessary commits