### PR TITLE
add L3Type to bind request

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -83,15 +83,20 @@ fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
     debug!(target: FLOW_MGMT, "link {dock_link_id}: Issuing bind request for {five_tuple} (is now set PENDING)");
 
     match asm.ph_mode {
-        PhMode::Adapter => {
-            mgmt::requests::send_bind_actor_address_request(asm, dock_link_id, txn_id, &packet_body)
-                .enqueue()
-        }
+        PhMode::Adapter => mgmt::requests::send_bind_actor_address_request(
+            asm,
+            dock_link_id,
+            txn_id,
+            five_tuple.l3_type,
+            &packet_body,
+        )
+        .enqueue(),
 
         PhMode::Node => mgmt::dock::bind_actor_address(
             asm,
             NonZero::new(LOCAL_ACTOR_LINK_ID).unwrap(),
             txn_id,
+            five_tuple.l3_type,
             &packet_body,
         ),
     }

--- a/adapter/ph/src/mgmt/dock.rs
+++ b/adapter/ph/src/mgmt/dock.rs
@@ -29,7 +29,7 @@ use std::num::NonZero;
 use std::sync::Arc;
 use tracing::*;
 use zpr::packet_info::{
-    DOCK_LINK_ID, ForwardingEntry, LOCAL_ACTOR_LINK_ID, LinkId, StreamId, VisaId,
+    DOCK_LINK_ID, ForwardingEntry, L3Type, LOCAL_ACTOR_LINK_ID, LinkId, StreamId, VisaId,
 };
 use zpr::vsapi_types;
 
@@ -111,6 +111,7 @@ pub fn bind_actor_address(
     asm: &Arc<Assembly>,
     ingress_link_id: NonZero<LinkId>,
     txn_id: TxnId,
+    l3_type: L3Type,
     packet_body: &[u8],
 ) {
     debug!(
@@ -205,7 +206,7 @@ pub fn bind_actor_address(
 
     let visa_req = vsconn::VisaRequest {
         source_tether_addr: five_tuple.src_address.into(),
-        l3_type: five_tuple.l3_type, // TODO: this should come from the bind request, not the packet body
+        l3_type,
         packet: packet_body.to_vec(),
     };
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -730,6 +730,8 @@ pub async fn handle_bind_actor_address_request(
         return Err(HandleMgmtError::BadStructure);
     };
 
+    let l3_type = hdr.l3_type;
+
     let endpoint_packet_length = hdr.endpoint_packet_length.get() as usize;
     if endpoint_packet_length > pkt.len() {
         return Err(HandleMgmtError::BadStructure);
@@ -746,7 +748,7 @@ pub async fn handle_bind_actor_address_request(
 
     debug!(target: ZDP, "Link {ingress_link_id}: handlers.handle_bind_actor_address_request");
 
-    dock::bind_actor_address(asm, ingress_link_id, txn_id, pkt.body());
+    dock::bind_actor_address(asm, ingress_link_id, txn_id, l3_type, pkt.body());
 
     Ok(())
 }

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -245,6 +245,7 @@ pub fn send_bind_actor_address_request<'a>(
     asm: &'a Assembly,
     link_id: LinkId,
     txn_id: TxnId,
+    l3_type: L3Type,
     packet_body: &[u8],
 ) -> Sent<'a> {
     debug!(target: ZDP, "Link {link_id}: sending BindActorAddressRequest with packet_body size {}", packet_body.len());
@@ -253,6 +254,7 @@ pub fn send_bind_actor_address_request<'a>(
     let bind_req_hdr = req.alloc_zeroed_header::<zdp::ZdpBindActorAddressRequestHeader>();
     let endpoint_packet_length =
         std::cmp::min(config::BIND_REQUEST_MAX_PAYLOAD_LENGTH, packet_body.len());
+    bind_req_hdr.l3_type = l3_type;
     bind_req_hdr
         .endpoint_packet_length
         .set(endpoint_packet_length as u16);

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -214,6 +214,7 @@ pub struct ZdpTerminateLinkOrDockingSessionHeader {
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct ZdpBindActorAddressRequestHeader {
+    pub l3_type: L3Type,
     pub endpoint_packet_length: U16,
     // Followed in memory by:
     // - <PACKET BODY starting with IP header>


### PR DESCRIPTION
While packet body is sufficient to distinguish IPv4 and IPv6 packets it's not sufficient for any sort of future protocol we might want to support.  So let's add L3Type back in to the bind request message.