### PR TITLE
Fix integration test

### DIFF
--- a/.github/workflows/adapter.yml
+++ b/.github/workflows/adapter.yml
@@ -32,7 +32,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_GIT_FETCH_WITH_CLI: true
-  VISA_SERVICE_RELEASE: v0.8.0-rc.1
+  VISA_SERVICE_RELEASE: v0.9.0
 
 jobs:
   # Build and upload ph

--- a/integration-test/lib/common_funcs.sh
+++ b/integration-test/lib/common_funcs.sh
@@ -166,17 +166,21 @@ function check_vs_valkey_port() {
 }
 
 function ping_test() {
-  sudo ip netns exec zpr-node ping -q -c 5 -w 5 "$VS_ZPR_ADDR" & wait -f $!
-  sudo ip netns exec zpr-vs ping -q -c 5 -w 5 "$NODE_ZPR_ADDR" & wait -f $!
-  sudo ip netns exec zpr-a ping -q -c 5 -w 5 "$B_ZPR_ADDR" & wait -f $!
-  sudo ip netns exec zpr-b ping -q -c 5 -w 5 "$A_ZPR_ADDR" & wait -f $!
+  RESULT=0
+
+  sudo ip netns exec zpr-node ping -q -c 5 -w 5 "$VS_ZPR_ADDR" & wait -f $!; let RESULT="RESULT||$?"
+  sudo ip netns exec zpr-vs ping -q -c 5 -w 5 "$NODE_ZPR_ADDR" & wait -f $!; let RESULT="RESULT||$?"
+  sudo ip netns exec zpr-a ping -q -c 5 -w 5 "$B_ZPR_ADDR" & wait -f $!; let RESULT="RESULT||$?"
+  sudo ip netns exec zpr-b ping -q -c 5 -w 5 "$A_ZPR_ADDR" & wait -f $!; let RESULT="RESULT||$?"
 
   if [[ "$NUM_ACTORS" -ge 3 ]]; then
-    sudo ip netns exec zpr-a ping -q -c 5 -w 5 "$C_ZPR_ADDR" & wait -f $!
-    sudo ip netns exec zpr-b ping -q -c 5 -w 5 "$C_ZPR_ADDR" & wait -f $!
-    sudo ip netns exec zpr-c ping -q -c 5 -w 5 "$A_ZPR_ADDR" & wait -f $!
-    sudo ip netns exec zpr-c ping -q -c 5 -w 5 "$B_ZPR_ADDR" & wait -f $!
+    sudo ip netns exec zpr-a ping -q -c 5 -w 5 "$C_ZPR_ADDR" & wait -f $!; let RESULT="RESULT||$?"
+    sudo ip netns exec zpr-b ping -q -c 5 -w 5 "$C_ZPR_ADDR" & wait -f $!; let RESULT="RESULT||$?"
+    sudo ip netns exec zpr-c ping -q -c 5 -w 5 "$A_ZPR_ADDR" & wait -f $!; let RESULT="RESULT||$?"
+    sudo ip netns exec zpr-c ping -q -c 5 -w 5 "$B_ZPR_ADDR" & wait -f $!; let RESULT="RESULT||$?"
   fi
+
+  return "$RESULT"
 }
 
 function check_carrier() {

--- a/integration-test/lib/common_funcs.sh
+++ b/integration-test/lib/common_funcs.sh
@@ -165,15 +165,11 @@ function check_vs_valkey_port() {
   sudo ip netns exec zpr-vs bash -lc 'exec 3<>/dev/tcp/127.0.0.1/6379'
 }
 
-function ping_a_b() {
-  sudo ip netns exec zpr-a ping -q -c 5 -w 5 "$B_ZPR_ADDR" & wait -f $!
-  sudo ip netns exec zpr-b ping -q -c 5 -w 5 "$A_ZPR_ADDR" & wait -f $!
-}
-
 function ping_test() {
   sudo ip netns exec zpr-node ping -q -c 5 -w 5 "$VS_ZPR_ADDR" & wait -f $!
   sudo ip netns exec zpr-vs ping -q -c 5 -w 5 "$NODE_ZPR_ADDR" & wait -f $!
-  ping_a_b
+  sudo ip netns exec zpr-a ping -q -c 5 -w 5 "$B_ZPR_ADDR" & wait -f $!
+  sudo ip netns exec zpr-b ping -q -c 5 -w 5 "$A_ZPR_ADDR" & wait -f $!
 
   if [[ "$NUM_ACTORS" -ge 3 ]]; then
     sudo ip netns exec zpr-a ping -q -c 5 -w 5 "$C_ZPR_ADDR" & wait -f $!

--- a/integration-test/one-node-test.sh
+++ b/integration-test/one-node-test.sh
@@ -292,19 +292,6 @@ fi
 
 sleep 1
 
-#
-# Revoke zpr-b's visa and try to ping again
-#
-
-sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$VS_ADMIN_BIN" \
-	--ca-cert ca.crt \
-	--svc-url "https://[$VS_ZPR_ADDR]:8182" \
-	actors --cn adapter2 --revoke
-
-if ! ping_a_b
-then PASS=0
-fi
-
 fi
 #
 # Check stats

--- a/integration-test/one-node-test.sh
+++ b/integration-test/one-node-test.sh
@@ -10,7 +10,7 @@ PH_BIN="${PH_BIN:-$(realpath "$(dirname "$0")/../target/debug/ph")}"
 PH_DEBUG_BIN="${PH_DEBUG_BIN:-$(realpath "$(dirname "$0")/../target/debug/ph-cli")}"
 VS_BIN="${VS_BIN:-$(realpath "$(dirname "$0")/vs")}"
 VS_ADMIN_BIN="${VS_ADMIN_BIN:-$(realpath "$(dirname "$0")/vs-admin")}"
-VALKEY_SERVER_BIN="${VALKEY_SERVER_BIN:-$(realpath "$(dirname "$0")/valkey-server")}"
+VALKEY_SERVER_BIN="${VALKEY_SERVER_BIN:-$(realpath -s "$(dirname "$0")/valkey-server")}"
 
 PREGEN=$(realpath "$(dirname $0)/pregen")
 NODE_AUTH_PRIVATE_KEY="${NODE_AUTH_PRIVATE_KEY:-$PREGEN/node-rsa-key.pem}"


### PR DESCRIPTION
Fix various integ test issues:

1. The error logic for the ping tests was wrong in a couple places, causing failures to be lost.
2. The visa revocation test is no longer valid: revoking a visa just causes a new one to be re-requested (which succeeds).
3. The valkey lookup was causing issues on Debian (where the symlink resolved to a binary with a different name, causing VK to do something different).