### PR TITLE
Mk/1194 blobs

### DIFF
--- a/adapter/ph/Cargo.lock
+++ b/adapter/ph/Cargo.lock
@@ -3165,13 +3165,12 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.4.0"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.1.0#7edfe8212acc1d661db01a7f8bb60302f441695e"
+version = "0.6.0"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.6.0#d5eb7cfc362e3f70a035758b6fa92b4735cbe988"
 dependencies = [
  "capnp",
  "capnpc",
  "open-enum",
- "strum 0.26.3",
  "thiserror",
  "url",
  "vsapi",

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -50,7 +50,7 @@ url = "2.5.4"
 zerocopy = { version = "0.8.3", features = ["derive", "std"] }
 zpr-ext = { path = "../../zpr-ext", features = ["bytes", "tokio", "socket2", "zerocopy"] }
 zpr-utils = { path = "../../zpr-utils" }
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.1.0", features = ["vsapi"] }
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.6.0", features = ["vsapi"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7.4", optional = true }

--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -147,7 +147,7 @@ pub struct ZdpAuthCodeBlob {
 /// Enum used to return different blob types based on their blob_type field.
 #[allow(dead_code)]
 #[derive(Debug)]
-pub enum DecodedBlob {
+pub enum AuthBlob {
     SelfSigned(ZdpSelfSignedBlob),
     AuthCode(ZdpAuthCodeBlob),
 }
@@ -202,6 +202,12 @@ impl ZdpAuthCodeBlob {
 }
 
 impl ZdpSelfSignedBlob {
+    /// Gets the "encoded" form of the blob: base64 encoded JSON.
+    pub fn encode(&self) -> String {
+        let json_txt = serde_json::to_string(self).unwrap();
+        BASE64_STANDARD.encode(&json_txt)
+    }
+
     /// The `challenge` field in the blob is a base64 encoded [zdp::ZdpInitAuthenticationPayload].
     /// This extracts that data and checks that:
     ///   - The CN in the provided `peer_cert` matches the CN in the blob.
@@ -286,9 +292,9 @@ impl ZdpInitAuthenticationPayload {
     }
 }
 
-/// Decode a blob string into a [DecodedBlob] object.
+/// Decode a blob string into a [AuthBlob] object.
 /// The blob string is base64 encoded JSON which contains a "blob_type" field.
-pub fn decode_blob(blob_str: &str) -> Result<DecodedBlob, AuthError> {
+pub fn decode_blob(blob_str: &str) -> Result<AuthBlob, AuthError> {
     let json_txt = BASE64_STANDARD.decode(blob_str)?;
 
     let jobj: Value = serde_json::from_slice(&json_txt)?;
@@ -299,11 +305,11 @@ pub fn decode_blob(blob_str: &str) -> Result<DecodedBlob, AuthError> {
     match blob_type.as_str() {
         Some(BLOB_TYPE_SS) => {
             let ss_blob = serde_json::from_slice::<ZdpSelfSignedBlob>(&json_txt)?;
-            Ok(DecodedBlob::SelfSigned(ss_blob))
+            Ok(AuthBlob::SelfSigned(ss_blob))
         }
         Some(BLOB_TYPE_AC) => {
             let ac_blob = serde_json::from_slice::<ZdpAuthCodeBlob>(&json_txt)?;
-            Ok(DecodedBlob::AuthCode(ac_blob))
+            Ok(AuthBlob::AuthCode(ac_blob))
         }
         _ => Err(AuthError::FormatError(format!(
             "unknown blob_type: {:?}",
@@ -386,10 +392,7 @@ impl RsaBootstrapAuth {
             challenge: BASE64_STANDARD.encode(&challenge),
             sig: sig_str,
         };
-
-        let json_txt = serde_json::to_string(&blob)?;
-        let blob_str = BASE64_STANDARD.encode(&json_txt);
-        Ok(blob_str)
+        Ok(blob.encode())
     }
 }
 

--- a/adapter/ph/src/five_tuple_lookup_table.rs
+++ b/adapter/ph/src/five_tuple_lookup_table.rs
@@ -348,7 +348,7 @@ impl ProtoAndId {
 mod tests {
     use super::*;
 
-    use libnode::vsapi;
+    use libnode::vsapi_thrift;
     use zpr::packet_info::L3Type;
     use zpr::vsapi_types;
     use zpr::vsapi_types::vsapi_ip_number;
@@ -356,13 +356,19 @@ mod tests {
     fn make_visa(
         src_addr: [u8; 16],
         dst_addr: [u8; 16],
-        l4proto: vsapi::PEPIndex,
+        l4proto: vsapi_thrift::PEPIndex,
         src_port: i32,
         dst_port: i32,
     ) -> Visa {
-        let src_dst =
-            vsapi::PEPArgsTCPUDP::new(Vec::new(), Vec::new(), src_port, dst_port, None, None);
-        let visa: vsapi::Visa = vsapi::Visa::new(
+        let src_dst = vsapi_thrift::PEPArgsTCPUDP::new(
+            Vec::new(),
+            Vec::new(),
+            src_port,
+            dst_port,
+            None,
+            None,
+        );
+        let visa: vsapi_thrift::Visa = vsapi_thrift::Visa::new(
             0,
             0,
             0,
@@ -386,7 +392,7 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port = 10;
         let dst_port = 11;
 
@@ -446,8 +452,8 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto1 = vsapi::PEPIndex::TCP;
-        let l4proto2 = vsapi::PEPIndex::UDP;
+        let l4proto1 = vsapi_thrift::PEPIndex::TCP;
+        let l4proto2 = vsapi_thrift::PEPIndex::UDP;
         let src_port = 10;
         let dst_port = 11;
 
@@ -526,7 +532,7 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port1 = 10;
         let src_port2 = 14;
         let dst_port = 11;
@@ -642,7 +648,7 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port = 10;
         let dst_port1 = 11;
         let dst_port2 = 14;
@@ -728,7 +734,7 @@ mod tests {
         let src_addr2 = [3u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port = 10;
         let dst_port = 11;
 
@@ -831,7 +837,7 @@ mod tests {
         let dst_addr1 = [2u8; 16];
         let dst_addr2 = [3u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port = 10;
         let dst_port = 11;
 
@@ -932,7 +938,7 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port = 10;
         let dst_port = 11;
 
@@ -961,7 +967,7 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port = 10;
         let dst_port = 11;
 
@@ -974,7 +980,7 @@ mod tests {
             dst_port as u16,
         );
 
-        let l4proto_diff = vsapi::PEPIndex::UDP;
+        let l4proto_diff = vsapi_thrift::PEPIndex::UDP;
         let src_port_diff = 13;
         let dst_port_diff = 14;
         let src_addr_diff = [3u8; 16];
@@ -1004,7 +1010,7 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port = 10;
         let dst_port = 11;
 
@@ -1073,7 +1079,7 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port = 10;
         let dst_port = 11;
 
@@ -1086,7 +1092,7 @@ mod tests {
             dst_port as u16,
         );
 
-        let l4proto_diff = vsapi::PEPIndex::UDP;
+        let l4proto_diff = vsapi_thrift::PEPIndex::UDP;
         let src_port_diff = 13;
         let dst_port_diff = 14;
         let src_addr_diff = [3u8; 16];
@@ -1162,7 +1168,7 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port = 0;
         let dst_port = 11;
 
@@ -1251,7 +1257,7 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port = 10;
         let dst_port = 0;
 
@@ -1341,8 +1347,8 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto1 = vsapi::PEPIndex::UDP;
-        let l4proto2 = vsapi::PEPIndex::TCP;
+        let l4proto1 = vsapi_thrift::PEPIndex::UDP;
+        let l4proto2 = vsapi_thrift::PEPIndex::TCP;
         let src_port_specified = 10;
         let src_port_wild = 0;
         let dst_port = 11;
@@ -1418,8 +1424,8 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto1 = vsapi::PEPIndex::UDP;
-        let l4proto2 = vsapi::PEPIndex::TCP;
+        let l4proto1 = vsapi_thrift::PEPIndex::UDP;
+        let l4proto2 = vsapi_thrift::PEPIndex::TCP;
         let src_port_specified = 10;
         let src_port_wild = 0;
         let dst_port = 11;
@@ -1495,7 +1501,7 @@ mod tests {
         let src_addr = [1u8; 16];
         let dst_addr = [2u8; 16];
 
-        let l4proto = vsapi::PEPIndex::TCP;
+        let l4proto = vsapi_thrift::PEPIndex::TCP;
         let src_port = 10;
         let dst_port = 11;
 
@@ -1508,7 +1514,7 @@ mod tests {
             dst_port as u16,
         );
 
-        let l4proto_diff = vsapi::PEPIndex::UDP;
+        let l4proto_diff = vsapi_thrift::PEPIndex::UDP;
         let src_port_diff = 13;
         let dst_port_diff = 14;
         let src_addr_diff = [3u8; 16];

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1,5 +1,5 @@
 use crate::assembly::Assembly;
-use crate::auth::{self, AUTH_KEY_SIZE_BYTES, DecodedBlob, ZdpAuthCodeBlob, ZdpSelfSignedBlob};
+use crate::auth::{self, AUTH_KEY_SIZE_BYTES, AuthBlob, ZdpAuthCodeBlob, ZdpSelfSignedBlob};
 use crate::config;
 use crate::counters::ManagementCounterType;
 use crate::km::{PeerCertificate, ZPIPair};
@@ -832,10 +832,10 @@ impl LinkStateWrapper {
             return self.process_error_response(asm);
         };
 
-        match d_blob {
-            DecodedBlob::AuthCode(_) => {}
-            DecodedBlob::SelfSigned(ss_blob) => {
-                if !self.check_self_signed_blob(asm, link_id, &ss_blob) {
+        match &d_blob {
+            AuthBlob::AuthCode(_) => {}
+            AuthBlob::SelfSigned(ss_blob) => {
+                if !self.check_self_signed_blob(asm, link_id, ss_blob) {
                     drop(locked_fsm);
                     return self.process_error_response(asm);
                 }
@@ -849,7 +849,7 @@ impl LinkStateWrapper {
             "About to build connect request"
         );
         // Now we have verified our part of the blob, we can send to the visa service for checking the signature.
-        match visa_mgmt::build_connect_request(asm, link_id, requested_addr, &blob) {
+        match visa_mgmt::build_connect_request(asm, link_id, requested_addr, &d_blob) {
             Ok(Some(conn_req)) => {
                 drop(locked_fsm);
                 Ok(visa_mgmt::authorize_connect(asm, link_id, conn_req))

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -1,4 +1,5 @@
 use crate::assembly::Assembly;
+use crate::auth::AuthBlob;
 use crate::counters::ManagementCounterType;
 use crate::link_state::{LinkEvent, LinkStateError};
 use crate::logging::targets::VISA_MGMT;
@@ -9,6 +10,7 @@ use std::num::NonZero;
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 use tracing::*;
+
 use zpr::dn::VISA_SERVICE_CN;
 use zpr::packet_info::{LinkId, VisaId};
 use zpr::vsapi_types::{self, AuthServicesList};
@@ -17,7 +19,7 @@ use zpr_utils::net_defs::IpAddress;
 pub fn authorize_connect(
     asm: &Arc<Assembly>,
     link_id: LinkId,
-    connect_req: vsapi_types::ConnectRequest,
+    connect_req: vsapi_types::ConnectRequestV1,
 ) {
     let task_asm = asm.clone();
     tokio::task::spawn_local(async move {
@@ -65,18 +67,28 @@ pub fn build_connect_request(
     asm: &Arc<Assembly>,
     id: LinkId,
     addr: IpAddress,
-    blob: &str,
-) -> Result<Option<vsapi_types::ConnectRequest>, LinkStateError> {
+    blob: &AuthBlob,
+) -> Result<Option<vsapi_types::ConnectRequestV1>, LinkStateError> {
     let cn = get_common_name(asm, id)?;
 
     if cn == VISA_SERVICE_CN {
         return Ok(None);
     }
 
-    // The visa service expects to find the BLOBs in the challenge response buffers.
-    let mut ss = vsapi_types::ZprSelfSignedBlob::default();
-    ss.challenge = blob.as_bytes().to_vec();
-    let crbufs: Vec<vsapi_types::AuthBlob> = vec![vsapi_types::AuthBlob::SS(ss)];
+    // In v2 the blobs are transported to the VS in a typed structure.
+    // In v1 (prototype) the blobs are b64 encoded json.
+    let mut crbufs: Vec<Vec<u8>> = Vec::new();
+    match blob {
+        AuthBlob::SelfSigned(ss_blob) => {
+            crbufs.push(ss_blob.encode().as_bytes().to_vec());
+        }
+        AuthBlob::AuthCode(ac_blob) => {
+            crbufs.push(ac_blob.encode().as_bytes().to_vec());
+        }
+    }
+
+    //let mut ss = vsapi_types::ZprSelfSignedBlob::default();
+    //ss.challenge = blob.as_bytes().to_vec();
 
     let mut claims = Vec::new();
     if addr != IpAddress::UNSPECIFIED {
@@ -91,11 +103,11 @@ pub fn build_connect_request(
     });
 
     // issue an Authorize Connect Request to the visa service for this adapter
-    let connect_req = vsapi_types::ConnectRequest {
-        substrate_addr: asm.get_local_dock_addr(),
+    let connect_req = vsapi_types::ConnectRequestV1 {
+        challenge_responses: crbufs,
         claims: claims,
-        blobs: crbufs,
-        dock_interface: 0,
+        dock_addr: asm.get_local_dock_addr(),
+        connection_id: 1,
     };
     Ok(Some(connect_req))
 }

--- a/libnode/Cargo.lock
+++ b/libnode/Cargo.lock
@@ -197,12 +197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,12 +622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustversion"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,28 +702,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "syn"
@@ -1129,13 +1095,12 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.4.0"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.1.0#7edfe8212acc1d661db01a7f8bb60302f441695e"
+version = "0.6.0"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.6.0#d5eb7cfc362e3f70a035758b6fa92b4735cbe988"
 dependencies = [
  "capnp",
  "capnpc",
  "open-enum",
- "strum",
  "thiserror",
  "url",
  "vsapi",

--- a/libnode/Cargo.toml
+++ b/libnode/Cargo.toml
@@ -13,7 +13,7 @@ thrift = "0.17.0"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-util = { version = "0.7.12", features = ["rt"] }
 tracing = "0.1.40"
-vsapi = { git = "https://github.com/org-zpr/zpr-vsapi-rs.git", tag = "v0.4.1" }
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.1.0" }
+vsapi_thrift = { package = "vsapi", git = "https://github.com/org-zpr/zpr-vsapi-rs.git", tag = "v0.4.1" }
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.6.0" }
 zerocopy = { version = "0.8.3", features = ["derive", "std"] }
 zpr-utils = { path = "../zpr-utils" }

--- a/libnode/src/display.rs
+++ b/libnode/src/display.rs
@@ -34,7 +34,7 @@ impl fmt::Display for VSSMsg {
 
 #[allow(dead_code)]
 /// Human readable version of the MSSMsg which includes some interior details of the visa.
-fn summarize_visa_hop(f: &mut Formatter<'_>, vh: &vsapi::VisaHop) -> fmt::Result {
+fn summarize_visa_hop(f: &mut Formatter<'_>, vh: &vsapi_thrift::VisaHop) -> fmt::Result {
     write!(
         f,
         "VisaHop(issuer_id: {}, hop_count: {}, visa: ",
@@ -83,7 +83,7 @@ fn summarize_visa(f: &mut Formatter<'_>, v: &vsapi_types::Visa) -> fmt::Result {
 
 #[allow(dead_code)]
 /// Attempt to surface the most critical bits of a visa.
-fn summarize_vsapi_visa(f: &mut Formatter<'_>, v: &vsapi::Visa) -> fmt::Result {
+fn summarize_vsapi_visa(f: &mut Formatter<'_>, v: &vsapi_thrift::Visa) -> fmt::Result {
     let mut icmp = false;
     let proto: String;
     let sport: String;
@@ -91,7 +91,7 @@ fn summarize_vsapi_visa(f: &mut Formatter<'_>, v: &vsapi::Visa) -> fmt::Result {
 
     match v.dock_pep {
         Some(pep) => match pep {
-            vsapi::PEPIndex::UDP | vsapi::PEPIndex::TCP => {
+            vsapi_thrift::PEPIndex::UDP | vsapi_thrift::PEPIndex::TCP => {
                 match &v.tcpudp_pep_args {
                     Some(args) => {
                         sport = to_string_or(&args.source_port, "(?)");
@@ -102,13 +102,13 @@ fn summarize_vsapi_visa(f: &mut Formatter<'_>, v: &vsapi::Visa) -> fmt::Result {
                         dport = "(none)".to_string();
                     }
                 }
-                if pep == vsapi::PEPIndex::UDP {
+                if pep == vsapi_thrift::PEPIndex::UDP {
                     proto = "UDP".to_string();
                 } else {
                     proto = "TCP".to_string();
                 }
             }
-            vsapi::PEPIndex::ICMP => {
+            vsapi_thrift::PEPIndex::ICMP => {
                 icmp = true;
                 proto = "ICMP".to_string();
                 match &v.icmp_pep_args {

--- a/libnode/src/lib.rs
+++ b/libnode/src/lib.rs
@@ -4,6 +4,6 @@ pub mod errors;
 pub mod logging;
 pub mod m2;
 mod vscli;
-pub use vsapi;
+pub use vsapi_thrift;
 pub mod vsconn;
 pub mod vss;

--- a/libnode/src/m2.rs
+++ b/libnode/src/m2.rs
@@ -1,13 +1,17 @@
 use openssl::hash::{Hasher, MessageDigest};
 use std::io::prelude::*;
-use vsapi;
+use vsapi_thrift;
 
 /// Create the milestone 2 version of the auth HMAC used in the node challenge response.
 ///
 /// The prototype version of this is HMAC(challenge + timestamp + session_id) using the RSA private key.
 ///
 /// For milestone two we just create a SHA256 hash of (challenge + timestamp + session_id). No auth at all.
-pub fn milestone2_create_hmac(chal: vsapi::Challenge, session_id: i32, timestamp: u64) -> Vec<u8> {
+pub fn milestone2_create_hmac(
+    chal: vsapi_thrift::Challenge,
+    session_id: i32,
+    timestamp: u64,
+) -> Vec<u8> {
     let mut buf = Vec::new();
     buf.write_all(&chal.challenge_data.unwrap()).unwrap();
     buf.write_all(&timestamp.to_be_bytes()).unwrap();

--- a/libnode/src/vscli.rs
+++ b/libnode/src/vscli.rs
@@ -9,7 +9,7 @@ use tracing::*;
 use crate::errors::VSClientError;
 use crate::logging::targets::VS_RPC;
 use crate::m2;
-use vsapi::{self, TVisaServiceSyncClient, VisaServiceSyncClient};
+use vsapi_thrift::{self, TVisaServiceSyncClient, VisaServiceSyncClient};
 use zpr::packet_info::L3Type;
 use zpr::vsapi_types::VisaResponse;
 
@@ -36,11 +36,11 @@ pub struct VSClient {
 pub trait VSClientI: Send {
     fn authenticate(
         &mut self,
-        actor: &vsapi::Actor,
+        actor: &vsapi_thrift::Actor,
         cert_pem_data: &str,
         vss_service_addr: SocketAddr,
     ) -> Result<String, VSClientError>;
-    fn ping_vs(&mut self) -> Result<vsapi::Pong, VSClientError>;
+    fn ping_vs(&mut self) -> Result<vsapi_thrift::Pong, VSClientError>;
     fn de_register(&mut self) -> Result<(), VSClientError>;
     fn request_visa(
         &mut self,
@@ -50,10 +50,10 @@ pub trait VSClientI: Send {
     ) -> Result<VisaResponse, VSClientError>;
     fn authorize_connect(
         &mut self,
-        req: vsapi::ConnectRequest,
-    ) -> Result<vsapi::ConnectResponse, VSClientError>;
+        req: vsapi_thrift::ConnectRequest,
+    ) -> Result<vsapi_thrift::ConnectResponse, VSClientError>;
     fn actor_disconnect(&mut self, actor_zpr_addr: IpAddr) -> Result<(), VSClientError>;
-    fn request_services(&mut self) -> Result<vsapi::ServicesResponse, VSClientError>;
+    fn request_services(&mut self) -> Result<vsapi_thrift::ServicesResponse, VSClientError>;
 }
 
 /// Wrapper on top of the the THRIFT generated code.
@@ -70,7 +70,7 @@ impl VSClient {
         let o_prot = TBinaryOutputProtocol::new(TFramedWriteTransport::new(o_chan), true);
 
         debug!(target: VS_RPC, "VSClient.new creating VisaServiceSyncClient");
-        let tcli = vsapi::VisaServiceSyncClient::new(i_prot, o_prot);
+        let tcli = vsapi_thrift::VisaServiceSyncClient::new(i_prot, o_prot);
 
         Ok(VSClient {
             service: service.to_string(),
@@ -103,7 +103,7 @@ impl VSClientI for VSClient {
     ///
     fn authenticate(
         &mut self,
-        actor: &vsapi::Actor,
+        actor: &vsapi_thrift::Actor,
         cert_pem_data: &str,
         vss_service_addr: SocketAddr,
     ) -> Result<String, VSClientError> {
@@ -121,7 +121,7 @@ impl VSClientI for VSClient {
         let hmac =
             m2::milestone2_create_hmac(hrchal, hello_response.session_id.unwrap(), timestamp);
 
-        let authreq = vsapi::NodeAuthRequest {
+        let authreq = vsapi_thrift::NodeAuthRequest {
             session_id: hello_response.session_id,
             challenge: Some(chal_copy),
             timestamp: Some(timestamp as i64),
@@ -152,7 +152,7 @@ impl VSClientI for VSClient {
     }
 
     /// Synchronous ping.
-    fn ping_vs(&mut self) -> Result<vsapi::Pong, VSClientError> {
+    fn ping_vs(&mut self) -> Result<vsapi_thrift::Pong, VSClientError> {
         if self.key.is_none() {
             return Err(VSClientError::NoAPIKey);
         }
@@ -197,8 +197,8 @@ impl VSClientI for VSClient {
     /// Synchronous authorize connect request.
     fn authorize_connect(
         &mut self,
-        req: vsapi::ConnectRequest,
-    ) -> Result<vsapi::ConnectResponse, VSClientError> {
+        req: vsapi_thrift::ConnectRequest,
+    ) -> Result<vsapi_thrift::ConnectResponse, VSClientError> {
         if self.key.is_none() {
             return Err(VSClientError::NoAPIKey);
         }
@@ -227,7 +227,7 @@ impl VSClientI for VSClient {
         }
     }
 
-    fn request_services(&mut self) -> Result<vsapi::ServicesResponse, VSClientError> {
+    fn request_services(&mut self) -> Result<vsapi_thrift::ServicesResponse, VSClientError> {
         if self.key.is_none() {
             return Err(VSClientError::NoAPIKey);
         }

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -922,7 +922,8 @@ s5JVZ48=
             challenge: Some(vec![1, 2, 3, 4]),
             challenge_responses: Some(vec![vec![5, 6, 7, 8]]),
         };
-        let resp = conn_handle.authorize_connect(req.into().unwrap());
+
+        let resp = conn_handle.authorize_connect(req.try_into().unwrap());
 
         match timeout(Duration::from_millis(100), resp).await {
             Ok(_resp) => {
@@ -942,7 +943,7 @@ s5JVZ48=
         {
             // Run again check that we get the error:
             let req = vsapi_thrift::ConnectRequest {
-                connection_id: None,
+                connection_id: Some(100),
                 dock_addr: Some(vec![10, 0, 0, 1]),
                 claims: Some(claims.clone()),
                 challenge: None,

--- a/libnode/src/vsconn.rs
+++ b/libnode/src/vsconn.rs
@@ -20,9 +20,9 @@ use crate::errors::{VSClientError, VSError};
 use crate::logging::targets::VS_RPC;
 use crate::vscli::{self, VSClientI};
 use crate::vss::DEFAULT_VSS_PORT;
-use zpr::vsapi_types::{ConnectRequest, Connection, VisaResponse};
+use zpr::vsapi_types::{ConnectRequestV1, Connection, VisaResponse};
 
-use vsapi;
+use vsapi_thrift;
 use zpr::packet_info::L3Type;
 
 const PING_INTERVAL: Duration = Duration::from_millis(10000);
@@ -38,7 +38,7 @@ pub struct VisaRequest {
 type VisaRequestResponse = Result<VisaResponse, VSClientError>;
 type AuthorizeConnectResponse = Result<Connection, VSClientError>;
 type DisconnectStatus = Result<(), VSClientError>;
-type RequestServicesResponse = Result<vsapi::ServicesResponse, VSClientError>;
+type RequestServicesResponse = Result<vsapi_thrift::ServicesResponse, VSClientError>;
 
 // The async "commands" that can be sent into the running visa service client.
 #[derive(Debug)]
@@ -46,7 +46,7 @@ type RequestServicesResponse = Result<vsapi::ServicesResponse, VSClientError>;
 enum VSCommand {
     Stop(bool), // Stop the run loop, optionally de-register from the visa service first.
     RequestVisa(VisaRequest, oneshot::Sender<VisaRequestResponse>),
-    AuthorizeConnect(ConnectRequest, oneshot::Sender<AuthorizeConnectResponse>),
+    AuthorizeConnect(ConnectRequestV1, oneshot::Sender<AuthorizeConnectResponse>),
     ActorDisconnect(IpAddr, oneshot::Sender<DisconnectStatus>), // takes a ZPR address assigned to the actor
     RequestServices(oneshot::Sender<RequestServicesResponse>),
 }
@@ -67,13 +67,13 @@ pub struct VSConn {
     output_tx: mpsc::Sender<VSOutput>,
     client_fac: vscli::VSClientFactory,
     vss_service_addr: SocketAddr, // visa support service listen address
-    actor: vsapi::Actor,
+    actor: vsapi_thrift::Actor,
 }
 
 /// Helper function to create a basic node actor. Probably only useful for early versions
 /// of the node.  In the future the node will create it's own actor datastructure and
 /// had it to [VSConn::new].
-pub fn new_node_actor(node_addr: IpAddr, claims: &BTreeMap<String, String>) -> vsapi::Actor {
+pub fn new_node_actor(node_addr: IpAddr, claims: &BTreeMap<String, String>) -> vsapi_thrift::Actor {
     // In prototype, the node zpr address is the same as its tether address. May not be true going forward.
     let zaddr_bytes = match node_addr {
         IpAddr::V4(a) => a.octets().to_vec(),
@@ -92,8 +92,8 @@ pub fn new_node_actor(node_addr: IpAddr, claims: &BTreeMap<String, String>) -> v
     }
     augmented_claims.insert(claims::KATTR_EPID.into(), node_addr.to_string());
 
-    vsapi::Actor {
-        actor_type: Some(vsapi::ActorType::NODE),
+    vsapi_thrift::Actor {
+        actor_type: Some(vsapi_thrift::ActorType::NODE),
         attrs: Some(augmented_claims),
         auth_expires: Some((timestamp + 60 * 60) as i64),
         zpr_addr: Some(zaddr_bytes),
@@ -118,7 +118,7 @@ impl VSConn {
     ///   support service. If not set, then we will advertise `<NODE_ZPR_ADDR>:<DEFAULT_VSS_PORT>`.
     //
     pub fn new(
-        node_actor: vsapi::Actor,
+        node_actor: vsapi_thrift::Actor,
         output_tx: mpsc::Sender<VSOutput>,
         service_addr: &str,
         node_cert_file: &Path,
@@ -274,7 +274,7 @@ impl VSConn {
 
     fn handle_authorize_connect(
         client: &mut Box<dyn VSClientI>,
-        cr: vsapi::ConnectRequest,
+        cr: vsapi_thrift::ConnectRequest,
     ) -> AuthorizeConnectResponse {
         match client.authorize_connect(cr) {
             Ok(acr) => {
@@ -336,7 +336,7 @@ impl VSConnHandle {
     ///
     /// ## Errors
     /// - [VSError::EnqueueError] if the request could not be enqueued.
-    pub async fn authorize_connect(&self, req: ConnectRequest) -> AuthorizeConnectResponse {
+    pub async fn authorize_connect(&self, req: ConnectRequestV1) -> AuthorizeConnectResponse {
         let (tx, rx) = oneshot::channel();
         self.send_command(VSCommand::AuthorizeConnect(req, tx))
             .await?;
@@ -514,7 +514,7 @@ s5JVZ48=
     impl VSClientI for TestVSCli {
         fn authenticate(
             &mut self,
-            _actor: &vsapi::Actor,
+            _actor: &vsapi_thrift::Actor,
             _cert_pem_data: &str,
             _vss_service_addr: SocketAddr,
         ) -> Result<String, VSClientError> {
@@ -525,12 +525,12 @@ s5JVZ48=
             Ok(String::from("le_key"))
         }
 
-        fn ping_vs(&mut self) -> Result<vsapi::Pong, VSClientError> {
+        fn ping_vs(&mut self) -> Result<vsapi_thrift::Pong, VSClientError> {
             incr(CounterT::Ping);
             if let Some(e) = take_next_error() {
                 return Err(e);
             }
-            Ok(vsapi::Pong {
+            Ok(vsapi_thrift::Pong {
                 configuration: Some(1),
                 policy_version: Some(2),
             })
@@ -553,8 +553,8 @@ s5JVZ48=
             if let Some(e) = take_next_error() {
                 return Err(e);
             }
-            let vrr = vsapi::VisaResponse {
-                status: Some(vsapi::StatusCode::FAIL),
+            let vrr = vsapi_thrift::VisaResponse {
+                status: Some(vsapi_thrift::StatusCode::FAIL),
                 visa: None,
                 reason: Some(format!("addr: {}, type: {}", source_tether_addr, l3_type)),
             };
@@ -564,8 +564,8 @@ s5JVZ48=
 
         fn authorize_connect(
             &mut self,
-            req: vsapi::ConnectRequest,
-        ) -> Result<vsapi::ConnectResponse, VSClientError> {
+            req: vsapi_thrift::ConnectRequest,
+        ) -> Result<vsapi_thrift::ConnectResponse, VSClientError> {
             if let Some(e) = take_next_error() {
                 return Err(e);
             }
@@ -578,8 +578,8 @@ s5JVZ48=
                 }
                 None => {}
             };
-            let agnt = vsapi::Actor {
-                actor_type: Some(vsapi::ActorType::ADAPTER),
+            let agnt = vsapi_thrift::Actor {
+                actor_type: Some(vsapi_thrift::ActorType::ADAPTER),
                 attrs: Some(attrs),
                 auth_expires: Some(0),
                 zpr_addr: None,
@@ -587,9 +587,9 @@ s5JVZ48=
                 ident: None,
                 provides: None,
             };
-            let cr = vsapi::ConnectResponse {
+            let cr = vsapi_thrift::ConnectResponse {
                 connection_id: req.connection_id,
-                status: Some(vsapi::StatusCode::SUCCESS),
+                status: Some(vsapi_thrift::StatusCode::SUCCESS),
                 actor: Some(agnt),
                 reason: Some(format!("")),
             };
@@ -604,13 +604,13 @@ s5JVZ48=
             Ok(())
         }
 
-        fn request_services(&mut self) -> Result<vsapi::ServicesResponse, VSClientError> {
+        fn request_services(&mut self) -> Result<vsapi_thrift::ServicesResponse, VSClientError> {
             incr(CounterT::RequestServices);
             if let Some(e) = take_next_error() {
                 return Err(e);
             }
-            let response = vsapi::ServicesResponse {
-                services: Some(vsapi::ServicesList {
+            let response = vsapi_thrift::ServicesResponse {
+                services: Some(vsapi_thrift::ServicesList {
                     expiration: Some(
                         SystemTime::now()
                             .duration_since(UNIX_EPOCH)
@@ -915,14 +915,14 @@ s5JVZ48=
         claims.insert("foo".to_string(), "fee".to_string());
         claims.insert("hello".to_string(), "goodbye".to_string());
 
-        let req = vsapi::ConnectRequest {
+        let req = vsapi_thrift::ConnectRequest {
             connection_id: Some(456),
             dock_addr: Some(vec![10, 0, 0, 1]),
             claims: Some(claims.clone()),
             challenge: Some(vec![1, 2, 3, 4]),
             challenge_responses: Some(vec![vec![5, 6, 7, 8]]),
         };
-        let resp = conn_handle.authorize_connect(req.try_into().unwrap());
+        let resp = conn_handle.authorize_connect(req.into().unwrap());
 
         match timeout(Duration::from_millis(100), resp).await {
             Ok(_resp) => {
@@ -941,7 +941,7 @@ s5JVZ48=
 
         {
             // Run again check that we get the error:
-            let req = vsapi::ConnectRequest {
+            let req = vsapi_thrift::ConnectRequest {
                 connection_id: None,
                 dock_addr: Some(vec![10, 0, 0, 1]),
                 claims: Some(claims.clone()),

--- a/libnode/src/vss.rs
+++ b/libnode/src/vss.rs
@@ -13,7 +13,9 @@ use tokio::sync::mpsc::Sender;
 use tracing::{debug, error, info};
 
 use crate::logging::targets::VSS_RPC;
-use vsapi::{self, PolicyInfo, ServicesList, VisaSupportSyncHandler, VisaSupportSyncProcessor};
+use vsapi_thrift::{
+    self, PolicyInfo, ServicesList, VisaSupportSyncHandler, VisaSupportSyncProcessor,
+};
 use zpr::vsapi_types::{AuthServicesList, Visa, VisaOp, VsapiTypeError};
 
 /// Default port for the visa support service. Note that the visa support service
@@ -83,7 +85,7 @@ pub fn start_vss_server(tx_chan: Sender<VSSMsg>, listen_addr: SocketAddr) {
 
 impl VisaSupportSyncHandler for VisaSupportHandlerImpl {
     /// Accept the visa service message and put in on the message channel.
-    fn handle_network_policy_installed(&self, pi: vsapi::PolicyInfo) -> thrift::Result<()> {
+    fn handle_network_policy_installed(&self, pi: vsapi_thrift::PolicyInfo) -> thrift::Result<()> {
         debug!(target: VSS_RPC, "handle_network_policy_installed: {pi:?}");
         self.msg_chan_out
             .blocking_send(VSSMsg::PolicyInstall(pi))
@@ -94,7 +96,7 @@ impl VisaSupportSyncHandler for VisaSupportHandlerImpl {
     }
 
     /// Accept the pushed visa(s) and put on to the message channel.
-    fn handle_install_visas(&self, vh: Vec<vsapi::VisaHop>) -> thrift::Result<()> {
+    fn handle_install_visas(&self, vh: Vec<vsapi_thrift::VisaHop>) -> thrift::Result<()> {
         debug!(target: VSS_RPC, "handle_install_visas, count={}", vh.len());
         for v in vh {
             let visa = match Visa::try_from(v) {
@@ -116,7 +118,7 @@ impl VisaSupportSyncHandler for VisaSupportHandlerImpl {
     }
 
     /// Accept the visa revocation(s) and put on to the message channel.
-    fn handle_revoke_visas(&self, vr: Vec<vsapi::VisaRevocation>) -> thrift::Result<()> {
+    fn handle_revoke_visas(&self, vr: Vec<vsapi_thrift::VisaRevocation>) -> thrift::Result<()> {
         debug!(target: VSS_RPC, "handle_revoke_visas, count={}", vr.len());
         for r in vr {
             let vo = VisaOp::try_from(r);

--- a/libnode2/Cargo.lock
+++ b/libnode2/Cargo.lock
@@ -800,12 +800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
 name = "rustyline"
 version = "17.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,28 +914,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "syn"
@@ -1481,13 +1453,12 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.4.0"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.2.0#c96759d458b4172f0c662c91536e537f5058b523"
+version = "0.6.0"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.6.0#d5eb7cfc362e3f70a035758b6fa92b4735cbe988"
 dependencies = [
  "capnp",
  "capnpc",
  "open-enum",
- "strum",
  "thiserror 1.0.69",
  "url",
  "vsapi",

--- a/libnode2/Cargo.toml
+++ b/libnode2/Cargo.toml
@@ -16,7 +16,7 @@ tokio-util = { version = "0.7.17", features = ["rt", "compat"] }
 tokio = { version = "1.48.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", optional = true } # lnt
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.2.0", features = ["vsapi"] }
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.6.0", features = ["vsapi"] }
 
 [features]
 build-lnt = ["clap", "tracing-subscriber", "rustyline"]

--- a/zpr-utils/Cargo.lock
+++ b/zpr-utils/Cargo.lock
@@ -59,12 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,12 +272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,28 +312,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "syn"
@@ -558,13 +524,12 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.4.0"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.1.0#7edfe8212acc1d661db01a7f8bb60302f441695e"
+version = "0.6.0"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.6.0#d5eb7cfc362e3f70a035758b6fa92b4735cbe988"
 dependencies = [
  "capnp",
  "capnpc",
  "open-enum",
- "strum",
  "thiserror",
  "url",
  "vsapi",

--- a/zpr-utils/Cargo.toml
+++ b/zpr-utils/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 
 [dependencies]
 zerocopy = { version = "0.8.3", features = ["derive", "std"] }
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.1.0", features = ["vsapi"] }
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.6.0", features = ["vsapi"] }

--- a/zpr-utils/Makefile
+++ b/zpr-utils/Makefile
@@ -1,0 +1,18 @@
+
+.PHONY: all build test clean check
+
+all: build
+
+build:
+	cargo build --all-targets
+
+test:
+	cargo test --verbose
+
+check:
+	cargo fmt --check && cargo rustc --lib -- -D warnings
+
+clean:
+	cargo clean
+
+.DEFAULT_GOAL := all


### PR DESCRIPTION
Fix a bug in the handling of connect-request payloads.

This required some clean up in zpr-common first.  Now propagated into zpr-core.

Becuase it was incredibly confusing in libnode, I renamed the "vsapi" import of the thrift to "vsapi_thrift".