### PR TITLE
Mk/set topo - VSS handling of the set-topology call.

### DIFF
--- a/adapter/ph/src/vss_worker.rs
+++ b/adapter/ph/src/vss_worker.rs
@@ -147,10 +147,10 @@ fn process_configuration(asm: &Arc<Assembly>, params: Vec<Param>) -> ConfigureRe
 }
 
 /// Placeholder. Links not yet acted on.
-fn process_topology(asm: &Arc<Assembly>, links: Vec<Link>) -> SetTopologyResponse {
+fn process_topology(_asm: &Arc<Assembly>, links: Vec<Link>) -> SetTopologyResponse {
     info!(target: VSS_RPC, "received topology update with {} links (not yet implemented)", links.len());
     for (i, link) in links.iter().enumerate() {
-        debug!(target: VSS_RPC, "link {i}: -> {:?}", link.peer);
+        info!(target: VSS_RPC, "[link {i}]-> {:?}", link.peer);
     }
     Ok(())
 }

--- a/adapter/ph/src/vss_worker.rs
+++ b/adapter/ph/src/vss_worker.rs
@@ -3,12 +3,12 @@ use crate::assembly::Assembly;
 use crate::logging::targets::{VISA_MGMT, VSS_RPC};
 use crate::{visa_mgmt, visa_table};
 
-use libnode::vss::{ConfigureResponse, ListProcessingResponse, VSSMessage};
+use libnode::vss::{ConfigureResponse, ListProcessingResponse, SetTopologyResponse, VSSMessage};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::*;
 use zpr::packet_info::VisaId;
-use zpr::vsapi_types::{ApiResponseError, ErrorCode, Param, ParamValue, VisaOp, pname};
+use zpr::vsapi_types::{ApiResponseError, ErrorCode, Link, Param, ParamValue, VisaOp, pname};
 
 pub async fn launch(asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSSMessage>) {
     while let Some(msg) = queue.recv().await {
@@ -56,6 +56,12 @@ pub async fn launch(asm: Arc<Assembly>, mut queue: mpsc::Receiver<VSSMessage>) {
             VSSMessage::Configure(params, resp_tx) => {
                 debug!(target: VSS_RPC, "received VSS configuration update with {} entries", params.len());
                 let resp = process_configuration(&asm, params);
+                let _ = resp_tx.send(resp);
+            }
+
+            VSSMessage::SetTopology(links, resp_tx) => {
+                debug!(target: VSS_RPC, "received topology update with {} links", links.len());
+                let resp = process_topology(&asm, links);
                 let _ = resp_tx.send(resp);
             }
         }
@@ -137,5 +143,14 @@ fn process_configuration(asm: &Arc<Assembly>, params: Vec<Param>) -> ConfigureRe
         }
     }
 
+    Ok(())
+}
+
+/// Placeholder. Links not yet acted on.
+fn process_topology(asm: &Arc<Assembly>, links: Vec<Link>) -> SetTopologyResponse {
+    info!(target: VSS_RPC, "received topology update with {} links (not yet implemented)", links.len());
+    for (i, link) in links.iter().enumerate() {
+        debug!(target: VSS_RPC, "link {i}: -> {:?}", link.peer);
+    }
     Ok(())
 }

--- a/libnode2/src/vss.rs
+++ b/libnode2/src/vss.rs
@@ -203,6 +203,47 @@ impl VSSHandleImpl {
         let mut err_builder = ack_builder.reborrow().init_error();
         api_error.write_to(&mut err_builder);
     }
