### PR TITLE
aligned core with new blob format in vsapi_types::ConnectRequest

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -1315,7 +1315,7 @@ dependencies = [
  "tracing",
  "vsapi",
  "zerocopy 0.8.9",
- "zpr",
+ "zpr 0.4.0",
  "zpr-utils",
 ]
 
@@ -1669,7 +1669,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "zerocopy 0.8.9",
- "zpr",
+ "zpr 0.5.0",
  "zpr-ext",
  "zpr-utils",
 ]
@@ -3179,6 +3179,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "zpr"
+version = "0.5.0"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.5.0#55a97cbe63a8d951e8aab7b196737f6a900a7616"
+dependencies = [
+ "capnp",
+ "capnpc",
+ "open-enum",
+ "thiserror",
+ "url",
+ "vsapi",
+ "zerocopy 0.8.9",
+]
+
+[[package]]
 name = "zpr-ext"
 version = "0.5.3"
 dependencies = [
@@ -3195,5 +3209,5 @@ name = "zpr-utils"
 version = "0.1.0"
 dependencies = [
  "zerocopy 0.8.9",
- "zpr",
+ "zpr 0.4.0",
 ]

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -50,7 +50,7 @@ url = "2.5.4"
 zerocopy = { version = "0.8.3", features = ["derive", "std"] }
 zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "socket2", "zerocopy"] }
 zpr-utils = { path = "../../zpr-utils" }
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.1.0", features = ["vsapi"] }
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.6.0", features = ["vsapi"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7.4", optional = true }

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -74,9 +74,7 @@ pub fn build_connect_request(
     }
 
     // The visa service expects to find the BLOBs in the challenge response buffers.
-    let mut ss = vsapi_types::ZprSelfSignedBlob::default();
-    ss.challenge = blob.as_bytes().to_vec();
-    let crbufs: Vec<vsapi_types::AuthBlob> = vec![vsapi_types::AuthBlob::SS(ss)];
+    let crbufs = vsapi_types::AuthBlobV1::new(vec![blob.as_bytes().to_vec()]);
 
     let mut claims = Vec::new();
     if addr != IpAddress::UNSPECIFIED {
@@ -94,7 +92,7 @@ pub fn build_connect_request(
     let connect_req = vsapi_types::ConnectRequest {
         substrate_addr: asm.get_local_dock_addr(),
         claims: claims,
-        blobs: crbufs,
+        blobs: vsapi_types::AuthBlobs::V1(crbufs),
         dock_interface: 0,
     };
     Ok(Some(connect_req))


### PR DESCRIPTION
Will not compile until zpr-common v0.6.0 is tagged. May require some other updates since core is currently relying on zpr-common v0.1.0, so other breaking changes may have been introduced, but I don't think so. I compiled it locally and it worked, so I think it should be fine.