### PR TITLE
ZDPR cancel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,6 +2628,7 @@ dependencies = [
  "openssl-sys",
  "rand 0.9.4",
  "rcu 0.1.1",
+ "replace_with",
  "reqwest",
  "serde",
  "serde_json",
@@ -3183,6 +3184,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "reqwest"

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -32,6 +32,7 @@ open-enum = { version = "0.5.1" }
 openssl = { workspace = true }
 openssl-sys = { version = "0.9.102" }
 rcu = { git = "https://github.com/org-zpr/zpr-utils.git", tag = "rcu-v0.1.1", default-features = false }
+replace_with = "0.1.8"
 reqwest = { version = "0.13.1", features = ["json", "query"] }
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.140"

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -2,12 +2,13 @@ use crate::adapter_tables;
 use crate::assembly::{Assembly, PhMode};
 use crate::counters::ManagementCounterType;
 use crate::logging::targets::FLOW_MGMT;
-use crate::mgmt;
+use crate::mgmt::{self, core::MgmtSendError};
 use crate::packet::{Packet, PacketBuffer};
 use crate::queues::AdapterManagerMessage;
 use crate::two_way_queue;
 use std::num::NonZero;
 use std::sync::Arc;
+use tokio;
 use tracing::*;
 use zpr::packet_info::{DOCK_LINK_ID, LOCAL_ACTOR_LINK_ID};
 
@@ -83,14 +84,23 @@ fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
     debug!(target: FLOW_MGMT, "link {dock_link_id}: Issuing bind request for {five_tuple} (is now set PENDING)");
 
     match asm.ph_mode {
-        PhMode::Adapter => mgmt::requests::send_bind_actor_address_request(
-            asm,
-            dock_link_id,
-            txn_id,
-            five_tuple.l3_type,
-            &packet_body,
-        )
-        .enqueue(),
+        PhMode::Adapter => {
+            let task_asm = asm.clone();
+            tokio::task::spawn_local(async move {
+                match mgmt::requests::send_bind_actor_address_request(
+                    &task_asm,
+                    dock_link_id,
+                    txn_id,
+                    five_tuple.l3_type,
+                    &packet_body,
+                )
+                .await
+                {
+                    Ok(_acked) => (),
+                    Err(MgmtSendError::LinkClosed) => (),
+                }
+            });
+        }
 
         PhMode::Node => mgmt::dock::bind_actor_address(
             asm,

--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -1,8 +1,9 @@
 use crate::adapter_tables;
 use crate::assembly::{Assembly, PhMode};
+use crate::config;
 use crate::counters::ManagementCounterType;
 use crate::logging::targets::FLOW_MGMT;
-use crate::mgmt::{self, core::MgmtSendError};
+use crate::mgmt::{self, core::MgmtSendError, core::PacketStatus};
 use crate::packet::{Packet, PacketBuffer};
 use crate::queues::AdapterManagerMessage;
 use crate::two_way_queue;
@@ -87,6 +88,11 @@ fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
         PhMode::Adapter => {
             let task_asm = asm.clone();
             tokio::task::spawn_local(async move {
+                // Bind requests are "large", since they contain packet
+                // bodies, and may be manifestly undeliverable by the
+                // network due to MTU or middleware issues.  So we allow
+                // them to deterministically time out, returning an error
+                // to the requestor.
                 match mgmt::requests::send_bind_actor_address_request(
                     &task_asm,
                     dock_link_id,
@@ -94,9 +100,20 @@ fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
                     five_tuple.l3_type,
                     &packet_body,
                 )
+                .limit_retries(config::DEFAULT_ZDPR_RETRY_LIMIT)
                 .await
                 {
-                    Ok(_acked) => (),
+                    Ok(PacketStatus::Acked) => (),
+
+                    Ok(PacketStatus::Canceled) => {
+                        mgmt::adapter::deny_tether(
+                            &task_asm,
+                            &txn,
+                            "Network error issuing bind request",
+                        )
+                        .unwrap();
+                    }
+
                     Err(MgmtSendError::LinkClosed) => (),
                 }
             });

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -42,6 +42,10 @@ pub const DEFAULT_ZDPR_RECEIVE_WINDOW_SIZE: usize = 32;
 
 pub const DEFAULT_ZDPR_RETRY_TIMER: std::time::Duration = std::time::Duration::from_millis(600);
 
+/// Used for specific messages to limit the number of ZDPR retries before giving up.
+/// (Not a global default!)
+pub const DEFAULT_ZDPR_RETRY_LIMIT: u8 = 3;
+
 pub const DEFAULT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 pub const DEFAULT_TERMINATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -46,7 +46,7 @@ pub const DEFAULT_ZDPR_RETRY_TIMER: std::time::Duration = std::time::Duration::f
 /// (Not a global default!)
 pub const DEFAULT_ZDPR_RETRY_LIMIT: u8 = 3;
 
-pub const DEFAULT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+pub const LINK_HELLO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 pub const DEFAULT_TERMINATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
 pub const DEFAULT_VSS_PORT: u16 = 8183;

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -6,6 +6,7 @@ use crate::km::{PeerCertificate, ZPIPair};
 use crate::km_multiplexor;
 use crate::logging::targets::LINK_STATE;
 use crate::mgmt;
+use crate::mgmt::core::{MgmtSendError, PacketStatus};
 use crate::sample_ring::SampleRing;
 use crate::special_peers;
 use crate::special_peers::SpecialPeerName;
@@ -146,6 +147,7 @@ pub enum LinkEvent {
 
     ReceivedInitAuth((bool, Option<auth::ZdpInitAuthenticationPayload>)), // (bootstrap_flag, challenge)
     ReceivedInitAuthAck,
+    ReceivedInitAuthTimeout,
 
     ReceivedAcquireZprAddressRequest(Option<Vec<IpAddress>>, String), // (requested_addrs, auth_blob)
 
@@ -469,6 +471,7 @@ impl LinkStateWrapper {
             }
 
             LinkEvent::ReceivedInitAuthAck => self.process_init_auth_ack(asm),
+            LinkEvent::ReceivedInitAuthTimeout => self.process_init_auth_timeout(asm),
 
             LinkEvent::ReceivedGrantZprAddressRequest(addrs) => {
                 self.process_grant_zpr_address_request(asm, addrs)
@@ -642,7 +645,7 @@ impl LinkStateWrapper {
         // IF this is an adapter, it's expected to issue the hello
         if self.link_type == LinkType::AdapterToNode {
             mgmt::requests::send_hello_request(asm, self.id).enqueue();
-            self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_TIMEOUT);
+            self.set_timeout(asm, &mut locked_fsm, config::LINK_HELLO_TIMEOUT);
             debug!(
                 target: LINK_STATE,
                 "Link {link_id} sent HelloRequest.  Waiting for other side to respond."
@@ -710,8 +713,6 @@ impl LinkStateWrapper {
 
                 locked_fsm.set_state(LinkState::WaitForAcquireZprAddress);
                 self.send_init_authentication_request(asm);
-                // short timeout until we at least get the ACK
-                self.set_timeout(asm, &mut locked_fsm, config::DEFAULT_REQUEST_TIMEOUT);
                 debug!(
                     target: LINK_STATE,
                     "Link {link_id} finished helloing.  Waiting for other side to respond to init-auth"
@@ -1237,7 +1238,22 @@ impl LinkStateWrapper {
         }
     }
 
-    /// Send off the Inti-Authentication message with a blob that the receiver could
+    fn process_init_auth_timeout(&self, asm: &Arc<Assembly>) -> Result<(), LinkStateError> {
+        let mut locked_fsm = self.locked_fsm.lock().unwrap();
+        match (self.link_type, locked_fsm.state) {
+            (LinkType::NodeToAdapter, LinkState::WaitForAcquireZprAddress) => {
+                error!(target: LINK_STATE, "Link {} received init auth timeout", self.id);
+                locked_fsm.set_state(LinkState::Error);
+                drop(locked_fsm);
+                self.initiate_close(asm, TerminateReason::RequestTimedOut)
+            }
+            (_, _) => Err(LinkStateError::InvalidOperation(
+                "Discarded unsolicited init auth timeout".to_string(),
+            )),
+        }
+    }
+
+    /// Send off the Init-Authentication message with a blob that the receiver could
     /// use for authentication.
     fn send_init_authentication_request(&self, asm: &Arc<Assembly>) {
         let link_id = self.id;
@@ -1278,16 +1294,29 @@ impl LinkStateWrapper {
 
         let task_asm = asm.clone();
         tokio::task::spawn_local(async move {
-            if mgmt::requests::send_init_authentication_request(&task_asm, link_id, flags, payload)
-                .acked()
-                .await
-                .is_err()
+            match mgmt::requests::send_init_authentication_request(
+                &task_asm, link_id, flags, payload,
+            )
+            .limit_retries(config::DEFAULT_ZDPR_RETRY_LIMIT)
+            .await
             {
-                // link was terminated
-                return;
+                Ok(PacketStatus::Acked) => {
+                    // ignore error here, it just means we've moved on to another state and got the ACK (very) late
+                    let _ =
+                        task_asm.process_link_state_event(link_id, LinkEvent::ReceivedInitAuthAck);
+                }
+
+                Ok(PacketStatus::Canceled) => {
+                    // timed out getting the ACK, tear down the link
+                    let _ = task_asm
+                        .process_link_state_event(link_id, LinkEvent::ReceivedInitAuthTimeout);
+                }
+
+                Err(MgmtSendError::LinkClosed) => {
+                    // link was terminated, simply return
+                    return;
+                }
             }
-            // ignore error here, it just means we've moved on to another state and got the ACK (very) late
-            let _ = task_asm.process_link_state_event(link_id, LinkEvent::ReceivedInitAuthAck);
         });
     }
 
@@ -1433,8 +1462,7 @@ impl LinkStateWrapper {
         // handle the timeout...
         match (self.link_type, locked_fsm.state) {
             (LinkType::AdapterToNode, LinkState::RegisterAA)
-            | (LinkType::AdapterToNode, LinkState::Helloing)
-            | (LinkType::NodeToAdapter, LinkState::WaitForAcquireZprAddress) => {
+            | (LinkType::AdapterToNode, LinkState::Helloing) => {
                 // Timeout here means we give up on the link.
                 error!(target: LINK_STATE, "Link {} timed out in state {:?}", self.id, locked_fsm.state);
                 locked_fsm.set_state(LinkState::Error);

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 //! Core management packet functions.
 //!
 //! These are low-level primitives; most code should use the higher-level
@@ -180,6 +178,7 @@ impl<'a> Sent<'a> {
     ///
     /// Once true, [try_cancel()] can no longer succeed, dropping will no
     /// longer cancel the packet, and this future will be ready immediately.
+    #[allow(dead_code)]
     pub fn is_sent(&self) -> bool {
         let PacketId::Queued(packet_id) = self.packet_id else {
             return true;
@@ -197,6 +196,7 @@ impl<'a> Sent<'a> {
     /// Explicitly try to cancel sending the packet, returning the packet if
     /// successful, or an error if unsuccessful (meaning the packet was
     /// already sent).
+    #[allow(dead_code)]
     pub fn try_cancel(mut self) -> Result<Packet, Acked<'a>> {
         match self.try_cancel_internal() {
             Ok(packet) => Ok(packet),
@@ -242,6 +242,7 @@ impl<'a> Sent<'a> {
     ///
     /// Returns a future which resolves to an indication of whether the
     /// packet was indeed canceled.
+    #[allow(dead_code)]
     pub fn request_cancel(mut self) -> AckedOrCanceled<'a> {
         self.request_cancel_internal();
         AckedOrCanceled(self)
@@ -258,8 +259,6 @@ impl<'a> Sent<'a> {
             return;
         };
 
-        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
-
         if matches!(self.packet_id, PacketId::Queued(_)) {
             if self.try_cancel_internal().is_ok() {
                 // immediately canceled
@@ -274,10 +273,12 @@ impl<'a> Sent<'a> {
             unreachable!();
         };
 
+        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
         let Some(_pkt) = zdpr_send.cancel_sent_packet(seq_num) else {
             // already acked or cancel-requested
             return;
         };
+        drop(zdpr_send);
 
         // note, we drop the user's packet here; we could return it to them
 
@@ -374,18 +375,22 @@ impl<'a> std::future::Future for Sent<'a> {
 pub struct Acked<'a>(Sent<'a>);
 
 impl<'a> Acked<'a> {
+    #[allow(dead_code)]
     pub fn enqueue(self) {
         self.0.enqueue()
     }
 
+    #[allow(dead_code)]
     pub fn is_sent(&self) -> bool {
         self.0.is_sent()
     }
 
+    #[allow(dead_code)]
     pub fn request_cancel(self) -> AckedOrCanceled<'a> {
         self.0.request_cancel()
     }
 
+    #[allow(dead_code)]
     pub fn limit_retries(self, retry_limit: u8) -> AckedOrCanceled<'a> {
         self.0.limit_retries(retry_limit)
     }
@@ -394,7 +399,7 @@ impl<'a> Acked<'a> {
 impl<'a> std::future::Future for Acked<'a> {
     type Output = Result<(), MgmtSendError>;
 
-    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if matches!(self.0.packet_id, PacketId::Acked) {
             return Poll::Ready(Ok(()));
         }
@@ -405,14 +410,22 @@ impl<'a> std::future::Future for Acked<'a> {
 
         let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
 
+        let seq_num;
         match self.0.packet_id {
             PacketId::Queued(packet_id) => {
-                zdpr_send.poll_send_and_ack(cx, packet_id).map(|()| Ok(()))
+                let Some(sn) = ready!(zdpr_send.poll_send(cx, packet_id)) else {
+                    return Poll::Ready(Ok(()));
+                };
+                // There may/will be further polls, so update `packet_id` with our new knowledge.
+                self.0.packet_id = PacketId::Sent(sn);
+                seq_num = sn;
             }
-            PacketId::Sent(seq_num) => zdpr_send.poll_ack(cx, seq_num).map(|()| Ok(())),
+            PacketId::Sent(sn) => seq_num = sn,
             PacketId::Acked => unreachable!(),    // handled above
             PacketId::Canceled => unreachable!(), // not possible in this state
         }
+
+        zdpr_send.poll_ack(cx, seq_num).map(|()| Ok(()))
     }
 }
 
@@ -436,12 +449,14 @@ pub enum PacketStatus {
 pub struct AckedOrCanceled<'a>(Sent<'a>);
 
 impl<'a> AckedOrCanceled<'a> {
+    #[allow(dead_code)]
     pub fn enqueue(mut self) {
         // skip Sent destructor, but not our destructor
         self.forget_internal();
         std::mem::forget(self);
     }
 
+    #[allow(dead_code)]
     pub fn is_sent(&self) -> bool {
         self.0.is_sent()
     }
@@ -449,11 +464,13 @@ impl<'a> AckedOrCanceled<'a> {
     /// Although this packet is already scheduled for cancellation,
     /// the cancellation may be in the form of a retry limit;
     /// if so, this may still be used to immediately request cancellation.
+    #[allow(dead_code)]
     pub fn request_cancel(mut self) -> Self {
         self.0.request_cancel_internal();
         self
     }
 
+    #[allow(dead_code)]
     pub fn limit_retries(mut self, retry_limit: u8) -> Self {
         self.0.limit_retries_internal(retry_limit);
         self
@@ -476,7 +493,7 @@ impl<'a> AckedOrCanceled<'a> {
 impl<'a> std::future::Future for AckedOrCanceled<'a> {
     type Output = Result<PacketStatus, MgmtSendError>;
 
-    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.0.packet_id {
             PacketId::Acked => {
                 return Poll::Ready(Ok(PacketStatus::Acked));
@@ -493,22 +510,28 @@ impl<'a> std::future::Future for AckedOrCanceled<'a> {
 
         let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
 
+        let seq_num;
         match self.0.packet_id {
             PacketId::Queued(packet_id) => {
-                ready!(zdpr_send.poll_send_and_ack(cx, packet_id));
-                Poll::Ready(Ok(PacketStatus::Acked))
+                let Some(sn) = ready!(zdpr_send.poll_send(cx, packet_id)) else {
+                    return Poll::Ready(Ok(PacketStatus::Acked));
+                };
+                // There may/will be further polls, so update `packet_id` with our new knowledge.
+                self.0.packet_id = PacketId::Sent(sn);
+                seq_num = sn;
             }
 
-            PacketId::Sent(seq_num) => {
-                ready!(zdpr_send.poll_ack(cx, seq_num));
-                if zdpr_send.is_cancel_acked(seq_num) {
-                    Poll::Ready(Ok(PacketStatus::Canceled))
-                } else {
-                    Poll::Ready(Ok(PacketStatus::Acked))
-                }
-            }
+            PacketId::Sent(sn) => seq_num = sn,
 
             PacketId::Acked | PacketId::Canceled => unreachable!(), // handled above
+        }
+
+        ready!(zdpr_send.poll_ack(cx, seq_num));
+
+        if zdpr_send.is_cancel_acked(seq_num) {
+            Poll::Ready(Ok(PacketStatus::Canceled))
+        } else {
+            Poll::Ready(Ok(PacketStatus::Acked))
         }
     }
 }

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -6,7 +6,7 @@
 use crate::assembly::Assembly;
 use crate::config;
 use crate::counters::ManagementCounterType;
-use crate::packet::{self, Packet};
+use crate::packet::Packet;
 use crate::zdp;
 use crate::zdpr;
 use std::task::{Context, Poll};
@@ -90,17 +90,36 @@ pub fn send_per_flow_txn_mgmt(
 }
 
 pub fn send_acknowledgement(asm: &Assembly, link_id: LinkId, sequence_number: SeqNum) {
+    send_zdpr_common(
+        asm,
+        link_id,
+        sequence_number,
+        zdp::ZdpPacketType::Acknowledgement,
+    )
+}
+
+pub fn send_cancel(asm: &Assembly, link_id: LinkId, sequence_number: SeqNum) {
+    send_zdpr_common(asm, link_id, sequence_number, zdp::ZdpPacketType::Cancel)
+}
+
+pub fn send_canceled(asm: &Assembly, link_id: LinkId, sequence_number: SeqNum) {
+    send_zdpr_common(asm, link_id, sequence_number, zdp::ZdpPacketType::Canceled)
+}
+
+fn send_zdpr_common(
+    asm: &Assembly,
+    link_id: LinkId,
+    sequence_number: SeqNum,
+    packet_type: zdp::ZdpPacketType,
+) {
     // TODO: just allocate this on the stack, pending #985.
     let mut packet = new_tiny_heap_packet();
-
-    // let the OS know we're ACKing data from the peer
-    packet.metadata_mut().flags |= packet::flags::CONFIRM;
 
     let mgmt_hdr = packet.alloc_zeroed_header::<zdp::ZdpMgmtHeader>();
     mgmt_hdr.sequence_number = sequence_number.into();
 
     let base_hdr = packet.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
-    base_hdr.packet_type = zdp::ZdpPacketType::Acknowledgement;
+    base_hdr.packet_type = packet_type;
 
     // It's possible (but unlikely) the MgmtSubstrateEgress queue fills up.
     // In that case, just ignore the error; act as if the packet was dropped
@@ -122,8 +141,10 @@ enum PacketId {
 
 /// Future which represents a packet waiting to be sent on the link.
 ///
-/// Dropping this future cancels delivery of the packet if
-/// it has not already been sent.
+/// Dropping this future cancels delivery of the packet if it has not
+/// already been sent.  (This ensures that the number of queued unsent
+/// packets is bounded by the number of active waiters.  `self.enqueue()`
+/// can be used to explicitly bypass this limit.)
 ///
 /// Note that completion of this future does not indicate whether the peer
 /// has actually received the packet!  It merely indicates that we have
@@ -147,7 +168,7 @@ impl<'a> Sent<'a> {
         // Note that in fact, if we are blocked, we already are in the
         // queue.  So we just need to prevent running our Drop impl which
         // would take us _out_ of the queue.  `forget()` is the simplest way
-        // to do that.  (This do not leak anything because we have no
+        // to do that.  (This does not leak anything because we have no
         // members with nontrivial destructors.)
         std::mem::forget(self)
     }
@@ -176,7 +197,7 @@ impl<'a> Sent<'a> {
                     });
                 };
                 let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
-                if let Some(pkt) = zdpr_send.cancel_packet(packet_id) {
+                if let Some(pkt) = zdpr_send.cancel_sent_packet(packet_id) {
                     Ok(pkt)
                 } else {
                     Err(Acked {
@@ -237,10 +258,52 @@ impl<'a> std::future::Future for Sent<'a> {
 ///
 /// Resolves to an error if the link was terminated (and therefore
 /// it is unknown whether the peer ever received the packet).
+///
+/// Unlike `Sent`, dropping `Acked` has no impact on delivery of the packet.
 pub struct Acked<'a> {
     asm: &'a Assembly,
     link_id: LinkId,
     seq_num: Option<SeqNum>, // None indicates acked before we knew the sequenece number
+}
+
+impl<'a> Acked<'a> {
+    /// Request that the peer cancel this packet.
+    ///
+    /// This is only useful if the caller has reason to suspect that the
+    /// packet is manifestly undeliverable after having been sent (e.g. due
+    /// to MTU issues or deep-packet inspection).  Requesting cancellation
+    /// ensures forward progress of the peer.
+    ///
+    /// Returns a future which resolves to an indication of whether the
+    /// packet was indeed canceled.
+    #[allow(dead_code)]
+    pub fn request_cancel(self) -> AckedOrCanceled<'a> {
+        let Some(seq_num) = self.seq_num else {
+            // was acked before we even knew the sequence number
+            return AckedOrCanceled(self);
+        };
+
+        let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
+            // no more link
+            return AckedOrCanceled(self);
+        };
+
+        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+        let Some(_pkt) = zdpr_send.cancel_sent_packet(seq_num) else {
+            // already acked
+            return AckedOrCanceled(self);
+        };
+
+        // note, we drop the user's packet here; we could return it to them
+
+        // send an immediate cancellation request
+        // (future cancellation requests will be sent via the retry mechanism)
+        send_cancel(self.asm, self.link_id, seq_num);
+
+        AckedOrCanceled(self)
+    }
+
+    // TODO: request_cancel_after aka limit_retries
 }
 
 impl<'a> std::future::Future for Acked<'a> {
@@ -260,6 +323,65 @@ impl<'a> std::future::Future for Acked<'a> {
     }
 }
 
+/// Future which represents the acknowledgement or cancellation of a packet
+/// by the link peer.  (Does _not_ indicate that the peer has necessarily
+/// done anything useful with the packet!  Just that we've made forward
+/// progress in communicating the packet or cancellation thereof.)
+///
+/// Resolves to an error if the link was terminated (and therefore
+/// it is unknown whether the peer ever received the packet).
+///
+/// Unlike `Sent`, dropping `AckedOrCanceled` has no impact on delivery
+/// or cancellation of the packet.
+pub struct AckedOrCanceled<'a>(Acked<'a>);
+
+pub enum PacketStatus {
+    /// The packet was acknowledged by the peer.  It will (should) act
+    /// on the packet.
+    Acked,
+    /// The packet was acknowledged as canceled by the peer.  It will not
+    /// act on the packet.
+    Canceled,
+}
+
+impl<'a> std::future::Future for AckedOrCanceled<'a> {
+    type Output = Result<PacketStatus, MgmtSendError>;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let Some(seq_num) = self.0.seq_num else {
+            return Poll::Ready(Ok(PacketStatus::Acked));
+        };
+
+        let Some(peer_state) = self.0.asm.peer_table.get(self.0.link_id) else {
+            return Poll::Ready(Err(MgmtSendError::LinkClosed));
+        };
+
+        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+        zdpr_send.poll_ack(cx, seq_num).map(|()| {
+            if zdpr_send.is_cancel_acked(seq_num) {
+                Ok(PacketStatus::Canceled)
+            } else {
+                Ok(PacketStatus::Acked)
+            }
+        })
+    }
+}
+
+impl<'a> Drop for AckedOrCanceled<'a> {
+    fn drop(&mut self) {
+        let Some(seq_num) = self.0.seq_num else {
+            return;
+        };
+
+        let Some(peer_state) = self.0.asm.peer_table.get(self.0.link_id) else {
+            return;
+        };
+
+        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+        zdpr_send.forget_canceled_packet(seq_num);
+    }
+}
+
 /// Future which waits for a packet to be both sent and acknowledged.
 ///
 /// Dropping this future cancels delivery of the packet if
@@ -272,16 +394,23 @@ pub struct SentAndAcked<'a>(Sent<'a>);
 
 #[allow(dead_code)]
 impl<'a> SentAndAcked<'a> {
-    /// if sending would block, queue this packet instead
+    /// Returns a future which waits for this packet to be sent only.
+    pub fn sent(self) -> Sent<'a> {
+        self.0
+    }
+
+    /// If sending would block, queue this packet instead.
     pub fn enqueue(self) {
         self.0.enqueue()
     }
 
-    /// explicitly try to cancel the packet, returning the packet if successful,
-    /// or an `Acked` future if unsuccessful
+    /// Explicitly try to cancel the packet, returning the packet if successful,
+    /// or an `Acked` future if unsuccessful (meaning the packet was already sent).
     pub fn try_cancel(self) -> Result<Packet, Acked<'a>> {
         self.0.try_cancel()
     }
+
+    // TODO: request_cancel_after
 }
 
 impl<'a> std::future::Future for SentAndAcked<'a> {

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+
 //! Core management packet functions.
 //!
 //! These are low-level primitives; most code should use the higher-level
@@ -203,7 +204,7 @@ impl<'a> Sent<'a> {
         }
     }
 
-    pub fn try_cancel_internal(&mut self) -> Result<Packet, ()> {
+    fn try_cancel_internal(&mut self) -> Result<Packet, ()> {
         let PacketId::Queued(packet_id) = self.packet_id else {
             return Err(());
         };
@@ -226,6 +227,11 @@ impl<'a> Sent<'a> {
     pub fn acked(self) -> Acked<'a> {
         Acked(self)
     }
+
+    // Design note: Why does request_cancel() transition to AckedOrCanceled
+    // and not a hypothetical SentCancellable?  This is because it's not in
+    // fact possible/meaningful to wait for a canceled packet to be sent: if
+    // the packet is not yet sent, it will be canceled immediately!
 
     /// Request that the peer cancel this packet.
     ///
@@ -280,13 +286,38 @@ impl<'a> Sent<'a> {
         send_cancel(self.asm, self.link_id, seq_num);
     }
 
-    pub fn limit_retries(mut self, limit: u8) -> AckedOrCanceled<'a> {
-        self.limit_retries_internal(limit);
+    // Design note: Why does limit_retries() transition to AckedOrCanceled?
+    // This is a deliberate philosophical choice, under the belief that
+    // waiting for a packet to be sent, but then not caring whether it gets
+    // delivered, is inadvisable at the application layer.  It would require
+    // adding an extra state "SentCancelable" to represent this scenario,
+    // which is simply not worth it.  If the user really wants to do this,
+    // they can explicitly wait for the packet to be sent, and then add a
+    // retry limit.
+
+    pub fn limit_retries(mut self, retry_limit: u8) -> AckedOrCanceled<'a> {
+        self.limit_retries_internal(retry_limit);
         AckedOrCanceled(self)
     }
 
-    fn limit_retries_internal(&mut self, _limit: u8) {
-        unimplemented!("TODO")
+    fn limit_retries_internal(&mut self, retry_limit: u8) {
+        if matches!(self.packet_id, PacketId::Acked | PacketId::Canceled) {
+            // already acked or canceled
+            return;
+        }
+
+        let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
+            // no more link
+            return;
+        };
+
+        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+
+        match self.packet_id {
+            PacketId::Queued(packet_id) => zdpr_send.limit_retries_by_id(packet_id, retry_limit),
+            PacketId::Sent(seq_num) => zdpr_send.limit_retries_by_seq_num(seq_num, retry_limit),
+            PacketId::Acked | PacketId::Canceled => unreachable!(), // handled above
+        }
     }
 
     fn update_sent_packet_id(&mut self, seq_num: Option<SeqNum>) {
@@ -343,6 +374,10 @@ impl<'a> std::future::Future for Sent<'a> {
 pub struct Acked<'a>(Sent<'a>);
 
 impl<'a> Acked<'a> {
+    pub fn enqueue(self) {
+        self.0.enqueue()
+    }
+
     pub fn is_sent(&self) -> bool {
         self.0.is_sent()
     }
@@ -351,8 +386,8 @@ impl<'a> Acked<'a> {
         self.0.request_cancel()
     }
 
-    pub fn limit_retries(self, limit: u8) -> AckedOrCanceled<'a> {
-        self.0.limit_retries(limit)
+    pub fn limit_retries(self, retry_limit: u8) -> AckedOrCanceled<'a> {
+        self.0.limit_retries(retry_limit)
     }
 }
 
@@ -401,6 +436,12 @@ pub enum PacketStatus {
 pub struct AckedOrCanceled<'a>(Sent<'a>);
 
 impl<'a> AckedOrCanceled<'a> {
+    pub fn enqueue(mut self) {
+        // skip Sent destructor, but not our destructor
+        self.forget_internal();
+        std::mem::forget(self);
+    }
+
     pub fn is_sent(&self) -> bool {
         self.0.is_sent()
     }
@@ -408,17 +449,27 @@ impl<'a> AckedOrCanceled<'a> {
     /// Although this packet is already scheduled for cancellation,
     /// the cancellation may be in the form of a retry limit;
     /// if so, this may still be used to immediately request cancellation.
-    pub fn request_cancel(mut self) -> AckedOrCanceled<'a> {
+    pub fn request_cancel(mut self) -> Self {
         self.0.request_cancel_internal();
         self
     }
 
-    /// Although this packet is already scheduled for cancellation,
-    /// the cancellation may be in the form of a retry limit;
-    /// this may still be used to reduce (but not increase) the limit.
-    pub fn limit_retries(mut self, limit: u8) -> AckedOrCanceled<'a> {
-        self.0.limit_retries_internal(limit);
+    pub fn limit_retries(mut self, retry_limit: u8) -> Self {
+        self.0.limit_retries_internal(retry_limit);
         self
+    }
+
+    fn forget_internal(&mut self) {
+        let PacketId::Sent(seq_num) = self.0.packet_id else {
+            return;
+        };
+
+        let Some(peer_state) = self.0.asm.peer_table.get(self.0.link_id) else {
+            return;
+        };
+
+        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+        zdpr_send.forget_canceled_packet(seq_num);
     }
 }
 
@@ -457,30 +508,20 @@ impl<'a> std::future::Future for AckedOrCanceled<'a> {
                 }
             }
 
-            PacketId::Acked => unreachable!(),    // handled above
-            PacketId::Canceled => unreachable!(), // not possible in this state
+            PacketId::Acked | PacketId::Canceled => unreachable!(), // handled above
         }
-    }
-}
-
-impl<'a> Drop for AckedOrCanceled<'a> {
-    fn drop(&mut self) {
-        let PacketId::Sent(seq_num) = self.0.packet_id else {
-            return;
-        };
-
-        let Some(peer_state) = self.0.asm.peer_table.get(self.0.link_id) else {
-            return;
-        };
-
-        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
-        zdpr_send.forget_canceled_packet(seq_num);
     }
 }
 
 impl<'a> From<Acked<'a>> for AckedOrCanceled<'a> {
     fn from(value: Acked<'a>) -> Self {
         Self(value.0)
+    }
+}
+
+impl<'a> Drop for AckedOrCanceled<'a> {
+    fn drop(&mut self) {
+        self.forget_internal()
     }
 }
 

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 //! Core management packet functions.
 //!
 //! These are low-level primitives; most code should use the higher-level
@@ -9,7 +10,7 @@ use crate::counters::ManagementCounterType;
 use crate::packet::Packet;
 use crate::zdp;
 use crate::zdpr;
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, ready};
 use tracing::*;
 use zerocopy::FromBytes;
 use zpr::packet_info::{LINK_ID_UNKNOWN, LinkId, SeqNum, StreamId};
@@ -60,7 +61,6 @@ pub fn send_non_flow_mgmt(
 
 /// Send a unidirectional per-flow management message on the given link.
 /// The packet should contain only the message body.
-#[allow(dead_code)]
 pub fn send_per_flow_mgmt(
     asm: &Assembly,
     link_id: LinkId,
@@ -133,10 +133,12 @@ pub enum MgmtSendError {
     LinkClosed,
 }
 
-#[allow(dead_code)]
+#[derive(Clone, Copy)]
 enum PacketId {
-    Sent(SeqNum),
     Queued(zdpr::QueuedPacketId),
+    Sent(SeqNum),
+    Acked,
+    Canceled,
 }
 
 /// Future which represents a packet waiting to be sent on the link.
@@ -173,46 +175,125 @@ impl<'a> Sent<'a> {
         std::mem::forget(self)
     }
 
-    /// Explicitly try to cancel the packet, returning the packet if successful,
-    /// or an `Acked` future if unsuccessful (meaning the packet was already sent).
-    #[allow(dead_code)]
-    pub fn try_cancel(mut self) -> Result<Packet, Acked<'a>> {
-        self.try_cancel_internal()
+    /// Has the packet been dequeued and sent?
+    ///
+    /// Once true, [try_cancel()] can no longer succeed, dropping will no
+    /// longer cancel the packet, and this future will be ready immediately.
+    pub fn is_sent(&self) -> bool {
+        let PacketId::Queued(packet_id) = self.packet_id else {
+            return true;
+        };
+
+        let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
+            // We don't know whether the packet got sent before the link was dropped,
+            // but `true` is compatible with the packet having been sent then dropped.
+            return true;
+        };
+        let zdpr_send = peer_state.zdpr_send.lock().unwrap();
+        zdpr_send.is_sent(packet_id)
     }
 
-    fn try_cancel_internal(&mut self) -> Result<Packet, Acked<'a>> {
-        match self.packet_id {
-            PacketId::Sent(seq_num) => Err(Acked {
-                asm: self.asm,
-                link_id: self.link_id,
-                seq_num: Some(seq_num),
-            }),
+    /// Explicitly try to cancel sending the packet, returning the packet if
+    /// successful, or an error if unsuccessful (meaning the packet was
+    /// already sent).
+    pub fn try_cancel(mut self) -> Result<Packet, Acked<'a>> {
+        match self.try_cancel_internal() {
+            Ok(packet) => Ok(packet),
+            Err(()) => Err(Acked(self)),
+        }
+    }
 
-            PacketId::Queued(packet_id) => {
-                let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
-                    return Err(Acked {
-                        asm: self.asm,
-                        link_id: LINK_ID_UNKNOWN,
-                        seq_num: None,
-                    });
-                };
-                let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
-                if let Some(pkt) = zdpr_send.cancel_sent_packet(packet_id) {
-                    Ok(pkt)
-                } else {
-                    Err(Acked {
-                        asm: self.asm,
-                        link_id: self.link_id,
-                        seq_num: zdpr_send.lookup_seq_num(packet_id),
-                    })
-                }
-            }
+    pub fn try_cancel_internal(&mut self) -> Result<Packet, ()> {
+        let PacketId::Queued(packet_id) = self.packet_id else {
+            return Err(());
+        };
+
+        let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
+            return Err(());
+        };
+
+        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+
+        if let Some(pkt) = zdpr_send.cancel_queued_packet(packet_id) {
+            Ok(pkt)
+        } else {
+            self.update_sent_packet_id(zdpr_send.lookup_seq_num(packet_id));
+            Err(())
         }
     }
 
     /// Returns a future which waits for this packet to be acked (after it is sent).
-    pub fn acked(self) -> SentAndAcked<'a> {
-        SentAndAcked(self)
+    pub fn acked(self) -> Acked<'a> {
+        Acked(self)
+    }
+
+    /// Request that the peer cancel this packet.
+    ///
+    /// This is only useful if the caller has reason to suspect that the
+    /// packet is manifestly undeliverable after having been sent (e.g. due
+    /// to MTU issues or deep-packet inspection).  Requesting cancellation
+    /// ensures forward progress of the peer.
+    ///
+    /// Returns a future which resolves to an indication of whether the
+    /// packet was indeed canceled.
+    pub fn request_cancel(mut self) -> AckedOrCanceled<'a> {
+        self.request_cancel_internal();
+        AckedOrCanceled(self)
+    }
+
+    fn request_cancel_internal(&mut self) {
+        if matches!(self.packet_id, PacketId::Acked | PacketId::Canceled) {
+            // already acked or canceled
+            return;
+        }
+
+        let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
+            // no more link
+            return;
+        };
+
+        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
+
+        if matches!(self.packet_id, PacketId::Queued(_)) {
+            if self.try_cancel_internal().is_ok() {
+                // immediately canceled
+                self.packet_id = PacketId::Canceled;
+                return;
+            }
+            // else, packet_id is now mutated to Sent
+        }
+
+        let PacketId::Sent(seq_num) = self.packet_id else {
+            // handled above
+            unreachable!();
+        };
+
+        let Some(_pkt) = zdpr_send.cancel_sent_packet(seq_num) else {
+            // already acked or cancel-requested
+            return;
+        };
+
+        // note, we drop the user's packet here; we could return it to them
+
+        // send an immediate cancellation request
+        // (future cancellation requests will be sent via the retry mechanism)
+        send_cancel(self.asm, self.link_id, seq_num);
+    }
+
+    pub fn limit_retries(mut self, limit: u8) -> AckedOrCanceled<'a> {
+        self.limit_retries_internal(limit);
+        AckedOrCanceled(self)
+    }
+
+    fn limit_retries_internal(&mut self, _limit: u8) {
+        unimplemented!("TODO")
+    }
+
+    fn update_sent_packet_id(&mut self, seq_num: Option<SeqNum>) {
+        match seq_num {
+            Some(seq_num) => self.packet_id = PacketId::Sent(seq_num),
+            None => self.packet_id = PacketId::Acked,
+        }
     }
 }
 
@@ -225,28 +306,28 @@ impl<'a> Drop for Sent<'a> {
 impl<'a> std::future::Future for Sent<'a> {
     type Output = Result<Acked<'a>, MgmtSendError>;
 
-    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.packet_id {
-            PacketId::Sent(seq_num) => Poll::Ready(Ok(Acked {
-                asm: self.asm,
-                link_id: self.link_id,
-                seq_num: Some(seq_num),
-            })),
-
             PacketId::Queued(packet_id) => {
                 let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
                     return Poll::Ready(Err(MgmtSendError::LinkClosed));
                 };
 
                 let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
-                zdpr_send.poll_send(cx, packet_id).map(|seq_num| {
-                    Ok(Acked {
-                        asm: self.asm,
-                        link_id: self.link_id,
-                        seq_num,
-                    })
-                })
+                let seq_num = ready!(zdpr_send.poll_send(cx, packet_id));
+                self.update_sent_packet_id(seq_num);
+                Poll::Ready(Ok(Acked(Sent {
+                    asm: self.asm,
+                    link_id: self.link_id,
+                    packet_id: self.packet_id,
+                })))
             }
+
+            packet_id => Poll::Ready(Ok(Acked(Sent {
+                asm: self.asm,
+                link_id: self.link_id,
+                packet_id,
+            }))),
         }
     }
 }
@@ -258,82 +339,47 @@ impl<'a> std::future::Future for Sent<'a> {
 ///
 /// Resolves to an error if the link was terminated (and therefore
 /// it is unknown whether the peer ever received the packet).
-///
-/// Unlike `Sent`, dropping `Acked` has no impact on delivery of the packet.
-pub struct Acked<'a> {
-    asm: &'a Assembly,
-    link_id: LinkId,
-    seq_num: Option<SeqNum>, // None indicates acked before we knew the sequenece number
-}
+#[must_use = "dropping a sent packet may cancel it"]
+pub struct Acked<'a>(Sent<'a>);
 
 impl<'a> Acked<'a> {
-    /// Request that the peer cancel this packet.
-    ///
-    /// This is only useful if the caller has reason to suspect that the
-    /// packet is manifestly undeliverable after having been sent (e.g. due
-    /// to MTU issues or deep-packet inspection).  Requesting cancellation
-    /// ensures forward progress of the peer.
-    ///
-    /// Returns a future which resolves to an indication of whether the
-    /// packet was indeed canceled.
-    #[allow(dead_code)]
-    pub fn request_cancel(self) -> AckedOrCanceled<'a> {
-        let Some(seq_num) = self.seq_num else {
-            // was acked before we even knew the sequence number
-            return AckedOrCanceled(self);
-        };
-
-        let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
-            // no more link
-            return AckedOrCanceled(self);
-        };
-
-        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
-        let Some(_pkt) = zdpr_send.cancel_sent_packet(seq_num) else {
-            // already acked
-            return AckedOrCanceled(self);
-        };
-
-        // note, we drop the user's packet here; we could return it to them
-
-        // send an immediate cancellation request
-        // (future cancellation requests will be sent via the retry mechanism)
-        send_cancel(self.asm, self.link_id, seq_num);
-
-        AckedOrCanceled(self)
+    pub fn is_sent(&self) -> bool {
+        self.0.is_sent()
     }
 
-    // TODO: request_cancel_after aka limit_retries
+    pub fn request_cancel(self) -> AckedOrCanceled<'a> {
+        self.0.request_cancel()
+    }
+
+    pub fn limit_retries(self, limit: u8) -> AckedOrCanceled<'a> {
+        self.0.limit_retries(limit)
+    }
 }
 
 impl<'a> std::future::Future for Acked<'a> {
     type Output = Result<(), MgmtSendError>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let Some(seq_num) = self.seq_num else {
+        if matches!(self.0.packet_id, PacketId::Acked) {
             return Poll::Ready(Ok(()));
-        };
+        }
 
-        let Some(peer_state) = self.asm.peer_table.get(self.link_id) else {
+        let Some(peer_state) = self.0.asm.peer_table.get(self.0.link_id) else {
             return Poll::Ready(Err(MgmtSendError::LinkClosed));
         };
 
         let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
-        zdpr_send.poll_ack(cx, seq_num).map(|()| Ok(()))
+
+        match self.0.packet_id {
+            PacketId::Queued(packet_id) => {
+                zdpr_send.poll_send_and_ack(cx, packet_id).map(|()| Ok(()))
+            }
+            PacketId::Sent(seq_num) => zdpr_send.poll_ack(cx, seq_num).map(|()| Ok(())),
+            PacketId::Acked => unreachable!(),    // handled above
+            PacketId::Canceled => unreachable!(), // not possible in this state
+        }
     }
 }
-
-/// Future which represents the acknowledgement or cancellation of a packet
-/// by the link peer.  (Does _not_ indicate that the peer has necessarily
-/// done anything useful with the packet!  Just that we've made forward
-/// progress in communicating the packet or cancellation thereof.)
-///
-/// Resolves to an error if the link was terminated (and therefore
-/// it is unknown whether the peer ever received the packet).
-///
-/// Unlike `Sent`, dropping `AckedOrCanceled` has no impact on delivery
-/// or cancellation of the packet.
-pub struct AckedOrCanceled<'a>(Acked<'a>);
 
 pub enum PacketStatus {
     /// The packet was acknowledged by the peer.  It will (should) act
@@ -344,32 +390,82 @@ pub enum PacketStatus {
     Canceled,
 }
 
+/// Future which represents the acknowledgement or cancellation of a packet
+/// by the link peer.  (Does _not_ indicate that the peer has necessarily
+/// done anything useful with the packet!  Just that we've made forward
+/// progress in communicating the packet or cancellation thereof.)
+///
+/// Resolves to an error if the link was terminated (and therefore
+/// it is unknown whether the peer ever received the packet).
+#[must_use = "dropping a sent packet may cancel it"]
+pub struct AckedOrCanceled<'a>(Sent<'a>);
+
+impl<'a> AckedOrCanceled<'a> {
+    pub fn is_sent(&self) -> bool {
+        self.0.is_sent()
+    }
+
+    /// Although this packet is already scheduled for cancellation,
+    /// the cancellation may be in the form of a retry limit;
+    /// if so, this may still be used to immediately request cancellation.
+    pub fn request_cancel(mut self) -> AckedOrCanceled<'a> {
+        self.0.request_cancel_internal();
+        self
+    }
+
+    /// Although this packet is already scheduled for cancellation,
+    /// the cancellation may be in the form of a retry limit;
+    /// this may still be used to reduce (but not increase) the limit.
+    pub fn limit_retries(mut self, limit: u8) -> AckedOrCanceled<'a> {
+        self.0.limit_retries_internal(limit);
+        self
+    }
+}
+
 impl<'a> std::future::Future for AckedOrCanceled<'a> {
     type Output = Result<PacketStatus, MgmtSendError>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let Some(seq_num) = self.0.seq_num else {
-            return Poll::Ready(Ok(PacketStatus::Acked));
-        };
+        match self.0.packet_id {
+            PacketId::Acked => {
+                return Poll::Ready(Ok(PacketStatus::Acked));
+            }
+            PacketId::Canceled => {
+                return Poll::Ready(Ok(PacketStatus::Canceled));
+            }
+            _ => (),
+        }
 
         let Some(peer_state) = self.0.asm.peer_table.get(self.0.link_id) else {
             return Poll::Ready(Err(MgmtSendError::LinkClosed));
         };
 
         let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
-        zdpr_send.poll_ack(cx, seq_num).map(|()| {
-            if zdpr_send.is_cancel_acked(seq_num) {
-                Ok(PacketStatus::Canceled)
-            } else {
-                Ok(PacketStatus::Acked)
+
+        match self.0.packet_id {
+            PacketId::Queued(packet_id) => {
+                ready!(zdpr_send.poll_send_and_ack(cx, packet_id));
+                Poll::Ready(Ok(PacketStatus::Acked))
             }
-        })
+
+            PacketId::Sent(seq_num) => {
+                ready!(zdpr_send.poll_ack(cx, seq_num));
+                if zdpr_send.is_cancel_acked(seq_num) {
+                    Poll::Ready(Ok(PacketStatus::Canceled))
+                } else {
+                    Poll::Ready(Ok(PacketStatus::Acked))
+                }
+            }
+
+            PacketId::Acked => unreachable!(),    // handled above
+            PacketId::Canceled => unreachable!(), // not possible in this state
+        }
     }
 }
 
 impl<'a> Drop for AckedOrCanceled<'a> {
     fn drop(&mut self) {
-        let Some(seq_num) = self.0.seq_num else {
+        let PacketId::Sent(seq_num) = self.0.packet_id else {
             return;
         };
 
@@ -382,53 +478,9 @@ impl<'a> Drop for AckedOrCanceled<'a> {
     }
 }
 
-/// Future which waits for a packet to be both sent and acknowledged.
-///
-/// Dropping this future cancels delivery of the packet if
-/// it has not already been sent.
-///
-/// Resolves to an error if the link was terminated (and therefore
-/// it is unknown whether the peer ever received the packet).
-#[must_use = "dropping a sent packet may cancel it"]
-pub struct SentAndAcked<'a>(Sent<'a>);
-
-#[allow(dead_code)]
-impl<'a> SentAndAcked<'a> {
-    /// Returns a future which waits for this packet to be sent only.
-    pub fn sent(self) -> Sent<'a> {
-        self.0
-    }
-
-    /// If sending would block, queue this packet instead.
-    pub fn enqueue(self) {
-        self.0.enqueue()
-    }
-
-    /// Explicitly try to cancel the packet, returning the packet if successful,
-    /// or an `Acked` future if unsuccessful (meaning the packet was already sent).
-    pub fn try_cancel(self) -> Result<Packet, Acked<'a>> {
-        self.0.try_cancel()
-    }
-
-    // TODO: request_cancel_after
-}
-
-impl<'a> std::future::Future for SentAndAcked<'a> {
-    type Output = Result<(), MgmtSendError>;
-
-    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let Some(peer_state) = self.0.asm.peer_table.get(self.0.link_id) else {
-            return Poll::Ready(Err(MgmtSendError::LinkClosed));
-        };
-
-        let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
-
-        match self.0.packet_id {
-            PacketId::Sent(seq_num) => zdpr_send.poll_ack(cx, seq_num).map(|()| Ok(())),
-            PacketId::Queued(packet_id) => {
-                zdpr_send.poll_send_and_ack(cx, packet_id).map(|()| Ok(()))
-            }
-        }
+impl<'a> From<Acked<'a>> for AckedOrCanceled<'a> {
+    fn from(value: Acked<'a>) -> Self {
+        Self(value.0)
     }
 }
 

--- a/adapter/ph/src/mgmt/dispatch.rs
+++ b/adapter/ph/src/mgmt/dispatch.rs
@@ -82,6 +82,16 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
             handle_acknowledgement(asm, pkt)
         }
 
+        Ok((base_hdr, _)) if base_hdr.packet_type == zdp::ZdpPacketType::Cancel => {
+            pkt.advance(std::mem::size_of::<zdp::ZdpBaseHeader>());
+            handle_cancel(asm, pkt)
+        }
+
+        Ok((base_hdr, _)) if base_hdr.packet_type == zdp::ZdpPacketType::Canceled => {
+            pkt.advance(std::mem::size_of::<zdp::ZdpBaseHeader>());
+            handle_canceled(asm, pkt)
+        }
+
         Ok((_base_hdr, rest)) => {
             let (mgmt_hdr, _) = zdp::ZdpMgmtHeader::ref_from_prefix(rest).unwrap();
 
@@ -101,7 +111,11 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
             drop(receiver);
 
             if disp.should_ack() {
-                core::send_acknowledgement(&asm, pkt.metadata().ingress_link_id, seq_num);
+                if disp.ack_is_canceled() {
+                    core::send_canceled(&asm, pkt.metadata().ingress_link_id, seq_num);
+                } else {
+                    core::send_acknowledgement(&asm, pkt.metadata().ingress_link_id, seq_num);
+                }
             }
 
             if disp.should_process() {
@@ -120,7 +134,47 @@ pub fn dispatch_mgmt_packet_with_link(asm: &Arc<Assembly>, pkt: &mut Packet) {
     }
 }
 
+fn handle_cancel(asm: &Assembly, pkt: &mut Packet) {
+    let Ok(mgmt_hdr) = zdp::ZdpMgmtHeader::read_from_buf(pkt) else {
+        core::count_event(asm, ManagementCounterType::BadStructure);
+        return;
+    };
+
+    let seq_num = mgmt_hdr.sequence_number.get();
+    let ingress_link_id = pkt.metadata().ingress_link_id;
+
+    let Some(peer_state) = asm.peer_table.get(ingress_link_id) else {
+        core::count_event(asm, ManagementCounterType::PeerRemoved);
+        return;
+    };
+
+    let mut receiver = peer_state.zdpr_recv.lock().unwrap();
+    let disp = receiver.process_cancel(seq_num);
+    count_zdpr_receiver_stats(&asm.counters.management, &mut receiver);
+
+    if disp.should_ack() {
+        if disp.ack_is_canceled() {
+            core::send_canceled(&asm, pkt.metadata().ingress_link_id, seq_num);
+        } else {
+            core::send_acknowledgement(&asm, pkt.metadata().ingress_link_id, seq_num);
+        }
+    }
+}
+
 fn handle_acknowledgement(asm: &Assembly, pkt: &mut Packet) {
+    handle_acknowledgement_canceled_common(asm, pkt, false)
+}
+
+fn handle_canceled(asm: &Assembly, pkt: &mut Packet) {
+    handle_acknowledgement_canceled_common(asm, pkt, true)
+}
+
+fn handle_acknowledgement_canceled_common(asm: &Assembly, pkt: &mut Packet, is_canceled: bool) {
+    // From dispatch's point of view, acknowledgement and cancellation of a packet are
+    // identical; either way, we don't care about the referenced packet any more.
+    // The only difference is ultimately to the sender/canceller, who must learn whether
+    // the remote canceled or processed the packet.
+
     let Ok(mgmt_hdr) = zdp::ZdpMgmtHeader::read_from_buf(pkt) else {
         core::count_event(asm, ManagementCounterType::BadStructure);
         return;
@@ -135,7 +189,12 @@ fn handle_acknowledgement(asm: &Assembly, pkt: &mut Packet) {
     };
     let mut sender = peer_state.zdpr_send.lock().unwrap();
 
-    sender.process_ack(seq_num);
+    if is_canceled {
+        sender.process_canceled(seq_num);
+    } else {
+        sender.process_ack(seq_num);
+    }
+    count_zdpr_sender_stats(&asm.counters.management, &mut sender);
 
     // If at this point (after processing the ACK) we should not have our
     // retry timer running (because all outstanding packets have been
@@ -203,6 +262,16 @@ fn handle_key_management(asm: &Arc<Assembly>, pkt: &mut Packet) {
     return;
 }
 
+/// Maps a `zdpr::SenderStat` to a `CounterType`.
+fn zdpr_sender_stat_to_counter(sn_stat: zdpr::SenderStat) -> ManagementCounterType {
+    match sn_stat {
+        zdpr::SenderStat::InvalidAck => ManagementCounterType::BadMgmtResponse,
+        zdpr::SenderStat::TooOldAck => ManagementCounterType::DroppedTooOld,
+        zdpr::SenderStat::DuplicateAck => ManagementCounterType::DroppedDuplicate,
+        zdpr::SenderStat::TooNewAck => ManagementCounterType::DroppedTooNew,
+    }
+}
+
 /// Maps a `zdpr::ReceiverStat` to a `CounterType`.
 fn zdpr_receiver_stat_to_counter(sn_stat: zdpr::ReceiverStat) -> ManagementCounterType {
     match sn_stat {
@@ -210,6 +279,16 @@ fn zdpr_receiver_stat_to_counter(sn_stat: zdpr::ReceiverStat) -> ManagementCount
         zdpr::ReceiverStat::Duplicate => ManagementCounterType::DroppedDuplicate,
         zdpr::ReceiverStat::TooNew => ManagementCounterType::DroppedTooNew,
         zdpr::ReceiverStat::OutOfOrder => ManagementCounterType::OutOfOrderPacket,
+    }
+}
+
+/// Pulls stats delta from `zdpr::Sender` and feeds them into the global counters.
+fn count_zdpr_sender_stats<Pkt>(
+    mgmt_counters: &ManagementCounters,
+    sender: &mut zdpr::Sender<Pkt>,
+) {
+    for stat in zdpr::SenderStat::iter() {
+        mgmt_counters[zdpr_sender_stat_to_counter(stat)].increase_by(sender.fetch_reset_stat(stat));
     }
 }
 

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -192,6 +192,7 @@ pub mod flags {
     /// Packets marked `PRIORITY` are not dropped on egress queue backpressure.
     pub const PRIORITY: PacketFlags = 1; // 1b
 
+    #[allow(dead_code)]
     pub const CONFIRM: PacketFlags = 2; // 10b
 }
 

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -198,8 +198,8 @@ impl VisaTable {
             0,
             &vs_zpr_addr,
             VISA_SERVICE_PORT,
-            expires_ms,
             VS_VISAS_CONFIG_ID,
+            expires_ms,
         );
         let vs2node = make_tcp_visa(
             2,
@@ -207,8 +207,8 @@ impl VisaTable {
             VISA_SERVICE_PORT,
             &node_zpr_addr,
             0,
-            expires_ms,
             VS_VISAS_CONFIG_ID,
+            expires_ms,
         );
 
         let mut visa_table = Self::new();
@@ -747,8 +747,8 @@ mod tests {
             + Duration::from_secs(3600))
         .as_millis() as i64;
 
-        let visa1_raw = make_tcp_visa(4000, &client1_addr, 0, &service_addr, 80, expires_ms, 100);
-        let visa2_raw = make_tcp_visa(4001, &client2_addr, 0, &service_addr, 80, expires_ms, 100);
+        let visa1_raw = make_tcp_visa(4000, &client1_addr, 0, &service_addr, 80, 100, expires_ms);
+        let visa2_raw = make_tcp_visa(4001, &client2_addr, 0, &service_addr, 80, 100, expires_ms);
 
         let mut visa_table = asm.visa_table.write().unwrap();
         let visa1_id = visa_table.insert_visa(visa1_raw).unwrap();
@@ -813,8 +813,8 @@ mod tests {
             + Duration::from_millis(10000))
         .as_millis() as i64;
 
-        let visa1 = make_tcp_visa(1000, &client1_addr, 0, &service_addr, 80, expires_ms, 100);
-        let visa2 = make_tcp_visa(1001, &client2_addr, 0, &service_addr, 80, expires_ms, 100);
+        let visa1 = make_tcp_visa(1000, &client1_addr, 0, &service_addr, 80, 100, expires_ms);
+        let visa2 = make_tcp_visa(1001, &client2_addr, 0, &service_addr, 80, 100, expires_ms);
         let v1 = new_vsapi_visa_tcp_default(12345, DateTime::<Utc>::MAX_UTC.into());
         let _ = visa_table.insert_visa(v1);
 

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -40,6 +40,8 @@ pub enum ZdpPacketType {
     RevokeZprAddress = 140,
     InitAuthenticationRequest = 141, // TODO: add to RFC 6
 
+    Canceled = 252, // TODO: add to RFC 17
+    Cancel = 253,   // TODO: add to RFC 17
     Acknowledgement = 254,
     Reserved255 = 255,
 }

--- a/adapter/ph/src/zdpr.rs
+++ b/adapter/ph/src/zdpr.rs
@@ -249,6 +249,58 @@ pub struct Sender<Pkt> {
     stats: EnumMap<SenderStat, u64>,
 }
 
+impl<Pkt> std::fmt::Display for Sender<Pkt> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "window size: {}", self.window_size)?;
+
+        let oldest_sent = self
+            .last_sent
+            .wrapping_add(1)
+            .wrapping_sub(self.unacked.len() as u64);
+        write!(f, "Unacked: {oldest_sent} ")?;
+        for st in &self.unacked {
+            match st {
+                UnackedState::Unacked {
+                    retry_limit: None, ..
+                } => write!(f, "u")?,
+                UnackedState::Unacked {
+                    retry_limit: Some(limit),
+                    retry_count,
+                    ..
+                } => write!(f, "{}", limit - retry_count)?,
+                UnackedState::Canceled {
+                    forgotten: true, ..
+                } => write!(f, "f")?,
+                UnackedState::Canceled {
+                    forgotten: false, ..
+                } => write!(f, "c")?,
+                UnackedState::Acked => write!(f, "A")?,
+                UnackedState::CancelAcked => write!(f, "C")?,
+            }
+        }
+        writeln!(f, " {}", self.last_sent)?;
+
+        let oldest_enqueued = self
+            .last_enqueued
+            .wrapping_add(1)
+            .wrapping_sub(self.blocked.len() as u64);
+        write!(f, "Blocked: {oldest_enqueued} ")?;
+        for st in &self.blocked {
+            match st {
+                BlockedState::Blocked {
+                    retry_limit: None, ..
+                } => write!(f, "b")?,
+                BlockedState::Blocked {
+                    retry_limit: Some(limit),
+                    ..
+                } => write!(f, "{limit}")?,
+                BlockedState::Canceled => write!(f, "C")?,
+            }
+        }
+        writeln!(f, " {}", self.last_enqueued)
+    }
+}
+
 // Individual sent packets conceptually follow the following state machine.
 //
 // States:
@@ -873,14 +925,14 @@ impl<Pkt> Sender<Pkt> {
     /// Transitions only occur in response to `enqueue_packet()`,
     /// `process_ack()`, or `process_canceled()`.
     pub fn retry_needed(&self) -> bool {
-        !self.unacked.is_empty()
+        self.unacked.iter().any(|pkt| !pkt.is_acked())
     }
 
     /// Ages packet retry counts, and transitions expired packets to `Canceled`.
     ///
     /// Should be called first before querying [retry_packets()] and [retry_cancels()].
     ///
-    /// Returns a list of cancel packets to be dropped.
+    /// Returns a list of canceled packets to be dropped.
     pub fn age_retries(&mut self) -> impl Iterator<Item = Pkt> {
         self.unacked.iter_mut().filter_map(|pkt| pkt.age_retries())
     }
@@ -1195,7 +1247,7 @@ impl Receiver {
 
 #[cfg(test)]
 mod sender_tests {
-    use super::{EnqueueResult::*, QueuedPacketId, Sender, SeqNum};
+    use super::{EnqueueResult::*, QueuedPacketId, Sender, SenderStat, SeqNum};
     use std::sync::{Arc, atomic};
     use std::task::{Context, Wake};
 
@@ -1238,6 +1290,12 @@ mod sender_tests {
         retry_packets
     }
 
+    fn retry_cancels_cloned_sorted<Pkt: Clone>(send: &Sender<Pkt>) -> Vec<SeqNum> {
+        let mut retry_cancels: Vec<_> = send.retry_cancels().collect();
+        retry_cancels.sort();
+        retry_cancels
+    }
+
     fn enqueue_packet_expect_sent<Pkt>(send: &mut Sender<Pkt>, body: Pkt) -> (SeqNum, &mut Pkt) {
         let Sent(sn, pkt) = send.enqueue_packet(body) else {
             panic!("packet blocked");
@@ -1267,6 +1325,7 @@ mod sender_tests {
         let mut send: Sender<()> = Sender::new();
         assert_quiesced(&send);
         assert_eq!(send.retry_packets().count(), 0);
+        assert_eq!(send.retry_cancels().count(), 0);
         assert_eq!(send.destruct().count(), 0);
     }
 
@@ -1498,7 +1557,7 @@ mod sender_tests {
     }
 
     #[test]
-    fn test_cancel_and_lookup() {
+    fn test_queued_cancel_and_lookup() {
         let mut send: Sender<_> = Sender::new();
         send.adjust_window_size(3);
 
@@ -1517,7 +1576,7 @@ mod sender_tests {
         assert!(!send.is_sent(id6));
 
         // cancel a packet
-        assert_eq!(send.cancel_packet(id4), Some(104));
+        assert_eq!(send.cancel_queued_packet(id4), Some(104));
 
         // unblock a non-canceled packet
         assert_eq!(send.process_ack(0), Some(100));
@@ -1529,7 +1588,7 @@ mod sender_tests {
         assert_eq!(send.lookup_seq_num(id3), Some(3));
 
         // try to cancel a now-sent packet
-        assert_eq!(send.cancel_packet(id3), None);
+        assert_eq!(send.cancel_queued_packet(id3), None);
         assert!(send.is_sent(id3));
         assert_eq!(send.lookup_seq_num(id3), Some(3));
 
@@ -1547,7 +1606,7 @@ mod sender_tests {
         // cancel the last packet, which is currently blocked
         assert!(send.has_blocked_packets());
         assert!(send.unblock_needed());
-        assert_eq!(send.cancel_packet(id6), Some(106));
+        assert_eq!(send.cancel_queued_packet(id6), Some(106));
         assert!(!send.has_blocked_packets());
         assert!(!send.unblock_needed());
 
@@ -1558,6 +1617,235 @@ mod sender_tests {
         assert_eq!(send.lookup_seq_num(id3), None);
         assert_eq!(send.lookup_seq_num(id5), None);
 
+        assert_quiesced(&send);
+    }
+
+    #[test]
+    fn test_sent_cancel() {
+        let mut send: Sender<_> = Sender::new();
+        send.adjust_window_size(3);
+
+        for i in 0..=2 {
+            enqueue_packet_expect_sent_with_sn(&mut send, 100 + i, i);
+        }
+
+        // ack a later packet
+        assert_eq!(send.process_ack(2), Some(102));
+
+        // cancel the first two packets
+        assert_eq!(send.cancel_sent_packet(0), Some(100));
+        assert_eq!(send.cancel_sent_packet(1), Some(101));
+
+        assert!(!send.is_acked(0));
+        assert!(!send.is_acked(1));
+        assert!(send.is_acked(2));
+        assert!(!send.is_cancel_acked(2));
+
+        // ack one canceled packet, and cancel-ack the other
+        assert_eq!(send.process_ack(0), None);
+        assert!(!send.is_blocked()); // should no longer be blocked
+        send.process_canceled(1);
+
+        assert!(send.is_acked(0));
+        assert!(send.is_acked(1));
+        assert!(!send.retry_needed()); // acked cancel means no more retry
+
+        assert!(!send.is_cancel_acked(0));
+        assert!(send.is_cancel_acked(1));
+
+        // send another packet, should be blocked again
+        enqueue_packet_expect_sent_with_sn(&mut send, 103, 3);
+        assert!(send.is_blocked());
+
+        // forget our canceled packets
+        send.forget_canceled_packet(0);
+        send.forget_canceled_packet(1);
+
+        assert!(!send.is_blocked()); // now, should no longer be blocked
+
+        // queue should be empty now
+        // (save the one packet we sent earlier)
+        for i in 4..=5 {
+            enqueue_packet_expect_sent_with_sn(&mut send, 100 + i, i);
+        }
+
+        for i in 3..=5 {
+            assert_eq!(send.process_ack(i), Some(100 + i));
+            assert!(send.is_acked(i));
+            assert!(!send.is_cancel_acked(i));
+        }
+
+        assert_quiesced(&send);
+    }
+
+    #[test]
+    fn test_sent_cancel_retries() {
+        let mut send: Sender<_> = Sender::new();
+        send.adjust_window_size(4);
+
+        for i in 0..=2 {
+            enqueue_packet_expect_sent_with_sn(&mut send, 100 + i, i);
+        }
+
+        // cancel the first two packets
+        assert_eq!(send.cancel_sent_packet(0), Some(100));
+        assert_eq!(send.cancel_sent_packet(1), Some(101));
+        // test no packets acked
+
+        assert!(send.retry_needed());
+        assert_eq!(&retry_packets_cloned_sorted(&mut send), &[(2, 102)]);
+
+        assert_eq!(&retry_cancels_cloned_sorted(&send), &[0, 1]);
+
+        // test one packet cancel-acked
+        send.process_canceled(1);
+        assert!(send.retry_needed());
+        assert_eq!(&retry_cancels_cloned_sorted(&send), &[0]);
+
+        // test all acked
+        send.process_ack(0);
+        send.process_ack(2);
+        assert!(!send.retry_needed());
+        assert!(retry_packets_cloned_sorted(&mut send).is_empty());
+        assert!(retry_cancels_cloned_sorted(&mut send).is_empty());
+
+        assert_quiesced(&send);
+    }
+
+    #[test]
+    fn test_limit_retries() {
+        let mut send: Sender<_> = Sender::new();
+        send.adjust_window_size(4);
+
+        // immediately send four packets
+        for i in 0..=3 {
+            enqueue_packet_expect_sent_with_sn(&mut send, 100 + i, i);
+        }
+
+        // immediately limit retries of packets 0, 2, and 3
+        send.limit_retries_by_seq_num(0, 3);
+        send.limit_retries_by_seq_num(2, 3);
+        send.limit_retries_by_seq_num(3, 3);
+
+        // queue a fifth packet & limit its retries
+        let id4 = enqueue_packet_expect_queued(&mut send, 104);
+        send.limit_retries_by_id(id4, 3);
+
+        // first retry (initial send for packet 4); packets 1-4 should still be active
+        send.age_retries().for_each(drop);
+
+        assert_eq!(
+            &retry_packets_cloned_sorted(&mut send),
+            &[(0, 100), (1, 101), (2, 102), (3, 103)]
+        );
+
+        assert!(retry_cancels_cloned_sorted(&send).is_empty());
+
+        // acknowledge packet 0 to let packet 4 through
+        send.process_ack(0);
+        assert!(send.unblock_needed());
+        let (sn4, _) = send.enqueue_next_blocked_packet();
+        assert_eq!(sn4, 4);
+
+        // retroactively limit retries of packet 1
+        send.limit_retries_by_seq_num(1, 3);
+
+        // further limit retries of packet 2 to only 2
+        send.limit_retries_by_seq_num(2, 2);
+
+        // immediately cancel packet 3
+        send.cancel_sent_packet(3);
+
+        // second retry (first for packet 4); packet 3 should now be in cancel
+        send.age_retries().for_each(drop);
+
+        assert_eq!(
+            &retry_packets_cloned_sorted(&mut send),
+            &[(1, 101), (2, 102), (4, 104)]
+        );
+
+        assert_eq!(&retry_cancels_cloned_sorted(&send), &[3]);
+
+        // try to raise retry limit of packet 1 (should have no effect)
+        send.limit_retries_by_seq_num(1, 10);
+
+        // third retry (second for packet 4); packets 2 and 3 should now be in cancel
+        send.age_retries().for_each(drop);
+
+        assert_eq!(
+            &retry_packets_cloned_sorted(&mut send),
+            &[(1, 101), (4, 104)]
+        );
+
+        assert_eq!(&retry_cancels_cloned_sorted(&send), &[2, 3]);
+
+        // fourth retry (third for packet 4); only packet 4 should still be active
+        send.age_retries().for_each(drop);
+
+        assert_eq!(&retry_packets_cloned_sorted(&mut send), &[(4, 104)]);
+
+        assert_eq!(&retry_cancels_cloned_sorted(&send), &[1, 2, 3]);
+
+        // fourth retry for packet 4; all should now be in cancel
+        send.age_retries().for_each(drop);
+
+        assert!(retry_packets_cloned_sorted(&mut send).is_empty());
+
+        assert_eq!(&retry_cancels_cloned_sorted(&send), &[1, 2, 3, 4]);
+
+        // cancel all
+        for sn in 1..=4 {
+            send.process_canceled(sn);
+            send.forget_canceled_packet(sn);
+        }
+
+        assert_quiesced(&send);
+    }
+
+    #[test]
+    fn test_sent_stats() {
+        let mut send: Sender<_> = Sender::new();
+        send.adjust_window_size(4);
+
+        // immediately send four packets
+        for i in 0..=3 {
+            enqueue_packet_expect_sent_with_sn(&mut send, 100 + i, i);
+        }
+
+        // ack the first packet
+        send.process_ack(0);
+
+        // cancel packets 1 and 2
+        send.cancel_sent_packet(1);
+        send.cancel_sent_packet(2);
+
+        // 1 gets canceled, 2 gets acked
+        send.process_ack(2);
+        send.process_canceled(1);
+
+        // this ack is too new
+        send.process_ack(4);
+        assert_eq!(send.fetch_reset_stat(SenderStat::TooNewAck), 1);
+
+        // this ack is too old
+        send.process_ack(0);
+        assert_eq!(send.fetch_reset_stat(SenderStat::TooOldAck), 1);
+
+        // this ack and cancel are duplicate
+        send.process_ack(2);
+        send.process_canceled(1);
+        assert_eq!(send.fetch_reset_stat(SenderStat::DuplicateAck), 2);
+
+        // this ack and both cancels are erroneous (for two different reasons)
+        send.process_ack(1);
+        send.process_canceled(2);
+        send.process_canceled(3);
+        assert_eq!(send.fetch_reset_stat(SenderStat::InvalidAck), 3);
+
+        // clean up
+        send.process_ack(3);
+        send.forget_canceled_packet(1);
+        send.forget_canceled_packet(2);
         assert_quiesced(&send);
     }
 
@@ -1659,7 +1947,7 @@ mod sender_tests {
 
 #[cfg(test)]
 mod receiver_tests {
-    use super::{Disposition::*, Receiver};
+    use super::{Disposition::*, Receiver, ReceiverStat};
 
     #[test]
     fn test_in_order() {
@@ -1679,6 +1967,7 @@ mod receiver_tests {
         assert!(matches!(recv.process_packet(3), AckAndProcess));
         assert!(matches!(recv.process_packet(1), AckAndProcess));
         assert!(matches!(recv.process_packet(6), AckAndProcess));
+        assert_eq!(recv.fetch_reset_stat(ReceiverStat::OutOfOrder), 2);
     }
 
     #[test]
@@ -1689,10 +1978,12 @@ mod receiver_tests {
         assert!(matches!(recv.process_packet(0), AckAndProcess));
         assert!(matches!(recv.process_packet(3), AckAndProcess));
         assert!(matches!(recv.process_packet(4), Ignore));
+        assert!(matches!(recv.process_cancel(4), Ignore));
+        assert_eq!(recv.fetch_reset_stat(ReceiverStat::TooNew), 4);
     }
 
     #[test]
-    fn duplicate_within_window() {
+    fn test_duplicate_within_window() {
         let mut recv = Receiver::new(3);
         assert!(matches!(recv.process_packet(0), AckAndProcess));
         assert!(matches!(recv.process_packet(2), AckAndProcess));
@@ -1700,10 +1991,11 @@ mod receiver_tests {
         assert!(matches!(recv.process_packet(2), AckDoNotProcess));
         assert!(matches!(recv.process_packet(1), AckAndProcess));
         assert!(matches!(recv.process_packet(1), AckDoNotProcess));
+        assert_eq!(recv.fetch_reset_stat(ReceiverStat::Duplicate), 3);
     }
 
     #[test]
-    fn duplicate_behind_window() {
+    fn test_duplicate_behind_window() {
         let mut recv = Receiver::new(1);
         assert!(matches!(recv.process_packet(0), AckAndProcess));
         assert!(matches!(recv.process_packet(1), AckAndProcess));
@@ -1712,5 +2004,19 @@ mod receiver_tests {
         assert!(matches!(recv.process_packet(0), Ignore));
         assert!(matches!(recv.process_packet(4), AckAndProcess));
         assert!(matches!(recv.process_packet(1), Ignore));
+        assert!(matches!(recv.process_cancel(1), Ignore));
+        assert_eq!(recv.fetch_reset_stat(ReceiverStat::TooOld), 3);
+    }
+
+    #[test]
+    fn test_cancel() {
+        let mut recv = Receiver::new(3);
+        assert!(matches!(recv.process_packet(0), AckAndProcess));
+        assert!(matches!(recv.process_cancel(0), AckDoNotProcess));
+        assert!(matches!(recv.process_cancel(1), AckCancelDoNotProcess));
+        assert!(matches!(recv.process_packet(1), AckCancelDoNotProcess));
+        assert!(matches!(recv.process_packet(2), AckAndProcess));
+        assert!(matches!(recv.process_cancel(0), AckDoNotProcess));
+        assert!(matches!(recv.process_packet(1), AckCancelDoNotProcess));
     }
 }

--- a/adapter/ph/src/zdpr.rs
+++ b/adapter/ph/src/zdpr.rs
@@ -12,6 +12,7 @@
 //! timeouts live elsewhere.
 
 use enum_map::{Enum, EnumMap};
+use replace_with::*;
 use std::collections::VecDeque;
 use std::task::{Context, Poll, Waker, ready};
 use zpr::packet_info::SeqNum;
@@ -19,9 +20,127 @@ use zpr::packet_info::SeqNum;
 /// ID of a packet which was queued for sending (but maybe not yet sent).
 pub type QueuedPacketId = u64;
 
+/// State of a packet which was just enqueued.
 pub enum EnqueueResult<'a, Pkt> {
+    /// The packet is ready to be sent with the given sequence number.
     Sent(SeqNum, &'a mut Pkt),
+    /// The packet has been enqueued with the given packet ID.
     Queued(QueuedPacketId),
+}
+
+/// Sender statistic.
+///
+/// Note that statistics exist only for those things which are opaque
+/// to the caller.  Statistics such as "number of packets sent" or
+/// "number of ACKs received" are therefore not tracked.
+#[derive(Clone, Copy, Debug, Enum, strum::EnumIter)]
+pub enum SenderStat {
+    /// how many acknowledgement or cancel-acknowledgements were ignored
+    /// due to either being unrequested, or sent in conflict with a previous
+    /// acknowledgment (a peer error)
+    InvalidAck,
+    /// how many acknowledgements or cancel-acknowledgements were received
+    /// after the sequence number exited the window (benign, but indicative of
+    /// weird network behavior): such acks are _either_ invalid or duplicate,
+    /// but we don't know which
+    TooOldAck,
+    /// how many acknowledgements or cancel-acknowledgements were received
+    /// in duplicate (benign, but indicative of weird network behavior)
+    DuplicateAck,
+    /// how many acknowledgements or cancel-acknowledgements were received
+    /// before they were requested (a peer error)
+    TooNewAck,
+}
+
+impl SenderStat {
+    /// Is a non-zero value for this statistic indicative of a protocol error
+    /// perpetrated by the peer?
+    ///
+    /// The caller may wish to take corrective action such as resetting the link.
+    pub fn is_protocol_error(&self) -> bool {
+        matches!(self, Self::InvalidAck | Self::TooNewAck)
+    }
+}
+
+enum UnackedState<Pkt> {
+    Unacked { packet: Pkt, waker: Waker },
+    Canceled { waker: Waker, forgotten: bool },
+    Acked,
+    CancelAcked,
+}
+
+impl<Pkt> UnackedState<Pkt> {
+    /// Does this represent an acknowledgement or cancel-acknowledgement.
+    pub fn is_acked(&self) -> bool {
+        matches!(self, UnackedState::Acked | UnackedState::CancelAcked)
+    }
+
+    /// Attempt to transition from Unacked to Canceled.
+    /// Returns the canceled packet if successful.
+    pub fn cancel(&mut self) -> Option<Pkt> {
+        replace_with_or_abort_and_return(self, |s| match s {
+            Self::Unacked { packet, waker } => (
+                Some(packet),
+                Self::Canceled {
+                    waker,
+                    forgotten: false,
+                },
+            ),
+            s => (None, s),
+        })
+    }
+
+    /// Forget (or, preemptively forget) the cancellation status
+    /// of this packet.
+    pub fn forget(&mut self) {
+        match self {
+            Self::Canceled { forgotten, .. } => *forgotten = true,
+            Self::CancelAcked => *self = Self::Acked,
+            _ => (),
+        }
+    }
+
+    /// Wake any associated waker, and return any associated packet.
+    pub fn destruct(self) -> Option<Pkt> {
+        match self {
+            Self::Unacked { packet, waker } => {
+                waker.wake();
+                Some(packet)
+            }
+            Self::Canceled { waker, .. } => {
+                waker.wake();
+                None
+            }
+            Self::Acked | Self::CancelAcked => None,
+        }
+    }
+}
+
+enum BlockedState<Pkt> {
+    Blocked { packet: Pkt, waker: Waker },
+    Canceled,
+}
+
+impl<Pkt> BlockedState<Pkt> {
+    /// Attempt to transition from Blocked to Canceled.
+    /// Returns the canceled packet and associated waker if successful.
+    pub fn cancel(&mut self) -> Option<(Pkt, Waker)> {
+        replace_with_or_abort_and_return(self, |s| match s {
+            Self::Blocked { packet, waker } => (Some((packet, waker)), Self::Canceled),
+            s => (None, s),
+        })
+    }
+
+    /// Wake any associated waker, and return any associated packet.
+    pub fn destruct(self) -> Option<Pkt> {
+        match self {
+            Self::Blocked { packet, waker } => {
+                waker.wake();
+                Some(packet)
+            }
+            Self::Canceled => None,
+        }
+    }
 }
 
 /// State of the sending side of a reliable ZDP session.
@@ -37,11 +156,11 @@ pub struct Sender<Pkt> {
 
     /// A queue representing the window of outstanding packets, indexed by
     /// sequence number.  The rightmost entry (if any) is the most recent
-    /// packet sent (with sequence number `last_sent`).  Packets which have
-    /// been acknowledged are marked `None`.  The contiguous prefix of
-    /// oldest packets which have been acknowledged are removed entirely.
-    /// Thus the maximum length of this deque is exactly the window size.
-    unacked: VecDeque<Option<(Pkt, Waker)>>,
+    /// packet sent (with sequence number `last_sent`).  The contiguous
+    /// prefix of oldest packets which have been acknowledged are removed
+    /// entirely.  Thus the maximum length of this deque is exactly the
+    /// window size.
+    unacked: VecDeque<UnackedState<Pkt>>,
 
     /// The ID of the most recent packet queued waiting to be sent.
     last_enqueued: QueuedPacketId,
@@ -51,7 +170,7 @@ pub struct Sender<Pkt> {
     /// enqueued (with packet ID `last_enqueued`).  Packets which have been
     /// canceled are marked `None`.  Packets are moved to the `sent` queue
     /// upon being sent, as are any preceding packets which have been canceled.
-    blocked: VecDeque<Option<(Pkt, Waker)>>,
+    blocked: VecDeque<BlockedState<Pkt>>,
 
     /// A queue containing packets which had been queued but have now been
     /// sent, indexed by packet ID.  The rightmost entry (if any) is the
@@ -62,6 +181,9 @@ pub struct Sender<Pkt> {
     /// were canceled and never sent.  (However, any such prefix of canceled
     /// packets are always immediately removed.)
     sent: VecDeque<Option<SeqNum>>,
+
+    /// Sender statistics.
+    stats: EnumMap<SenderStat, u64>,
 }
 
 // Individual sent packets conceptually follow the following state machine.
@@ -70,13 +192,20 @@ pub struct Sender<Pkt> {
 //
 //   BLOCKED: This packet is waiting to be sent on the wire.
 //
-//   CANCELED: This packet was cancelled by the caller while blocked.
+//   CANCELED: This packet was canceled by the caller while in BLOCKED
+//     (and thus has not yet been assigned a sequence number).
 //
 //   UNACKED: This packet has been sent and we are waiting for the
 //     remote to acknowledge receipt.  The caller should periodically
 //     resend packets which are in this state.
 //
+//   CANCEL_REQUESTED: This packet was canceled by the caller while in
+//     UNACKED and we are waiting for the remote to acknowledge receipt.
+//     The caller should periodically resend packets which are in this state.
+//
 //   ACKED: This packet has been acknowledged by the remote.
+//
+//   CANCEL_ACKED: This packet has been cancelled by the remote.
 //
 //   FORGOTTEN: We no longer have any record of this packet.
 //
@@ -87,6 +216,8 @@ pub struct Sender<Pkt> {
 //   CANCEL: The caller requests to cancel a packet.
 //
 //   ACK: An acknowledgement is received for the packet.
+//
+//   CANCEL_ACK: A cancellation acknowledgement is received for the packet.
 //
 //   UNBLOCK: There is now room in the window for this packet.
 //
@@ -102,31 +233,41 @@ pub struct Sender<Pkt> {
 //
 //   BLOCKED -[UNBLOCK]> UNACKED
 //
+//   UNACKED -[CANCEL]> CANCEL_REQUESTED
+//
 //   UNACKED -[ACK]> ACKED
 //
+//   CANCEL_REQUESTED -[ACK]> ACKED
+//
+//   CANCEL_REQUESTED -[CANCEL_ACK]> CANCEL_ACKED
+//
 //   ACKED -[AGED]> FORGOTTEN
+//
+//   CANCEL_ACKED -[AGED]> FORGOTTEN
 //
 //   CANCELED -[AGED]> FORGOTTEN
 //
 //
-// It can be seen from the above that the number of packets in UNACKED or
-// ACKED is bounded by the window size.  However, the number of packets in
-// BLOCKED and CANCELED (and trivially, in FORGOTTEN) are not bounded.
+// It can be seen from the above that the number of packets in UNACKED,
+// CANCEL_REQUESTED, ACKED, or CANCEL_ACKED is bounded by the window size.
+// However, the number of packets in BLOCKED and CANCELED (and trivially, in
+// FORGOTTEN) are not bounded.
 //
 // `Waker` objects may be registered for notification when a packet leaves
-// the BLOCKED and UNACKED states.  By waiting on exit of the BLOCKED state,
-// the caller may implement basic flow control.  By waiting on exit of the
-// UNACKED state, the caller may track forward progress of the channel.
+// the BLOCKED, UNACKED, or CANCEL_REQUESTED states.  By waiting on exit of
+// the BLOCKED state, the caller may implement basic flow control.  By
+// waiting on exit of the UNACKED or CANCEL_REQUESTED states, the caller may
+// track forward progress of the channel.
 //
 // Packets which are initially BLOCKED are assigned a `QueuedPacketId` which
 // may be used to refer to this packet for the rest of its lifetime.
 // Packets which are initially UNACKED are likewise assigned a `SeqNum`.
 // (Packets which were BLOCKED and became UNACKED are also assigned a
 // `SeqNum` which the caller may look up based on the packet's
-// `QueuedPacketId` while the packet is UNACKED in order to register for
-// notification when the packet leaves UNACKED.  If the caller performs this
-// lookup in ACKED it is simply informed that the packet has already been
-// acknowledged.)
+// `QueuedPacketId` while the packet is UNACKED or CANCEL_REQUESTED in order
+// to register for notification when the packet leaves either of these
+// states.  If the caller performs this lookup in ACKED or CANCEL_ACKED it
+// is simply informed that the packet has already been acknowledged.)
 
 impl<Pkt> Sender<Pkt> {
     /// The maximum window size supported by the sender.
@@ -148,6 +289,7 @@ impl<Pkt> Sender<Pkt> {
             last_enqueued: QueuedPacketId::MAX,
             blocked: VecDeque::new(),
             sent: VecDeque::new(),
+            stats: Default::default(),
         }
     }
 
@@ -182,13 +324,14 @@ impl<Pkt> Sender<Pkt> {
 
     /// Returns whether the given non-cancelled queued packet has been sent.
     ///
-    /// Result is undefined if packet has been cancelled.
+    /// Result is undefined if packet has been cancelled while queued.
     pub fn is_sent(&self, id: QueuedPacketId) -> bool {
         let offset = id.wrapping_sub(self.last_enqueued) as i64;
         -offset >= self.blocked.len() as i64
     }
 
-    /// Returns whether the given sent packet has been acknowledged.
+    /// Returns whether the given sent packet has been acknowledged,
+    /// or acknowledged as canceled.
     pub fn is_acked(&self, sn: SeqNum) -> bool {
         let offset = sn.wrapping_sub(self.last_sent) as i64;
 
@@ -201,10 +344,42 @@ impl<Pkt> Sender<Pkt> {
         }
 
         let idx = (self.unacked.len() as i64 + offset - 1) as usize;
-        self.unacked[idx].is_none()
+        self.unacked[idx].is_acked()
+    }
+
+    /// Returns whether the given packet has been acknowledged as canceled.
+    ///
+    /// Panics if called on a sequence number which has not been requested
+    /// to be canceled, or which had, but has been forgotten.
+    pub fn is_cancel_acked(&self, sn: SeqNum) -> bool {
+        let offset = sn.wrapping_sub(self.last_sent) as i64;
+
+        if offset > 0 {
+            panic!("packet cancellation must have been requested");
+        }
+
+        if -offset >= self.unacked.len() as i64 {
+            panic!("packet cancellation must have been requested and not yet forgotten");
+        }
+
+        let idx = (self.unacked.len() as i64 + offset - 1) as usize;
+        match self.unacked[idx] {
+            UnackedState::Unacked { .. } | UnackedState::Acked => {
+                panic!("packet cancellation must have been requested")
+            }
+
+            UnackedState::CancelAcked => true,
+            UnackedState::Canceled { .. } => false,
+        }
     }
 
     /// Implementation of `Future::poll` to wait for send of a given packet.
+    ///
+    /// Panics if the indicated packet was canceled.
+    ///
+    /// Returns `None` if the packet has already been acknowledged; else returns
+    /// the sequence number assigned to the packet which is suitable for
+    /// passing to `poll_ack()`.
     pub fn poll_send(&mut self, cx: &mut Context<'_>, id: QueuedPacketId) -> Poll<Option<SeqNum>> {
         let offset = id.wrapping_sub(self.last_enqueued) as i64;
         assert!(
@@ -218,17 +393,17 @@ impl<Pkt> Sender<Pkt> {
 
         let idx = (self.blocked.len() as i64 + offset - 1) as usize;
         match self.blocked[idx] {
-            None => panic!("poll of cancelled packet"),
+            BlockedState::Canceled => panic!("poll of cancelled packet"),
 
-            Some((_, ref mut waker)) => {
+            BlockedState::Blocked { ref mut waker, .. } => {
                 waker.clone_from(cx.waker());
                 Poll::Pending
             }
         }
     }
 
-    /// Implementation of `Future::poll` to wait for acknowledgement
-    /// of a given packet.
+    /// Implementation of `Future::poll` to wait for acknowledgement of a given packet
+    /// (or of the cancellation thereof).
     pub fn poll_ack(&mut self, cx: &mut Context<'_>, sn: SeqNum) -> Poll<()> {
         let offset = sn.wrapping_sub(self.last_sent) as i64;
         assert!(offset <= 0, "poll of packet which has not yet been sent");
@@ -239,9 +414,9 @@ impl<Pkt> Sender<Pkt> {
 
         let idx = (self.unacked.len() as i64 + offset - 1) as usize;
         match self.unacked[idx] {
-            None => Poll::Ready(()),
-
-            Some((_, ref mut waker)) => {
+            UnackedState::Acked | UnackedState::CancelAcked => Poll::Ready(()),
+            UnackedState::Unacked { ref mut waker, .. }
+            | UnackedState::Canceled { ref mut waker, .. } => {
                 waker.clone_from(cx.waker());
                 Poll::Pending
             }
@@ -250,9 +425,11 @@ impl<Pkt> Sender<Pkt> {
 
     /// Implementation of `Future::poll` to wait for acknowledgement
     /// of a given packet which may not yet be sent.
+    ///
+    /// Panics if the indicated packet was canceled.
     pub fn poll_send_and_ack(&mut self, cx: &mut Context<'_>, id: QueuedPacketId) -> Poll<()> {
         match ready!(self.poll_send(cx, id)) {
-            Some(sn) => self.poll_ack(cx, sn),
+            Some(sn) => self.poll_ack(cx, sn).map(|_| ()),
             None => Poll::Ready(()),
         }
     }
@@ -277,28 +454,38 @@ impl<Pkt> Sender<Pkt> {
     pub fn enqueue_packet(&mut self, packet: Pkt) -> EnqueueResult<'_, Pkt> {
         if self.is_blocked() || self.has_blocked_packets() {
             self.last_enqueued = self.last_enqueued.wrapping_add(1);
-            self.blocked
-                .push_back(Some((packet, Waker::noop().clone())));
+            self.blocked.push_back(BlockedState::Blocked {
+                packet,
+                waker: Waker::noop().clone(),
+            });
             return EnqueueResult::Queued(self.last_enqueued);
         }
 
-        self.unacked
-            .push_back(Some((packet, Waker::noop().clone())));
+        let UnackedState::Unacked { packet, .. } =
+            self.unacked.push_back_mut(UnackedState::Unacked {
+                packet,
+                waker: Waker::noop().clone(),
+            })
+        else {
+            unreachable!()
+        };
+
         let sn = self.last_sent.wrapping_add(1);
         self.last_sent = sn;
 
-        EnqueueResult::Sent(
-            sn,
-            &mut self.unacked.back_mut().unwrap().as_mut().unwrap().0,
-        )
+        EnqueueResult::Sent(sn, packet)
     }
 
     /// Attempt to cancel the specified queued packet.
     ///
     /// If the packet has not yet been sent, it is returned as `Some(pkt)`.
+    /// The packet is now canceled.
     ///
-    /// Else, `None` is returned.
-    pub fn cancel_packet(&mut self, id: QueuedPacketId) -> Option<Pkt> {
+    /// Else, `None` is returned, indicating that the packet has already
+    /// been sent.  The caller may then lookup the sequence numer with
+    /// `lookup_seq_num()` and use `cancel_sent_packet()` to request
+    /// that the receiver cancel the packet.
+    pub fn cancel_queued_packet(&mut self, id: QueuedPacketId) -> Option<Pkt> {
         let offset = id.wrapping_sub(self.last_enqueued) as i64;
         assert!(
             offset <= 0,
@@ -312,7 +499,7 @@ impl<Pkt> Sender<Pkt> {
 
         let idx = (self.blocked.len() as i64 + offset - 1) as usize;
 
-        let (pkt, waker) = self.blocked[idx].take()?;
+        let (pkt, waker) = self.blocked[idx].cancel()?;
 
         if idx == 0 {
             self.clean_blocked_queue();
@@ -323,13 +510,75 @@ impl<Pkt> Sender<Pkt> {
         Some(pkt)
     }
 
+    /// Attempt to cancel the specified sent packet.
+    ///
+    /// This simply marks the packet to be sent as a cancellation request
+    /// on future retries.
+    ///
+    /// Returns `None` if the packet has already been acknowledged, or a
+    /// cancel requested.  Otherwise, returns `Some(pkt)`, and remote
+    /// cancellation will be attempted: future retries will send
+    /// cancellation requests.  Successful cancellation will then be
+    /// indicated to the caller via `poll_ack()`.
+    ///
+    /// If `Some(pkt)` is returned, the caller may optionally also
+    /// immediately send a cancellation request, rather than waiting for
+    /// the next retry.
+    ///
+    /// If a remote cancellation is attempted, the caller *must* at
+    /// some point call `forget_canceled_packet()` to indicate that
+    /// it is no longer interested in the status this packet.
+    pub fn cancel_sent_packet(&mut self, sn: SeqNum) -> Option<Pkt> {
+        let offset = sn.wrapping_sub(self.last_sent) as i64;
+
+        if offset > 0 || -offset >= self.unacked.len() as i64 {
+            // already acknowledged
+            return None;
+        }
+
+        let idx = (self.unacked.len() as i64 + offset - 1) as usize;
+
+        let pkt = self.unacked[idx].cancel();
+
+        self.clean_sent_queue();
+
+        pkt
+    }
+
+    /// After a sent packet is canceled, we track the status of
+    /// whether the cancellation was successful or not.
+    /// This method allows the caller to cease tracking this status
+    /// for the given packet.
+    ///
+    /// It is *required* to call this method at some point after a remote
+    /// cancellation is issued.  (It may be called before or after
+    /// the cancellation is acknowledged.)
+    pub fn forget_canceled_packet(&mut self, sn: SeqNum) {
+        let offset = sn.wrapping_sub(self.last_sent) as i64;
+
+        if offset > 0 || -offset >= self.unacked.len() as i64 {
+            return;
+        }
+
+        let idx = (self.unacked.len() as i64 + offset - 1) as usize;
+
+        self.unacked[idx].forget();
+
+        if idx == 0 {
+            self.clean_unacked_queue();
+        }
+        self.clean_sent_queue();
+    }
+
     /// Lookup the sequence number of a packet which had been queued
     /// and has now been sent.
     ///
     /// If the packet has already been acknowledged `None` is returned.
+    /// (However, packets which have been cancel-acknowledged and not
+    /// yet forgotten do still resolve to a sequence number.)
     ///
     /// Panics if the packet has not yet been sent (check `is_sent()` before calling).
-    /// Result is undefined if packet has been cancelled.
+    /// Result is undefined if packet has been cancelled prior to sending.
     pub fn lookup_seq_num(&self, id: QueuedPacketId) -> Option<SeqNum> {
         let offset = id.wrapping_sub(self.last_enqueued) as i64 + self.blocked.len() as i64;
         assert!(offset <= 0, "lookup of packet which has not yet been sent");
@@ -345,33 +594,111 @@ impl<Pkt> Sender<Pkt> {
     /// Process a received acknowledgement of the given sequence number.
     ///
     /// If this is the first acknowledgement received for that sequence
-    /// number, the corresponding packet is marked acknowledged and returned
-    /// for the caller to dispose of.  (In this case, it is possible also
-    /// the sender has become unblocked if it were blocked.) Else `None` is
-    /// returned.
+    /// number, the corresponding packet is marked acknowledged and, if a
+    /// cancel had not been requested, the packet is returned for the caller
+    /// to dispose of.  It is possible also the sender has
+    /// become unblocked if it were blocked.
+    ///
+    /// Else, `None` is returned.  (Note that this does _not_ necessarily
+    /// indicate the acknowledgment was not heeded!  This may also occur
+    /// if a cancel was requested but rejected, since the packet will have
+    /// been already returned to the caller earlier.)
     ///
     /// Upon return, callers should query `retry_needed()` to
     /// determine whether to cancel any oustanding retry timer,
     /// and `unblock_needed()` to determine whether to send
     /// blocked packets.
     pub fn process_ack(&mut self, sn: SeqNum) -> Option<Pkt> {
-        let offset = sn.wrapping_sub(self.last_sent) as i64;
+        let idx = self.lookup_ack_index(sn)?;
 
-        if offset > 0 || -offset >= self.unacked.len() as i64 {
-            return None;
-        }
+        let (pkt, waker) = replace_with_or_abort_and_return(&mut self.unacked[idx], |s| match s {
+            UnackedState::Unacked { packet, waker } => {
+                (Some((Some(packet), waker)), UnackedState::Acked)
+            }
 
-        let idx = (self.unacked.len() as i64 + offset - 1) as usize;
-        let (pkt, waker) = self.unacked[idx].take()?;
+            UnackedState::Canceled { waker, .. } => (Some((None, waker)), UnackedState::Acked),
+
+            UnackedState::Acked => {
+                self.stats[SenderStat::DuplicateAck] += 1;
+                (None, s)
+            }
+
+            UnackedState::CancelAcked => {
+                self.stats[SenderStat::InvalidAck] += 1;
+                (None, s)
+            }
+        })?;
 
         if idx == 0 {
             self.clean_unacked_queue();
-            self.clean_sent_queue();
         }
+        self.clean_sent_queue();
 
         // TODO: move wake up to caller? to minimize time under lock
         waker.wake();
-        Some(pkt)
+
+        pkt
+    }
+
+    /// Process a received cancellation acknowledgement of the given sequence number.
+    ///
+    /// Upon return, callers should query `retry_needed()` to
+    /// determine whether to cancel any oustanding retry timer,
+    /// and `unblock_needed()` to determine whether to send
+    /// blocked packets.
+    pub fn process_canceled(&mut self, sn: SeqNum) {
+        let Some(idx) = self.lookup_ack_index(sn) else {
+            return;
+        };
+
+        let Some(waker) = replace_with_or_abort_and_return(&mut self.unacked[idx], |s| match s {
+            UnackedState::Canceled { waker, forgotten } => {
+                if forgotten {
+                    (Some(waker), UnackedState::Acked)
+                } else {
+                    (Some(waker), UnackedState::CancelAcked)
+                }
+            }
+
+            UnackedState::Unacked { .. } | UnackedState::Acked => {
+                self.stats[SenderStat::InvalidAck] += 1;
+                (None, s)
+            }
+
+            UnackedState::CancelAcked => {
+                self.stats[SenderStat::DuplicateAck] += 1;
+                (None, s)
+            }
+        }) else {
+            return;
+        };
+
+        if idx == 0 {
+            // Note, this will only have an effect if the canceled packet was marked "forgotten".
+            self.clean_unacked_queue();
+        }
+        self.clean_sent_queue();
+
+        // TODO: move wake up to caller? to minimize time under lock
+        waker.wake();
+    }
+
+    /// Returns `Some(idx)` if the ack or cancel is valid, `None` otherwise,
+    /// where `idx` is the unacked index. Counts stats appropriately.
+    fn lookup_ack_index(&mut self, sn: SeqNum) -> Option<usize> {
+        let offset = sn.wrapping_sub(self.last_sent) as i64;
+
+        if offset > 0 {
+            self.stats[SenderStat::TooNewAck] += 1;
+            return None;
+        }
+
+        if -offset >= self.unacked.len() as i64 {
+            self.stats[SenderStat::TooOldAck] += 1;
+            return None;
+        }
+
+        Some((self.unacked.len() as i64 + offset - 1) as usize)
     }
 
     /// Returns true if there are queued unsent packets.
@@ -393,24 +720,28 @@ impl<Pkt> Sender<Pkt> {
     pub fn enqueue_next_blocked_packet(&mut self) -> (SeqNum, &mut Pkt) {
         assert!(!self.is_blocked(), "sender is blocked");
 
-        let (pkt, waker) = self
-            .blocked
-            .pop_front()
-            .expect("no blocked packets")
-            .unwrap();
+        let BlockedState::Blocked { packet, waker } =
+            self.blocked.pop_front().expect("no blocked packets")
+        else {
+            panic!("sender is blocked");
+        };
 
-        self.unacked.push_back(Some((pkt, Waker::noop().clone())));
+        self.unacked.push_back(UnackedState::Unacked {
+            packet,
+            waker: Waker::noop().clone(),
+        });
         let sn = self.last_sent.wrapping_add(1);
         self.last_sent = sn;
 
         self.sent.push_back(Some(sn));
         self.clean_blocked_queue();
 
+        let Some(UnackedState::Unacked { packet, .. }) = self.unacked.back_mut() else {
+            unreachable!()
+        };
+
         waker.wake(); // TODO: move this up to the caller outside of the lock?
-        (
-            sn,
-            &mut self.unacked.back_mut().unwrap().as_mut().unwrap().0,
-        )
+        (sn, packet)
     }
 
     /// Returns whether a retry timer should currently be scheduled.
@@ -420,8 +751,8 @@ impl<Pkt> Sender<Pkt> {
     ///
     /// On a false->true transition, a timer should be started.
     /// On a true->false transition, the timer should be cancelled.
-    /// Transitions only occur in response to `enqueue_packet()` and
-    /// `process_ack()`.
+    /// Transitions only occur in response to `enqueue_packet()`,
+    /// `process_ack()`, or `process_canceled()`.
     pub fn retry_needed(&self) -> bool {
         !self.unacked.is_empty()
     }
@@ -438,9 +769,29 @@ impl<Pkt> Sender<Pkt> {
         self.unacked
             .iter_mut()
             .enumerate()
-            .filter_map(move |(offset, pkt)| {
-                pkt.as_mut()
-                    .map(|(pkt, _waker)| (sn_base.wrapping_add(offset as u64), pkt))
+            .filter_map(move |(offset, pkt)| match pkt {
+                UnackedState::Unacked { packet, .. } => {
+                    Some((sn_base.wrapping_add(offset as u64), packet))
+                }
+                _ => None,
+            })
+    }
+
+    /// Retrieve the list of cancels which need to be retried.
+    ///
+    /// The caller should send a cancellation request for each
+    /// sequence number returned.
+    pub fn retry_cancels(&self) -> impl Iterator<Item = SeqNum> {
+        let sn_base = self
+            .last_sent
+            .wrapping_sub(self.unacked.len() as u64)
+            .wrapping_add(1);
+        self.unacked
+            .iter()
+            .enumerate()
+            .filter_map(move |(offset, pkt)| match pkt {
+                UnackedState::Canceled { .. } => Some(sn_base.wrapping_add(offset as u64)),
+                _ => None,
             })
     }
 
@@ -458,40 +809,34 @@ impl<Pkt> Sender<Pkt> {
 
         unacked
             .into_iter()
-            .filter_map(|pkt| {
-                pkt.map(|(pkt, waker)| {
-                    waker.wake();
-                    pkt
-                })
-            })
-            .chain(blocked.into_iter().filter_map(|pkt| {
-                pkt.map(|(pkt, waker)| {
-                    waker.wake();
-                    pkt
-                })
-            }))
+            .filter_map(|pkt| pkt.destruct())
+            .chain(blocked.into_iter().filter_map(|pkt| pkt.destruct()))
     }
 
-    /// Maintain the invariant that there are no `None` (cancelled) entries
+    /// Maintain the invariant that there are no canceled entries
     /// at the front of the `blocked` queue by moving them all to the end of
     /// the `sent` queue.
     fn clean_blocked_queue(&mut self) {
-        while let Some(None) = self.blocked.front() {
+        while let Some(BlockedState::Canceled) = self.blocked.front() {
             self.blocked.pop_front().unwrap();
             self.sent.push_back(None);
         }
     }
 
-    /// Maintain the invariant that there are no `None` (acknowledged)
-    /// entries at the front of the `unacked` queue by removing them.
+    /// Maintain the invariant that there are no `Acked` entries at the
+    /// front of the `unacked` queue by removing them.
+    ///
+    /// Note that `CancelAcked` entries stay put until they are explicitly
+    /// "purified" into `Acked` entries, since that is an operation
+    /// which loses information.
     fn clean_unacked_queue(&mut self) {
-        while let Some(None) = self.unacked.front() {
+        while let Some(UnackedState::Acked) = self.unacked.front() {
             self.unacked.pop_front();
         }
     }
 
     /// Maintain the invariant that there are no "stale"
-    /// (cancelled/acknowledged) entries at the front of the `sent` queue by
+    /// (acknowledged/canceled) entries at the front of the `sent` queue by
     /// removing them.
     fn clean_sent_queue(&mut self) {
         while let Some(sn) = self.sent.front() {
@@ -502,6 +847,11 @@ impl<Pkt> Sender<Pkt> {
                 }
             }
         }
+    }
+
+    /// Fetch & reset the specified statistic.
+    pub fn fetch_reset_stat(&mut self, stat: SenderStat) -> u64 {
+        std::mem::take(&mut self.stats[stat])
     }
 }
 
@@ -518,17 +868,28 @@ pub enum Disposition {
     AckAndProcess,
     /// Acknowledge, but do not process the packet.
     AckDoNotProcess,
+    /// Acknowledge cancellation, and do not process the packet.
+    AckCancelDoNotProcess,
     /// Do not acknowledge or process the packet.
     Ignore,
 }
 
 impl Disposition {
-    /// Does the disposition indicate that the packet should be acknowledged.
+    /// Does the disposition indicate that the packet should be acknowledged,
+    /// either as received, or as canceled.  (`self.ack_is_canceled()`
+    /// should be used to determine the acknowledgement type.)
     pub fn should_ack(&self) -> bool {
         matches!(
             self,
-            Disposition::AckAndProcess | Disposition::AckDoNotProcess
+            Disposition::AckAndProcess
+                | Disposition::AckDoNotProcess
+                | Disposition::AckCancelDoNotProcess
         )
+    }
+
+    /// Does the disposition indicate that the acknowledgement is of a packet cancellation.
+    pub fn ack_is_canceled(&self) -> bool {
+        matches!(self, Disposition::AckCancelDoNotProcess)
     }
 
     /// Does the disposition indicate that the packet should be processed.
@@ -557,6 +918,16 @@ pub enum ReceiverStat {
     OutOfOrder,
 }
 
+impl ReceiverStat {
+    /// Is a non-zero value for this statistic indicative of a protocol error
+    /// perpetrated by the peer?
+    ///
+    /// The caller may wish to take corrective action such as resetting the link.
+    pub fn is_protocol_error(&self) -> bool {
+        matches!(self, Self::TooNew)
+    }
+}
+
 // Just use a u64 for a bitset for now.
 // Why?  It's simple, large enough, and none of the common
 // "bitset" crates support efficient arbitrary shift operations.
@@ -577,6 +948,13 @@ pub struct Receiver {
     /// Note that bit 0 will always be 1 (since we only adjust `highest_seen`
     /// upon receiving a packet).  We represent it anyway to simplify the implementation.
     recvd: WindowBitset,
+
+    /// A bitset representing which acknowledged packets were canceled.
+    ///
+    /// Indexing matches that of `recvd`.
+    ///
+    /// We track canceled packets so we can provide idempotent responses.
+    canceled: WindowBitset,
 
     /// Receiver statistics.
     stats: EnumMap<ReceiverStat, u64>,
@@ -600,6 +978,7 @@ impl Receiver {
             window_size,
             highest_seen: SeqNum::MAX,
             recvd: WindowBitset::MAX,
+            canceled: WindowBitset::MAX,
             stats: Default::default(),
         }
     }
@@ -608,11 +987,24 @@ impl Receiver {
         -(WindowBitset::BITS as i64) + (self.recvd.leading_ones() as i64) + 1
     }
 
-    /// Process the full sequence number of a received packet.
+    /// Process a received packet.
     ///
     /// The return value indicates whether and how to process
     /// the associated packet.
     pub fn process_packet(&mut self, sn: SeqNum) -> Disposition {
+        self.process_packet_or_cancel(sn, false)
+    }
+
+    /// Process a received cancellation request.
+    ///
+    /// The return value indicates whether and how to process
+    /// the associated packet.  Note that `AckAndProcess` will
+    /// never be returned from this method.
+    pub fn process_cancel(&mut self, sn: SeqNum) -> Disposition {
+        self.process_packet_or_cancel(sn, true)
+    }
+
+    fn process_packet_or_cancel(&mut self, sn: SeqNum, is_cancel: bool) -> Disposition {
         let offset = sn.wrapping_sub(self.highest_seen) as i64;
 
         if offset <= -(self.window_size as i64) {
@@ -632,19 +1024,34 @@ impl Receiver {
             self.highest_seen = self.highest_seen.wrapping_add(offset as SeqNum);
             self.recvd <<= offset;
             self.recvd |= 1;
-            return Disposition::AckAndProcess;
+            self.canceled <<= offset;
+            if is_cancel {
+                self.canceled |= 1;
+                return Disposition::AckCancelDoNotProcess;
+            } else {
+                return Disposition::AckAndProcess;
+            }
         }
 
         if (self.recvd >> -offset) & 1 == 0 {
             // Old, but within our window.  Accept and mark.
             self.stats[ReceiverStat::OutOfOrder] += 1;
             self.recvd |= 1 << -offset;
-            return Disposition::AckAndProcess;
+            if is_cancel {
+                self.canceled |= 1 << -offset;
+                return Disposition::AckCancelDoNotProcess;
+            } else {
+                return Disposition::AckAndProcess;
+            }
         }
 
-        // Already seen.  Do not process, but still acknowledge.
+        // Already seen and within our window.  Do not process, but still acknowledge.
         self.stats[ReceiverStat::Duplicate] += 1;
-        return Disposition::AckDoNotProcess;
+        if (self.canceled >> -offset) & 1 == 0 {
+            return Disposition::AckDoNotProcess;
+        } else {
+            return Disposition::AckCancelDoNotProcess;
+        }
     }
 
     /// Fetch & reset the specified statistic.
@@ -652,6 +1059,7 @@ impl Receiver {
         std::mem::take(&mut self.stats[stat])
     }
 
+    /// Returns the configured window size.
     pub fn window_size(&self) -> usize {
         self.window_size
     }
@@ -983,7 +1391,7 @@ mod sender_tests {
         // cancel a packet
         assert_eq!(send.cancel_packet(id4), Some(104));
 
-        // unblock a non-cancelled packet
+        // unblock a non-canceled packet
         assert_eq!(send.process_ack(0), Some(100));
         assert!(send.unblock_needed());
         let (sn3, pkt3) = send.enqueue_next_blocked_packet();
@@ -997,7 +1405,7 @@ mod sender_tests {
         assert!(send.is_sent(id3));
         assert_eq!(send.lookup_seq_num(id3), Some(3));
 
-        // unblock the next packet, which is after a cancelled packet
+        // unblock the next packet, which is after a canceled packet
         assert_eq!(send.process_ack(1), Some(101));
         assert!(send.unblock_needed());
         let (sn5, pkt5) = send.enqueue_next_blocked_packet();

--- a/adapter/ph/src/zdpr.rs
+++ b/adapter/ph/src/zdpr.rs
@@ -73,7 +73,7 @@ enum UnackedState<Pkt> {
         retry_count: u8,
         forgotten: bool,
     },
-    Canceled {
+    CancelRequested {
         waker: Waker,
         forgotten: bool,
     },
@@ -87,7 +87,7 @@ impl<Pkt> UnackedState<Pkt> {
         matches!(self, UnackedState::Acked | UnackedState::CancelAcked)
     }
 
-    /// Attempt to transition from `Unacked` to `Canceled`.
+    /// Attempt to transition from `Unacked` to `CancelRequested`.
     /// Returns the canceled packet if successful.
     pub fn cancel(&mut self) -> Option<Pkt> {
         replace_with_or_abort_and_return(self, |s| match s {
@@ -96,7 +96,7 @@ impl<Pkt> UnackedState<Pkt> {
                 waker,
                 forgotten,
                 ..
-            } => (Some(packet), Self::Canceled { waker, forgotten }),
+            } => (Some(packet), Self::CancelRequested { waker, forgotten }),
             s => (None, s),
         })
     }
@@ -122,14 +122,14 @@ impl<Pkt> UnackedState<Pkt> {
                 forgotten,
                 ..
             }
-            | Self::Canceled { forgotten, .. } => *forgotten = true,
+            | Self::CancelRequested { forgotten, .. } => *forgotten = true,
             Self::CancelAcked => *self = Self::Acked,
             _ => (),
         }
     }
 
     /// Increment the retry count for an `Unacked` packet.
-    /// If this goes below zero, transition the packet to `Canceled` and
+    /// If this goes below zero, transition the packet to `CancelRequested` and
     /// returns the canceled packet.
     pub fn age_retries(&mut self) -> Option<Pkt> {
         let UnackedState::Unacked {
@@ -158,7 +158,7 @@ impl<Pkt> UnackedState<Pkt> {
                 waker.wake();
                 Some(packet)
             }
-            Self::Canceled { waker, .. } => {
+            Self::CancelRequested { waker, .. } => {
                 waker.wake();
                 None
             }
@@ -268,10 +268,10 @@ impl<Pkt> std::fmt::Display for Sender<Pkt> {
                     retry_count,
                     ..
                 } => write!(f, "{}", limit - retry_count)?,
-                UnackedState::Canceled {
+                UnackedState::CancelRequested {
                     forgotten: true, ..
                 } => write!(f, "f")?,
-                UnackedState::Canceled {
+                UnackedState::CancelRequested {
                     forgotten: false, ..
                 } => write!(f, "c")?,
                 UnackedState::Acked => write!(f, "A")?,
@@ -488,7 +488,7 @@ impl<Pkt> Sender<Pkt> {
 
         let idx = (self.unacked.len() as i64 + offset - 1) as usize;
         match self.unacked[idx] {
-            UnackedState::Unacked { .. } | UnackedState::Canceled { .. } => {
+            UnackedState::Unacked { .. } | UnackedState::CancelRequested { .. } => {
                 panic!("packet must have been acknowledged")
             }
 
@@ -499,7 +499,7 @@ impl<Pkt> Sender<Pkt> {
 
     /// Implementation of `Future::poll` to wait for send of a given packet.
     ///
-    /// Panics if the indicated packet was canceled.
+    /// Panics if the indicated packet was canceled while blocked.
     ///
     /// Returns `None` if the packet has already been acknowledged; else returns
     /// the sequence number assigned to the packet which is suitable for
@@ -540,7 +540,7 @@ impl<Pkt> Sender<Pkt> {
         match self.unacked[idx] {
             UnackedState::Acked | UnackedState::CancelAcked => Poll::Ready(()),
             UnackedState::Unacked { ref mut waker, .. }
-            | UnackedState::Canceled { ref mut waker, .. } => {
+            | UnackedState::CancelRequested { ref mut waker, .. } => {
                 waker.clone_from(cx.waker());
                 Poll::Pending
             }
@@ -550,10 +550,16 @@ impl<Pkt> Sender<Pkt> {
     /// Implementation of `Future::poll` to wait for acknowledgement
     /// of a given packet which may not yet be sent.
     ///
-    /// Panics if the indicated packet was canceled.
+    /// Panics if the indicated packet was canceled while blocked.
+    ///
+    /// Returns `None` if the packet has already been forgotten; else returns
+    /// the sequence number assigned to the packet.
     pub fn poll_send_and_ack(&mut self, cx: &mut Context<'_>, id: QueuedPacketId) -> Poll<()> {
         match ready!(self.poll_send(cx, id)) {
-            Some(sn) => self.poll_ack(cx, sn).map(|_| ()),
+            Some(sn) => {
+                ready!(self.poll_ack(cx, sn));
+                Poll::Ready(())
+            }
             None => Poll::Ready(()),
         }
     }
@@ -702,7 +708,7 @@ impl<Pkt> Sender<Pkt> {
     /// Limit the number of times this packet will be retried.
     ///
     /// Same as [limit_retries_by_id()], but by sequence number.
-    pub fn limit_retries_by_seq_num(&mut self, sn: QueuedPacketId, retry_limit: u8) {
+    pub fn limit_retries_by_seq_num(&mut self, sn: SeqNum, retry_limit: u8) {
         let offset = sn.wrapping_sub(self.last_sent) as i64;
 
         if offset > 0 || -offset >= self.unacked.len() as i64 {
@@ -787,7 +793,9 @@ impl<Pkt> Sender<Pkt> {
                 (Some((Some(packet), waker)), UnackedState::Acked)
             }
 
-            UnackedState::Canceled { waker, .. } => (Some((None, waker)), UnackedState::Acked),
+            UnackedState::CancelRequested { waker, .. } => {
+                (Some((None, waker)), UnackedState::Acked)
+            }
 
             UnackedState::Acked => {
                 self.stats[SenderStat::DuplicateAck] += 1;
@@ -823,7 +831,7 @@ impl<Pkt> Sender<Pkt> {
         };
 
         let Some(waker) = replace_with_or_abort_and_return(&mut self.unacked[idx], |s| match s {
-            UnackedState::Canceled { waker, forgotten } => {
+            UnackedState::CancelRequested { waker, forgotten } => {
                 if forgotten {
                     (Some(waker), UnackedState::Acked)
                 } else {
@@ -934,7 +942,7 @@ impl<Pkt> Sender<Pkt> {
         self.unacked.iter().any(|pkt| !pkt.is_acked())
     }
 
-    /// Ages packet retry counts, and transitions expired packets to `Canceled`.
+    /// Ages packet retry counts, and transitions expired packets to `CancelRequested`.
     ///
     /// Should be called first before querying [retry_packets()] and [retry_cancels()].
     ///
@@ -976,7 +984,7 @@ impl<Pkt> Sender<Pkt> {
             .iter()
             .enumerate()
             .filter_map(move |(offset, pkt)| match pkt {
-                UnackedState::Canceled { .. } => Some(sn_base.wrapping_add(offset as u64)),
+                UnackedState::CancelRequested { .. } => Some(sn_base.wrapping_add(offset as u64)),
                 _ => None,
             })
     }

--- a/adapter/ph/src/zdpr.rs
+++ b/adapter/ph/src/zdpr.rs
@@ -63,8 +63,20 @@ impl SenderStat {
 }
 
 enum UnackedState<Pkt> {
-    Unacked { packet: Pkt, waker: Waker },
-    Canceled { waker: Waker, forgotten: bool },
+    // Note that `retries_remaining` can be 0 after a packet is sent,
+    // but before retries are aged.  (This is needed so the sender can
+    // still reference the packet body.)
+    Unacked {
+        packet: Pkt,
+        waker: Waker,
+        retry_limit: Option<u8>,
+        retry_count: u8,
+        forgotten: bool,
+    },
+    Canceled {
+        waker: Waker,
+        forgotten: bool,
+    },
     Acked,
     CancelAcked,
 }
@@ -75,35 +87,74 @@ impl<Pkt> UnackedState<Pkt> {
         matches!(self, UnackedState::Acked | UnackedState::CancelAcked)
     }
 
-    /// Attempt to transition from Unacked to Canceled.
+    /// Attempt to transition from `Unacked` to `Canceled`.
     /// Returns the canceled packet if successful.
     pub fn cancel(&mut self) -> Option<Pkt> {
         replace_with_or_abort_and_return(self, |s| match s {
-            Self::Unacked { packet, waker } => (
-                Some(packet),
-                Self::Canceled {
-                    waker,
-                    forgotten: false,
-                },
-            ),
+            Self::Unacked {
+                packet,
+                waker,
+                forgotten,
+                ..
+            } => (Some(packet), Self::Canceled { waker, forgotten }),
             s => (None, s),
         })
     }
 
+    /// Set, or reduce, a retry limit.
+    ///
+    /// Does not enforce the limit: [age_retries()] must be called
+    /// to do that.
+    pub fn limit_retries(&mut self, limit: u8) {
+        let Self::Unacked { retry_limit, .. } = self else {
+            return;
+        };
+        *retry_limit = Some(std::cmp::min(limit, retry_limit.unwrap_or(u8::MAX)));
+    }
+
     /// Forget (or, preemptively forget) the cancellation status
-    /// of this packet.
+    /// of this packet.  Can also be used on packets which have retry limits,
+    /// but not on packets which are neither cancelled nor have retry limits.
     pub fn forget(&mut self) {
         match self {
-            Self::Canceled { forgotten, .. } => *forgotten = true,
+            Self::Unacked {
+                retry_limit: Some(_),
+                forgotten,
+                ..
+            }
+            | Self::Canceled { forgotten, .. } => *forgotten = true,
             Self::CancelAcked => *self = Self::Acked,
             _ => (),
+        }
+    }
+
+    /// Increment the retry count for an `Unacked` packet.
+    /// If this goes below zero, transition the packet to `Canceled` and
+    /// returns the canceled packet.
+    pub fn age_retries(&mut self) -> Option<Pkt> {
+        let UnackedState::Unacked {
+            retry_limit,
+            retry_count,
+            ..
+        } = self
+        else {
+            return None;
+        };
+
+        if let Some(limit) = retry_limit
+            && retry_count >= limit
+        {
+            self.cancel()
+        } else {
+            *retry_count = retry_count.saturating_add(1);
+            None
         }
     }
 
     /// Wake any associated waker, and return any associated packet.
     pub fn destruct(self) -> Option<Pkt> {
         match self {
-            Self::Unacked { packet, waker } => {
+            Self::Unacked { packet, waker, .. } => {
                 waker.wake();
                 Some(packet)
             }
@@ -117,7 +168,11 @@ impl<Pkt> UnackedState<Pkt> {
 }
 
 enum BlockedState<Pkt> {
-    Blocked { packet: Pkt, waker: Waker },
+    Blocked {
+        packet: Pkt,
+        waker: Waker,
+        retry_limit: Option<u8>,
+    },
     Canceled,
 }
 
@@ -126,15 +181,23 @@ impl<Pkt> BlockedState<Pkt> {
     /// Returns the canceled packet and associated waker if successful.
     pub fn cancel(&mut self) -> Option<(Pkt, Waker)> {
         replace_with_or_abort_and_return(self, |s| match s {
-            Self::Blocked { packet, waker } => (Some((packet, waker)), Self::Canceled),
+            Self::Blocked { packet, waker, .. } => (Some((packet, waker)), Self::Canceled),
             s => (None, s),
         })
+    }
+
+    /// Set, or reduce, a retry limit.
+    pub fn limit_retries(&mut self, limit: u8) {
+        let Self::Blocked { retry_limit, .. } = self else {
+            return;
+        };
+        *retry_limit = Some(std::cmp::min(limit, retry_limit.unwrap_or(u8::MAX)));
     }
 
     /// Wake any associated waker, and return any associated packet.
     pub fn destruct(self) -> Option<Pkt> {
         match self {
-            Self::Blocked { packet, waker } => {
+            Self::Blocked { packet, waker, .. } => {
                 waker.wake();
                 Some(packet)
             }
@@ -213,7 +276,7 @@ pub struct Sender<Pkt> {
 //
 //   ENQUEUE: The caller requests to enqueue a packet.
 //
-//   CANCEL: The caller requests to cancel a packet.
+//   CANCEL: The caller requests to cancel a packet, or the packet's retry count is exceeded.
 //
 //   ACK: An acknowledgement is received for the packet.
 //
@@ -460,6 +523,7 @@ impl<Pkt> Sender<Pkt> {
             self.blocked.push_back(BlockedState::Blocked {
                 packet,
                 waker: Waker::noop().clone(),
+                retry_limit: None,
             });
             return EnqueueResult::Queued(self.last_enqueued);
         }
@@ -468,6 +532,9 @@ impl<Pkt> Sender<Pkt> {
             self.unacked.push_back_mut(UnackedState::Unacked {
                 packet,
                 waker: Waker::noop().clone(),
+                retry_limit: None,
+                retry_count: 0,
+                forgotten: false,
             })
         else {
             unreachable!()
@@ -540,12 +607,53 @@ impl<Pkt> Sender<Pkt> {
         }
 
         let idx = (self.unacked.len() as i64 + offset - 1) as usize;
+        self.unacked[idx].cancel()
+    }
 
-        let pkt = self.unacked[idx].cancel();
+    /// Limit the number of times this packet will be retried.
+    ///
+    /// May be called multiple times; the lowest limit specified
+    /// remains in effect.
+    ///
+    /// Each time a packet is retried _after_ the initial attempt counts
+    /// toward this limit.  This count is relative to the initial attempt,
+    /// even if retries have already been attempted.
+    ///
+    /// When the specified number of retries have been reached, no further
+    /// retries are attempted, and instead cancellation attempts will be made.
+    ///
+    /// If the packet is already canceled, this has no effect.
+    pub fn limit_retries_by_id(&mut self, id: QueuedPacketId, retry_limit: u8) {
+        let offset = id.wrapping_sub(self.last_enqueued) as i64;
+        assert!(
+            offset <= 0,
+            "retry-limiting of packet which has not yet been enqueued"
+        );
 
-        self.clean_sent_queue();
+        if -offset >= self.blocked.len() as i64 {
+            if let Some(sn) = self.lookup_seq_num(id) {
+                self.limit_retries_by_seq_num(sn, retry_limit);
+            }
+            return;
+        }
 
-        pkt
+        let idx = (self.blocked.len() as i64 + offset - 1) as usize;
+        self.blocked[idx].limit_retries(retry_limit);
+    }
+
+    /// Limit the number of times this packet will be retried.
+    ///
+    /// Same as [limit_retries_by_id()], but by sequence number.
+    pub fn limit_retries_by_seq_num(&mut self, sn: QueuedPacketId, retry_limit: u8) {
+        let offset = sn.wrapping_sub(self.last_sent) as i64;
+
+        if offset > 0 || -offset >= self.unacked.len() as i64 {
+            // already acknowledged
+            return;
+        }
+
+        let idx = (self.unacked.len() as i64 + offset - 1) as usize;
+        self.unacked[idx].limit_retries(retry_limit);
     }
 
     /// After a sent packet is canceled, we track the status of
@@ -617,7 +725,7 @@ impl<Pkt> Sender<Pkt> {
         let idx = self.lookup_ack_index(sn)?;
 
         let (pkt, waker) = replace_with_or_abort_and_return(&mut self.unacked[idx], |s| match s {
-            UnackedState::Unacked { packet, waker } => {
+            UnackedState::Unacked { packet, waker, .. } => {
                 (Some((Some(packet), waker)), UnackedState::Acked)
             }
 
@@ -725,8 +833,11 @@ impl<Pkt> Sender<Pkt> {
     pub fn enqueue_next_blocked_packet(&mut self) -> (SeqNum, &mut Pkt) {
         assert!(!self.is_blocked(), "sender is blocked");
 
-        let BlockedState::Blocked { packet, waker } =
-            self.blocked.pop_front().expect("no blocked packets")
+        let BlockedState::Blocked {
+            packet,
+            waker,
+            retry_limit,
+        } = self.blocked.pop_front().expect("no blocked packets")
         else {
             panic!("sender is blocked");
         };
@@ -734,6 +845,9 @@ impl<Pkt> Sender<Pkt> {
         self.unacked.push_back(UnackedState::Unacked {
             packet,
             waker: Waker::noop().clone(),
+            retry_limit,
+            retry_count: 0,
+            forgotten: false,
         });
         let sn = self.last_sent.wrapping_add(1);
         self.last_sent = sn;
@@ -760,6 +874,15 @@ impl<Pkt> Sender<Pkt> {
     /// `process_ack()`, or `process_canceled()`.
     pub fn retry_needed(&self) -> bool {
         !self.unacked.is_empty()
+    }
+
+    /// Ages packet retry counts, and transitions expired packets to `Canceled`.
+    ///
+    /// Should be called first before querying [retry_packets()] and [retry_cancels()].
+    ///
+    /// Returns a list of cancel packets to be dropped.
+    pub fn age_retries(&mut self) -> impl Iterator<Item = Pkt> {
+        self.unacked.iter_mut().filter_map(|pkt| pkt.age_retries())
     }
 
     /// Retrieve the list of packets which need to be retried.

--- a/adapter/ph/src/zdpr.rs
+++ b/adapter/ph/src/zdpr.rs
@@ -336,6 +336,8 @@ impl<Pkt> std::fmt::Display for Sender<Pkt> {
 //
 //   UNBLOCK: There is now room in the window for this packet.
 //
+//   FORGET: The caller requests to forget the cancellation status of a packet.
+//
 //   AGED: This packet is now the oldest packet which is not FORGOTTEN.
 //
 // Transitions:
@@ -358,7 +360,7 @@ impl<Pkt> std::fmt::Display for Sender<Pkt> {
 //
 //   ACKED -[AGED]> FORGOTTEN
 //
-//   CANCEL_ACKED -[AGED]> FORGOTTEN
+//   CANCEL_ACKED -[FORGET]> FORGOTTEN
 //
 //   CANCELED -[AGED]> FORGOTTEN
 //
@@ -383,6 +385,10 @@ impl<Pkt> std::fmt::Display for Sender<Pkt> {
 // to register for notification when the packet leaves either of these
 // states.  If the caller performs this lookup in ACKED or CANCEL_ACKED it
 // is simply informed that the packet has already been acknowledged.)
+//
+// CANCEL_ACKED packets are not automatically aged and must be explicitly
+// FORGOTten by the caller: this prevents the caller racing with the network
+// to try to retrieve cancellation status.
 
 impl<Pkt> Sender<Pkt> {
     /// The maximum window size supported by the sender.

--- a/adapter/ph/src/zdpr.rs
+++ b/adapter/ph/src/zdpr.rs
@@ -349,27 +349,30 @@ impl<Pkt> Sender<Pkt> {
 
     /// Returns whether the given packet has been acknowledged as canceled.
     ///
-    /// Panics if called on a sequence number which has not been requested
-    /// to be canceled, or which had, but has been forgotten.
+    /// Panics if called on a sequence number which has not been acknowledged
+    /// (i.e., for which [is_acked()] returns `false`).
+    ///
+    /// Returns `false` for any packet whose cancellation has been forgotten,
+    /// regardless of whether it was actually canceled.
     pub fn is_cancel_acked(&self, sn: SeqNum) -> bool {
         let offset = sn.wrapping_sub(self.last_sent) as i64;
 
         if offset > 0 {
-            panic!("packet cancellation must have been requested");
+            panic!("packet must have been acknowledged");
         }
 
         if -offset >= self.unacked.len() as i64 {
-            panic!("packet cancellation must have been requested and not yet forgotten");
+            return false;
         }
 
         let idx = (self.unacked.len() as i64 + offset - 1) as usize;
         match self.unacked[idx] {
-            UnackedState::Unacked { .. } | UnackedState::Acked => {
-                panic!("packet cancellation must have been requested")
+            UnackedState::Unacked { .. } | UnackedState::Canceled { .. } => {
+                panic!("packet must have been acknowledged")
             }
 
             UnackedState::CancelAcked => true,
-            UnackedState::Canceled { .. } => false,
+            UnackedState::Acked => false,
         }
     }
 
@@ -553,6 +556,8 @@ impl<Pkt> Sender<Pkt> {
     /// It is *required* to call this method at some point after a remote
     /// cancellation is issued.  (It may be called before or after
     /// the cancellation is acknowledged.)
+    ///
+    /// This method is a no-op if cancellation was not in fact requested.
     pub fn forget_canceled_packet(&mut self, sn: SeqNum) {
         let offset = sn.wrapping_sub(self.last_sent) as i64;
 

--- a/adapter/ph/src/zdpr_worker.rs
+++ b/adapter/ph/src/zdpr_worker.rs
@@ -25,10 +25,15 @@ pub async fn launch(asm: Arc<Assembly>, link_id: LinkId) {
             _ = retry_interval.tick(), if retry_needed => {
                 let mut zdpr_send = peer_state.zdpr_send.lock().unwrap();
                 let mut count = 0;
+
+                // Resend any packets which must be resent.
                 let packets = zdpr_send.retry_packets();
                 let packets = packets.inspect(|_| count += 1);
                 mgmt::core::build_and_egress_packets(&asm, link_id, packets);
                 mgmt::core::count_events(&asm, counters::ManagementCounterType::ResentPacket, count);
+
+                // Resend any cancels which must be resent.
+                zdpr_send.retry_cancels().for_each(|sn| mgmt::core::send_cancel(&asm, link_id, sn));
             }
 
             () = peer_state.zdpr_retry_timer_reset.notified() => retry_interval.reset(),

--- a/adapter/ph/src/zdpr_worker.rs
+++ b/adapter/ph/src/zdpr_worker.rs
@@ -27,6 +27,7 @@ pub async fn launch(asm: Arc<Assembly>, link_id: LinkId) {
                 let mut count = 0;
 
                 // Resend any packets which must be resent.
+                zdpr_send.age_retries().for_each(drop);
                 let packets = zdpr_send.retry_packets();
                 let packets = packets.inspect(|_| count += 1);
                 mgmt::core::build_and_egress_packets(&asm, link_id, packets);


### PR DESCRIPTION
Imbues ZDPR with the ability to deterministically cancel packets which have already been sent, either immediately, or after a specified number of retries.

The purpose of this ability is to account for the case where some packet is "manifestly" undeliverable, because of e.g. an MTU issue or deep-packet inspection.  Since ZDPR normally guarantees reliable delivery of every packet, were such a packet encountered, this would result in a stalled link and eventual link timeout/teardown, with a high chance of reoccurring when the link is reestablished and the operation which originated the packet performed again.  Furthermore, such behavior could be triggerable by an end-user, since some management packets (namely, bind request) encapsulate user packets.

By allowing certain packets (again, namely bind requests) to be marked for cancellation after a specified number of retries, we avoid this situation: instead, an error is returned and the specific operation which originated the packet is aborted.  By permitting control of this feature on a case-by-case basis, we retain the guarantee of reliable delivery for all sent packets which do _not_ request cancellation (which presumably are those which either are not expected to be manifestly undeliverable, and/or are required for operation of the link).

There are several changes herein:

zdp.rs:
* "Cancel" and "Canceled" ZDP packets are added.  These have no bodies, and indicate respectively that a given packet has been _requested_ to be canceled, or has been _acknowledged_ to be canceled.

zdpr.rs:
* Sender statistics were added to ZDPR, to permit users to detect when the remote side does something weird like send conflicting Ack/Canceled notifications.  (We don't currently do anything with these statistics.)
* Added a Display trait for ZDPR sender state to aid debugging.
* Two packet states were added to the ZDPR sender: CANCEL_REQUESTED (represented in the code as UnackedState::Canceled), and CANCEL_ACKED (UnackedState::CancelAcked).  The meaning of these states is described in detail the updated comment section in that file.
* Due to the addition of CANCEL_ACKED as an additional penultimate state for each packet beside ACKED, in order for the user to tell the two apart in a non-racy fashion, CANCEL_ACKED does not age into FORGOTTEN automatically like ACKED does, but must be explicitly aged by the user, so added a mechanism for that.
* The BLOCKED and UNACKED packet states were augmented with an optional retry limit.  After the specified number of retries, the packet is automatically transitioned to CANCEL_REQUESTED.
* The representation of packet states was changed from an Option to dedicated enums to better support the new states.
* Methods to request cancellation, set retry limit, query cancellation status, process cancellation requests and ACKs, and age retry counters, were all added to ZDPR.

zdpr_worker.rs:
* The ZDPR worker was modified to properly age retry counters, and send cancellation request retries.

dispatch.rs:
* Dispatch modified to correctly hand off cancellation requests and ACKs to ZDPR, and to respond to the peer as warranted.

mgmt/core.rs:
* Added methods to send cancel-request/cancel-ACK packets.
* Eliminated the distinction between `Acked` and `SentAndAcked` futures.  Previously, `Acked` meant that a packet had been sent, and so dropping it could not possibly dequeue the packet (like in `Sent`).  `SentAndAcked` provided no such guarantee.  In practice this distinction wasn't very useful, since these futures were typically awaited immediately at the instantiation site, so there is little doubt what they represent, and it complicated the changes necessary to support cancellation, so instead now there is only `Acked`, which has the semantics that `SentAndAcked` used to.
* Added the `AckedOrCanceled` future, to represent packets which have been canceled or retry-limited, which completes when a packet is acknowledged or cancel-acked.  (Like the reworked `Acked`, its type is not indicative that a packet has been sent, but canceling/retry-limiting a packet and then _not_ waiting for its final disposition is typically inadvisable.)
* Added methods to explicitly cancel a packet, or to limit retries.

adapter_manager_worker.rs:
* The issuance of bind requests was modified to enforce a retry limit.  If the limit is reached and the packet canceled, we treat this as a tether denial.

config.rs:
* Default retry limit defined.  It's 3, for no particular reason.

packet.rs:
* Unrelated change to make the macOS build happy (not sure why this is needed now).