### PR TITLE
Cleanup handlers.rs

### DIFF
--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -143,7 +143,6 @@ pub enum LinkEvent {
     ReceivedHelloRequest,
     AssignedAAA(IpAddress), // Assigned AAA address for this link
     ReceivedHelloResponse(ResponseCode, IpAddress, Option<Vec<SocketAddr>>), // (response code, AAA address, ASA addresses)
-    SentHelloResponse,
 
     ReceivedInitAuth((bool, Option<auth::ZdpInitAuthenticationPayload>)), // (bootstrap_flag, challenge)
     ReceivedInitAuthAck,
@@ -446,8 +445,6 @@ impl LinkStateWrapper {
                 self.process_hello_response(asm, code, aaa_addr, maybe_asa_addrs)
             }
 
-            LinkEvent::SentHelloResponse => self.process_sent_hello_response(asm),
-
             LinkEvent::ReceivedAcquireZprAddressRequest(addrs, blob) => {
                 self.process_acquire_zpr_address_request(asm, addrs, blob)
             }
@@ -622,7 +619,7 @@ impl LinkStateWrapper {
     /// Update link state based on received hello request
     /// Transitions from Helloing to Registering Actor Address
     /// Does not generate any packets
-    fn process_hello_request(&self, _asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
+    fn process_hello_request(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
         let mut locked_fsm = self.locked_fsm.lock().unwrap();
         let link_id = self.id;
         match (self.link_type, locked_fsm.state) {
@@ -636,15 +633,59 @@ impl LinkStateWrapper {
                     target: LINK_STATE,
                     "Link {link_id} received hello request",
                 );
-                // State transition processing happens in [LinkStateWrapper::process_sent_hello_response]
+
+                // Reply with a Hello Response.
+
+                // Technically we do not need to supply an AAA address to an adapter fronting the visa service,
+                // or if we do not have an external authentication service available.  For simplicity we just
+                // always hand one out.
+                let mut address_pool = asm.address_pool.lock().unwrap();
+                let Some(pool) = address_pool.as_mut() else {
+                    // Programming error: if we are a node, we must have a pool.
+                    panic!("adapter (node) handling a hello-request missing address pool");
+                };
+
+                let aaa_address = pool.get_aaa_address();
+                debug!(target: LINK_STATE, "Link {link_id}: HelloResponse - allocated AAA address: {aaa_address} (active pool size: {})",
+                    pool.len());
+
+                drop(address_pool);
+
+                // Store the AAA in the link memory so we can free it later.
+                self.process_assigned_aaa(asm, aaa_address)?;
+
+                let policy_id: i64 = 0; // TODO: We get policy ID from visa service. Record that somewhere, access it here.
+                let asa_addresses = get_available_asa_addresses(&asm, link_id);
+
+                mgmt::requests::send_hello_success_response(
+                    &asm,
+                    link_id,
+                    policy_id,
+                    &asa_addresses,
+                    aaa_address.into(),
+                )
+                .enqueue();
+
+                // Now follow with an init auth request.
+
+                locked_fsm.set_state(LinkState::WaitForAcquireZprAddress);
+                self.send_init_authentication_request(asm);
+                // short timeout until we at least get the ACK
+                self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_TIMEOUT);
+                debug!(
+                    target: LINK_STATE,
+                    "Link {link_id} finished helloing.  Waiting for other side to respond to init-auth"
+                );
                 Ok(())
             }
+
             (LinkType::AdapterToNode, _) => {
                 // Adapters should not be receiving these messages from nodes
                 Err(LinkStateError::InvalidOperation(
                     "Discarded unsolicited Hello Request".to_string(),
                 ))
             }
+
             (_, _) => Err(LinkStateError::UnexpectedTransition(
                 locked_fsm.state,
                 "ReceivedHelloRequest",
@@ -665,36 +706,6 @@ impl LinkStateWrapper {
         let mut link_data = self.locked_data.lock().unwrap();
         link_data.aaa_address = Some(aaa_addr);
         Ok(())
-    }
-
-    fn process_sent_hello_response(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
-        let mut locked_fsm = self.locked_fsm.lock().unwrap();
-        let link_id = self.id;
-        match (self.link_type, locked_fsm.state) {
-            // Node->Adapter - we are in helloing state until we have fired off our
-            // HelloResponse.  At that point we can send an init-auth request.
-            (LinkType::NodeToAdapter, LinkState::Helloing) => {
-                locked_fsm.set_state(LinkState::WaitForAcquireZprAddress);
-                self.send_init_authentication_request(asm);
-                // short timeout until we at least get the ACK
-                self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_TIMEOUT);
-                debug!(
-                    target: LINK_STATE,
-                    "Link {link_id} finished helloing.  Waiting for other side to respond to init-auth"
-                );
-                Ok(())
-            }
-            (LinkType::AdapterToNode, _) => {
-                // Adapters should not be sending hello-response to a node.
-                Err(LinkStateError::InvalidOperation(
-                    "Adapter should not send hello-response".to_string(),
-                ))
-            }
-            (_, _) => Err(LinkStateError::UnexpectedTransition(
-                locked_fsm.state,
-                "SentHelloResponse",
-            )),
-        }
     }
 
     /// This is kicked off by [LinkEvent::ReceivedHelloResponse].
@@ -1715,6 +1726,28 @@ impl LinkStateWrapper {
         });
         Ok(())
     }
+}
+
+fn get_available_asa_addresses(asm: &Assembly, link_id: LinkId) -> Vec<SocketAddr> {
+    let mut asa_addresses = Vec::new();
+
+    let svclist = asm.vs_auth_services.read().unwrap();
+    if svclist.is_valid() {
+        // If we have a list of services, include them in the response.
+        // TODO: The ASA is set as a SocketAddr which doesn't feel quite right.  Maybe should be a URI.
+        for authservice in &svclist.services {
+            if let Some(sa) = authservice.get_socket_addr() {
+                debug!(target: LINK_STATE, "Link {link_id}: HelloResponse - adding ASA address: {sa}");
+                asa_addresses.push(sa);
+            } else {
+                warn!(target: LINK_STATE, "Link {link_id}: HelloResponse - service {} has no valid ASA address", authservice.service_id);
+            }
+        }
+    } else {
+        warn!(target: LINK_STATE, "Link {link_id}: HelloResponse - no valid auth services available");
+    }
+
+    asa_addresses
 }
 
 impl Display for LinkStateWrapper {

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -1,20 +1,19 @@
 //! Handlers for management requests.
 //!
 //! These handlers just decode the packet and forward work to whatever
-//! internal API is responsible for handling it.  There are (should be) no
-//! "smarts" in this module.  (FIXME: this is currently not true!)
+//! internal API is responsible for handling it.  There are no "smarts" in
+//! this module.
 
 use super::txn_mgr::TxnId;
 use super::{adapter, dock};
-use crate::assembly::{Assembly, PhMode, VERSION};
+use crate::assembly::{Assembly, PhMode};
 use crate::auth;
-use crate::config;
 use crate::counters;
 use crate::link_state::{LinkEvent, LinkStateError};
 use crate::logging::targets::{FLOW_MGMT, REPORTING, ZDP};
 use crate::packet::Packet;
 use crate::tc;
-use crate::tlv::{self, TlvEncoding};
+use crate::tlv;
 use crate::zdp;
 use bytes::Buf;
 use std::net::SocketAddr;
@@ -235,71 +234,7 @@ pub async fn handle_hello_request(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
         }
     }
 
-    let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
-    let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpHelloResponseHeader>();
-
     asm.process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloRequest)?;
