### PR TITLE
link state: keepalives & timeouts to trace level, not debug

### DIFF
--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -443,7 +443,13 @@ impl LinkStateWrapper {
         asm: &Arc<Assembly>,
         event: LinkEvent,
     ) -> Result<(), LinkStateError> {
-        debug!(target: LINK_STATE, "Link {}: *EVENT* {event:?}", self.id);
+        match event {
+            LinkEvent::ReceivedKeepAliveResponse | LinkEvent::Timeout { .. } => {
+                trace!(target: LINK_STATE, "Link {}: *EVENT* {event:?}", self.id)
+            }
+
+            _ => debug!(target: LINK_STATE, "Link {}: *EVENT* {event:?}", self.id),
+        }
 
         match event {
             LinkEvent::Start => self.process_start(asm),


### PR DESCRIPTION
These messages get emitted on every keepalive tick, making link state debug logs super chatty.

Move them to trace level.  Although for Timeout messages this is a bit heavy-handed, all other timeouts have a log message associated with them anyway.

Closes #1252.