### PR TITLE
bind request rework

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -21,17 +21,14 @@ pub async fn launch(
                 let mgmt_pkt = Packet::new_with_existing_metadata(pkt.buffer().clone());
                 drop(msg);
 
-                // for now, perform these sequentially...
-                // ideally, we place these into a JoinSet,
-                // but let's work out how message sequencing works before doing that!!
-                do_request_tether_id(&asm, mgmt_pkt).await;
+                do_request_tether_id(&asm, mgmt_pkt);
             }
         }
     }
 }
 
 // RFC 6.5 § 6.3.11
-async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
+fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
     let dock_link_id = DOCK_LINK_ID;
 
     // copy out five tuple so we can give away packet
@@ -87,36 +84,15 @@ async fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
 
     match asm.ph_mode {
         PhMode::Adapter => {
-            mgmt::requests::send_bind_actor_address_request(
-                asm,
-                dock_link_id,
-                txn_id,
-                &five_tuple,
-                &packet_body,
-            )
-            .enqueue();
+            mgmt::requests::send_bind_actor_address_request(asm, dock_link_id, txn_id, &packet_body)
+                .enqueue()
         }
 
-        PhMode::Node => {
-            let bind_result = mgmt::dock::bind_actor_address(
-                asm,
-                NonZero::new(LOCAL_ACTOR_LINK_ID).unwrap(),
-                &five_tuple,
-                &packet_body,
-            )
-            .await;
-
-            match bind_result {
-                Ok((tether_id, tc)) => {
-                    mgmt::adapter::install_tether(asm, &txn, tether_id, tc).unwrap()
-                }
-
-                Err(err) => {
-                    // Bind failed; remove pending entry from ELT.
-                    debug!(target: FLOW_MGMT, "Bind of {five_tuple} failed: {err}");
-                    asm.elt.remove(&five_tuple).unwrap();
-                }
-            }
-        }
+        PhMode::Node => mgmt::dock::bind_actor_address(
+            asm,
+            NonZero::new(LOCAL_ACTOR_LINK_ID).unwrap(),
+            txn_id,
+            &packet_body,
+        ),
     }
 }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -4,20 +4,17 @@ use crate::capture_worker::CaptureWorker;
 use crate::config;
 use crate::counters::*;
 use crate::flow_control::FlowControl;
-use crate::forwarding_tables;
 use crate::km_cert_exchange::KmCertExchange;
 use crate::km_multiplexor::KmState;
 use crate::km_noise;
 use crate::link_state::{LinkEvent, LinkStateError, LinkType};
 use crate::logging::targets::PEER_MGMT;
-use crate::mgmt;
 use crate::mgmt_processor_worker;
 use crate::peer_table;
 use crate::peer_table::PeerInsertError;
 use crate::queues::*;
 use crate::rcu;
 use crate::special_peers::SpecialPeerName;
-use crate::tc;
 use crate::tun_ctl::TunCtl;
 use crate::visa_table;
 use crate::zdp::TerminateReason;
@@ -28,14 +25,11 @@ use std::net::IpAddr;
 use std::num::NonZero;
 use std::result::Result;
 use std::sync::{Arc, Mutex};
-use thiserror::Error;
 use tracing::*;
 use tracing_subscriber::filter::targets::Targets;
 #[allow(unused_imports)]
 use tracing_subscriber::{Layer, Registry, filter, fmt, reload};
-use zpr::packet_info::{
-    ForwardingEntry, LOCAL_ACTOR_LINK_ID, LinkId, StreamId, SubstrateAddr, VisaId,
-};
+use zpr::packet_info::{LOCAL_ACTOR_LINK_ID, LinkId, SubstrateAddr};
 use zpr::vsapi_types::AuthServicesList;
 use zpr_utils::net_defs::{IpAddress, ScopedIpAddr};
 
@@ -107,18 +101,6 @@ pub struct Assembly {
     pub logging: Mutex<HashMap<String, String>>,
     pub reload_handle:
         reload::Handle<filter::Filtered<fmt::Layer<Registry>, Targets, Registry>, Registry>,
-}
-
-#[derive(Debug, Error)]
-pub enum AddRouteError {
-    #[error("bind failed: {0}")]
-    BindFailed(#[from] mgmt::requests::BindActorAddressError),
-    #[error("peer gone")]
-    PeerGone,
-    #[error("PFT full")]
-    PftFull,
-    #[error("Visa gone")]
-    VisaGone,
 }
 
 impl Assembly {
@@ -370,69 +352,6 @@ impl Assembly {
                     .any(|addr| *addr == actor_addr)
             })
             .map(|(id, _peer)| id)
-    }
-
-    // CTP TODO: so much to fix here as we properly implement classification & forwarding
-    pub async fn add_route(
-        &self,
-        ingress_link_id: NonZero<LinkId>,
-        visa_id: VisaId,
-        tc: tc::Ip5TupleTc,
-        egress_link_id: NonZero<LinkId>,
-    ) -> Result<StreamId, AddRouteError> {
-        let egress_tether_id;
-        if egress_link_id.get() == LOCAL_ACTOR_LINK_ID {
-            egress_tether_id = self
-                .dlt
-                .insert(adapter_tables::DltPep {
-                    compression_mode: tc.compression_mode(),
-                    five_tuple: *tc.five_tuple(),
-                })
-                .map_err(|()| {
-                    AddRouteError::BindFailed(
-                        mgmt::requests::BindActorAddressError::BindActorAddressError(
-                            "DLT full".into(),
-                        ),
-                    )
-                })?;
-        } else {
-            egress_tether_id =
-                mgmt::requests::send_bind_egress_stream_request(self, egress_link_id.get(), tc)
-                    .await?;
-        }
-
-        // form PEP
-        let pep = forwarding_tables::PftPep {
-            next_hop: ForwardingEntry(egress_link_id.get(), egress_tether_id),
-            visa_id: visa_id,
-        };
-
-        let Some(ingress_peer_state) = self.peer_table.get(ingress_link_id.get()) else {
-            return Err(AddRouteError::PeerGone);
-        };
-
-        let ingress_tether_id = ingress_peer_state
-            .pft
-            .insert(pep)
-            .map_err(|()| AddRouteError::PftFull)?;
-
-        if self
-            .visa_table
-            .write()
-            .unwrap()
-            .link_forwarding_entry(
-                visa_id,
-                ForwardingEntry(ingress_link_id.get(), ingress_tether_id),
-            )
-            .is_err()
-        {
-            // Visa was either never granted or has already been removed
-            // Route is no longer valid
-            ingress_peer_state.pft.remove(ingress_tether_id);
-            return Err(AddRouteError::VisaGone);
-        }
-
-        Ok(ingress_tether_id)
     }
 }
 

--- a/adapter/ph/src/forwarding_tables.rs
+++ b/adapter/ph/src/forwarding_tables.rs
@@ -6,7 +6,7 @@
 
 use crate::rcu::{RcuBox, RcuCslabEntryGuard};
 use cslab::{RcuCslab, RcuCslabReader};
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 use zpr::packet_info::{ForwardingEntry, StreamId, VisaId};
 
 const PEER_FORWARDING_TABLE_SIZE: usize = 1 << 20; // 1 million
@@ -16,6 +16,7 @@ const PEER_FORWARDING_TABLE_SIZE: usize = 1 << 20; // 1 million
 // and recompress
 // (necessary since (a) adapter can choose compression level, and (b)
 // visas may be more narrowly scoped than what can be compressed out)
+#[derive(Clone)]
 pub struct PftPep {
     pub next_hop: ForwardingEntry,
     pub visa_id: VisaId,
@@ -56,8 +57,18 @@ impl PeerForwardingTable {
             .get_guarded((tether_id as usize).wrapping_sub(1))
     }
 
+    pub fn vacant_entry(&self) -> Result<VacantPeerForwardingTableEntry<'_>, ()> {
+        let table_guard = self.table.lock().unwrap();
+
+        if matches!(table_guard.vacant_key(), Err(_)) {
+            return Err(());
+        };
+
+        Ok(VacantPeerForwardingTableEntry { table_guard })
+    }
+
     pub fn insert(&self, pep: PftPep) -> Result<StreamId, ()> {
-        Ok((self.table.lock().unwrap().insert(pep)? + 1) as StreamId)
+        Ok(self.vacant_entry()?.insert(pep))
     }
 
     pub fn remove(&self, tether_id: StreamId) {
@@ -73,5 +84,19 @@ impl PeerForwardingTable {
 
     pub fn clear(&self) {
         // TODO
+    }
+}
+
+pub struct VacantPeerForwardingTableEntry<'a> {
+    table_guard: MutexGuard<'a, RcuCslab<PftPep>>,
+}
+
+impl VacantPeerForwardingTableEntry<'_> {
+    pub fn key(&self) -> StreamId {
+        (self.table_guard.vacant_key().unwrap() + 1) as StreamId
+    }
+
+    pub fn insert(mut self, pep: PftPep) -> StreamId {
+        (self.table_guard.insert(pep).unwrap() + 1) as StreamId
     }
 }

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -395,6 +395,26 @@ impl LinkStateWrapper {
         addr_list
     }
 
