### PR TITLE
workspace packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-api"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "capnp",
  "capnpc",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "libnode2"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "capnp",
  "capnp-rpc",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "ph-cli"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "admin-api",
  "capnp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@
 resolver = "3"
 members = ["adapter/admin-api", "adapter/ph", "adapter/cli", "libnode2"]
 
+[workspace.package]
+version = "0.6.0"
+edition = "2024"
+license = "Apache-2.0"
+
 [workspace.dependencies]
 capnp = { version = "0.25.0", features = ["sync_reader"] }
 capnp-rpc = "0.25.0"

--- a/adapter/admin-api/Cargo.toml
+++ b/adapter/admin-api/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "admin-api"
-version = "0.1.0"
-edition = "2024"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 capnp = { workspace = true }

--- a/adapter/cli/Cargo.toml
+++ b/adapter/cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ph-cli"
-version = "0.1.0"
-edition = "2024"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ph"
-version = "0.6.0"
-edition = "2024"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 admin-api = { path = "../admin-api" }

--- a/libnode2/Cargo.toml
+++ b/libnode2/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "libnode2"
-version = "0.1.0"
-edition = "2024"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 capnp = { workspace = true }


### PR DESCRIPTION
Moved the version, edition, and license packages to the workspace toml

I picked v0.6.0 because that was the version of the ph. The most recent release is v0.3.1, so we also could revert to v0.4.0. 