+
+    /// Send a message and await a `Result<(), ApiResponseError>` response.
+    /// Logs and returns an Internal error if sending or receiving fails.
+    async fn dispatch_and_recv_result(
+        &self,
+        msg: VSSMessage,
+        resp_rx: oneshot::Receiver<Result<(), ApiResponseError>>,
+        op_name: &str,
+    ) -> Result<(), ApiResponseError> {
+        if let Err(e) = self.send_message(msg).await {
+            error!(target: VSS_RPC, "failed to send {op_name} message to handler: {e}");
+            return Err(ApiResponseError::new_code_msg(
+                ErrorCode::Internal,
+                "message processing failed",
+            ));
+        }
+        match resp_rx.await {
+            Ok(r) => r,
+            Err(e) => {
+                error!(target: VSS_RPC, "failed to receive {op_name} response from handler: {e}");
+                Err(ApiResponseError::new_code_msg(
+                    ErrorCode::Internal,
+                    "failed to receive response from VSS handler",
+                ))
+            }
+        }
+    }
+}
+
+/// Helper to write our channel result into a Capn Proto result.
+fn write_api_result(
+    result: Result<(), ApiResponseError>,
+    mut res_builder: v1::ok_or_error::Builder<'_>,
+) {
+    match result {
+        Ok(()) => res_builder.set_ok(()),
+        Err(api_err) => {
+            let mut err_builder = res_builder.init_error();
+            api_err.write_to(&mut err_builder);
+        }
+    }
 }
 
 impl v1::visa_support_service::Server for VisaSupportServiceImpl {
@@ -390,42 +431,14 @@ impl v1::v_s_s_handle::Server for VSSHandleImpl {
         }
 
         let (resp_tx, resp_rx) = oneshot::channel();
-        if let Err(e) = self
-            .send_message(VSSMessage::SetServices(services, resp_tx))
-            .await
-        {
-            // Probably our handler has gone away.
-            // TODO: Shut down this VSS service connection. How?
-            error!("failed to send SetServices message to handler: {}", e);
-            let res_builder = results.get().init_res();
-            let mut err_builder = res_builder.init_error();
-            ApiResponseError::new_code_msg(ErrorCode::Internal, "message processing failed")
-                .write_to(&mut err_builder);
-            return Ok(()); // Exit early with error
-        }
-
-        match resp_rx.await {
-            Ok(Ok(())) => {
-                let mut res_builder = results.get().init_res();
-                res_builder.set_ok(());
-            }
-            Ok(Err(api_err)) => {
-                let res_builder = results.get().init_res();
-                let mut err_builder = res_builder.init_error();
-                api_err.write_to(&mut err_builder);
-            }
-            Err(e) => {
-                error!("failed to receive SetServices response from handler: {}", e);
-                let res_builder = results.get().init_res();
-                let mut err_builder = res_builder.init_error();
-                ApiResponseError::new_code_msg(
-                    ErrorCode::Internal,
-                    "failed to receive response from VSS handler",
-                )
-                .write_to(&mut err_builder);
-            }
-        }
-
+        let result = self
+            .dispatch_and_recv_result(
+                VSSMessage::SetServices(services, resp_tx),
+                resp_rx,
+                "SetServices",
+            )
+            .await;
+        write_api_result(result, results.get().init_res());
         Ok(())
     }
 
@@ -458,41 +471,14 @@ impl v1::v_s_s_handle::Server for VSSHandleImpl {
         }
 
         let (resp_tx, resp_rx) = oneshot::channel();
-        if let Err(e) = self
-            .send_message(VSSMessage::Configure(cfg_params, resp_tx))
-            .await
-        {
-            // Probably our handler has gone away.
-            error!("failed to send Configure message to handler: {}", e);
-            let res_builder = results.get().init_res();
-            let mut err_builder = res_builder.init_error();
-            ApiResponseError::new_code_msg(ErrorCode::Internal, "message processing failed")
-                .write_to(&mut err_builder);
-            return Ok(()); // Exit early with error
-        }
-
-        match resp_rx.await {
-            Ok(Ok(())) => {
-                let mut res_builder = results.get().init_res();
-                res_builder.set_ok(());
-            }
-            Ok(Err(api_err)) => {
-                let res_builder = results.get().init_res();
-                let mut err_builder = res_builder.init_error();
-                api_err.write_to(&mut err_builder);
-            }
-            Err(e) => {
-                error!("failed to receive Configure response from handler: {}", e);
-                let res_builder = results.get().init_res();
-                let mut err_builder = res_builder.init_error();
-                ApiResponseError::new_code_msg(
-                    ErrorCode::Internal,
-                    "failed to receive response from VSS handler",
-                )
-                .write_to(&mut err_builder);
-            }
-        }
-
+        let result = self
+            .dispatch_and_recv_result(
+                VSSMessage::Configure(cfg_params, resp_tx),
+                resp_rx,
+                "Configure",
+            )
+            .await;
+        write_api_result(result, results.get().init_res());
         Ok(())
     }
 
@@ -534,41 +520,14 @@ impl v1::v_s_s_handle::Server for VSSHandleImpl {
         }
 
         let (resp_tx, resp_rx) = oneshot::channel();
-        if let Err(e) = self
-            .send_message(VSSMessage::SetTopology(links, resp_tx))
-            .await
-        {
-            // Probably our handler has gone away.
-            error!("failed to send SetTopology message to handler: {}", e);
-            let res_builder = results.get().init_res();
-            let mut err_builder = res_builder.init_error();
-            ApiResponseError::new_code_msg(ErrorCode::Internal, "message processing failed")
-                .write_to(&mut err_builder);
-            return Ok(()); // Exit early with error
-        }
-
-        match resp_rx.await {
-            Ok(Ok(())) => {
-                let mut res_builder = results.get().init_res();
-                res_builder.set_ok(());
-            }
-            Ok(Err(api_err)) => {
-                let res_builder = results.get().init_res();
-                let mut err_builder = res_builder.init_error();
-                api_err.write_to(&mut err_builder);
-            }
-            Err(e) => {
-                error!("failed to receive SetTopology response from handler: {}", e);
-                let res_builder = results.get().init_res();
-                let mut err_builder = res_builder.init_error();
-                ApiResponseError::new_code_msg(
-                    ErrorCode::Internal,
-                    "failed to receive response from VSS handler",
-                )
-                .write_to(&mut err_builder);
-            }
-        }
-
+        let result = self
+            .dispatch_and_recv_result(
+                VSSMessage::SetTopology(links, resp_tx),
+                resp_rx,
+                "SetTopology",
+            )
+            .await;
+        write_api_result(result, results.get().init_res());
         Ok(())
     }
 }