-
-    // Technically we do not need to supply an AAA address to an adapter fronting the visa service,
-    // or if we do not have an external authentication service available.  For simplicity we just
-    // always hand one out.
-    let mut address_pool = asm.address_pool.lock().unwrap();
-    let Some(pool) = address_pool.as_mut() else {
-        // Programming error: if we are a node, we must have a pool.
-        panic!("adapter (node) handling a hello-request missing address pool");
-    };
-
-    let aaa_address = pool.get_aaa_address();
-    debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {aaa_address} (active pool size: {})",
-        pool.len());
-
-    // Store the AAA in the link memory so we can free it later.
-    match asm.process_link_state_event(ingress_link_id, LinkEvent::AssignedAAA(aaa_address)) {
-        Err(e) => {
-            // Highly improbable
-            panic!("Link {ingress_link_id}: failed to process AssignedAAA event: {e}");
-        }
-        Ok(()) => (),
-    }
-
-    drop(address_pool);
-
-    hdr.status = zdp::ResponseCode::Success;
-
-    // Policy ID and version are always included, even if not SUCCESS.
-    let policy_id: i64 = 0; // TODO: We get policy ID from visa service. Record that somewhere, access it here.
-    TlvEncoding::new_policy_id(policy_id).put(&mut rsp_pkt);
-    TlvEncoding::new_version(VERSION).put(&mut rsp_pkt);
-    super::helpers::put_window_size_tlv(&asm, ingress_link_id, &mut rsp_pkt);
-
-    let svclist = asm.vs_auth_services.read().unwrap();
-    if svclist.is_valid() {
-        // If we have a list of services, include them in the response.
-        // TODO: The ASA is set as a SocketAddr which doesn't feel quite right.  Maybe should be a URI.
-        for authservice in &svclist.services {
-            if let Some(sa) = authservice.get_socket_addr() {
-                debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - adding ASA address: {sa}");
-                TlvEncoding::new_asa(sa).put(&mut rsp_pkt);
-            } else {
-                warn!(target: ZDP, "Link {ingress_link_id}: HelloResponse - service {} has no valid ASA address", authservice.service_id);
-            }
-        }
-    } else {
-        warn!(target: ZDP, "Link {ingress_link_id}: HelloResponse - no valid auth services available");
-    }
-    drop(svclist);
-
-    TlvEncoding::new_aaa(aaa_address).put(&mut rsp_pkt);
-
-    super::core::send_non_flow_mgmt(
-        asm,
-        ingress_link_id,
-        zdp::ZdpPacketType::HelloResponse,
-        rsp_pkt,
-    )
-    .await?;
-
-    asm.process_link_state_event(ingress_link_id, LinkEvent::SentHelloResponse)?;
 
     Ok(())
 }

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -44,17 +44,21 @@ pub enum HandleMgmtError {
     #[error("unknown transaction")]
     UnknownTransaction,
 
+    #[error("link state error: {0}")]
+    LinkStateError(#[from] LinkStateError),
+
     #[error("link closed")]
     LinkClosed,
 }
 
-impl From<HandleMgmtError> for counters::ManagementCounterType {
-    fn from(err: HandleMgmtError) -> Self {
+impl From<&HandleMgmtError> for counters::ManagementCounterType {
+    fn from(err: &HandleMgmtError) -> Self {
         match err {
             HandleMgmtError::UnknownType(_type) => Self::UnknownType,
             HandleMgmtError::BadStructure => Self::BadStructure,
             HandleMgmtError::MessageNotPermitted => Self::OtherError,
             HandleMgmtError::UnknownTransaction => Self::UnknownTransaction,
+            HandleMgmtError::LinkStateError(_) => Self::OtherError,
             HandleMgmtError::LinkClosed => Self::OtherError,
         }
     }
@@ -86,33 +90,6 @@ impl From<dock::InstallTetherError> for HandleMgmtError {
 }
 
 pub type HandleMgmtResult = Result<(), HandleMgmtError>;
-
-/// Fire an event into the given link state machine. If there is an event handler error
-/// it will be returned but only after we try to send in an ERROR event which should
-/// end up triggering a link shutdown.
-///
-/// The error result is returned for informational purposes only. If you are getting an
-/// error we have already logged it and have attempted to send an Error event into the
-/// link state machine.
-fn dispatch_link_state_event_or_error(
-    asm: &Arc<Assembly>,
-    link_id: LinkId,
-    event: LinkEvent,
-) -> Result<(), LinkStateError> {
-    if let Err(ls_err) = asm.process_link_state_event(link_id, event) {
-        error!(target: ZDP, "Link {link_id} failed to process link state event:  {ls_err}");
-        match asm.process_link_state_event(link_id, LinkEvent::Error) {
-            Err(e) => {
-                // TODO: I assume this is possible if we for example have async closed the link.
-                error!(target: ZDP, "Link {link_id}: failed to process Error event: {e}");
-            }
-            Ok(()) => (),
-        }
-        Err(ls_err)
-    } else {
-        Ok(())
-    }
-}
 
 /// handle a Report message (RFC 6.5 § 6.3.13)
 pub async fn handle_report(_asm: &Arc<Assembly>, mut pkt: Packet) -> HandleMgmtResult {
@@ -193,11 +170,10 @@ pub async fn handle_init_authentication_request(
         challenge_opt = None;
     }
 
-    let _ = dispatch_link_state_event_or_error(
-        asm,
+    asm.process_link_state_event(
         ingress_link_id,
         LinkEvent::ReceivedInitAuth((is_bootstrap, challenge_opt)),
-    );
+    )?;
 
     Ok(())
 }
@@ -218,10 +194,10 @@ pub async fn handle_terminate_link_or_docking_session(
 
     info!(target: ZDP, "Received Terminate Link or Docking Session for link {ingress_link_id}");
 
-    let _ = asm.process_link_state_event(
+    asm.process_link_state_event(
         ingress_link_id,
         LinkEvent::ReceivedTerminateLink(hdr.reason_code),
-    );
+    )?;
 
     Ok(())
 }
@@ -262,11 +238,13 @@ pub async fn handle_hello_request(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
     let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpHelloResponseHeader>();
 
-    let response_status =
-        match asm.process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloRequest) {
-            Err(_) => zdp::ResponseCode::Other,
-            Ok(()) => zdp::ResponseCode::Success,
-        };
+    let hello_status =
+        asm.process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloRequest);
+
+    let response_status = match hello_status {
+        Err(_) => zdp::ResponseCode::Other,
+        Ok(()) => zdp::ResponseCode::Success,
+    };
 
     let mut aaa_address: Option<IpAddress> = None;
 
@@ -331,29 +309,9 @@ pub async fn handle_hello_request(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
     )
     .await?;
 
-    let close_link = if response_status == zdp::ResponseCode::Success {
-        match asm.process_link_state_event(ingress_link_id, LinkEvent::SentHelloResponse) {
-            Err(e) => {
-                error!(target: ZDP, "Link {ingress_link_id}: Failed to process SentHelloResponse event: {:?}", e);
-                true
-            }
-            Ok(()) => false,
-        }
-    } else {
-        // TODO: The framework within which this function is called does not allow us to
-        // return an error back which would trigger a link shutdown.  So we do it manually
-        // and just return Ok() though things are not in fact OK.
-        info!(target: ZDP, "Link {ingress_link_id}: HelloRequest processing failed, shutting down link");
-        true
-    };
-    if close_link {
-        match asm.process_link_state_event(ingress_link_id, LinkEvent::Error) {
-            Err(e) => {
-                error!(target: ZDP, "Link {ingress_link_id}: failed to process Error event: {e}");
-            }
-            Ok(()) => (),
-        }
-    }
+    hello_status?;
+
+    asm.process_link_state_event(ingress_link_id, LinkEvent::SentHelloResponse)?;
 
     Ok(())
 }
@@ -447,11 +405,10 @@ pub async fn handle_hello_response(asm: &Arc<Assembly>, mut pkt: Packet) -> Hand
         Some(asa_addresses)
     };
 
-    let _ = dispatch_link_state_event_or_error(
-        asm,
+    asm.process_link_state_event(
         link_id,
         LinkEvent::ReceivedHelloResponse(status, aaa_address.unwrap(), maybe_asa_addrs),
-    );
+    )?;
 
     Ok(())
 }
