### PR TITLE
frag ID should not be compressed out

### DIFF
--- a/adapter/ph/src/compress.rs
+++ b/adapter/ph/src/compress.rs
@@ -36,13 +36,12 @@ fn compress_addrs_v4(pkt: &mut Packet) {
 
     pkt.push_header(&ttl);
 
-    let frag_info_present = frag_id != [0u8; 2] || frag_offset.get() != 0;
-    // NOTE/TODO: this differs slightly from the spec, in that the ID field
-    // is also optional.  I have an ask out to Frank to change this in the spec.
+    let frag_info_present = frag_offset.get() != 0;
     if frag_info_present {
         pkt.push_header(&frag_offset);
-        pkt.push_header(&frag_id);
     }
+
+    pkt.push_header(&frag_id);
 
     let hl_zdpflags = (hl << 4)
         | (if frag_info_present {
@@ -64,13 +63,12 @@ fn expand_addrs_v4(pkt: &mut Packet, proto: u8, src_address: Ipv4Addr, dst_addre
     let frag_info_present = (hl_zdpflags & ZDP_V4_FRAG_INFO_PRESENT) != 0;
     let frag_flags = hl_zdpflags & 0x07;
 
-    let frag_id;
+    let frag_id = pkt.get_array::<2>();
+
     let mut frag_offset;
     if frag_info_present {
-        frag_id = pkt.get_array::<2>();
         frag_offset = pkt.get_u16();
     } else {
-        frag_id = [0u8; 2];
         frag_offset = 0u16;
     }
     frag_offset |= (frag_flags as u16) << 13; // NOTE/TODO: spec deviation


### PR DESCRIPTION
Per discussion with Frank – the IPv4 fragment ID field should not be compressed out.  Though nominally it is used for fragments, in practice it is also used for non-fragments for a similar purpose as the IPv6 flow ID field, and thus it may be nonzero for a vast majority of packets on certain OSes (e.g. Linux).

This realigns the code with RFC 17, with the exception of the fragmentation bits (which Frank agrees we should change the spec to match the code here).

May need a corresponding change to the Wireshark dissector, will check.