### PR TITLE
update to zpr-policy 0.6.7

### DIFF
--- a/zpr/Makefile
+++ b/zpr/Makefile
@@ -4,7 +4,7 @@
 all: build
 
 build:
-	cargo build --all-targets
+	cargo build --all-targets -F all
 
 test:
 	cargo test --verbose

--- a/zpr/src/lib.rs
+++ b/zpr/src/lib.rs
@@ -3,12 +3,14 @@
 pub mod addrs;
 pub mod dn;
 pub mod packet_info;
-pub mod policy_types;
 pub mod rpc_commands;
 #[cfg(feature = "vsapi")]
 pub mod vsapi_types;
 #[cfg(feature = "vsapi")]
 pub mod vsapi_types_writers;
+#[cfg(feature = "policy")]
+pub mod policy_types;
+
 
 #[cfg(feature = "admin-api")]
 capnp::generated_code!(pub mod cli_capnp);

--- a/zpr/src/lib.rs
+++ b/zpr/src/lib.rs
@@ -3,14 +3,13 @@
 pub mod addrs;
 pub mod dn;
 pub mod packet_info;
+#[cfg(feature = "policy")]
+pub mod policy_types;
 pub mod rpc_commands;
 #[cfg(feature = "vsapi")]
 pub mod vsapi_types;
 #[cfg(feature = "vsapi")]
 pub mod vsapi_types_writers;
-#[cfg(feature = "policy")]
-pub mod policy_types;
-
 
 #[cfg(feature = "admin-api")]
 capnp::generated_code!(pub mod cli_capnp);

--- a/zpr/src/lib.rs
+++ b/zpr/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod addrs;
 pub mod dn;
 pub mod packet_info;
+pub mod policy_types;
 pub mod rpc_commands;
 pub mod vsapi_types;
 pub mod vsapi_types_writers;

