### PR TITLE
GH workflows should be triggered by changes to workspace Cargo files

### DIFF
--- a/.github/workflows/adapter.yml
+++ b/.github/workflows/adapter.yml
@@ -13,6 +13,8 @@ on:
       - 'integration-test/**'
       - 'zpr/**'
       - '.github/workflows/adapter.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
   pull_request:
     paths:
       - 'adapter/ph/**'
@@ -24,6 +26,8 @@ on:
       - 'integration-test/**'
       - 'zpr/**'
       - '.github/workflows/adapter.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/libnode.yml
+++ b/.github/workflows/libnode.yml
@@ -6,10 +6,14 @@ on:
     paths:
       - 'libnode2/**'
       - '.github/workflows/libnode.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
   pull_request:
     paths:
       - 'libnode2/**'
       - '.github/workflows/libnode.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
I realized that e.g. https://github.com/org-zpr/zpr-core/pull/1284 didn't trigger any builds, when it should in fact have triggered all of them.

See also <https://github.com/org-zpr/zpr-visaservice/pull/198>.