### PR TITLE
merge TerminateRequest and TerminateIndication and replace TerminateResponse with ZDPR ACK

### DIFF
--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -157,9 +157,8 @@ pub enum LinkEvent {
 
     ReceivedAuthorizeResponse(IpAddress), // from visa service
     ReceivedKeepAliveResponse,
-    ReceivedTerminateRequest(TerminateReason),
+    ReceivedTerminateLink(TerminateReason),
     ReceivedTerminateResponse(ResponseCode),
-    ReceivedTerminateIndication(TerminateReason),
     SentTerminate,
     Close(TerminateReason),
     CloseDone,
@@ -453,11 +452,8 @@ impl LinkStateWrapper {
                 self.process_authorize_response(asm, zpr_addr)
             }
 
-            LinkEvent::ReceivedTerminateRequest(code) => self.process_terminate_request(asm, code),
+            LinkEvent::ReceivedTerminateLink(code) => self.process_terminate_link(asm, code),
             LinkEvent::ReceivedTerminateResponse(_) => self.process_terminate_response(asm),
-            LinkEvent::ReceivedTerminateIndication(code) => {
-                self.process_terminate_indication(asm, code)
-            }
             LinkEvent::SentTerminate => Ok(self.clean_up_link_state(asm).detach_all()),
             LinkEvent::ReceivedKeepAliveResponse => Err(LinkStateError::OperationNotSupportedYet),
             LinkEvent::Close(code) => self.initiate_close(asm, code),
@@ -1396,43 +1392,6 @@ impl LinkStateWrapper {
         }
     }
 
-    /// Validate a received terminate request
-    /// May generate a thrift message (over TUN) to the visa service.
-    ///
-    /// Unless we are inactive, this transitions to closing. The state machine is now
-    /// stuck waiting for a SentTerminate event which triggers `clean_up_link_state`.
-    ///
-    /// Returns Ok unless this is in a state that cannot handle this message.
-    fn process_terminate_request(
-        &self,
-        asm: &Arc<Assembly>,
-        reason: TerminateReason,
-    ) -> Result<(), LinkStateError> {
-        let link_id = self.id;
-        info!(target: LINK_STATE,
-            "Received terminate request on link {link_id} for reason {reason:?}"
-        );
-
-        let mut locked_fsm = self.locked_fsm.lock().unwrap();
-
-        match (self.link_type, locked_fsm.state) {
-            (_, LinkState::Inactive) => Err(LinkStateError::UnexpectedTransition(
-                locked_fsm.state,
-                "ReceivedTerminateRequest",
-            )),
-
-            (ltype, _lstate) => {
-                if ltype == LinkType::NodeToAdapter {
-                    // If this was from our special friend, the visa service adapter, then de-register.
-                    // TODO: The de-register message never makes it across before link closes.
-                    self.disconnect_visa_service_client(asm, true);
-                }
-                locked_fsm.set_state(LinkState::Closing);
-                Ok(())
-            }
-        }
-    }
-
     /// Nodes only. Check if this is the link to the adapter in front of the visa service
     /// and if so try to de-register this node from the VS and also stop the VSConn.
     ///
@@ -1489,7 +1448,7 @@ impl LinkStateWrapper {
         // If this timeout fires, we end up going to `clean_up_link_state`.
         // If we get a response to our terminate we also go to `clean_up_link_state`.
         self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_TERMINATE_TIMEOUT);
-        mgmt::requests::send_terminate_request(asm, self.id, reason).enqueue();
+        mgmt::requests::send_terminate_link_or_docking_session(asm, self.id, reason).enqueue();
         Ok(())
     }
 
@@ -1610,7 +1569,12 @@ impl LinkStateWrapper {
             .lock()
             .unwrap()
             .set_state(LinkState::Resetting);
-        mgmt::requests::send_terminate_indication(asm, link_id, TerminateReason::Reset).enqueue();
+        mgmt::requests::send_terminate_link_or_docking_session(
+            asm,
+            link_id,
+            TerminateReason::Reset,
+        )
+        .enqueue();
         let _ = self.clean_up_link_state(asm).join_all().await;
     }
 
@@ -1634,22 +1598,30 @@ impl LinkStateWrapper {
         }
     }
 
-    /// Peer has sent a terminate-indication message.
+    /// Peer has sent a terminate-link message.
+    /// May generate a thrift message (over TUN) to the visa service.
     /// Peer has shut down or shutting down so don't expect it to be there anymore.