--- a/libnode2/src/vss.rs
+++ b/libnode2/src/vss.rs
@@ -12,7 +12,7 @@ use tokio_rustls::TlsAcceptor;
 use tokio_util::compat::*;
 use tracing::{debug, error, info, trace, warn};
 use zpr::vsapi::v1;
-use zpr::vsapi_types::{ApiResponseError, ErrorCode, Param, ServiceDescriptor, VisaOp};
+use zpr::vsapi_types::{ApiResponseError, ErrorCode, Link, Param, ServiceDescriptor, VisaOp};
 use zpr::write_to::WriteTo;
 
 use crate::error::VSApiError;
@@ -33,6 +33,7 @@ pub enum ListProcessingResponse {
 
 pub type SetServicesResponse = Result<(), ApiResponseError>;
 pub type ConfigureResponse = Result<(), ApiResponseError>;
+pub type SetTopologyResponse = Result<(), ApiResponseError>;
 
 /// VSS Messages arrive from the visa service.
 #[derive(Debug)]
@@ -44,6 +45,7 @@ pub enum VSSMessage {
         oneshot::Sender<SetServicesResponse>,
     ),
     Configure(Vec<Param>, oneshot::Sender<ConfigureResponse>),
+    SetTopology(Vec<Link>, oneshot::Sender<SetTopologyResponse>),
 }
 
 /// Launch the VSS. Pings are responded to internally. Other VSS messages are sent
@@ -503,6 +505,70 @@ impl v1::v_s_s_handle::Server for VSSHandleImpl {
         let mut res_builder = results.get().init_res();
         res_builder.set_ok(());
         self.data.borrow_mut().last_ping = Some(std::time::Instant::now());
+        Ok(())
+    }
+
+    async fn set_topology(
+        self: Rc<Self>,
+        params: v1::v_s_s_handle::SetTopologyParams,
+        mut results: v1::v_s_s_handle::SetTopologyResults,
+    ) -> Result<(), capnp::Error> {
+        debug!(target: VSS_RPC, "set_topology called by {}", self.remote);
+
+        let params_rdr = params.get()?;
+        let links_rdr = params_rdr.get_links()?;
+
+        let mut links = Vec::new();
+        for link_rdr in links_rdr.iter() {
+            match Link::try_from(link_rdr) {
+                Ok(l) => links.push(l),
+                Err(e) => {
+                    warn!(target: VSS_RPC, "received invalid Link from vs: {}", e);
+                    let res_builder = results.get().init_res();
+                    let mut err_builder = res_builder.init_error();
+                    ApiResponseError::new_code_msg(ErrorCode::ParamError, "failed to parse a Link")
+                        .write_to(&mut err_builder);
+                    return Ok(()); // Exit early with error
+                }
+            }
+        }
+
+        let (resp_tx, resp_rx) = oneshot::channel();
+        if let Err(e) = self
+            .send_message(VSSMessage::SetTopology(links, resp_tx))
+            .await
+        {
+            // Probably our handler has gone away.
+            error!("failed to send SetTopology message to handler: {}", e);
+            let res_builder = results.get().init_res();
+            let mut err_builder = res_builder.init_error();
+            ApiResponseError::new_code_msg(ErrorCode::Internal, "message processing failed")
+                .write_to(&mut err_builder);
+            return Ok(()); // Exit early with error
+        }
+
+        match resp_rx.await {
+            Ok(Ok(())) => {
+                let mut res_builder = results.get().init_res();
+                res_builder.set_ok(());
+            }
+            Ok(Err(api_err)) => {
+                let res_builder = results.get().init_res();
+                let mut err_builder = res_builder.init_error();
+                api_err.write_to(&mut err_builder);
+            }
+            Err(e) => {
+                error!("failed to receive SetTopology response from handler: {}", e);
+                let res_builder = results.get().init_res();
+                let mut err_builder = res_builder.init_error();
+                ApiResponseError::new_code_msg(
+                    ErrorCode::Internal,
+                    "failed to receive response from VSS handler",
+                )
+                .write_to(&mut err_builder);
+            }
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
I guess Cap'n Proto adds a default not-implemented impl for unimplemented service endpoints because libnode2 was not complaining about not having an endpoint for SetTopology.  This has been added now, but the message doesn't go anywhere (except to logging) -- pending implementation to link awareness in PH.