@@ -519,11 +476,10 @@ pub async fn handle_acquire_zpr_address_request(
 
     debug!(target: ZDP, "Link {}: received Acquire ZPR Address Request for link with addresses {:?}", ingress_link_id, actor_addresses);
 
-    let _ = dispatch_link_state_event_or_error(
-        asm,
+    asm.process_link_state_event(
         ingress_link_id,
         LinkEvent::ReceivedAcquireZprAddressRequest(actor_addresses, blob),
-    );
+    )?;
 
     Ok(())
 }
@@ -563,16 +519,11 @@ pub async fn handle_grant_zpr_address_request(
         }
     };
 
-    let processing_result = asm.process_link_state_event(
+    asm.process_link_state_event(
         ingress_link_id,
         LinkEvent::ReceivedGrantZprAddressRequest(grant_event_payload),
-    );
+    )?;
 
-    // If we got an error from the state machine, send an error back into it.
-    if let Err(e) = processing_result {
-        error!(target: ZDP, "Link {ingress_link_id}: Failed to process GrantZprAddressRequest event: {:?}", e);
-        let _ignore_errors = asm.process_link_state_event(ingress_link_id, LinkEvent::Error);
-    }
     Ok(())
 }
 

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -238,41 +238,33 @@ pub async fn handle_hello_request(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
     let mut rsp_pkt = Packet::new(pkt.destroy(), config::DEFAULT_MESSAGE_HEADROOM);
     let hdr = rsp_pkt.alloc_zeroed_header::<zdp::ZdpHelloResponseHeader>();
 
-    let hello_status =
-        asm.process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloRequest);
+    asm.process_link_state_event(ingress_link_id, LinkEvent::ReceivedHelloRequest)?;
 
