### PR TITLE
remove unnecessay second zpr path spec

### DIFF
--- a/.github/workflows/libnode.yml
+++ b/.github/workflows/libnode.yml
@@ -7,13 +7,11 @@ on:
       - 'libnode/**'
       - 'zpr/**'
       - '.github/workflows/libnode.yml'
-      - 'zpr/**'
   pull_request:
     paths:
       - 'libnode/**'
       - 'zpr/**'
       - '.github/workflows/libnode.yml'
-      - 'zpr/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This removes second zpr ref in the workflow that I'm not sure how I managed to introduce earlier.