### PR TITLE
add to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 integration-test/vs-admin
 integration-test/vs
 integration-test/pregen/zplc
+integration-test/valkey-server
 target/
+completions/


### PR DESCRIPTION
- completions/ ignores the tab completion scripts generated in ph and cli
- integration-test/valkey-server ignores the valkey server binary, which is now required for the integration test