-    let response_status = match hello_status {
-        Err(_) => zdp::ResponseCode::Other,
-        Ok(()) => zdp::ResponseCode::Success,
+    // Technically we do not need to supply an AAA address to an adapter fronting the visa service,
+    // or if we do not have an external authentication service available.  For simplicity we just
+    // always hand one out.
+    let mut address_pool = asm.address_pool.lock().unwrap();
+    let Some(pool) = address_pool.as_mut() else {
+        // Programming error: if we are a node, we must have a pool.
+        panic!("adapter (node) handling a hello-request missing address pool");
     };
 
-    let mut aaa_address: Option<IpAddress> = None;
+    let aaa_address = pool.get_aaa_address();
+    debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {aaa_address} (active pool size: {})",
+        pool.len());
 
-    if response_status == zdp::ResponseCode::Success {
-        // Technically we do not need to supply an AAA address to an adapter fronting the visa service,
-        // or if we do not have an external authentication service available.  For simplicity we just
-        // always hand one out.
-        if let Some(pool) = asm.address_pool.lock().unwrap().as_mut() {
-            let addr = pool.get_aaa_address();
-            debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - allocated AAA address: {addr} (active pool size: {})",
-                pool.len());
-            aaa_address = Some(addr);
-
-            // Store the AAA in the link memory so we can free it later.
-            match asm.process_link_state_event(ingress_link_id, LinkEvent::AssignedAAA(addr)) {
-                Err(e) => {
-                    // Highly improbable
-                    panic!("Link {ingress_link_id}: failed to process AssignedAAA event: {e}");
-                }
-                Ok(()) => (),
-            }
-        } else {
-            // Programming error: if we are a node, we must have a pool.
-            panic!("adapter (node) handling a hello-request missing address pool");
+    // Store the AAA in the link memory so we can free it later.
+    match asm.process_link_state_event(ingress_link_id, LinkEvent::AssignedAAA(aaa_address)) {
+        Err(e) => {
+            // Highly improbable
+            panic!("Link {ingress_link_id}: failed to process AssignedAAA event: {e}");
         }
+        Ok(()) => (),
     }
 
-    hdr.status = response_status;
+    drop(address_pool);
+
+    hdr.status = zdp::ResponseCode::Success;
 
     // Policy ID and version are always included, even if not SUCCESS.
     let policy_id: i64 = 0; // TODO: We get policy ID from visa service. Record that somewhere, access it here.
@@ -280,26 +272,24 @@ pub async fn handle_hello_request(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
     TlvEncoding::new_version(VERSION).put(&mut rsp_pkt);
     super::helpers::put_window_size_tlv(&asm, ingress_link_id, &mut rsp_pkt);
 
-    if response_status == zdp::ResponseCode::Success {
-        let svclist = asm.vs_auth_services.read().unwrap();
-        if svclist.is_valid() {
-            // If we have a list of services, include them in the response.
-            // TODO: The ASA is set as a SocketAddr which doesn't feel quite right.  Maybe should be a URI.
-            for authservice in &svclist.services {
-                if let Some(sa) = authservice.get_socket_addr() {
-                    debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - adding ASA address: {sa}");
-                    TlvEncoding::new_asa(sa).put(&mut rsp_pkt);
-                } else {
-                    warn!(target: ZDP, "Link {ingress_link_id}: HelloResponse - service {} has no valid ASA address", authservice.service_id);
-                }
+    let svclist = asm.vs_auth_services.read().unwrap();
+    if svclist.is_valid() {
+        // If we have a list of services, include them in the response.
+        // TODO: The ASA is set as a SocketAddr which doesn't feel quite right.  Maybe should be a URI.
+        for authservice in &svclist.services {
+            if let Some(sa) = authservice.get_socket_addr() {
+                debug!(target: ZDP, "Link {ingress_link_id}: HelloResponse - adding ASA address: {sa}");
+                TlvEncoding::new_asa(sa).put(&mut rsp_pkt);
+            } else {
+                warn!(target: ZDP, "Link {ingress_link_id}: HelloResponse - service {} has no valid ASA address", authservice.service_id);
             }
-        } else {
-            warn!(target: ZDP, "Link {ingress_link_id}: HelloResponse - no valid auth services available");
         }
-        if let Some(aaa_addr) = aaa_address {
-            TlvEncoding::new_aaa(aaa_addr).put(&mut rsp_pkt);
-        }
+    } else {
+        warn!(target: ZDP, "Link {ingress_link_id}: HelloResponse - no valid auth services available");
     }
+    drop(svclist);
+
+    TlvEncoding::new_aaa(aaa_address).put(&mut rsp_pkt);
 
     super::core::send_non_flow_mgmt(
         asm,
@@ -308,8 +298,6 @@ pub async fn handle_hello_request(asm: &Arc<Assembly>, mut pkt: Packet) -> Handl
         rsp_pkt,
     )
     .await?;
-
-    hello_status?;
 
     asm.process_link_state_event(ingress_link_id, LinkEvent::SentHelloResponse)?;
 

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -6,14 +6,16 @@
 
 use super::core::{self, Sent};
 use super::txn_mgr::TxnId;
+use crate::assembly;
 use crate::config;
 use crate::logging::targets::ZDP;
 use crate::tc;
+use crate::tlv;
 use crate::zdp;
 use crate::{assembly::Assembly, auth};
 
 use bytes::BufMut;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use tracing::*;
 use zpr::packet_info::{KmId, L3Type, L3TypeDeriveable, LinkId, StreamId, Tcst};
 use zpr_ext::zerocopy::IntoBytesExt;
@@ -50,7 +52,7 @@ pub fn send_echo_request(asm: &Assembly, link_id: LinkId) -> Sent<'_> {
     core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::EchoRequest, pkt)
 }
 
-/// send a Hello Request and wait for the Response (RFC 6.5 § 6.3.4)
+/// send a Hello Request (RFC 6.5 § 6.3.4)
 ///
 /// Originally this was used to send the pre-configured ZPR address of the
 /// remote adapter into the node.  This is no longer necessary.
@@ -60,6 +62,32 @@ pub fn send_hello_request(asm: &Assembly, link_id: LinkId) -> Sent<'_> {
     pkt.alloc_zeroed_header::<zdp::ZdpHelloRequestHeader>();
     super::helpers::put_window_size_tlv(asm, link_id, &mut pkt);
     core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::HelloRequest, pkt)
+}
+
+pub fn send_hello_success_response<'a>(
+    asm: &'a Assembly,
+    link_id: LinkId,
+    policy_id: i64,
+    asa_addresses: &[SocketAddr],
+    aaa_address: IpAddr,
+) -> Sent<'a> {
+    let mut pkt = core::new_heap_packet();
+    let hdr = pkt.alloc_zeroed_header::<zdp::ZdpHelloResponseHeader>();
+    hdr.status = zdp::ResponseCode::Success;
+
+    // Policy ID and version are always included, even if not SUCCESS.
+    tlv::TlvEncoding::new_policy_id(policy_id).put(&mut pkt);
+    tlv::TlvEncoding::new_version(assembly::VERSION).put(&mut pkt);
+
+    super::helpers::put_window_size_tlv(&asm, link_id, &mut pkt);
+
+    for asa_address in asa_addresses {
+        tlv::TlvEncoding::new_asa(*asa_address).put(&mut pkt);
+    }
+
+    tlv::TlvEncoding::new_aaa(aaa_address.into()).put(&mut pkt);
+
+    core::send_non_flow_mgmt(asm, link_id, zdp::ZdpPacketType::HelloResponse, pkt)
 }
 
 /// Send Init Authentication (NOT YET IN RFC 6)

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -41,7 +41,7 @@ pub async fn launch(
                         if let Err(e) = asm.process_link_state_event(link_id, LinkEvent::Error) {
                             error!(target: LINK_STATE, "Error handling link error on link {link_id}: {e}");
                         }
-                        mgmt::core::count_event(&asm, err.into());
+                        mgmt::core::count_event(&asm, (&err).into());
                     }
                 }
             }


### PR DESCRIPTION
These three changes finalize my push to move all the "smarts" out of handlers.rs and into modules associated with the things being controlled.  We do three things here:

1) Clean up link state error handling (it was done a few different ways and also redundantly)
2) Drop the link instead of replying with an error if we got a malformed HelloRequest (making this consistent with handling other protocol errors).
3) Move HelloRequest processing into link_state.rs & simplify by removing an intermediate state which wasn't actually waiting on anything.

Maybe easiest to review each commit separately.