--- a/zpr/src/policy_types/attribute.rs
+++ b/zpr/src/policy_types/attribute.rs
@@ -236,7 +236,7 @@ impl Attribute {
         } else {
             write!(f, "{}", key).unwrap();
             if self.is_multi_valued() {
-                write!(f, "{}", "{}").unwrap();
+                write!(f, "{{}}").unwrap();
             }
             if self.optional {
                 write!(f, "?").unwrap();
@@ -270,7 +270,7 @@ impl Attribute {
     ///
     /// ## Panics
     /// - if passed `name` does not start with `zpr`.
-    pub fn must_zpr_internal_attr<S: Into<String>>(name: S, value: S) -> Self {
+    pub fn must_zpr_internal_attr<S: Into<String>, T: Into<String>>(name: S, value: T) -> Self {
         if let Some(name_without_domain) = name
             .into()
             .strip_prefix(&format!("{}.", ATTR_DOMAIN_ZPR_INTERNAL))
@@ -293,7 +293,7 @@ impl Attribute {
     ///
     /// ## Panics
     /// - if passed `name` does not start with `zpr`.
-    pub fn must_zpr_internal_attr_mv<S: Into<String>>(name: S, value: S) -> Self {
+    pub fn must_zpr_internal_attr_mv<S: Into<String>, T: Into<String>>(name: S, value: T) -> Self {
         if let Some(name_without_domain) = name
             .into()
             .strip_prefix(&format!("{}.", ATTR_DOMAIN_ZPR_INTERNAL))

--- a/zpr/src/policy_types/attribute.rs
+++ b/zpr/src/policy_types/attribute.rs
@@ -1,0 +1,580 @@
+use crate::policy_types::error::AttributeError;
+use std::fmt;
+use std::fmt::Write;
+
+pub const ATTR_DOMAIN_SERVICE: &str = "service";
+pub const ATTR_DOMAIN_USER: &str = "user";
+pub const ATTR_DOMAIN_ENDPOINT: &str = "endpoint";
+pub const ATTR_DOMAIN_ZPR_INTERNAL: &str = "zpr";
+
+/// A ZPL attribute. Could be a tuple type attribute, eg "user.role:marketing" or a
+/// tag type.  An attribute may be optional or required, and may be multi-valued
+/// or single-valued.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Attribute {
+    domain: AttrDomain,
+    name: String, // For a tag this is the tag name, else this is the attribute name.
+    values: Option<Vec<String>>, // For a tag, this is always None.
+    attr_type: AttrT,
+    pub optional: bool,
+}
+
+/// An attribute must live in one of our domains. When parsing sometimes we
+/// end up in an intermediate state where we don't know the domain yet so
+/// we use `Unspecified`.  An error will occur if we try to write policy
+/// and there remain any unspecified domains.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+pub enum AttrDomain {
+    Unspecified,
+    Endpoint,
+    User,
+    Service,
+    ZprInternal, // For compiler/visa-service use only
+}
+
+impl fmt::Display for AttrDomain {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AttrDomain::Endpoint => write!(f, "{}", ATTR_DOMAIN_ENDPOINT),
+            AttrDomain::User => write!(f, "{}", ATTR_DOMAIN_USER),
+            AttrDomain::Service => write!(f, "{}", ATTR_DOMAIN_SERVICE),
+            AttrDomain::ZprInternal => write!(f, "{}", ATTR_DOMAIN_ZPR_INTERNAL),
+            AttrDomain::Unspecified => write!(f, "UNSPECIFIED"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AttrT {
+    Tag,
+    SingleValued,
+    MultiValued,
+}
+
+/// Strategy to use when parsing attribute names and a domain is
+/// not present.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DomainFallback {
+    UseHint(AttrDomain),
+    UseUnspecified,
+    ErrorIfMissing,
+}
+
+pub struct TagAttrBuilder {
+    raw_name: String,
+    optional: bool,
+    domain_fb: DomainFallback,
+}
+
+pub struct TupleAttrBuilder {
+    raw_name: String,
+    attr_type: AttrT,
+    values: Option<Vec<String>>,
+    optional: bool,
+    domain_fb: DomainFallback,
+}
+
+/// Used to build an attribute that holds a tag.
+impl TagAttrBuilder {
+    fn new<N: Into<String>>(name: N) -> Self {
+        TagAttrBuilder {
+            raw_name: name.into(),
+            optional: false,
+            domain_fb: DomainFallback::ErrorIfMissing,
+        }
+    }
+
+    pub fn optional(mut self, optional: bool) -> Self {
+        self.optional = optional;
+        self
+    }
+
+    pub fn domain_hint(mut self, domain: AttrDomain) -> Self {
+        self.domain_fb = DomainFallback::UseHint(domain);
+        self
+    }
+
+    pub fn allow_unspecified(mut self) -> Self {
+        self.domain_fb = DomainFallback::UseUnspecified;
+        self
+    }
+
+    pub fn build(self) -> Result<Attribute, AttributeError> {
+        let (domain, name) = resolve_domain(&self.raw_name, self.domain_fb)?;
+        Ok(Attribute {
+            domain,
+            name,
+            values: None,
+            attr_type: AttrT::Tag,
+            optional: self.optional,
+        })
+    }
+}
+
+/// Used to build an attribute that holds a tuple that may also be multi-valued.
+impl TupleAttrBuilder {
+    fn new<N: Into<String>>(name: N) -> Self {
+        TupleAttrBuilder {
+            raw_name: name.into(),
+            attr_type: AttrT::SingleValued,
+            values: None,
+            optional: false,
+            domain_fb: DomainFallback::ErrorIfMissing,
+        }
+    }
+
+    pub fn single(mut self) -> Self {
+        self.attr_type = AttrT::SingleValued;
+        self
+    }
+
+    /// Note that single-valued is the default.
+    pub fn multi(mut self) -> Self {
+        self.attr_type = AttrT::MultiValued;
+        self
+    }
+
+    pub fn multi_if(mut self, multi: bool) -> Self {
+        if multi {
+            self.attr_type = AttrT::MultiValued;
+        } else {
+            self.attr_type = AttrT::SingleValued;
+        }
+        self
+    }
+
+    pub fn optional(mut self, optional: bool) -> Self {
+        self.optional = optional;
+        self
+    }
+
+    pub fn value<V: Into<String>>(mut self, v: V) -> Self {
+        self.values = Some(vec![v.into()]);
+        self
+    }
+
+    /// If you sent more than one value the resulting tuple will be
+    /// multi-valued type (you do not need to explicitly call `multi()`).
+    pub fn values(mut self, vals: Vec<String>) -> Self {
+        self.values = Some(vals);
+        self
+    }
+
+    pub fn values_opt(mut self, opt_vals: Option<Vec<String>>) -> Self {
+        if opt_vals.is_some() {
+            self.values = opt_vals;
+        }
+        self
+    }
+
+    pub fn domain_hint(mut self, hint: AttrDomain) -> Self {
+        self.domain_fb = DomainFallback::UseHint(hint);
+        self
+    }
+
+    pub fn allow_unspecified(mut self) -> Self {
+        self.domain_fb = DomainFallback::UseUnspecified;
+        self
+    }
+
+    pub fn build(self) -> Result<Attribute, AttributeError> {
+        let (domain, name) = resolve_domain(&self.raw_name, self.domain_fb)?;
+        let attr_type = match (&self.values, self.attr_type) {
+            (_, AttrT::MultiValued) => AttrT::MultiValued, // explicitly set by caller
+            (Some(v), AttrT::SingleValued) if v.len() > 1 => AttrT::MultiValued, // inferred from values
+            _ => AttrT::SingleValued,
+        };
+        Ok(Attribute {
+            domain,
+            name,
+            values: self.values,
+            attr_type,
+            optional: self.optional,
+        })
+    }
+}
+
+fn resolve_domain(name: &str, fb: DomainFallback) -> Result<(AttrDomain, String), AttributeError> {
+    match Attribute::parse_domain(name) {
+        Ok(pair) => Ok(pair),
+        Err(_) => match fb {
+            DomainFallback::UseHint(hint) => Ok((hint, name.into())),
+            DomainFallback::UseUnspecified => Ok((AttrDomain::Unspecified, name.into())),
+            DomainFallback::ErrorIfMissing => Err(AttributeError::InvalidDomain(name.into())),
+        },
+    }
+}
+
+impl Attribute {
+    /// New API using the builders.  The other new_xxx functions that create tags use this.
+    pub fn tag<N: Into<String>>(name: N) -> TagAttrBuilder {
+        TagAttrBuilder::new(name)
+    }
+
+    /// New API using the builders.  The other new_xxx functions that create singel or
+    /// multi-value attributes use this.
+    pub fn tuple<N: Into<String>>(name: N) -> TupleAttrBuilder {
+        TupleAttrBuilder::new(name)
+    }
+
+    /// String form of the attribute that also includes the schema hints like
+    /// the '{}' suffix for multi-valued and '?' for optional.
+    pub fn to_schema_string(&self) -> String {
+        let mut f = String::new();
+        let key = format!("{}.{}", self.domain, self.name);
+
+        if self.is_tag() {
+            write!(f, "#{}", key).unwrap();
+        } else if let Some(v) = &self.values {
+            if v.is_empty() {
+                write!(f, "{key}:").unwrap();
+            } else if v.len() == 1 {
+                write!(f, "{key}:{}", v[0]).unwrap();
+            } else {
+                write!(f, "{key}:{{{}}}", v.join(", ")).unwrap();
+            }
+        } else {
+            write!(f, "{}", key).unwrap();
+            if self.is_multi_valued() {
+                write!(f, "{}", "{}").unwrap();
+            }
+            if self.optional {
+                write!(f, "?").unwrap();
+            }
+        }
+        f
+    }
+
+    /// String form of the attribute without the additional schema hints.
+    pub fn to_instance_string(&self) -> String {
+        let mut f = String::new();
+        let key = format!("{}.{}", self.domain, self.name);
+        if self.is_tag() {
+            write!(f, "#{}", key).unwrap();
+        } else if let Some(v) = &self.values {
+            if v.is_empty() {
+                write!(f, "{key}:").unwrap();
+            } else if v.len() == 1 {
+                write!(f, "{key}:{}", v[0]).unwrap();
+            } else {
+                write!(f, "{key}:{{{}}}", v.join(", ")).unwrap();
+            }
+        } else {
+            // Not a tag and has no values not even empty?
+            write!(f, "{}", key).unwrap();
+        }
+        f
+    }
+
+    /// Special constructor for ZPR internal attributes with a single value.
+    ///
+    /// ## Panics
+    /// - if passed `name` does not start with `zpr`.
+    pub fn must_zpr_internal_attr<S: Into<String>>(name: S, value: S) -> Self {
+        if let Some(name_without_domain) = name
+            .into()
+            .strip_prefix(&format!("{}.", ATTR_DOMAIN_ZPR_INTERNAL))
+        {
+            match Attribute::tuple(name_without_domain)
+                .domain_hint(AttrDomain::ZprInternal)
+                .value(value)
+                .build()
+            {
+                Ok(atr) => atr,
+                Err(e) => panic!("invalid attribute: {}", e),
+            }
+        } else {
+            panic!("zpr internal attribute must start with 'zpr.'");
+        }
+    }
+
+    /// Special constructor for ZPR internal attribute with single value but
+    /// sets the MULTI_VALUE flag.
+    ///
+    /// ## Panics
+    /// - if passed `name` does not start with `zpr`.
+    pub fn must_zpr_internal_attr_mv<S: Into<String>>(name: S, value: S) -> Self {
+        if let Some(name_without_domain) = name
+            .into()
+            .strip_prefix(&format!("{}.", ATTR_DOMAIN_ZPR_INTERNAL))
+        {
+            match Attribute::tuple(name_without_domain)
+                .domain_hint(AttrDomain::ZprInternal)
+                .multi()
+                .value(value)
+                .build()
+            {
+                Ok(atr) => atr,
+                Err(e) => panic!("invalid attribute: {}", e),
+            }
+        } else {
+            panic!("zpr internal attribute must start with 'zpr.'");
+        }
+    }
+
+    /// Create and return a new attribute with the same characteristics of this one but with the new name provided.
+    /// If `new_name` includes a valid domain prefix, the returned attribute will have that domain.
+    pub fn clone_with_new_name<S: Into<String>>(&self, new_name: S) -> Self {
+        let mut new_a = self.clone();
+        let new_name = new_name.into();
+        let (dom, name) = match Attribute::parse_domain(&new_name) {
+            Ok((d, n)) => (d, n),
+            // If the new name does not have a domain prefix, use the current domain.
+            Err(_) => (self.domain.clone(), new_name.to_string()),
+        };
+        new_a.name = name;
+        new_a.domain = dom;
+        new_a
+    }
+
+    pub fn is_tag(&self) -> bool {
+        self.attr_type == AttrT::Tag
+    }
+
+    pub fn is_single_valued(&self) -> bool {
+        self.attr_type == AttrT::SingleValued
+    }
+
+    pub fn is_multi_valued(&self) -> bool {
+        self.attr_type == AttrT::MultiValued
+    }
+
+    pub fn get_values(&self) -> Option<&[String]> {
+        self.values.as_deref()
+    }
+
+    pub fn set_multi_valued(&mut self) -> Result<(), AttributeError> {
+        if self.is_tag() {
+            return Err(AttributeError::InvalidOperation(format!(
+                "attempt to set tag as multi valued on {}",
+                self.zplc_key()
+            )));
+        }
+        self.attr_type = AttrT::MultiValued;
+        Ok(())
+    }
+
+    /// Parse off one the ZPR domains from the key.  Does not work with ZPR internal domain.
+    /// Returns `(<domain>, <rest>)` from given key.
+    pub fn parse_domain(key: &str) -> Result<(AttrDomain, String), AttributeError> {
+        if let Some(renamed) = key.strip_prefix(&format!("{}.", ATTR_DOMAIN_ENDPOINT)) {
+            Ok((AttrDomain::Endpoint, renamed.to_string()))
+        } else if let Some(renamed) = key.strip_prefix(&format!("{}.", ATTR_DOMAIN_USER)) {
+            Ok((AttrDomain::User, renamed.to_string()))
+        } else if let Some(renamed) = key.strip_prefix(&format!("{}.", ATTR_DOMAIN_SERVICE)) {
+            Ok((AttrDomain::Service, renamed.to_string()))
+        } else {
+            Err(AttributeError::InvalidDomain(key.to_string()))
+        }
+    }
+
+    pub fn get_domain_ref(&self) -> &AttrDomain {
+        &self.domain
+    }
+
+    pub fn is_unspecified_domain(&self) -> bool {
+        self.domain == AttrDomain::Unspecified
+    }
+
+    pub fn is_domain(&self, domain: AttrDomain) -> bool {
+        self.domain == domain
+    }
+
+    /// Update the domain.
+    pub fn set_domain(&mut self, domain: AttrDomain) {
+        self.domain = domain;
+    }
+
+    /// The the ZPL name for the key of this attribute. The key is just the attribute name
+    /// unless this is a tag, in which case the key is "\<domain\>.zpr.tag".
+    pub fn zpl_key(&self) -> String {
+        if self.is_tag() {
+            format!("{}.zpr.tag", self.domain)
+        } else {
+            format!("{}.{}", self.domain, self.name)
+        }
+    }
+
+    /// The ZPL value for this attribute. If there is no value an empty string is returned.
+    /// If there are multiple values a comma separated list is returned.
+    pub fn zpl_value(&self) -> String {
+        if self.is_tag() {
+            format!("{}.{}", self.domain, self.name)
+        } else if let Some(v) = &self.values {
+            v.join(", ")
+        } else {
+            "".to_string()
+        }
+    }
+
+    /// If this is a tag you get the domain qualified tag name as the single value.
+    /// Otherwise, you get the set of values (which may be empty).
+    pub fn zpl_values(&self) -> Vec<String> {
+        if self.is_tag() {
+            return vec![format!("{}.{}", self.domain, self.name)];
+        }
+        if let Some(v) = &self.values {
+            let mut sorted_values = v.clone();
+            sorted_values.sort();
+            sorted_values
+        } else {
+            vec![]
+        }
+    }
+
+    /// Write an attribute key name as it might appear in zplc.
+    /// Value of the attribute is ignored.
+    /// - tags look like `#domain.name`
+    /// - regular tuples look like `domain.name`
+    /// - multi-valued attributes look like `domain.name{}`
+    pub fn zplc_key(&self) -> String {
+        let mut result = String::new();
+        if self.is_tag() {
+            result.push_str("#");
+        }
+        result.push_str(&format!("{}.{}", self.domain, self.name));
+        if self.is_multi_valued() {
+            result.push_str("{}");
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_attributes_kv() {
+        let a = Attribute::tuple("user.role")
+            .single()
+            .value("admin")
+            .build()
+            .unwrap();
+        assert_eq!(a.domain, AttrDomain::User);
+        assert_eq!(a.name, "role");
+        assert_eq!(a.values, Some(vec!["admin".to_string()]));
+        assert_eq!(a.is_multi_valued(), false);
+        assert_eq!(a.is_tag(), false);
+        assert_eq!(a.optional, false);
+        assert_eq!("user.role:admin", a.to_instance_string());
+        assert_eq!("user.role", a.zpl_key());
+        assert_eq!("admin", a.zpl_value());
+    }
+
+    #[test]
+    fn test_attributes_tag() {
+        let a = Attribute::tag("endpoint.hardened").build().unwrap();
+        assert_eq!(a.domain, AttrDomain::Endpoint);
+        assert_eq!(a.name, "hardened");
+        assert_eq!(a.values, None);
+        assert_eq!(a.is_multi_valued(), false);
+        assert_eq!(a.is_tag(), true);
+        assert_eq!(a.optional, false);
+        assert_eq!("#endpoint.hardened", a.to_instance_string());
+        assert_eq!("endpoint.zpr.tag", a.zpl_key());
+        assert_eq!("endpoint.hardened", a.zpl_value());
+    }
+
+    #[test]
+    fn test_attrributes_internal() {
+        let a = Attribute::must_zpr_internal_attr("zpr.role", "admin");
+        assert_eq!(a.domain, AttrDomain::ZprInternal);
+        assert_eq!(a.name, "role");
+        assert_eq!(a.values, Some(vec!["admin".to_string()]));
+        assert_eq!(a.is_multi_valued(), false);
+        assert_eq!(a.is_tag(), false);
+        assert_eq!(a.optional, false);
+        assert_eq!("zpr.role:admin", a.to_instance_string());
+        assert_eq!("zpr.role", a.zpl_key());
+        assert_eq!("admin", a.zpl_value());
+    }
+
+    #[test]
+    fn test_zplc_key_regular_attribute() {
+        let a = Attribute::tuple("user.role")
+            .single()
+            .value("admin")
+            .build()
+            .unwrap();
+        assert_eq!("user.role", a.zplc_key());
+    }
+
+    #[test]
+    fn test_zplc_key_tag_attribute() {
+        let a = Attribute::tag("endpoint.hardened").build().unwrap();
+        assert_eq!("#endpoint.hardened", a.zplc_key());
+    }
+
+    #[test]
+    fn test_tag_representation() {
+        let a = Attribute::tag("user.red").build().unwrap();
+        assert_eq!("#user.red", a.to_instance_string());
+        assert_eq!("#user.red", a.to_schema_string());
+        assert_eq!("user.zpr.tag", a.zpl_key());
+        assert_eq!("user.red", a.zpl_value());
+    }
+
+    #[test]
+    fn test_zplc_key_multi_valued_attribute() {
+        let a = Attribute::tuple("user.groups").multi().build().unwrap();
+        assert_eq!("user.groups{}", a.zplc_key());
+    }
+
+    // ZPLC does not use "?" notation.
+    #[test]
+    fn test_zplc_key_optional() {
+        let mut a = Attribute::tuple("service.role").single().build().unwrap();
+        a.optional = true;
+        assert_eq!("service.role", a.zplc_key());
+        let mut a = Attribute::tag("endpoint.secure").build().unwrap();
+        a.optional = true;
+        assert_eq!("#endpoint.secure", a.zplc_key());
+        let mut a = Attribute::tuple("user.permissions")
+            .multi()
+            .build()
+            .unwrap();
+        a.optional = true;
+        assert_eq!("user.permissions{}", a.zplc_key());
+    }
+
+    #[test]
+    fn test_zplc_key_zpr_internal_attribute() {
+        let a = Attribute::must_zpr_internal_attr("zpr.adapter.cn", "test");
+        assert_eq!("zpr.adapter.cn", a.zplc_key());
+    }
+
+    #[test]
+    fn test_zplc_key_zpr_internal_multi_valued() {
+        let a = Attribute::must_zpr_internal_attr_mv("zpr.roles", "admin");
+        assert_eq!("zpr.roles{}", a.zplc_key());
+    }
+
+    #[test]
+    fn test_zplc_key_all_domains() {
+        // Test each domain type
+        let user_attr = Attribute::tuple("user.name")
+            .single()
+            .value("alice")
+            .build()
+            .unwrap();
+        assert_eq!("user.name", user_attr.zplc_key());
+
+        let service_attr = Attribute::tuple("service.type")
+            .single()
+            .value("web")
+            .build()
+            .unwrap();
+        assert_eq!("service.type", service_attr.zplc_key());
+
+        let endpoint_attr = Attribute::tuple("endpoint.ip")
+            .single()
+            .value("192.168.1.1")
+            .build()
+            .unwrap();
+        assert_eq!("endpoint.ip", endpoint_attr.zplc_key());
+
+        let zpr_attr = Attribute::must_zpr_internal_attr("zpr.test", "value");
+        assert_eq!("zpr.test", zpr_attr.zplc_key());
+    }
+}

--- a/zpr/src/policy_types/error.rs
+++ b/zpr/src/policy_types/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AttributeError {
+    #[error("Invalid attribute domain: {0}")]
+    InvalidDomain(String),
+
+    #[error("Invalid attribute: {0}")]
+    ParseError(String),
+
+    #[error("Invalid operation: {0}")]
+    InvalidOperation(String),
+}
+
+#[derive(Debug, Error)]
+pub enum PolicyTypeError {
+    #[error("attribute error: {0}")]
+    AttributeError(#[from] AttributeError),
+}

--- a/zpr/src/policy_types/join.rs
+++ b/zpr/src/policy_types/join.rs
@@ -1,0 +1,167 @@
+use crate::policy::v1;
+use crate::policy_types::writer::{WriteTo, write_attributes};
+
+use crate::policy_types::attribute::Attribute;
+
+pub struct JoinPolicy {
+    pub conditions: Vec<Attribute>,
+    pub flags: PFlags,
+    pub provides: Option<Vec<Service>>,
+}
+
+/// Service is part of a join policy.
+pub struct Service {
+    pub id: String,
+    pub endpoints: Vec<Scope>,
+    pub kind: ServiceType,
+}
+
+/// This struct mirrors what is in the capnp schema.
+/// Used in comm policies and join policies.
+pub struct Scope {
+    pub protocol: u8,
+    pub flag: Option<ScopeFlag>,
+    pub port: Option<u16>,
+    pub port_range: Option<(u16, u16)>,
+}
+
+/// This scope flag mirrors what is in the capnp schema.
+#[derive(PartialEq, Eq, Debug)]
+#[allow(dead_code)]
+pub enum ScopeFlag {
+    UdpOneWay,
+    IcmpRequestReply,
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub enum ServiceType {
+    #[default]
+    Undefined,
+    Trusted(String), // Takes the API name
+    Authentication,
+    Visa,
+    Regular,
+    BuiltIn, // eg, node access to VS, or VS access to VSS
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Copy)]
+pub struct PFlags {
+    pub node: bool,
+    pub vs: bool,
+    pub vs_dock: bool,
+}
+
+impl PFlags {
+    /// Create the set of flags for a node.
+    pub fn node(is_vs_dock: bool) -> PFlags {
+        PFlags {
+            node: true,
+            vs: false,
+            vs_dock: is_vs_dock,
+        }
+    }
+
+    /// Create the set of flags for a visa service.
+    pub fn vs() -> PFlags {
+        PFlags {
+            node: false,
+            vs: true,
+            vs_dock: false,
+        }
+    }
+
+    pub fn or(&mut self, other: Self) {
+        self.node |= other.node;
+        self.vs |= other.vs;
+        self.vs_dock |= other.vs_dock;
+    }
+
+    /// Returns number of "set" flags.
+    pub fn count(&self) -> usize {
+        let mut count = 0;
+        if self.node {
+            count += 1;
+        }
+        if self.vs {
+            count += 1;
+        }
+        if self.vs_dock {
+            count += 1;
+        }
+        count
+    }
+}
+
+impl WriteTo<v1::j_policy::Builder<'_>> for JoinPolicy {
+    fn write_to(&self, bldr: &mut v1::j_policy::Builder) {
+        let mut matches_bldr = bldr.reborrow().init_match(self.conditions.len() as u32);
+        write_attributes(&self.conditions, &mut matches_bldr);
+
+        if let Some(provides) = &self.provides {
+            let mut provides_bldr = bldr.reborrow().init_provides(provides.len() as u32);
+            write_services(provides, &mut provides_bldr);
+        }
+
+        if self.flags.count() > 0 {
+            let mut flags_bldr = bldr.reborrow().init_flags(self.flags.count() as u32);
+            let mut idx = 0;
+            if self.flags.node {
+                flags_bldr.set(idx, v1::JoinFlag::Node);
+                idx += 1;
+            }
+            if self.flags.vs {
+                flags_bldr.set(idx, v1::JoinFlag::Vs);
+                idx += 1;
+            }
+            if self.flags.vs_dock {
+                flags_bldr.set(idx, v1::JoinFlag::Vsdock);
+            }
+        }
+    }
+}
+
+/// Write a services list into capn proto List.
+fn write_services(
+    services: &[Service],
+    builder: &mut capnp::struct_list::Builder<'_, v1::service::Owned>,
+) {
+    for (i, service) in services.iter().enumerate() {
+        let mut s = builder.reborrow().get(i as u32);
+        s.set_id(&service.id);
+        let mut endpoints = s.reborrow().init_endpoints(service.endpoints.len() as u32);
+        for (j, endpoint) in service.endpoints.iter().enumerate() {
+            let mut scope_bldr = endpoints.reborrow().get(j as u32);
+            scope_bldr.set_protocol(endpoint.protocol as u8);
+            if let Some(flowtype) = &endpoint.flag {
+                match flowtype {
+                    ScopeFlag::IcmpRequestReply => {
+                        scope_bldr.set_flag(v1::ScopeFlag::IcmpRequestRepl);
+                    }
+                    ScopeFlag::UdpOneWay => {
+                        scope_bldr.set_flag(v1::ScopeFlag::UdpOneWay);
+                    }
+                }
+            }
+            if let Some(port) = endpoint.port {
+                let mut portnum_bldr = scope_bldr.reborrow().init_port();
+                portnum_bldr.set_port_num(port);
+            }
+            if let Some(port_range) = endpoint.port_range {
+                let mut port_range_bldr = scope_bldr.reborrow().init_port_range();
+                port_range_bldr.set_low(port_range.0);
+                port_range_bldr.set_high(port_range.1);
+            }
+        }
+        let mut kind_bldr = s.init_kind();
+        match &service.kind {
+            ServiceType::Authentication => kind_bldr.set_auth(()),
+            ServiceType::Regular => kind_bldr.set_regular(()),
+            ServiceType::BuiltIn => kind_bldr.set_builtin(()),
+            ServiceType::Visa => kind_bldr.set_visa(()),
+            ServiceType::Trusted(name) => kind_bldr.set_trusted(name),
+            ServiceType::Undefined => {
+                panic!("service with undefined type/kind"); // programming error
+            }
+        }
+    }
+}

--- a/zpr/src/policy_types/mod.rs
+++ b/zpr/src/policy_types/mod.rs
@@ -1,0 +1,11 @@
+//! Shared implementations of types related to the policy Capn Proto.
+
+mod attribute;
+mod error;
+mod join;
+mod writer;
+
+pub use attribute::{AttrDomain, Attribute};
+pub use error::{AttributeError, PolicyTypeError};
+pub use join::{JoinPolicy, PFlags, Scope, ScopeFlag, Service, ServiceType};
+pub use writer::{WriteTo, write_attributes};

--- a/zpr/src/policy_types/writer.rs
+++ b/zpr/src/policy_types/writer.rs
@@ -1,0 +1,32 @@
+use crate::policy::v1;
+use crate::policy_types::attribute::Attribute;
+
+/// A trait for writing to a builder type. This is the pattern used to write Cap'n Proto messages.
+pub trait WriteTo<Bldr> {
+    fn write_to(&self, bldr: &mut Bldr);
+}
+
+/// Helper to write attributes into capnp AttrExpr list.
+/// We have to do this for client conditions and service conditions.
+pub fn write_attributes(
+    attrs: &[Attribute],
+    conds: &mut capnp::struct_list::Builder<'_, v1::attr_expr::Owned>,
+) {
+    for (j, attr) in attrs.iter().enumerate() {
+        let mut ccond = conds.reborrow().get(j as u32);
+        // foo:fee    (foo, eq, fee)
+        // foo:       (foo, has, "")
+        ccond.set_key(&attr.zpl_key());
+        let vals = attr.zpl_values();
+
+        if vals.is_empty() || vals[0].is_empty() || attr.is_multi_valued() {
+            ccond.set_op(v1::AttrOp::Has);
+        } else {
+            ccond.set_op(v1::AttrOp::Eq);
+        }
+        let mut cvals = ccond.init_value(vals.len() as u32);
+        for (i, val) in vals.iter().enumerate() {
+            cvals.set(i as u32, val);
+        }
+    }
+}


### PR DESCRIPTION
I believe this now pulls in v0.6.7 of zpr-policy.  Once this goes in I'll tag zpr crate so that I can use the new features in the compiler and visa service.

This also now includes "policy_types" which are a bunch of type code from the compiler that will also be useful in the visa service.