+    /// Returns true if the specified address matches any of this link's assigned actor addresses.
+    pub fn has_actor_address(&self, addr: &IpAddress) -> bool {
+        self.locked_fsm
+            .lock()
+            .unwrap()
+            .actor_addresses
+            .iter()
+            .any(|a| a == addr)
+            || self.locked_data.lock().unwrap().aaa_address.as_ref() == Some(addr)
+    }
+
+    /// Sets the actor address of an internal link.
+    pub fn add_internal_actor_address(&self, addr: IpAddress) {
+        assert!(
+            self.is_internal(),
+            "attempt to directly set actor address of non-internal link"
+        );
+        self.locked_fsm.lock().unwrap().actor_addresses.push(addr);
+    }
+
     /// Tell the VS that this actor has disconnected.
     /// Used in a NODE context only.
     fn deregister_actor_addresses(&self, asm: &Arc<Assembly>) -> tokio::task::JoinSet<()> {

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -588,6 +588,20 @@ fn main() -> ExitCode {
         LOCAL_ACTOR_LINK_ID
     );
 
+    if matches!(ph_mode, PhMode::Node) {
+        // Nodes use this link as the source of bind requests from the
+        // internal adapter, which require that the originator has a valid
+        // actor address (which matches the requested source address).
+
+        for addr in &asm.config.get().zpr_addr {
+            asm.peer_table
+                .get(LOCAL_ACTOR_LINK_ID)
+                .unwrap()
+                .link_state_machine
+                .add_internal_actor_address(addr.into());
+        }
+    }
+
     //
     // instantiate tether if we're an adapter,
     // or "fake" internal dock link if we're a node

--- a/adapter/ph/src/mgmt/adapter.rs
+++ b/adapter/ph/src/mgmt/adapter.rs
@@ -1,12 +1,124 @@
-use super::txn_mgr;
-use crate::adapter_tables::EltPep;
-use crate::assembly::Assembly;
+//! Adapter API.
+//!
+//! These functions operate on the local adapter state at a high level.
+//!
+//! They are meant to be invoked either from [super::handlers] by an
+//! adapter in response to a message from a node, or directly by a node
+//! managing its local adapter.
+
+use super::{dock, txn_mgr};
+use crate::adapter_tables::{DltPep, EltPep};
+use crate::assembly::{Assembly, PhMode};
 use crate::counters::ManagementCounterType;
 use crate::logging::targets::FLOW_MGMT;
 use crate::queues;
 use crate::tc;
+use std::num::NonZero;
+use std::sync::Arc;
 use tracing::*;
-use zpr::packet_info::StreamId;
+use zpr::packet_info::{LOCAL_ACTOR_LINK_ID, LinkId, StreamId};
+
+/// Request to bind a stream which egresses from the local adapter.
+///
+/// `dock_link_id` identifies the link of the dock making this request.
+/// (This is currently always [zpr::packet_info::DOCK_LINK_ID]; on adapters,
+/// this represents the remote dock; on nodes, this represents the internal
+/// dock.)
+///
+/// `txn_id` is used when issuing responses to the dock to link them to
+/// this request.
+///
+/// `tc` is the traffic classifier for which the request is being made.
+///
+/// The bind is performed simply by inserting a PEP corresponding to the
+/// given TC into the DLT, generating a tether ID.
+///
+/// A success response (containing the tether ID) or error response (in
+/// the event that the DLT is full) is then issued to the dock, where these
+/// responses are handled by [`dock::install_tether()`] and [`dock::deny_tether()`]
+/// respectively.
+pub fn bind_egress_stream(
+    asm: &Arc<Assembly>,
+    dock_link_id: NonZero<LinkId>,
+    txn_id: txn_mgr::TxnId,
+    tc: tc::Ip5TupleTc,
+) {
+    debug!(
+        target: FLOW_MGMT,
+        "bind_egress_stream(dock_link_id={dock_link_id}, txn_id={txn_id}, tc={tc})");
+
+    // form PEP
+    let pep = DltPep {
+        compression_mode: tc.compression_mode(),
+        five_tuple: *tc.five_tuple(),
+    };
+
+    // TODO: reverse path
+
+    // attempt to insert into DLT and respond to requestor
+    match asm.dlt.insert(pep) {
+        Ok(tid) => {
+            // TODO: maybe tick a counter somewhere?
+            match asm.ph_mode {
+                PhMode::Node => {
+                    // we're a node operating on our internal adapter; "respond" directly to local dock
+                    let dock_peer_state = asm.peer_table.get(LOCAL_ACTOR_LINK_ID).unwrap();
+                    let Some(txn) = dock_peer_state.txn_mgr.get(txn_id) else {
+                        // adapter no longer has this transaction; ignore
+                        return;
+                    };
+
+                    let _ = dock::install_tether(
+                        asm,
+                        NonZero::new(LOCAL_ACTOR_LINK_ID).unwrap(),
+                        &txn,
+                        tid,
+                    ); // ignore missing transaction
+                }
+
+                PhMode::Adapter => super::requests::send_bind_egress_stream_success_response(
+                    asm,
+                    dock_link_id.get(),
+                    txn_id,
+                    tid,
+                )
+                .enqueue(),
+            }
+        }
+
+        Err(()) => {
+            // DLT full; respond with error message
+            let msg = "DLT full";
+            // TODO: maybe tick a counter somewhere?
+
+            match asm.ph_mode {
+                PhMode::Node => {
+                    // we're a node operating on our internal adapter; "respond" directly to local dock
+                    let dock_peer_state = asm.peer_table.get(LOCAL_ACTOR_LINK_ID).unwrap();
+                    let Some(txn) = dock_peer_state.txn_mgr.get(txn_id) else {
+                        // adapter no longer has this transaction; ignore
+                        return;
+                    };
+
+                    let _ = dock::deny_tether(
+                        asm,
+                        NonZero::new(LOCAL_ACTOR_LINK_ID).unwrap(),
+                        &txn,
+                        msg,
+                    ); // ignore missing transaction
+                }
+
+                PhMode::Adapter => super::requests::send_bind_egress_stream_error_response(
+                    asm,
+                    dock_link_id.get(),
+                    txn_id,
+                    msg,
+                )
+                .enqueue(),
+            }
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum InstallTetherError {
@@ -14,6 +126,15 @@ pub enum InstallTetherError {
 }
 
 /// Install the given tether into the ELT.
+///
+/// `txn` must refer to an active transaction on the dock link
+/// which had previously requested a tether (e.g.  via BindActorAddress).
+///
+/// `tether_id` is the ID to be used to refer to this tether.
+///
+/// `tc` is the traffic classifier to use to match traffic for this tether.
+///
+/// On success, the queued initial packet is then forwarded on the new tether.
 ///
 /// Completes the indicated transaction.
 ///
@@ -73,9 +194,16 @@ pub fn install_tether(
     Ok(())
 }
 
-/// Deny the given tether request.
+/// Deny the given tether request, removing it from the ALT.
+///
+/// `txn` must refer to an active transaction on the dock link
+/// which had previously requested a tether.
+///
+/// `reason` is a human-readable reason why the tether was denied.
 ///
 /// Completes the indicated transaction.
+///
+/// Returns an error only if the transaction is invalid.
 pub fn deny_tether(
     asm: &Assembly,
     txn: &txn_mgr::TxnHandle,

--- a/adapter/ph/src/mgmt/adapter.rs
+++ b/adapter/ph/src/mgmt/adapter.rs
@@ -63,17 +63,17 @@ pub fn bind_egress_stream(
                 PhMode::Node => {
                     // we're a node operating on our internal adapter; "respond" directly to local dock
                     let dock_peer_state = asm.peer_table.get(LOCAL_ACTOR_LINK_ID).unwrap();
-                    let Some(txn) = dock_peer_state.txn_mgr.get(txn_id) else {
-                        // adapter no longer has this transaction; ignore
-                        return;
-                    };
-
-                    let _ = dock::install_tether(
+                    let txn = dock_peer_state
+                        .txn_mgr
+                        .get(txn_id)
+                        .expect("local dock lost transaction");
+                    dock::install_tether(
                         asm,
                         NonZero::new(LOCAL_ACTOR_LINK_ID).unwrap(),
                         &txn,
                         tid,
-                    ); // ignore missing transaction
+                    )
+                    .expect("local dock rejected tether response");
                 }
 
                 PhMode::Adapter => super::requests::send_bind_egress_stream_success_response(
@@ -95,17 +95,12 @@ pub fn bind_egress_stream(
                 PhMode::Node => {
                     // we're a node operating on our internal adapter; "respond" directly to local dock
                     let dock_peer_state = asm.peer_table.get(LOCAL_ACTOR_LINK_ID).unwrap();
-                    let Some(txn) = dock_peer_state.txn_mgr.get(txn_id) else {
-                        // adapter no longer has this transaction; ignore
-                        return;
-                    };
-
-                    let _ = dock::deny_tether(
-                        asm,
-                        NonZero::new(LOCAL_ACTOR_LINK_ID).unwrap(),
-                        &txn,
-                        msg,
-                    ); // ignore missing transaction
+                    let txn = dock_peer_state
+                        .txn_mgr
+                        .get(txn_id)
+                        .expect("local dock lost transaction");
+                    dock::deny_tether(asm, NonZero::new(LOCAL_ACTOR_LINK_ID).unwrap(), &txn, msg)
+                        .expect("local dock rejected tether response");
                 }
 
                 PhMode::Adapter => super::requests::send_bind_egress_stream_error_response(

--- a/adapter/ph/src/mgmt/dock.rs
+++ b/adapter/ph/src/mgmt/dock.rs
@@ -486,13 +486,13 @@ fn requested_tether_granted(
     // Send a success response to the requestor with the tether ID.
 
     if ingress_peer_state.is_internal() {
-        let dock_peer_state = asm.peer_table.get(DOCK_LINK_ID).unwrap();
-        let Some(txn) = dock_peer_state.txn_mgr.get(txn_id) else {
-            // adapter no longer has this transaction; ignore
-            return;
-        };
-
-        let _ = adapter::install_tether(asm, &txn, ingress_tether_id, tc); // ignore missing transaction
+        let adapter_peer_state = asm.peer_table.get(DOCK_LINK_ID).unwrap();
+        let txn = adapter_peer_state
+            .txn_mgr
+            .get(txn_id)
+            .expect("local adapter lost transaction");
+        adapter::install_tether(asm, &txn, ingress_tether_id, tc)
+            .expect("local adapter rejected tether response");
     } else {
         requests::send_bind_actor_address_success_response(
             asm,
@@ -560,13 +560,12 @@ fn bind_actor_address_reject(
     // Send an error response to the requestor.
 
     if ingress_peer_state.is_internal() {
-        let dock_peer_state = asm.peer_table.get(DOCK_LINK_ID).unwrap();
-        let Some(txn) = dock_peer_state.txn_mgr.get(txn_id) else {
-            // adapter no longer has this transaction; ignore
-            return;
-        };
-
-        let _ = adapter::deny_tether(asm, &txn, reason); // ignore missing transaciton
+        let adapter_peer_state = asm.peer_table.get(DOCK_LINK_ID).unwrap();
+        let txn = adapter_peer_state
+            .txn_mgr
+            .get(txn_id)
+            .expect("local adapter lost transaction");
+        adapter::deny_tether(asm, &txn, reason).expect("local adapter rejected tether response");
     } else {
         requests::send_bind_actor_address_error_response(
             asm,

--- a/adapter/ph/src/mgmt/dock.rs
+++ b/adapter/ph/src/mgmt/dock.rs
@@ -1,165 +1,708 @@
-use crate::assembly::{AddRouteError, Assembly};
+//! Dock API.
+//!
+//! These functions operate the local dock state at a high level.
+//!
+//! They are meant to be invoked either from [super::handlers] by a node in
+//! response to a message from an adapter, or directly by a node managing
+//! its local adapter.
+
+// A lot of this functionality is similar/shared between node->adapter
+// and node->node links.  It will need to be rearranged somewhat to reflect
+// the similarities and differences.  However since for now we don't have
+// node->node links, we don't make the distinction (so some terminology
+// choices are weird).
+
+use super::txn_mgr::{TxnHandle, TxnId};
+use super::{adapter, requests};
+use crate::assembly::Assembly;
+use crate::classifier;
 use crate::counters::ManagementCounterType;
 use crate::defs::FiveTuple;
+use crate::forwarding_tables;
 use crate::logging::targets::FLOW_MGMT;
-use crate::tc;
 use crate::visa_mgmt;
 use crate::visa_table::VisaTableError;
 
+use dashmap::DashMap;
 use libnode::vsconn;
 use std::num::NonZero;
 use std::sync::Arc;
-use thiserror::Error;
 use tracing::*;
-use zpr::packet_info::{LinkId, StreamId, VisaId};
+use zpr::packet_info::{
+    DOCK_LINK_ID, ForwardingEntry, LOCAL_ACTOR_LINK_ID, LinkId, StreamId, VisaId,
+};
 use zpr::vsapi_types;
 
-#[derive(Debug, Error)]
-pub enum BindActorAddressError {
-    #[error("policy error")]
-    PolicyError,
-    #[error("parse error: {0}")]
-    ParseError(&'static str),
-    #[error("adding route failed: {0}")]
-    AddRouteError(#[from] AddRouteError),
+/// State of an in-progress inbound bind request.
+enum BindRequestState {
+    /// We have issued a visa request and are currently awaiting a response.
+    /// The parameter is a join handle for the task which is performing the
+    /// visa request.  Note that this join handle is mostly only useful for
+    /// monitoring, since the subsequent state transitions are issued from
+    /// within the task it references, so we can't usefully join it.
+    AwaitingVisaResponse(#[allow(dead_code)] tokio::task::JoinHandle<()>),
+
+    //AwaitingVisaPush(VisaId),  // for future node->node use
+    /// We have a visa with the indicated ID, and are now waiting
+    /// on completion of the next-hop bind request issued on the indicated
+    /// next-hop link and identified by the indicated transaction handle.
+    AwaitingNextHopBind {
+        visa_id: VisaId,
+        egress_link_id: NonZero<LinkId>,
+        egress_bind_txn: TxnHandle,
+    },
 }
 
-pub struct ForwardingDecision {
-    pub egress_link_id: NonZero<LinkId>,
-    pub visa_id: VisaId,
+/// Per-peer state related to the docking session and managed by the code in this module.
+pub struct DockingSessionPeerState {
+    /// In-progress inbound bind requests from this peer.  The key is the ID
+    /// of a transaction opened by the peer; the value is the state of that
+    /// bind request.
+    bind_request_state: DashMap<TxnId, BindRequestState>,
+
+    /// In-progress outbound bind requests to this peer.  The key is the handle
+    /// of a transaction we opened; the value is a link ID × transaction ID
+    /// pair identifying the in-progress inbound bind request this request
+    /// was issued on behalf of.
+    awaiting_next_hop_bind_table: DashMap<TxnHandle, (NonZero<LinkId>, TxnId)>,
 }
 
-/// Fulfills a Bind Actor Address request.
-/// Returns the ingress tether ID on success.
-pub async fn bind_actor_address(
+impl DockingSessionPeerState {
+    pub fn new() -> Self {
+        Self {
+            bind_request_state: DashMap::new(),
+            awaiting_next_hop_bind_table: DashMap::new(),
+        }
+    }
+}
+
+/// Request to bind a stream which ingresses to this dock from an attached adapter.
+///
+/// `ingress_link_id` indicates the adapter which has made this request.
+///
+/// `txn_id` is used when issuing responses to the adapter to link them to this request.
+///
+/// `packet_body` is a prefix of the body of the packet which triggered this request which
+/// will be presented to the Visa service to categorize and authorize this flow.
+///
+/// This launches a state machine associated with the indicated ingress link
+/// and transaction which transitions through the following steps:
+///
+/// ```
+///           ↓            [← bind_actor_address()]
+///   AwaitingVisaResponse [→ issue visa request]
+///           ↓            [← requested_visa_granted()]
+///   AwaitingNextHopBind  [→ request next hop tether]
+///           ↓            [← requested_tether_granted()]
+///         Active         [create entry in visa table]
+/// ```
+///
+/// `AwaitingVisaResponse` is skipped if a matching visa is already present.
+///
+/// `requested_visa_denied()` and `deny_tether()`, as well as various other errors,
+/// result in the bind request being denied.
+///
+/// On completion of the state machine, a success response (containing the
+/// tether ID and traffic classifier) or error response (in the event that
+/// the bind request was denied) is then issued to the adapter, where these
+/// responses are handled by [`adapter::install_tether()`] and [`adapter::deny_tether()`]
+/// respectively.
+pub fn bind_actor_address(
     asm: &Arc<Assembly>,
     ingress_link_id: NonZero<LinkId>,
-    five_tuple: &FiveTuple,
+    txn_id: TxnId,
     packet_body: &[u8],
-) -> Result<(StreamId, tc::Ip5TupleTc), BindActorAddressError> {
-    let mut forwarding_decision: Option<ForwardingDecision> = None;
-
+) {
     debug!(
         target: FLOW_MGMT,
-        "DOCK.bind_actor_address called with five_tuple {five_tuple} from ingress_link_id {ingress_link_id}",
-    );
+        "bind_actor_address(ingress_link_id={ingress_link_id}, txn_id={txn_id})");
 
-    if let Some(matched) = asm.visa_table.read().unwrap().match_traffic(&five_tuple) {
+    // Determine five-tuple of the initial packet.
+
+    let mut five_tuple = FiveTuple::default();
+
+    let classifier_options =
+        classifier::ClassifierOptions::default().ignore_truncated_packets(true);
+
+    match classifier::classify_with_options(&mut five_tuple, packet_body, &classifier_options) {
+        Ok(classifier::ClassifierResult::OK) => (),
+        Ok(classifier::ClassifierResult::UnclassifiedL4) => {
+            warn!(target: FLOW_MGMT, "Link {ingress_link_id}: bind request: unsupported IP protocol {}", five_tuple.l4_protocol);
+            return requested_visa_denied(asm, ingress_link_id, txn_id);
+        }
+        _ => {
+            warn!(target: FLOW_MGMT, "Link {ingress_link_id}: bind request: invalid initial packet");
+            return requested_visa_denied(asm, ingress_link_id, txn_id);
+        }
+    }
+
+    let Some(peer_state) = asm.peer_table.get(ingress_link_id.get()) else {
+        return;
+    };
+
+    // Ensure this adapter actually owns this source address.
+
+    if !peer_state
+        .link_state_machine
+        .has_actor_address(&five_tuple.src_address)
+    {
+        warn!(target: FLOW_MGMT, "Link {ingress_link_id}: bind request: source address {} does not match actor address", &five_tuple.src_address);
+        return requested_visa_denied(asm, ingress_link_id, txn_id);
+    }
+
+    // Check if we already have a visa which matches this traffic.
+
+    let visa_table = asm.visa_table.read().unwrap();
+
+    if let Some(matched) = visa_table.match_traffic(&five_tuple) {
         // We matched a visa we already have.
+
         let matched_visa_id = matched;
+        drop(visa_table);
+
         let egress_link_id_query = visa_mgmt::get_egress_link_for_visa(asm, matched_visa_id);
         match egress_link_id_query {
             Ok(link_id) => {
-                forwarding_decision = Some(ForwardingDecision {
-                    egress_link_id: link_id,
-                    visa_id: matched_visa_id,
-                });
                 debug!(
                     target: FLOW_MGMT,
                     "matched existing visa {matched_visa_id} for {five_tuple}, egress_link_id = {link_id}"
                 );
+                // This visa is valid; treat as an immediate grant.
+                return requested_visa_granted(asm, ingress_link_id, txn_id, matched_visa_id);
             }
-            Err(VisaTableError::ParseError(field)) => {
-                asm.counters.management[ManagementCounterType::VisaRequestError].increment();
-                error!(target: FLOW_MGMT, "visa request matching error: {field}");
-                return Err(BindActorAddressError::ParseError(field));
-            }
+
             Err(VisaTableError::NotFound(_)) => {
+                // The visa disappeared.
                 // This could happen if visa is somehow removed before we get here. In this case we
                 // can just proceed with a request.
                 debug!(
                     target: FLOW_MGMT,
-                    "visa request matching error: visa not found for {five_tuple}, proceeding with request"
+                    "visa request matching error: visa {matched_visa_id} for {five_tuple} racily deleted, proceeding with request"
                 );
             }
+
             Err(VisaTableError::DestNotFound(addr)) => {
+                // A visa exists, but we have no egress path for this destination address.
+                // Treat as an immediate denial.
                 asm.counters.management[ManagementCounterType::VisaRequestError].increment();
                 error!(target: FLOW_MGMT, "visa request matching error: destination address {addr} not found so no egress link");
-                return Err(BindActorAddressError::ParseError(
-                    "destination address not found",
-                ));
+                return requested_visa_denied(asm, ingress_link_id, txn_id);
             }
+
             Err(e) => {
                 panic!("Got unexpected error type {e}");
             }
         }
     }
 
-    if forwarding_decision.is_none() {
-        debug!(
-            target: FLOW_MGMT,
-            "issuing visa request for {five_tuple} from ingress_link_id {ingress_link_id} packet_body.len() = {}",
-            packet_body.len()
-        );
-        let visa_req = vsconn::VisaRequest {
-            source_tether_addr: five_tuple.src_address.into(),
-            l3_type: five_tuple.l3_type,
-            packet: packet_body.to_vec(),
-        };
+    // We do not have an existing visa.  Request one.
 
-        asm.counters.management[ManagementCounterType::VisaRequested].increment();
-        match asm.vsconn.as_ref().unwrap().request_visa(visa_req).await {
-            Ok(visa_response) => match visa_response {
-                vsapi_types::VisaResponse::Allow(visa) => {
-                    let (visa_id, egress_link_id) =
-                        visa_mgmt::insert_visa(asm, visa).map_err(|e| match e {
-                            VisaTableError::ParseError(field) => {
-                                BindActorAddressError::ParseError(field)
-                            }
-                            e => panic!("Got unexpected error type {e}"),
-                        })?;
-                    forwarding_decision = Some(ForwardingDecision {
-                        egress_link_id,
-                        visa_id,
-                    });
-                    asm.counters.management[ManagementCounterType::VisaRequestSuccess].increment();
-                    debug!(
-                        target: FLOW_MGMT,
-                        "visa request succeeds, egress_link_id = {egress_link_id}"
-                    );
-                }
-                vsapi_types::VisaResponse::Deny(denied) => {
-                    asm.counters.management[ManagementCounterType::VisaRequestDenied].increment();
-                    debug!(target: FLOW_MGMT, "visa request denied: {:?}", denied.reason);
-                    return Err(BindActorAddressError::PolicyError);
-                }
-                // Not implemented as part of thrift visas
-                vsapi_types::VisaResponse::VSApiError(error) => {
-                    asm.counters.management[ManagementCounterType::VisaRequestError].increment();
-                    debug!(target: FLOW_MGMT, "visa request error with code: {:?} and message: {:?}", error.code, error.message);
-                    return Err(BindActorAddressError::PolicyError);
-                }
-            },
+    debug!(
+        target: FLOW_MGMT,
+        "issuing visa request for {five_tuple} from ingress_link_id {ingress_link_id} packet_body.len() = {}",
+        packet_body.len()
+    );
 
-            Err(err) => {
-                asm.counters.management[ManagementCounterType::VisaRequestError].increment();
-                error!(target: FLOW_MGMT, "visa request error: {err}");
-                return Err(BindActorAddressError::PolicyError);
-            }
+    let visa_req = vsconn::VisaRequest {
+        source_tether_addr: five_tuple.src_address.into(),
+        l3_type: five_tuple.l3_type, // TODO: this should come from the bind request, not the packet body
+        packet: packet_body.to_vec(),
+    };
+
+    asm.counters.management[ManagementCounterType::VisaRequested].increment();
+
+    // We need to ensure the visa-request task (spawned below) doesn't try
+    // to access the docking session state before this entry is in place.
+    // Since the task is spawned with `spawn_local()`, it will not start
+    // until after we yield somehow, which we don't between now and when we
+    // add this entry.  Nonetheless, to ensure this behavior isn't broken should
+    // the task be changed to spawn with `spawn()`, we begin instantiating the
+    // bind request state machine entry (i.e., take a lock on it) up here.
+    let bind_st_entry = peer_state
+        .docking_session_state
+        .bind_request_state
+        .entry(txn_id);
+
+    // Launch the visa-request task while holding a lock on its corresponding entry.
+    let jh = tokio::task::spawn_local(visa_request_task(
+        asm.clone(),
+        ingress_link_id,
+        txn_id,
+        visa_req,
+    ));
+
+    // Finish instantiating the bind request state.
+    bind_st_entry.insert(BindRequestState::AwaitingVisaResponse(jh));
+}
+
+/// Request a visa, on behalf of a bind request from the given link and transaction ID.
+///
+/// On completion, advances the bind-request state machine via
+/// `requested_visa_granted()` or `requested_visa_denied()` as appropriate.
+async fn visa_request_task(
+    asm: Arc<Assembly>,
+    ingress_link_id: NonZero<LinkId>,
+    txn_id: TxnId,
+    visa_req: vsconn::VisaRequest,
+) {
+    match asm.vsconn.as_ref().unwrap().request_visa(visa_req).await {
+        Ok(vsapi_types::VisaResponse::Allow(visa)) => {
+            let visa_id = match visa_mgmt::insert_visa(&asm, visa) {
+                Ok(vid) => vid,
+
+                Err(VisaTableError::ParseError(field)) => {
+                    error!(target: FLOW_MGMT, "Could not parse visa: {field}");
+                    return requested_visa_denied(&asm, ingress_link_id, txn_id);
+                }
+
+                Err(e) => panic!("Got unexpected error type {e}"),
+            };
+
+            asm.counters.management[ManagementCounterType::VisaRequestSuccess].increment();
+            debug!(target: FLOW_MGMT, "visa request succeeds, visa_id = {visa_id}");
+
+            requested_visa_granted(&asm, ingress_link_id, txn_id, visa_id);
+        }
+
+        Ok(vsapi_types::VisaResponse::Deny(denied)) => {
+            asm.counters.management[ManagementCounterType::VisaRequestDenied].increment();
+            debug!(target: FLOW_MGMT, "visa request denied: {:?}", denied.reason);
+            requested_visa_denied(&asm, ingress_link_id, txn_id)
+        }
+
+        // Not implemented as part of thrift visas
+        Ok(vsapi_types::VisaResponse::VSApiError(error)) => {
+            asm.counters.management[ManagementCounterType::VisaRequestError].increment();
+            debug!(target: FLOW_MGMT, "visa request error with code: {:?} and message: {:?}", error.code, error.message);
+            requested_visa_denied(&asm, ingress_link_id, txn_id)
+        }
+
+        Err(err) => {
+            error!(target: FLOW_MGMT, "visa request error: {err}");
+            requested_visa_denied(&asm, ingress_link_id, txn_id)
         }
     }
+}
 
-    // TODO: get this from the Visa Service
-    let tc = tc::Ip5TupleTc::new_with_compression_mode(0, *five_tuple);
+/// Notify the bind-request state machine that the visa it requested
+/// on behalf of transaction `txn_id` from adapter `ingress_link_id`
+/// is now available with the specified visa ID.
+///
+/// Advances the bind-request state machine from AwaitingVisaResponse to
+/// AwaitingNextHopBind by issuing a bind request to the next hop.
+fn requested_visa_granted(
+    asm: &Arc<Assembly>,
+    ingress_link_id: NonZero<LinkId>,
+    txn_id: TxnId,
+    visa_id: VisaId,
+) {
+    debug!(
+        target: FLOW_MGMT,
+        "requested_visa_granted(ingress_link_id={ingress_link_id}, txn_id={txn_id}, visa_id={visa_id})");
 
-    // Now way to get here without forwarding_decision being set.
-    let decision = forwarding_decision.unwrap();
-    debug!(target: FLOW_MGMT, "now routing {five_tuple} from {ingress_link_id} to {}",
-        decision.egress_link_id);
+    // Look up the egress link for this visa.
 
-    let route_result = asm
-        .add_route(
-            ingress_link_id,
-            decision.visa_id,
-            tc.clone(),
-            decision.egress_link_id,
+    let Ok(egress_link_id) = visa_mgmt::get_egress_link_for_visa(asm, visa_id) else {
+        // visa or egress link was deleted; consider visa denied
+        return requested_visa_denied(asm, ingress_link_id, txn_id);
+    };
+    let Some(egress_peer_state) = asm.peer_table.get(egress_link_id.get()) else {
+        // egress link was racily deleted; consider visa denied
+        return requested_visa_denied(asm, ingress_link_id, txn_id);
+    };
+
+    // Look up the traffic classifier for this visa.
+
+    let visa_table = asm.visa_table.read().unwrap();
+    let Some(visa) = visa_table.table.get(&visa_id) else {
+        // Visa was either never granted or has already been removed
+        // Route is no longer valid
+        return requested_visa_denied(asm, ingress_link_id, txn_id);
+    };
+    let tc = visa.get_tc();
+    drop(visa_table);
+
+    // Open a transaction on the egress link and move into AwaitingNextHopBind state.
+
+    let egress_bind_txn = egress_peer_state
+        .txn_mgr
+        .try_open()
+        .expect("FIXME TODO: bind backpressure #1176");
+
+    let Some(ingress_peer_state) = asm.peer_table.get(ingress_link_id.get()) else {
+        // requestor went away, bail!
+        return;
+    };
+    ingress_peer_state
+        .docking_session_state
+        .bind_request_state
+        .insert(
+            txn_id,
+            BindRequestState::AwaitingNextHopBind {
+                visa_id,
+                egress_link_id,
+                egress_bind_txn: egress_bind_txn.clone(),
+            },
+        );
+
+    // Issue a bind request on the egress link (first
+    // noting in the `awaiting_next_hop_bind_table` on the egress link
+    // how to route the reply).
+
+    let egress_bind_txn_id = egress_bind_txn.id();
+    egress_peer_state
+        .docking_session_state
+        .awaiting_next_hop_bind_table
+        .insert(egress_bind_txn, (ingress_link_id, txn_id));
+
+    if egress_link_id.get() == LOCAL_ACTOR_LINK_ID {
+        adapter::bind_egress_stream(
+            asm,
+            NonZero::new(DOCK_LINK_ID).unwrap(),
+            egress_bind_txn_id,
+            tc,
+        );
+    } else {
+        requests::send_bind_egress_stream_request(
+            asm,
+            egress_link_id.get(),
+            egress_bind_txn_id,
+            tc,
         )
-        .await;
+        .enqueue();
+    }
+}
 
-    // TODO: reverse ingress TID needs to be sent to next-hop;
-    // this is blocked on switching to new-style bind requests
+/// Notify the bind-request state machine that the visa it requested
+/// on behalf of transaction `txn_id` from adapter `ingress_link_id`
+/// was denied.
+///
+/// Terminates the bind-request state machine by sending a policy error
+/// back to the adapter which initiated the request.
+fn requested_visa_denied(asm: &Arc<Assembly>, ingress_link_id: NonZero<LinkId>, txn_id: TxnId) {
+    bind_actor_address_reject(asm, ingress_link_id, txn_id, "policy error")
+}
 
-    let ingress_stream_id = route_result?;
+/// Install the given tether into the PFT.
+///
+/// Essentially this is the core implementation of `install_tether()`,
+/// except (a) it's indexed by the link and transaction ID of the bind request
+/// which owns the state machine, and (b) it assumes the reverse mapping
+/// in the egress link has already been cleaned up.
+fn requested_tether_granted(
+    asm: &Arc<Assembly>,
+    ingress_link_id: NonZero<LinkId>,
+    txn_id: TxnId,
+    egress_tether_id: StreamId,
+) {
+    let Some(ingress_peer_state) = asm.peer_table.get(ingress_link_id.get()) else {
+        return;
+    };
 
-    Ok((ingress_stream_id, tc))
+    // Lookup (and hold locked) the bind-request state, to retrieve the
+    // associated egress information.  (It's a little redundant that we
+    // already have the egress information in our only caller
+    // (`install_tether()`), but retrieving it again here lets us maintain a
+    // clean API on this state machine.)
+
+    let dashmap::mapref::entry::Entry::Occupied(bind_st) = ingress_peer_state
+        .docking_session_state
+        .bind_request_state
+        .entry(txn_id)
+    else {
+        error!(target: FLOW_MGMT, "requested_tether_granted() called when no request outstanding (txn_id={txn_id})");
+        return;
+    };
+
+    let &BindRequestState::AwaitingNextHopBind {
+        visa_id,
+        egress_link_id,
+        ref egress_bind_txn,
+    } = bind_st.get()
+    else {
+        // should never happen; we check this in our only caller
+        error!(target: FLOW_MGMT, "requested_tether_granted() called in wrong state (txn_id={txn_id})");
+        return;
+    };
+
+    // Confirm that any associated next-hop-bind state no longer exists,
+    // since we're about to make it invalid.
+
+    if let Some(egress_peer_state) = asm.peer_table.get(egress_link_id.get()) {
+        assert!(
+            !egress_peer_state
+                .docking_session_state
+                .awaiting_next_hop_bind_table
+                .contains_key(&egress_bind_txn)
+        );
+    }
+
+    // Remove the bind-request state -- the state machine is now complete.
+
+    bind_st.remove();
+
+    // Reserve & lock a slot for (but do not yet insert) the ingress link's PFT.
+    // (This lets us query the tether ID which will be assigned before
+    // committing to an insert.)
+
+    let Ok(ingress_tether_entry) = ingress_peer_state.pft.vacant_entry() else {
+        // PFT full; respond with error message
+        // TODO: maybe tick a counter somewhere?
+        bind_actor_address_reject(asm, ingress_link_id, txn_id, "PFT full");
+        return;
+    };
+
+    // Link the PFT entry into the visa (while holding the lock on the PFT entry).
+
+    let mut visa_table = asm.visa_table.write().unwrap();
+
+    let Some(visa) = visa_table.table.get_mut(&visa_id) else {
+        // Visa was either never granted or has already been removed
+        // Route is no longer valid
+        requested_visa_denied(asm, ingress_link_id, txn_id);
+        return;
+    };
+
+    visa.link_forwarding_entry(ForwardingEntry(
+        ingress_link_id.get(),
+        ingress_tether_entry.key(),
+    ));
+
+    // Retrieve the traffic classifier from the visa.
+
+    let tc = visa.get_tc();
+
+    drop(visa_table);
+
+    // Form the PEP and insert into the PFT slot we reserved (producing a tether ID).
+
+    let pep = forwarding_tables::PftPep {
+        next_hop: ForwardingEntry(egress_link_id.get(), egress_tether_id),
+        visa_id,
+    };
+
+    let ingress_tether_id = ingress_tether_entry.insert(pep);
+
+    // Send a success response to the requestor with the tether ID.
+
+    if ingress_peer_state.is_internal() {
+        let dock_peer_state = asm.peer_table.get(DOCK_LINK_ID).unwrap();
+        let Some(txn) = dock_peer_state.txn_mgr.get(txn_id) else {
+            // adapter no longer has this transaction; ignore
+            return;
+        };
+
+        let _ = adapter::install_tether(asm, &txn, ingress_tether_id, tc); // ignore missing transaction
+    } else {
+        requests::send_bind_actor_address_success_response(
+            asm,
+            ingress_link_id.get(),
+            txn_id,
+            ingress_tether_id,
+            tc,
+        )
+        .enqueue();
+    }
+}
+
+/// Common functionality for exiting the bind request state machine with an error.
+///
+/// Removes this bind request from the `bind_request_state` table, and
+/// sends an error reply back to the requestor.
+///
+/// It is invalid and racy to call this while a next-hop-bind request is outstanding,
+/// as there is neither mechanism to discard replies to such a request, or to
+/// synchronize replies with termination of this state machine.
+fn bind_actor_address_reject(
+    asm: &Arc<Assembly>,
+    ingress_link_id: NonZero<LinkId>,
+    txn_id: TxnId,
+    reason: &str,
+) {
+    debug!(
+        target: FLOW_MGMT,
+        "bind_actor_address_reject(ingress_link_id={ingress_link_id}, txn_id={txn_id})");
+
+    let Some(ingress_peer_state) = asm.peer_table.get(ingress_link_id.get()) else {
+        return;
+    };
+
+    // Remove state from the bind-request state table.
+
+    if let Some((_, bind_st)) = ingress_peer_state
+        .docking_session_state
+        .bind_request_state
+        .remove(&txn_id)
+    {
+        // If we were awaiting the next-hop-bind...
+        if let BindRequestState::AwaitingNextHopBind {
+            egress_link_id,
+            egress_bind_txn,
+            ..
+        } = bind_st
+        {
+            // ...ensure we haven't left a lingering next-hop-bind entry.
+            // If we did, then we'd leave it referencing a no-longer-valid
+            // transaction.  This should never happen, and we can only check
+            // this racily since there's no synchronization between these
+            // flows, but check nonetheless.
+            if let Some(egress_peer_state) = asm.peer_table.get(egress_link_id.get()) {
+                assert!(
+                    !egress_peer_state
+                        .docking_session_state
+                        .awaiting_next_hop_bind_table
+                        .contains_key(&egress_bind_txn)
+                );
+            }
+        };
+    }
+
+    // Send an error response to the requestor.
+
+    if ingress_peer_state.is_internal() {
+        let dock_peer_state = asm.peer_table.get(DOCK_LINK_ID).unwrap();
+        let Some(txn) = dock_peer_state.txn_mgr.get(txn_id) else {
+            // adapter no longer has this transaction; ignore
+            return;
+        };
+
+        let _ = adapter::deny_tether(asm, &txn, reason); // ignore missing transaciton
+    } else {
+        requests::send_bind_actor_address_error_response(
+            asm,
+            ingress_link_id.get(),
+            txn_id,
+            reason,
+        )
+        .enqueue();
+    }
+}
+
+#[derive(Debug)]
+pub enum InstallTetherError {
+    /// The indicated egress transaction does not exist.
+    NoSuchTransaction,
+    /// The indicated egress link does not exist.
+    LinkClosed,
+}
+
+/// Install the given tether into the PFT.
+///
+/// `egress_link_id` indicates the adapter to which this tether is made.
+///
+/// `egress_txn` must refer to an active transaction on the adapter link which had
+/// previously requested a tether to the indicated adapter (e.g. via
+/// BindEgressStream).
+///
+/// `egress_tether_id` is the ID to be used to refer to this tether.
+///
+/// Completes the indicated transaction.
+///
+/// Returns an error only if the transaction is invalid.
+pub fn install_tether(
+    asm: &Arc<Assembly>,
+    egress_link_id: NonZero<LinkId>,
+    egress_txn: &TxnHandle,
+    egress_tether_id: StreamId,
+) -> Result<(), InstallTetherError> {
+    let (ingress_link_id, ingress_txn_id) =
+        resolve_next_hop_bind_originator(asm, egress_link_id, egress_txn)?;
+    Ok(requested_tether_granted(
+        asm,
+        ingress_link_id,
+        ingress_txn_id,
+        egress_tether_id,
+    ))
+}
+
+/// Deny the given tether request, removing it from the ALT.
+///
+/// `egress_link_id` indicates the adapter to which this tether is made.
+///
+/// `egress_txn` must refer to an active transaction on the adapter link
+/// which had previously requested a tether.
+///
+/// `reason` is a human-readable reason why the tether was denied.
+///
+/// Completes the indicated transaction.
+///
+/// Returns an error only if the transaction is invalid.
+pub fn deny_tether(
+    asm: &Arc<Assembly>,
+    egress_link_id: NonZero<LinkId>,
+    egress_txn: &TxnHandle,
+    reason: &str,
+) -> Result<(), InstallTetherError> {
+    let (ingress_link_id, ingress_txn_id) =
+        resolve_next_hop_bind_originator(asm, egress_link_id, egress_txn)?;
+    Ok(bind_actor_address_reject(
+        asm,
+        ingress_link_id,
+        ingress_txn_id,
+        reason,
+    ))
+}
+
+/// Resolve the originating bind-request state machine
+/// for the given next-hop-bind transaction.
+///
+/// Removes next-hop-bind state from the docking session state,
+/// and completes the indicated transaction.
+fn resolve_next_hop_bind_originator(
+    asm: &Arc<Assembly>,
+    egress_link_id: NonZero<LinkId>,
+    egress_txn: &TxnHandle,
+) -> Result<(NonZero<LinkId>, TxnId), InstallTetherError> {
+    // Find & remove the backlink to the inbound bind-request which
+    // initiated this next-hop-bind.
+
+    let Some(egress_peer_state) = asm.peer_table.get(egress_link_id.get()) else {
+        return Err(InstallTetherError::LinkClosed);
+    };
+    let Some((_, (ingress_link_id, ingress_txn_id))) = egress_peer_state
+        .docking_session_state
+        .awaiting_next_hop_bind_table
+        .remove(egress_txn)
+    else {
+        return Err(InstallTetherError::NoSuchTransaction);
+    };
+
+    if let Some(ingress_peer_state) = asm.peer_table.get(ingress_link_id.get()) {
+        // If originator still exists, check consistency
+        // (don't bother if originator no longer exists).
+
+        let Some(bind_st) = ingress_peer_state
+            .docking_session_state
+            .bind_request_state
+            .get(&ingress_txn_id)
+        else {
+            // should never happen
+            panic!(
+                "dock state consistency error; {ingress_txn_id} referenced by awaiting_next_hop_bind_table but is not an active bind request"
+            );
+        };
+
+        let &BindRequestState::AwaitingNextHopBind {
+            egress_link_id: expected_egress_link_id,
+            egress_bind_txn: ref expected_egress_txn,
+            ..
+        } = &*bind_st
+        else {
+            // should never happen
+            panic!(
+                "dock state consistency error; {ingress_txn_id} referenced by awaiting_next_hop_bind_table but not in AwaitingNextHopBind state"
+            );
+        };
+
+        assert_eq!(
+            expected_egress_link_id, egress_link_id,
+            "dock state consistency error"
+        );
+        assert_eq!(
+            expected_egress_txn, egress_txn,
+            "dock state consistency error"
+        );
+    }
+
+    Ok((ingress_link_id, ingress_txn_id))
 }

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -5,7 +5,7 @@
 //! "smarts" in this module.  (FIXME: this is currently not true!)
 
 use super::txn_mgr::TxnId;
-use super::{adapter, dock, txn_mgr};
+use super::{adapter, dock};
 use crate::assembly::{Assembly, PhMode, VERSION};
 use crate::auth;
 use crate::config;
@@ -764,7 +764,7 @@ fn parse_grant_zpr_address_request(
 /// handle a Bind Actor Address Request (RFC 6.5 § 6.3.11)
 pub async fn handle_bind_actor_address_request(
     asm: &Arc<Assembly>,
-    txn_id: txn_mgr::TxnId,
+    txn_id: TxnId,
     mut pkt: Packet,
 ) -> HandleMgmtResult {
     if !matches!(asm.ph_mode, PhMode::Node) {

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -1,10 +1,13 @@
 //! Handlers for management requests.
+//!
+//! These handlers just decode the packet and forward work to whatever
+//! internal API is responsible for handling it.  There are (should be) no
+//! "smarts" in this module.  (FIXME: this is currently not true!)
 
-use super::adapter;
-use crate::adapter_tables;
-use crate::assembly::{self, Assembly, PhMode, VERSION};
+use super::txn_mgr::TxnId;
+use super::{adapter, dock, txn_mgr};
+use crate::assembly::{Assembly, PhMode, VERSION};
 use crate::auth;
-use crate::classifier;
 use crate::config;
 use crate::counters;
 use crate::link_state::{LinkEvent, LinkStateError};
@@ -13,15 +16,16 @@ use crate::packet::Packet;
 use crate::tc;
 use crate::tlv::{self, TlvEncoding};
 use crate::zdp;
-use bytes::{Buf, BufMut};
+use bytes::Buf;
 use std::net::SocketAddr;
 use std::num::NonZero;
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::*;
 use zpr::packet_info::{L3Type, LinkId, Tcst};
-use zpr_ext::zerocopy::{FromBytesExt, IntoBytesExt};
+use zpr_ext::zerocopy::FromBytesExt;
 use zpr_utils::net_defs::IpAddress;
+
 /// Indicates whether the mgmt message was handled successfully.
 /// (It may be the case that the mgmt message itself indicates
 /// failure of a remote operation; modulo a parsing issue,
@@ -37,8 +41,8 @@ pub enum HandleMgmtError {
     #[error("bad packet structure")]
     BadStructure,
 
-    #[error("unknown transaction: {0}")]
-    UnknownTransaction(super::txn_mgr::TxnId),
+    #[error("unknown transaction")]
+    UnknownTransaction,
 
     #[error("link closed")]
     LinkClosed,
@@ -50,7 +54,7 @@ impl From<HandleMgmtError> for counters::ManagementCounterType {
             HandleMgmtError::UnknownType(_type) => Self::UnknownType,
             HandleMgmtError::BadStructure => Self::BadStructure,
             HandleMgmtError::MessageNotPermitted => Self::OtherError,
-            HandleMgmtError::UnknownTransaction(_id) => Self::UnknownTransaction,
+            HandleMgmtError::UnknownTransaction => Self::UnknownTransaction,
             HandleMgmtError::LinkClosed => Self::OtherError,
         }
     }
@@ -60,6 +64,23 @@ impl From<super::core::MgmtSendError> for HandleMgmtError {
     fn from(err: super::core::MgmtSendError) -> Self {
         match err {
             super::core::MgmtSendError::LinkClosed => HandleMgmtError::LinkClosed,
+        }
+    }
+}
+
+impl From<adapter::InstallTetherError> for HandleMgmtError {
+    fn from(err: adapter::InstallTetherError) -> Self {
+        match err {
+            adapter::InstallTetherError::NoSuchTransaction => HandleMgmtError::UnknownTransaction,
+        }
+    }
+}
+
+impl From<dock::InstallTetherError> for HandleMgmtError {
+    fn from(err: dock::InstallTetherError) -> Self {
+        match err {
+            dock::InstallTetherError::NoSuchTransaction => HandleMgmtError::UnknownTransaction,
+            dock::InstallTetherError::LinkClosed => HandleMgmtError::LinkClosed,
         }
     }
 }
@@ -743,9 +764,14 @@ fn parse_grant_zpr_address_request(
 /// handle a Bind Actor Address Request (RFC 6.5 § 6.3.11)
 pub async fn handle_bind_actor_address_request(
     asm: &Arc<Assembly>,
-    txn_id: u16,
+    txn_id: txn_mgr::TxnId,
     mut pkt: Packet,
 ) -> HandleMgmtResult {
+    if !matches!(asm.ph_mode, PhMode::Node) {
+        error!(target: ZDP, "Link {}: received BindActorAddress message on adapter", pkt.metadata().ingress_link_id);
+        return Err(HandleMgmtError::MessageNotPermitted);
+    }
+
     let Ok(hdr) = zdp::ZdpBindActorAddressRequestHeader::read_from_buf(&mut pkt) else {
         return Err(HandleMgmtError::BadStructure);
     };
@@ -758,195 +784,29 @@ pub async fn handle_bind_actor_address_request(
     // drop any garbage after the packet body
     pkt.shrink_by(pkt.len() - endpoint_packet_length);
 
-    // CTP TODO: this should be done by Visa Service
-    let classifier_options =
-        classifier::ClassifierOptions::default().ignore_truncated_packets(true);
-
-    let (metadata, body) = pkt.metadata_mut_and_body_mut();
-    let classification = match classifier::classify_with_options(
-        metadata.five_tuple_mut(),
-        body,
-        &classifier_options,
-    ) {
-        Ok(cls) => cls,
-        Err(_why) => {
-            warn!(target: ZDP, "Link {}: bind request: could not parse initial packet", pkt.metadata().ingress_link_id);
-            return Err(HandleMgmtError::BadStructure);
-        }
-    };
-
-    match classification {
-        classifier::ClassifierResult::OK => (),
-        classifier::ClassifierResult::UnclassifiedL4 => {
-            warn!(target: ZDP, "Link {}: bind request: unsupported IP protocol {}", pkt.metadata().ingress_link_id, pkt.metadata().get_l4_protocol());
-            return Err(HandleMgmtError::BadStructure);
-        }
-        _ => {
-            return Err(HandleMgmtError::BadStructure);
-        }
-    }
-
-    let five_tuple = *pkt.metadata().five_tuple();
-
-    let packet_body: Vec<u8> = pkt.body().to_vec(); // copy to send to visa service
-
     let Some(ingress_link_id) = NonZero::new(pkt.metadata().ingress_link_id) else {
         // who sent this??
         error!(target: FLOW_MGMT, "coding error: stray packet from unknown source; dropping");
         return Ok(());
     };
 
-    debug!(
-        target: ZDP,
-        "Link {}: handlers.handle_bind_actor_address_request -- five_tuple {five_tuple}", ingress_link_id.get(),
-    );
+    debug!(target: ZDP, "Link {ingress_link_id}: handlers.handle_bind_actor_address_request");
 
-    // recycle request buffer for response
-    let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-
-    let ingress_tether_id;
-
-    match asm.ph_mode {
-        PhMode::Node => {
-            // TODO: errors need more consideration here
-            match super::dock::bind_actor_address(asm, ingress_link_id, &five_tuple, &packet_body)
-                .await
-            {
-                Ok((ingress_tid, tc)) => {
-                    // success; respond with ingress tether ID
-                    zdp::ZdpBindActorAddressResponseHeader {
-                        status_code: zdp::ResponseCode::Success,
-                        info_len: 0,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    Tcst::Ip5Tuple.write_to_buf(&mut rsp_pkt).unwrap();
-                    tc.serialize(&mut rsp_pkt);
-
-                    ingress_tether_id = ingress_tid;
-                }
-
-                Err(super::dock::BindActorAddressError::PolicyError) => {
-                    // send error to requestor
-                    let message = "policy error";
-
-                    zdp::ZdpBindActorAddressResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: message.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(message.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-
-                Err(super::dock::BindActorAddressError::ParseError(error)) => {
-                    // send error to requestor
-                    zdp::ZdpBindActorAddressResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: error.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(error.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-
-                Err(super::dock::BindActorAddressError::AddRouteError(
-                    assembly::AddRouteError::PftFull,
-                )) => {
-                    // PFT full; respond with error message
-                    // TODO: maybe tick a counter somewhere?
-                    let message = "PFT full";
-
-                    zdp::ZdpBindActorAddressResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: message.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(message.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-
-                Err(super::dock::BindActorAddressError::AddRouteError(
-                    assembly::AddRouteError::PeerGone,
-                )) => {
-                    // peer went away; don't bother responding
-                    return Ok(());
-                }
-
-                Err(super::dock::BindActorAddressError::AddRouteError(
-                    assembly::AddRouteError::VisaGone,
-                )) => {
-                    // send error to requestor
-                    let message = "policy error";
-
-                    zdp::ZdpBindActorAddressResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: message.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(message.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-
-                Err(super::dock::BindActorAddressError::AddRouteError(
-                    assembly::AddRouteError::BindFailed(err),
-                )) => {
-                    // unable to bind next-hop; respond with error message
-                    // TODO: maybe tick a counter somewhere?
-                    let message = format!("unable to bind next-hop: {}", err);
-
-                    zdp::ZdpBindActorAddressResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: message.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(message.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-            }
-        }
-
-        PhMode::Adapter => {
-            error!(target: ZDP, "Link {ingress_link_id}: received BindActorAddress message on adapter");
-            return Err(HandleMgmtError::MessageNotPermitted);
-        }
-    }
-
-    // respond to requestor
-    super::core::send_per_flow_txn_mgmt(
-        asm,
-        ingress_link_id.get(),
-        zdp::ZdpPacketType::BindActorAddressResponse,
-        ingress_tether_id,
-        txn_id,
-        rsp_pkt,
-    )
-    .await?;
+    dock::bind_actor_address(asm, ingress_link_id, txn_id, pkt.body());
 
     Ok(())
 }
 
 pub async fn handle_bind_egress_stream_request(
     asm: &Arc<Assembly>,
-    txn_id: u16,
+    txn_id: TxnId,
     mut pkt: Packet,
 ) -> HandleMgmtResult {
+    if !matches!(asm.ph_mode, PhMode::Adapter) {
+        error!(target: ZDP, "Link {}: received BindEgressStream message on node", pkt.metadata().ingress_link_id);
+        return Err(HandleMgmtError::MessageNotPermitted);
+    }
+
     let Ok(hdr) = zdp::ZdpBindEgressStreamRequestHeader::read_from_buf(&mut pkt) else {
         return Err(HandleMgmtError::BadStructure);
     };
@@ -972,78 +832,14 @@ pub async fn handle_bind_egress_stream_request(
         ingress_link_id.get(), tc.five_tuple()
     );
 
-    // recycle request buffer for response
-    let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-
-    let ingress_tether_id;
-
-    match asm.ph_mode {
-        PhMode::Node => {
-            error!(target: ZDP, "Link {ingress_link_id}: received BindEgressStream message on node");
-            return Err(HandleMgmtError::MessageNotPermitted);
-        }
-
-        PhMode::Adapter => {
-            // form PEP
-            let pep = adapter_tables::DltPep {
-                compression_mode: tc.compression_mode(),
-                five_tuple: *tc.five_tuple(),
-            };
-
-            // TODO: reverse path
-
-            // attempt to insert into DLT
-            match asm.dlt.insert(pep) {
-                Ok(tid) => {
-                    // success; respond with tether ID
-                    // TODO: maybe tick a counter somewhere?
-                    zdp::ZdpBindEgressStreamResponseHeader {
-                        status_code: zdp::ResponseCode::Success,
-                        info_len: 0,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    ingress_tether_id = tid;
-                }
-
-                Err(()) => {
-                    // DLT full; respond with error message
-                    // TODO: maybe tick a counter somewhere?
-                    let message = "DLT full";
-
-                    zdp::ZdpBindEgressStreamResponseHeader {
-                        status_code: zdp::ResponseCode::Other,
-                        info_len: message.len() as u8,
-                    }
-                    .write_to_buf(&mut rsp_pkt)
-                    .unwrap();
-
-                    rsp_pkt.put(message.as_bytes());
-
-                    ingress_tether_id = 0;
-                }
-            }
-        }
-    }
-
-    // respond to requestor
-    super::core::send_per_flow_txn_mgmt(
-        asm,
-        ingress_link_id.get(),
-        zdp::ZdpPacketType::BindEgressStreamResponse,
-        ingress_tether_id,
-        txn_id,
-        rsp_pkt,
-    )
-    .await?;
+    adapter::bind_egress_stream(asm, ingress_link_id, txn_id, tc);
 
     Ok(())
 }
 
 pub async fn handle_bind_actor_address_response(
     asm: &Arc<Assembly>,
-    txn_id: u16,
+    txn_id: TxnId,
     mut pkt: Packet,
 ) -> HandleMgmtResult {
     let link_id = pkt.metadata().ingress_link_id;
@@ -1053,7 +849,7 @@ pub async fn handle_bind_actor_address_response(
     };
 
     let Some(txn) = peer_state.txn_mgr.get(txn_id) else {
-        return Err(HandleMgmtError::UnknownTransaction(txn_id));
+        return Err(HandleMgmtError::UnknownTransaction);
     };
 
     let Ok(hdr) = zdp::ZdpBindActorAddressResponseHeader::read_from_buf(&mut pkt) else {
@@ -1077,13 +873,8 @@ pub async fn handle_bind_actor_address_response(
                 return Err(HandleMgmtError::BadStructure);
             };
 
-            let txn_id = txn.id();
-
-            adapter::install_tether(&asm, &txn, stream_id, tc).map_err(
-                |adapter::InstallTetherError::NoSuchTransaction| {
-                    HandleMgmtError::UnknownTransaction(txn_id)
-                },
-            )
+            adapter::install_tether(&asm, &txn, stream_id, tc)?;
+            Ok(())
         }
 
         zdp::ResponseCode::Other => {
@@ -1095,11 +886,8 @@ pub async fn handle_bind_actor_address_response(
                 return Err(HandleMgmtError::BadStructure);
             };
 
-            adapter::deny_tether(&asm, &txn, msg).map_err(
-                |adapter::InstallTetherError::NoSuchTransaction| {
-                    HandleMgmtError::UnknownTransaction(txn_id)
-                },
-            )
+            adapter::deny_tether(&asm, &txn, msg)?;
+            Ok(())
         }
 
         _ => Err(HandleMgmtError::BadStructure),
@@ -1108,8 +896,8 @@ pub async fn handle_bind_actor_address_response(
 
 pub async fn handle_bind_egress_stream_response(
     asm: &Arc<Assembly>,
-    txn_id: u16,
-    pkt: Packet,
+    txn_id: TxnId,
+    mut pkt: Packet,
 ) -> HandleMgmtResult {
     let link_id = pkt.metadata().ingress_link_id;
 
@@ -1118,14 +906,34 @@ pub async fn handle_bind_egress_stream_response(
     };
 
     let Some(txn) = peer_state.txn_mgr.get(txn_id) else {
-        return Err(HandleMgmtError::UnknownTransaction(txn_id));
+        return Err(HandleMgmtError::UnknownTransaction);
     };
 
-    let Some(sender) = peer_state.bind_req_state.lock().unwrap().remove(&txn) else {
-        return Err(HandleMgmtError::UnknownTransaction(txn_id));
+    let Ok(hdr) = zdp::ZdpBindActorAddressResponseHeader::read_from_buf(&mut pkt) else {
+        return Err(HandleMgmtError::BadStructure);
     };
 
-    let _ = sender.send(pkt);
+    match hdr.status_code {
+        zdp::ResponseCode::Success => {
+            let stream_id = pkt.metadata().ingress_stream_id;
 
-    Ok(())
+            dock::install_tether(&asm, NonZero::new(link_id).unwrap(), &txn, stream_id)?;
+            Ok(())
+        }
+
+        zdp::ResponseCode::Other => {
+            if hdr.info_len as usize > pkt.remaining() {
+                return Err(HandleMgmtError::BadStructure);
+            }
+
+            let Ok(msg) = std::str::from_utf8(&pkt.body()[..hdr.info_len as usize]) else {
+                return Err(HandleMgmtError::BadStructure);
+            };
+
+            dock::deny_tether(&asm, NonZero::new(link_id).unwrap(), &txn, msg)?;
+            Ok(())
+        }
+
+        _ => Err(HandleMgmtError::BadStructure),
+    }
 }

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -7,19 +7,16 @@
 use super::core::{self, Sent};
 use super::txn_mgr::TxnId;
 use crate::config;
-use crate::counters::ManagementCounterType;
-use crate::defs::*;
 use crate::logging::targets::ZDP;
 use crate::tc;
 use crate::zdp;
 use crate::{assembly::Assembly, auth};
 
-use bytes::{Buf, BufMut};
+use bytes::BufMut;
 use std::net::IpAddr;
-use thiserror::Error;
 use tracing::*;
 use zpr::packet_info::{KmId, L3Type, L3TypeDeriveable, LinkId, StreamId, Tcst};
-use zpr_ext::zerocopy::{FromBytesExt, IntoBytesExt};
+use zpr_ext::zerocopy::IntoBytesExt;
 
 /// send a Key Management message (RFC 6.5 § 6.2.8)
 pub fn send_key_management(asm: &Assembly, link_id: LinkId, km_id: KmId, payload: &[u8]) {
@@ -180,7 +177,7 @@ pub fn send_grant_zpr_address_request<'a>(
     status_code: zdp::ResponseCode,
     actor_addrs: &'_ [IpAddr],
 ) -> Sent<'a> {
-    info!(target: ZDP, "Link {link_id} - sending GrantZprAddressRequest, status: {status_code:?}");
+    debug!(target: ZDP, "Link {link_id} - sending GrantZprAddressRequest, status: {status_code:?}");
 
     let mut req = core::new_heap_packet();
 
@@ -255,33 +252,14 @@ pub fn send_terminate_indication<'a, 'pktbuf>(
     )
 }
 
-#[derive(Debug, Error)]
-pub enum BindActorAddressError {
-    #[error("bad structure")]
-    BadStructure,
-    #[error("{0}")]
-    BindActorAddressError(String),
-    #[error("link closed")]
-    LinkClosed,
-}
-
-impl From<core::MgmtSendError> for BindActorAddressError {
-    fn from(err: core::MgmtSendError) -> Self {
-        match err {
-            core::MgmtSendError::LinkClosed => Self::LinkClosed,
-        }
-    }
-}
-
-/// send a Bind Actor Address Request and wait for the Response (RFC 6.5 § 6.3.11)
+/// send a Bind Actor Address Request (RFC 6.5 § 6.3.11)
 pub fn send_bind_actor_address_request<'a>(
     asm: &'a Assembly,
     link_id: LinkId,
     txn_id: TxnId,
-    five_tuple: &FiveTuple,
     packet_body: &[u8],
 ) -> Sent<'a> {
-    info!(target: ZDP, "Link {link_id}: sending BindActorAddressRequest for {five_tuple} with packet_body size {}", packet_body.len());
+    debug!(target: ZDP, "Link {link_id}: sending BindActorAddressRequest with packet_body size {}", packet_body.len());
 
     let mut req = core::new_heap_packet();
     let bind_req_hdr = req.alloc_zeroed_header::<zdp::ZdpBindActorAddressRequestHeader>();
@@ -302,28 +280,74 @@ pub fn send_bind_actor_address_request<'a>(
     )
 }
 
-pub async fn send_bind_egress_stream_request(
-    asm: &Assembly,
+pub fn send_bind_actor_address_success_response<'a>(
+    asm: &'a Assembly,
     link_id: LinkId,
+    txn_id: TxnId,
+    tether_id: StreamId,
     tc: tc::Ip5TupleTc,
-) -> Result<StreamId, BindActorAddressError> {
-    info!(target: ZDP, "Link {link_id}: sending BindEgressStreamRequest for {tc}");
+) -> Sent<'a> {
+    debug!(target: ZDP, "Link {link_id}: sending BindActorAddressResponse [success] for {txn_id}");
 
-    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let mut rsp_pkt = core::new_heap_packet();
 
-    let Some(peer_state) = asm.peer_table.get(link_id) else {
-        return Err(BindActorAddressError::LinkClosed);
-    };
+    zdp::ZdpBindActorAddressResponseHeader {
+        status_code: zdp::ResponseCode::Success,
+        info_len: 0,
+    }
+    .write_to_buf(&mut rsp_pkt)
+    .unwrap();
 
-    let txn = peer_state.txn_mgr.open().await;
-    let txn_id = txn.id();
-    peer_state
-        .bind_req_state
-        .lock()
-        .unwrap()
-        .insert(txn, sender);
+    Tcst::Ip5Tuple.write_to_buf(&mut rsp_pkt).unwrap();
+    tc.serialize(&mut rsp_pkt);
 
-    drop(peer_state);
+    super::core::send_per_flow_txn_mgmt(
+        asm,
+        link_id,
+        zdp::ZdpPacketType::BindActorAddressResponse,
+        tether_id,
+        txn_id,
+        rsp_pkt,
+    )
+}
+
+pub fn send_bind_actor_address_error_response<'a>(
+    asm: &'a Assembly,
+    link_id: LinkId,
+    txn_id: TxnId,
+    reason: &str,
+) -> Sent<'a> {
+    debug!(target: ZDP, "Link {link_id}: sending BindActorAddressResponse [error] for {txn_id}");
+
+    let mut rsp_pkt = core::new_heap_packet();
+
+    let reason = &reason[..=std::cmp::min(u8::MAX as usize + 1, reason.len())];
+    zdp::ZdpBindActorAddressResponseHeader {
+        status_code: zdp::ResponseCode::Other,
+        info_len: reason.len() as u8,
+    }
+    .write_to_buf(&mut rsp_pkt)
+    .unwrap();
+
+    rsp_pkt.put(reason.as_bytes());
+
+    super::core::send_per_flow_txn_mgmt(
+        asm,
+        link_id,
+        zdp::ZdpPacketType::BindActorAddressResponse,
+        0,
+        txn_id,
+        rsp_pkt,
+    )
+}
+
+pub fn send_bind_egress_stream_request<'a>(
+    asm: &'a Assembly,
+    link_id: LinkId,
+    txn_id: TxnId,
+    tc: tc::Ip5TupleTc,
+) -> Sent<'a> {
+    debug!(target: ZDP, "Link {link_id}: sending BindEgressStreamRequest for {tc}");
 
     let mut req = core::new_heap_packet();
     let bind_req_hdr = req.alloc_zeroed_header::<zdp::ZdpBindEgressStreamRequestHeader>();
@@ -338,39 +362,63 @@ pub async fn send_bind_egress_stream_request(
         txn_id,
         req,
     )
-    .await?;
+}
 
-    let Ok(mut resp) = receiver.await else {
-        return Err(BindActorAddressError::LinkClosed);
-    };
+pub fn send_bind_egress_stream_success_response<'a>(
+    asm: &'a Assembly,
+    link_id: LinkId,
+    txn_id: TxnId,
+    tether_id: StreamId,
+) -> Sent<'a> {
+    debug!(target: ZDP, "Link {link_id}: sending BindEgressStreamResponse [success] for {txn_id}");
 
-    let Ok(hdr) = zdp::ZdpBindEgressStreamResponseHeader::read_from_buf(&mut resp) else {
-        core::count_event(asm, ManagementCounterType::BadStructure);
-        return Err(BindActorAddressError::BadStructure);
-    };
+    let mut rsp_pkt = core::new_heap_packet();
 
-    match hdr.status_code {
-        zdp::ResponseCode::Success => Ok(resp.metadata().ingress_stream_id),
-
-        zdp::ResponseCode::Other => {
-            if hdr.info_len as usize > resp.remaining() {
-                core::count_event(asm, ManagementCounterType::BadStructure);
-                return Err(BindActorAddressError::BadStructure);
-            }
-
-            let Ok(msg) = std::str::from_utf8(&resp.body()[..hdr.info_len as usize]) else {
-                core::count_event(asm, ManagementCounterType::BadStructure);
-                return Err(BindActorAddressError::BadStructure);
-            };
-
-            Err(BindActorAddressError::BindActorAddressError(msg.to_owned()))
-        }
-
-        _ => {
-            core::count_event(asm, ManagementCounterType::BadStructure);
-            Err(BindActorAddressError::BadStructure)
-        }
+    zdp::ZdpBindEgressStreamResponseHeader {
+        status_code: zdp::ResponseCode::Success,
+        info_len: 0,
     }
+    .write_to_buf(&mut rsp_pkt)
+    .unwrap();
+
+    super::core::send_per_flow_txn_mgmt(
+        asm,
+        link_id,
+        zdp::ZdpPacketType::BindEgressStreamResponse,
+        tether_id,
+        txn_id,
+        rsp_pkt,
+    )
+}
+
+pub fn send_bind_egress_stream_error_response<'a>(
+    asm: &'a Assembly,
+    link_id: LinkId,
+    txn_id: TxnId,
+    reason: &str,
+) -> Sent<'a> {
+    debug!(target: ZDP, "Link {link_id}: sending BindEgressStreamResponse [error] for {txn_id}");
+
+    let mut rsp_pkt = core::new_heap_packet();
+
+    let reason = &reason[..=std::cmp::min(u8::MAX as usize + 1, reason.len())];
+    zdp::ZdpBindEgressStreamResponseHeader {
+        status_code: zdp::ResponseCode::Other,
+        info_len: reason.len() as u8,
+    }
+    .write_to_buf(&mut rsp_pkt)
+    .unwrap();
+
+    rsp_pkt.put(reason.as_bytes());
+
+    super::core::send_per_flow_txn_mgmt(
+        asm,
+        link_id,
+        zdp::ZdpPacketType::BindEgressStreamResponse,
+        0,
+        txn_id,
+        rsp_pkt,
+    )
 }
 
 /// send a Report message (RFC 6.5 § 6.3.13)

--- a/adapter/ph/src/mgmt/txn_mgr.rs
+++ b/adapter/ph/src/mgmt/txn_mgr.rs
@@ -27,6 +27,8 @@ pub type TxnId = u16;
 ///
 /// Handles implement `Eq` and `Hash` and thus may be used as
 /// keys in hash tables.
+///
+/// Handles should be used only by requesters, not responders.
 pub struct TxnHandle {
     mgr: Weak<TxnMgr>,
     id: TxnId,
@@ -137,6 +139,7 @@ impl TxnMgr {
     /// The transaction will remain open until the handle is dropped.
     ///
     /// Blocks until a suitable transaction ID is available.
+    #[allow(dead_code)]
     pub async fn open(self: &Arc<Self>) -> TxnHandle {
         let id = self.open_raw().await;
         TxnHandle {

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -4,7 +4,7 @@ use crate::config;
 use crate::forwarding_tables::PeerForwardingTable;
 use crate::km::{KeyManager, KmTransportSA};
 use crate::link_state::{LinkStateWrapper, LinkType};
-use crate::mgmt::txn_mgr;
+use crate::mgmt::{self, txn_mgr};
 use crate::queues;
 use crate::rcu::{RcuBox, RcuCslabEntryGuard, RcuOptionGuard};
 use crate::special_peers::*;
@@ -14,7 +14,6 @@ use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::DashMap;
 use enum_map::EnumMap;
 use openssl::rand::rand_bytes;
-use std::collections::hash_map::HashMap;
 use std::default::Default;
 use std::future::Future;
 use std::num::NonZero;
@@ -35,6 +34,7 @@ pub struct PeerState {
     pub interface_addr: ScopedIpAddr,
     pub link_state_machine: LinkStateWrapper,
     pub pft: PeerForwardingTable,
+    pub docking_session_state: mgmt::dock::DockingSessionPeerState,
     pub mgmt_processor: queues::MgmtProcessor,
     pub mgmt_processor_worker: task::JoinHandle<()>,
     pub auth_key: [u8; 32], // set in ::new and never changed.
@@ -42,9 +42,6 @@ pub struct PeerState {
     pub zdpr_recv: Mutex<zdpr::Receiver>,
     pub zdpr_retry_timer_reset: Notify,
     pub txn_mgr: Arc<txn_mgr::TxnMgr>,
-    /// temporary pending #906
-    pub bind_req_state:
-        Mutex<HashMap<txn_mgr::TxnHandle, tokio::sync::oneshot::Sender<crate::packet::Packet>>>,
     km_state: PeerKmState,
 }
 
@@ -102,6 +99,7 @@ impl PeerState {
             interface_addr,
             link_state_machine: LinkStateWrapper::new(link_id.get(), link_type),
             pft: PeerForwardingTable::new(),
+            docking_session_state: mgmt::dock::DockingSessionPeerState::new(),
             mgmt_processor,
             mgmt_processor_worker,
             auth_key: key,
@@ -111,7 +109,6 @@ impl PeerState {
             )),
             zdpr_retry_timer_reset: Notify::new(),
             txn_mgr: Arc::new(txn_mgr::TxnMgr::new()),
-            bind_req_state: Mutex::new(HashMap::new()),
             km_state: PeerKmState::new(),
         }
     }
@@ -476,6 +473,7 @@ pub mod test {
             interface_addr,
             link_state_machine: LinkStateWrapper::new(link_id.get(), link_type),
             pft: PeerForwardingTable::new(),
+            docking_session_state: mgmt::dock::DockingSessionPeerState::new(),
             mgmt_processor,
             mgmt_processor_worker: task::spawn(async {}),
             auth_key: [42u8; AUTH_KEY_SIZE_BYTES],
@@ -485,7 +483,6 @@ pub mod test {
             )),
             zdpr_retry_timer_reset: Notify::new(),
             txn_mgr: Arc::new(txn_mgr::TxnMgr::new()),
-            bind_req_state: Mutex::new(HashMap::new()),
             km_state: PeerKmState::new(),
         }
     }

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -146,18 +146,18 @@ pub async fn actor_disconnect(asm: Arc<Assembly>, addr: IpAddress) {
     }
 }
 
-/// Figure out egress link and insert visa into table.
+/// Insert visa into table.
 pub fn insert_visa(
     asm: &Arc<Assembly>,
     visa: vsapi_types::Visa,
-) -> Result<(VisaId, NonZero<LinkId>), visa_table::VisaTableError> {
+) -> Result<VisaId, visa_table::VisaTableError> {
     let addr = visa.dest_addr.clone();
-    let Some(link_id) = asm.find_egress_link(addr.into()) else {
+    if asm.find_egress_link(addr.into()).is_none() {
         asm.counters.management[ManagementCounterType::VisaRequestError].increment();
         return Err(visa_table::VisaTableError::DestNotFound(addr.into()));
-    };
+    }
     let visa_id = asm.visa_table.write().unwrap().insert_visa(visa)?;
-    Ok((visa_id, link_id))
+    Ok(visa_id)
 }
 
 /// Given a visa ID, look up the visa in our table to find the destination address

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -6,6 +6,7 @@ use crate::defs::FiveTuple;
 use crate::five_tuple_lookup_table::FiveTupleLookupTable;
 use crate::logging::targets::VISA_MGMT;
 use crate::peer_table;
+use crate::tc;
 
 use chrono::{DateTime, Utc};
 use std::cmp::Ordering;
@@ -127,6 +128,10 @@ impl Visa {
             return false;
         }
         return true;
+    }
+
+    pub fn get_tc(&self) -> tc::Ip5TupleTc {
+        tc::Ip5TupleTc::new_with_compression_mode(0, self.visa.get_five_tuple().into())
     }
 }
 

--- a/zpr-utils/src/net_defs.rs
+++ b/zpr-utils/src/net_defs.rs
@@ -120,6 +120,12 @@ impl From<Ipv4Addr> for IpAddress {
     }
 }
 
+impl From<&Ipv4Addr> for IpAddress {
+    fn from(addr: &Ipv4Addr) -> Self {
+        Self::new_from_std_v4(addr)
+    }
+}
+
 impl From<[u8; 4]> for IpAddress {
     fn from(addr: [u8; 4]) -> Self {
         Self::new_from_v4(addr)
@@ -132,6 +138,12 @@ impl From<Ipv6Addr> for IpAddress {
     }
 }
 
+impl From<&Ipv6Addr> for IpAddress {
+    fn from(addr: &Ipv6Addr) -> Self {
+        Self::new_from_std_v6(addr)
+    }
+}
+
 impl From<[u8; 16]> for IpAddress {
     fn from(addr: [u8; 16]) -> Self {
         Self { v6: addr }
@@ -141,6 +153,12 @@ impl From<[u8; 16]> for IpAddress {
 impl From<IpAddr> for IpAddress {
     fn from(addr: IpAddr) -> Self {
         Self::new_from_std(&addr)
+    }
+}
+
+impl From<&IpAddr> for IpAddress {
+    fn from(addr: &IpAddr) -> Self {
+        Self::new_from_std(addr)
     }
 }
 


### PR DESCRIPTION
OK!!!  This has been a long time coming.  These changes completely rework how bind requests work internally, they're now a state machine instead of a random sequence of things happening in an async block.

My two main goals with this rewrite are (a) make everything legible and easy to understand, (b) allow us to easily integrate multi-hop binds, and (c) fix shortcomings of the current bind request flow.

There's a couple of changes that still need to be made but those will come in separate commits.

Sorry this one is so big!  I will try my best to explain the changes below.

Minor changes:

* The PFT (in `forwarding_tables`) was given the ability to reserve an entry (to reference the ID) before adding it.
* The bind request handler now validates that the requested source address actually belongs to the adapter making the request.
* The node's internal adapter link now knows its own address (needed so we don't need to special-case the code which validates bind request source addresses).
* Inserting a visa into the visa table now just returns the visa ID, not visa ID + egress link.
* Added a function to get the traffic classifier of a visa.  This "should" be part of the visa itself, but for now we synthesize it from the visa's 5-tuple.
* Added some utility functions for converting to/from references to different IP address formats.
* The ZDP bind request send function now requires the caller to open a transaction on the link.
* The ZDP bind response send function is now broken into separate success and error variants.

Major changes:

* The ZDP bind request and response handlers now just immediately forward work on to the appropriate functions in the `mgmt::dock` and `mgmt::adapter` modules.  They no longer block, mess about with tables, or contain long complicated sequences of async logic.
* The logic from the ZDP bind actor address handler and the `assembly::add_route()` method are now restructured into a state machine defined by functions in the `mgmt::dock` module, which now contains all the logic for managing internal dock state.
* The `bind_req_state` table in the peer table is replaced with the dock state, which in turn contains a table containing active bind-request state machines.
* The logic from the ZDP bind egress stream handler is moved into `mgmt::adapter::bind_egress_stream()`.  So `mgmt::adapter` now contains all the logic for managing internal adapter state.