-    fn process_terminate_indication(
+    ////
+    /// Transitions to closing.  The state machine is now stuck waiting for
+    /// a SentTerminate event which triggers `clean_up_link_state`.
+    ///
+    /// Returns Ok unless this is in a state that cannot handle this message.
+    fn process_terminate_link(
         &self,
         asm: &Arc<Assembly>,
         reason: TerminateReason,
     ) -> Result<(), LinkStateError> {
         let link_id = self.id;
         info!(target: LINK_STATE,
-            "Received terminate indication for link {link_id} with reason {reason:?}"
+            "Received terminate for link {link_id} with reason {reason:?}"
         );
         self.locked_fsm
             .lock()
             .unwrap()
             .set_state(LinkState::Closing);
         if self.link_type == LinkType::NodeToAdapter {
+            // If this was from our special friend, the visa service adapter, then de-register.
+            // TODO: The de-register message never makes it across before link closes.
             self.disconnect_visa_service_client(asm, true);
         }
         self.clean_up_link_state(asm).detach_all();

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -158,8 +158,7 @@ pub enum LinkEvent {
     ReceivedAuthorizeResponse(IpAddress), // from visa service
     ReceivedKeepAliveResponse,
     ReceivedTerminateLink(TerminateReason),
-    ReceivedTerminateResponse(ResponseCode),
-    SentTerminate,
+    ReceivedTerminateAck,
     Close(TerminateReason),
     CloseDone,
     Error,
@@ -453,8 +452,7 @@ impl LinkStateWrapper {
             }
 
             LinkEvent::ReceivedTerminateLink(code) => self.process_terminate_link(asm, code),
-            LinkEvent::ReceivedTerminateResponse(_) => self.process_terminate_response(asm),
-            LinkEvent::SentTerminate => Ok(self.clean_up_link_state(asm).detach_all()),
+            LinkEvent::ReceivedTerminateAck => self.process_terminate_ack(asm),
             LinkEvent::ReceivedKeepAliveResponse => Err(LinkStateError::OperationNotSupportedYet),
             LinkEvent::Close(code) => self.initiate_close(asm, code),
             LinkEvent::CloseDone => Ok(self.complete_close(asm)),
@@ -1448,7 +1446,23 @@ impl LinkStateWrapper {
         // If this timeout fires, we end up going to `clean_up_link_state`.
         // If we get a response to our terminate we also go to `clean_up_link_state`.
         self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_TERMINATE_TIMEOUT);
-        mgmt::requests::send_terminate_link_or_docking_session(asm, self.id, reason).enqueue();
+        let task_asm = asm.clone();
+        let ingress_link_id = self.id;
+        tokio::task::spawn_local(async move {
+            let acked = mgmt::requests::send_terminate_link_or_docking_session(
+                &task_asm,
+                ingress_link_id,
+                reason,
+            )
+            .acked();
+            match acked.await {
+                Ok(()) => {
+                    let _ = task_asm
+                        .process_link_state_event(ingress_link_id, LinkEvent::ReceivedTerminateAck);
+                }
+                Err(mgmt::core::MgmtSendError::LinkClosed) => (),
+            }
+        });
         Ok(())
     }
 
@@ -1578,22 +1592,22 @@ impl LinkStateWrapper {
         let _ = self.clean_up_link_state(asm).join_all().await;
     }
 
-    /// Handle a terminate response packet.
+    /// Handle a terminate link acknowledgement.
     /// This means we sent a terminate request and set a timeout. Timeout is cancelled here
     /// before we proceed with shutting down the link.
-    fn process_terminate_response(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
+    fn process_terminate_ack(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
         let link_id = self.id;
         info!(target: LINK_STATE,"Received terminate response for link {link_id}");
-        let state = self.locked_fsm.lock().unwrap().state;
-        match state {
+        let mut locked_fsm = self.locked_fsm.lock().unwrap();
+        match locked_fsm.state {
             LinkState::Closing => {
-                self.locked_fsm.lock().unwrap().cancel_timeout();
+                locked_fsm.cancel_timeout();
                 self.clean_up_link_state(asm).detach_all();
                 Ok(())
             }
             _ => Err(LinkStateError::UnexpectedTransition(
-                state,
-                "ReceivedTerminateResponse",
+                locked_fsm.state,
+                "ReceivedTerminateAck",
             )),
         }
     }
@@ -1601,9 +1615,6 @@ impl LinkStateWrapper {
     /// Peer has sent a terminate-link message.
     /// May generate a thrift message (over TUN) to the visa service.
     /// Peer has shut down or shutting down so don't expect it to be there anymore.
-    ////
-    /// Transitions to closing.  The state machine is now stuck waiting for
-    /// a SentTerminate event which triggers `clean_up_link_state`.
     ///
     /// Returns Ok unless this is in a state that cannot handle this message.
     fn process_terminate_link(

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -181,22 +181,25 @@ pub async fn handle_init_authentication_request(
     Ok(())
 }
 
-/// handle a Terminate Request (RFC 6.5 § 6.3.3)
+/// handle a Terminate Link or Docking Session message (TODO: document in RFC 17)
 ///
-/// Sends [LinkEvent::ReceivedTerminateRequest] into the link state machine.
+/// Sends [LinkEvent::ReceivedTerminateLink] into the link state machine.
 /// Sends a ZdpTerminateResponse message back to the sender.
 /// Sends a [LinkEvent::SentTerminate] event into the link state machine.
-pub async fn handle_terminate_request(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
+pub async fn handle_terminate_link_or_docking_session(
+    asm: &Arc<Assembly>,
+    mut pkt: Packet,
+) -> HandleMgmtResult {
     let ingress_link_id = pkt.metadata().ingress_link_id;
-    let Ok(hdr) = zdp::ZdpTerminateLinkRequestHeader::read_from_buf(&mut pkt) else {
+    let Ok(hdr) = zdp::ZdpTerminateLinkOrDockingSessionHeader::read_from_buf(&mut pkt) else {
         return Err(HandleMgmtError::BadStructure);
     };
 
-    info!(target: ZDP, "Received Terminate Request for link {ingress_link_id}");
+    info!(target: ZDP, "Received Terminate Link or Docking Session for link {ingress_link_id}");
 
     let response_code = match asm.process_link_state_event(
         ingress_link_id,
-        LinkEvent::ReceivedTerminateRequest(hdr.reason_code),
+        LinkEvent::ReceivedTerminateLink(hdr.reason_code),
     ) {
         Ok(_) => zdp::ResponseCode::Success,
         Err(_) => zdp::ResponseCode::Other,
@@ -232,22 +235,6 @@ pub async fn handle_terminate_response(asm: &Arc<Assembly>, mut pkt: Packet) -> 
         .process_link_state_event(link_id, LinkEvent::ReceivedTerminateResponse(resp_code))
         .map_err(|_| ());
 
-    Ok(())
-}
-
-/// handle a Terminate Indication (RFC 6.5 § 6.3.3)
-pub async fn handle_terminate_indication(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
-    let ingress_link_id = pkt.metadata().ingress_link_id;
-    let Ok(hdr) = zdp::ZdpTerminateLinkIndicationHeader::read_from_buf(&mut pkt) else {
-        return Err(HandleMgmtError::BadStructure);
-    };
-
-    debug!(target: ZDP, "Received Terminate Indication for link {ingress_link_id}");
-
-    let _ignore_errors = asm.process_link_state_event(
-        ingress_link_id,
-        LinkEvent::ReceivedTerminateIndication(hdr.reason_code),
-    );
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -197,43 +197,10 @@ pub async fn handle_terminate_link_or_docking_session(
 
     info!(target: ZDP, "Received Terminate Link or Docking Session for link {ingress_link_id}");
 
-    let response_code = match asm.process_link_state_event(
+    let _ = asm.process_link_state_event(
         ingress_link_id,
         LinkEvent::ReceivedTerminateLink(hdr.reason_code),
-    ) {
-        Ok(_) => zdp::ResponseCode::Success,
-        Err(_) => zdp::ResponseCode::Other,
-    };
-
-    let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpTerminateLinkResponseHeader>();
-    hdr.response_code = response_code;
-
-    super::core::send_non_flow_mgmt(
-        asm,
-        ingress_link_id,
-        zdp::ZdpPacketType::TerminateLinkResponse,
-        rsp_pkt,
-    )
-    .await?;
-
-    // Tell state machine we sent a TerminateLinkResponse. This will trigger `clean_up_link_state`.
-    let _ = asm.process_link_state_event(ingress_link_id, LinkEvent::SentTerminate);
-
-    Ok(())
-}
-
-pub async fn handle_terminate_response(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
-    let Ok(hdr) = zdp::ZdpTerminateLinkResponseHeader::read_from_buf(&mut pkt) else {
-        return Err(HandleMgmtError::BadStructure);
-    };
-
-    let link_id = pkt.metadata().ingress_link_id;
-    let resp_code = hdr.response_code;
-    debug!(target: ZDP, "Link {link_id}: received TerminateLinkResponse, status: {resp_code:?}");
-    let _ignore_errors = asm
-        .process_link_state_event(link_id, LinkEvent::ReceivedTerminateResponse(resp_code))
-        .map_err(|_| ());
+    );
 
     Ok(())
 }

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -224,33 +224,21 @@ pub fn send_grant_zpr_address_request<'a>(
     )
 }
 
-/// send a Terminate Request (RFC 6.5 § 6.3.3)
-pub fn send_terminate_request<'a, 'pktbuf>(
+/// send a Terminate Link or Docking Session message (TODO: document)
+pub fn send_terminate_link_or_docking_session<'a, 'pktbuf>(
     asm: &Assembly,
     link_id: LinkId,
     reason: zdp::TerminateReason,
 ) -> Sent<'_> {
     let mut pkt = core::new_heap_packet();
-    pkt.push_header(&zdp::ZdpTerminateLinkRequestHeader {
+    pkt.push_header(&zdp::ZdpTerminateLinkOrDockingSessionHeader {
         reason_code: reason,
         data_len: 0,
     });
-    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::TerminateLinkRequest, pkt)
-}
-
-/// send a Terminate Indication (RFC 6.5 § 6.3.3)
-pub fn send_terminate_indication<'a, 'pktbuf>(
-    asm: &Assembly,
-    link_id: LinkId,
-    reason: zdp::TerminateReason,
-) -> Sent<'_> {
-    let mut pkt = core::new_heap_packet();
-    let hdr = pkt.alloc_zeroed_header::<zdp::ZdpTerminateLinkIndicationHeader>();
-    hdr.reason_code = reason;
     core::send_non_flow_mgmt(
         asm,
         link_id,
-        zdp::ZdpPacketType::TerminateLinkIndication,
+        zdp::ZdpPacketType::TerminateLinkOrDockingSession,
         pkt,
     )
 }

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -150,10 +150,6 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
                 handlers::handle_terminate_link_or_docking_session(asm, pkt).await
             }
 
-            ZdpPacketType::TerminateLinkResponse => {
-                handlers::handle_terminate_response(asm, pkt).await
-            }
-
             ZdpPacketType::HelloRequest => handlers::handle_hello_request(asm, pkt).await,
 
             ZdpPacketType::HelloResponse => handlers::handle_hello_response(asm, pkt).await,

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -146,16 +146,12 @@ async fn handle_packet(asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult
                 panic!("unexpected Key Management message in mgmt processor")
             }
 
-            ZdpPacketType::TerminateLinkRequest => {
-                handlers::handle_terminate_request(asm, pkt).await
+            ZdpPacketType::TerminateLinkOrDockingSession => {
+                handlers::handle_terminate_link_or_docking_session(asm, pkt).await
             }
 
             ZdpPacketType::TerminateLinkResponse => {
                 handlers::handle_terminate_response(asm, pkt).await
-            }
-
-            ZdpPacketType::TerminateLinkIndication => {
-                handlers::handle_terminate_indication(asm, pkt).await
             }
 
             ZdpPacketType::HelloRequest => handlers::handle_hello_request(asm, pkt).await,

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -38,7 +38,7 @@ pub enum ZdpPacketType {
     EchoRequest = 131,
     Unused132 = 132,
     TerminateLinkOrDockingSession = 133,
-    TerminateLinkResponse = 134,
+    Unused134 = 134,
     Unused135 = 135,
     HelloRequest = 136,
     HelloResponse = 137,
@@ -208,14 +208,6 @@ pub struct ZdpTerminateLinkOrDockingSessionHeader {
     pub reason_code: TerminateReason,
     pub data_len: u8,
     // followed by reason detail
-}
-
-/// Terminate Link Response (§ 6.3.3)
-#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
-#[repr(packed)]
-pub struct ZdpTerminateLinkResponseHeader {
-    pub response_code: ResponseCode,
-    pub data_len: u8,
 }
 
 /// Bind Actor Address request (§ 6.3.11)

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -37,9 +37,9 @@ pub enum ZdpPacketType {
     Discard = 130,
     EchoRequest = 131,
     Unused132 = 132,
-    TerminateLinkRequest = 133,
+    TerminateLinkOrDockingSession = 133,
     TerminateLinkResponse = 134,
-    TerminateLinkIndication = 135,
+    Unused135 = 135,
     HelloRequest = 136,
     HelloResponse = 137,
     ConfigurationRequest = 138,
@@ -201,20 +201,13 @@ pub enum TerminateReason {
     Shutdown = 4, // quell any restart behavior
 }
 
-/// Terminate Link Indication (§ 6.3.3)
+/// Terminate Link or Docking Session (TODO: document)
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(packed)]
-pub struct ZdpTerminateLinkIndicationHeader {
+pub struct ZdpTerminateLinkOrDockingSessionHeader {
     pub reason_code: TerminateReason,
     pub data_len: u8,
-}
-
-/// Terminate Link Request (§ 6.3.3)
-#[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
-#[repr(packed)]
-pub struct ZdpTerminateLinkRequestHeader {
-    pub reason_code: TerminateReason,
-    pub data_len: u8,
+    // followed by reason detail
 }
 
 /// Terminate Link Response (§ 6.3.3)


### PR DESCRIPTION
TerminateRequest and TerminateIndication now both do the same thing (terminate the link regardless of whether we're in Invalid or not, and reply with a ZDPR ACK).  TerminateResponse has been eliminated in favor of ZDPR ACK (which we wait for in a Tokio local task).

Maybe easier to view each commit separately.