### PR TITLE
Tighten up ca_file and certificate usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ Sample configuration, place in a file named `node-conf.toml`.
 
 ```toml
 [global]
-# ca_file is optional:
-#   ca_file = "auth-ca.crt"
-name = "node.zpr.org"
+# ca_file is needed for the node to verify adapter certificates and recognize
+# the visa-service adapter as special.  Without it, VS routing will not work.
+ca_file = "auth-ca.crt"
 certificate_file = "node-noise.crt"
 private_key_file = "node-noise.key"
 self_addr = "129.6.7.1:5000"
@@ -148,21 +148,42 @@ auth_private_key = "node-private-key.pem"
 ```
 
 
+### Create a signed noise certificate for the visa service adapter
+
+The visa service adapter must present a CA-signed certificate so the node can
+recognize it as the special visa-service peer.  The certificate CN **must** be
+`vs.zpr` — that is the hard-coded visa-service distinguished name the node
+matches against.  Generate and sign one:
+
+```sh
+./integration-test/lib/zpr-pki genkey >vs-noise.key
+./integration-test/lib/zpr-pki pubkey <vs-noise.key >vs-noise-pub.pem
+./integration-test/lib/zpr-pki gensignedcert authority/auth-ca.crt authority/auth-ca.key \
+  /CN=vs.zpr 365 < vs-noise-pub.pem >vs-noise.crt
+```
+
+
 ### Create a configuration file for the visa service adapter
 
 ```toml
 [global]
-# ca_file is required.
+# ca_file is optional for link establishment, but the VS adapter must present
+# a CA-signed certificate_file so the node can recognize it as the visa service.
 ca_file = "auth-ca.crt"
+certificate_file = "vs-noise.crt"   # CN must be "vs.zpr"
+private_key_file = "vs-noise.key"
 zpr_addr = [ "fd5a:5052::1" ]
 tun_if = "tun9"
 
 [adapter]
-node = "vs.zpr"
 node_addr = "129.6.7.1:5000"
 node_public_key_file = "node-noise-pub.pem"
 bootstrap_key = "vs-private-key.pem"
 ```
+
+`name` is not set here because `certificate_file` is present — the CN is read
+from the certificate, not from `name`.  `name` is only required for adapters
+that have no `certificate_file` (self-signed cert path).
 
 
 ### Configure the visa service (optional)
@@ -299,8 +320,56 @@ On the visa service host, in another terminal start the adapter:
 Now you can attach additional adapters and start up the "WebService".
 
 
+## Certificate and peer verification reference
+
+### Local certificate (`certificate_file` / `name`)
+
+| Role | `certificate_file` | `name` | Behavior |
+|------|-------------------|--------|-----------|
+| node | required | ignored | Provided cert is used; node name comes from the cert CN |
+| adapter | present | optional | Provided cert is used; CN comes from the cert where needed |
+| adapter | absent | required | Self-signed cert is generated with CN from `name` |
+| adapter | absent | absent | Config validation fails |
+
+For adapters, CLI `--name` overrides `[adapter].name` in the config file.
+
+### Peer certificate verification (`ca_file`)
+
+| `ca_file` | Behavior |
+|-----------|-----------|
+| present | Peer cert signatures are verified against the CA; unverified peers are handled by link-type rules (see below) |
+| absent | Peer cert signatures are not CA-verified; a warning is logged at startup and unverified peers are accepted |
+
+Link-type rules when `ca_file` is configured:
+
+| Link direction | Unverified peer cert | Action |
+|---------------|---------------------|--------|
+| Adapter → Node | Node cert unverified | Link rejected |
+| Node → Node | Peer node cert unverified | Link rejected |
+| Node → Adapter | Adapter cert unverified | Link accepted with a warning |
+
+### Special peers (visa service adapter)
+
+The visa service adapter is recognized as "special" by the node **only** when
+the adapter presents a CA-verified certificate claiming the visa-service DN.
+This means:
+
+- The **node** must configure `ca_file` (to verify the VS adapter's cert).
+- The **VS adapter** must present a CA-signed `certificate_file` (not a self-signed cert).
+
+Without both conditions, the VS adapter connects as an ordinary adapter and
+visa-service traffic is not routed to it.
+
+
 ## Updates
 
++ June 11, 2026
+  + `ca_file` is now optional for adapters (was previously required at startup).
+  + Adapter `certificate_file` is optional; a self-signed cert is generated from `name` when absent.
+  + Special-peer names (visa service) are now only assigned from CA-verified certs — both the node and the VS adapter must use a CA for VS routing to work.
+  + Fixed `--name` CLI ordering bug: the CN embedded in bootstrap/BAS auth objects now correctly reflects the CLI `--name` value.
+  + Removed the silently-ignored `name` key from the node config example.
+  + Added "Certificate and peer verification reference" section.
 + March 13, 2026
   + Rewrote the setup steps for latest code.
 + Aug 20, 2025

--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -581,11 +581,6 @@ impl OAuthRsa {
             ));
         }
     }
-
-    #[cfg(test)]
-    pub fn client_id(&self) -> &str {
-        &self.client_id
-    }
 }
 
 #[cfg(test)]

--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -394,6 +394,11 @@ impl RsaBootstrapAuth {
         };
         Ok(blob.encode())
     }
+
+    #[cfg(test)]
+    pub fn cn(&self) -> &str {
+        &self.cn
+    }
 }
 
 /// Response json object to initial auth request from an actor
@@ -575,6 +580,11 @@ impl OAuthRsa {
                 "failed to find location header in response".to_string(),
             ));
         }
+    }
+
+    #[cfg(test)]
+    pub fn client_id(&self) -> &str {
+        &self.client_id
     }
 }
 

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -109,8 +109,7 @@ impl ArgError for str {
 /// use [crate::main_argparse::argparse].
 #[derive(Debug, Clone)]
 pub struct Config {
-    /// Name of this node or adapter. If no signed certificate is available this is used as the CN.
-    /// This has no meaning for nodes.
+    /// Adapter CN fallback when no signed certificate is configured. Ignored by nodes.
     pub name: String,
 
     /// Path to the unix domain socket for the control interface.
@@ -162,6 +161,12 @@ pub struct Config {
 
     /// If present this has key material for use during a zpr-oauthrsa authentication.
     pub rsaoauth: Option<OAuthRsa>,
+
+    /// Resolved path to the bootstrap RSA key file; used by finalize() to construct `bootstrap`.
+    pub bootstrap_key_path: Option<PathBuf>,
+
+    /// Resolved path to the BAS RSA key file; used by finalize() to construct `rsaoauth`.
+    pub bas_key_path: Option<PathBuf>,
 
     /// The batch I/O engine to use.
     pub batch_io_engine: String,
@@ -254,12 +259,46 @@ impl Config {
     }
 
     /// If we have a `certificate_file` use that to figure out our CN.
-    /// Otherwise we return the `global.name` value.
+    /// Otherwise we return the `global.name` value. Returns an error if both are absent.
     pub fn get_noise_cn(&self) -> Result<String, ArgsError> {
         match self.certificate_file.as_ref() {
-            None => Ok(self.name.clone()),
+            None => {
+                if self.name.is_empty() {
+                    Err("certificate_file or name (required for CN derivation)".arg_missing())
+                } else {
+                    Ok(self.name.clone())
+                }
+            }
             Some(f) => get_noise_cn(&f),
         }
+    }
+
+    /// Construct auth objects from stored key paths, using the resolved CN.
+    /// Must be called after all name sources (config file and CLI) have been merged.
+    pub fn finalize(&mut self) -> Result<(), ArgsError> {
+        if let Some(path) = self.bootstrap_key_path.clone() {
+            let cn = self.get_noise_cn()?;
+            self.bootstrap = Some(RsaBootstrapAuth::new(&cn, &path)?);
+        }
+        if let Some(path) = self.bas_key_path.clone() {
+            let cn = self.get_noise_cn()?;
+            let pemdata = fs::read_to_string(&path).map_err(|e| {
+                ArgsError::PathError(format!(
+                    "failed to read bas_key file {}: {:?}",
+                    path.display(),
+                    e
+                ))
+            })?;
+            let priv_key = PKey::private_key_from_pem(pemdata.as_bytes()).map_err(|e| {
+                ArgsError::ParseError(format!(
+                    "failed to parse bas_key file {}: {:?}",
+                    path.display(),
+                    e
+                ))
+            })?;
+            self.rsaoauth = Some(OAuthRsa::new(&cn, priv_key));
+        }
+        Ok(())
     }
 
     // Check that the required bits are present based on mode.
@@ -324,6 +363,11 @@ impl Config {
                         "node public key file",
                         &self.node_public_key_file.as_ref().unwrap(),
                     )?;
+                }
+                if self.certificate_file.is_none() && self.name.is_empty() {
+                    return Err(
+                        "name (required when certificate_file is absent)".arg_missing(),
+                    );
                 }
                 if self.private_key_file.is_none()
                     && self.private_key_data.is_none()
@@ -420,18 +464,10 @@ impl Config {
         }
 
         if let Some(bootstrap_key_file) = &config.bootstrap_key {
-            // In order to set the bootstrap object, we need to know the CN which means we need
-            // the certificate_file arg to be valid.
-
-            let cn = self.get_noise_cn()?;
-
             if bootstrap_key_file.is_relative() {
-                self.bootstrap = Some(RsaBootstrapAuth::new(
-                    &cn,
-                    &base_dir.join(bootstrap_key_file),
-                )?);
+                self.bootstrap_key_path = Some(base_dir.join(bootstrap_key_file));
             } else {
-                self.bootstrap = Some(RsaBootstrapAuth::new(&cn, bootstrap_key_file)?);
+                self.bootstrap_key_path = Some(bootstrap_key_file.clone());
             }
         }
         Ok(())
@@ -444,26 +480,11 @@ impl Config {
     ) -> Result<(), ArgsError> {
         if let Some(config) = config {
             if let Some(bas_key) = &config.bas_key {
-                let keyfile = if bas_key.is_relative() {
-                    base_dir.join(bas_key)
+                if bas_key.is_relative() {
+                    self.bas_key_path = Some(base_dir.join(bas_key));
                 } else {
-                    bas_key.clone()
-                };
-                let pemdata = fs::read_to_string(&keyfile).map_err(|e| {
-                    ArgsError::PathError(format!(
-                        "failed to read bas_key file {}: {:?}",
-                        keyfile.display(),
-                        e
-                    ))
-                })?;
-                let priv_key = PKey::private_key_from_pem(&pemdata.as_bytes()).map_err(|e| {
-                    ArgsError::ParseError(format!(
-                        "failed to parse bas_key file {}: {:?}",
-                        keyfile.display(),
-                        e
-                    ))
-                })?;
-                self.rsaoauth = Some(OAuthRsa::new(&self.get_noise_cn()?, priv_key));
+                    self.bas_key_path = Some(bas_key.clone());
+                }
             }
             if let Some(auth_private_key) = &config.auth_private_key {
                 let keyfile = if auth_private_key.is_relative() {
@@ -603,6 +624,8 @@ impl Default for Config {
             node_public_key_file: None,
             bootstrap: None,
             rsaoauth: None,
+            bootstrap_key_path: None,
+            bas_key_path: None,
             batch_io_engine: batch_io::AUTO_ENGINE_NAME.to_owned(),
             km_impl: KM_ID_NOISE,
         }

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -237,17 +237,12 @@ impl Config {
     ) -> Result<Self, ArgsError> {
         let mut config = Config::default();
         if let Some(pkey_file) = auth_private_key {
-            if pkey_file.is_relative() {
-                let pkey_file = fs::canonicalize(pkey_file).or_else(|e| {
-                    Err(ArgsError::PathError(format!(
-                        "path error for auth_private_key: {:?}",
-                        e
-                    )))
-                })?;
-                config.auth_private_key = Some(pkey_file);
-            } else {
-                config.auth_private_key = Some(pkey_file);
-            }
+            config.auth_private_key = Some(path::absolute(pkey_file).or_else(|e| {
+                Err(ArgsError::PathError(format!(
+                    "path error for auth_private_key: {:?}",
+                    e
+                )))
+            })?);
         }
         config.set_from_common(common)?;
         if let Some(config_file) = config_file {
@@ -500,59 +495,42 @@ impl Config {
     fn set_from_common(&mut self, common: &CommonArgs) -> Result<(), ArgsError> {
         if let Some(control_path) = &common.control_path {
             let cp = PathBuf::from(control_path);
-            if cp.is_relative() {
-                self.control_path = path::absolute(cp).or_else(|e| {
-                    Err(ArgsError::PathError(format!(
-                        "path error for control_path: {:?}",
-                        e
-                    )))
-                })?;
-            } else {
-                self.control_path = cp;
-            }
+            self.control_path = path::absolute(cp).or_else(|e| {
+                Err(ArgsError::PathError(format!(
+                    "path error for control_path: {:?}",
+                    e
+                )))
+            })?;
         }
         if let Some(capture_path) = &common.capture_path {
             let cp = PathBuf::from(capture_path);
-            if cp.is_relative() {
-                self.capture_path = path::absolute(cp).or_else(|e| {
-                    Err(ArgsError::PathError(format!(
-                        "path error for capture_path: {:?}",
-                        e
-                    )))
-                })?;
-            } else {
-                self.capture_path = cp;
-            }
+            self.capture_path = path::absolute(cp).or_else(|e| {
+                Err(ArgsError::PathError(format!(
+                    "path error for capture_path: {:?}",
+                    e
+                )))
+            })?;
         }
         if let Some(self_addr) = &common.self_addr {
             self.self_addr = *self_addr;
         }
         if let Some(ca_file) = &common.ca_file {
             let cf = PathBuf::from(ca_file);
-            if cf.is_relative() {
-                self.ca_file = Some(fs::canonicalize(cf).or_else(|e| {
-                    Err(ArgsError::PathError(format!(
-                        "path error for ca_file: {:?}",
-                        e
-                    )))
-                })?);
-            } else {
-                self.ca_file = Some(PathBuf::from(ca_file));
-            }
+            self.ca_file = Some(path::absolute(cf).or_else(|e| {
+                Err(ArgsError::PathError(format!(
+                    "path error for ca_file: {:?}",
+                    e
+                )))
+            })?);
         }
         if let Some(certificate_file) = &common.certificate_file {
             let cf = PathBuf::from(certificate_file);
-            if cf.is_relative() {
-                let cfile = fs::canonicalize(cf).or_else(|e| {
-                    Err(ArgsError::PathError(format!(
-                        "path error for certificate_file: {:?}",
-                        e
-                    )))
-                })?;
-                self.certificate_file = Some(cfile);
-            } else {
-                self.certificate_file = Some(cf);
-            }
+            self.certificate_file = Some(path::absolute(cf).or_else(|e| {
+                Err(ArgsError::PathError(format!(
+                    "path error for certificate_file: {:?}",
+                    e
+                )))
+            })?);
         }
         if common.private_key_file.is_some() && common.noise_private_key.is_some() {
             return Err(ArgsError::ParseError(
@@ -566,17 +544,12 @@ impl Config {
         if let Some(private_key_file) = &common.private_key_file {
             self.private_key_data = None;
             let pkf = PathBuf::from(private_key_file);
-            if pkf.is_relative() {
-                let pkf_resolved = fs::canonicalize(pkf).or_else(|e| {
-                    Err(ArgsError::PathError(format!(
-                        "path error for private_key_file: {:?}",
-                        e
-                    )))
-                })?;
-                self.private_key_file = Some(pkf_resolved);
-            } else {
-                self.private_key_file = Some(PathBuf::from(private_key_file));
-            }
+            self.private_key_file = Some(path::absolute(pkf).or_else(|e| {
+                Err(ArgsError::PathError(format!(
+                    "path error for private_key_file: {:?}",
+                    e
+                )))
+            })?);
         }
         if let Some(tun_if) = &common.tun_if {
             self.tun_if = Some(tun_if.clone());

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -365,9 +365,7 @@ impl Config {
                     )?;
                 }
                 if self.certificate_file.is_none() && self.name.is_empty() {
-                    return Err(
-                        "name (required when certificate_file is absent)".arg_missing(),
-                    );
+                    return Err("name (required when certificate_file is absent)".arg_missing());
                 }
                 if self.private_key_file.is_none()
                     && self.private_key_data.is_none()

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -609,14 +609,23 @@ impl LinkStateWrapper {
                 }
             };
 
-            if is_verified || !require_ca_signature {
+            if !is_verified {
+                for name in
+                    special_peers::special_peer_names_from_x509_subject_name(cert.subject_name())
+                {
+                    warn!(
+                        target: LINK_STATE,
+                        "Link {link_id} presented unverified certificate claiming special peer name {name:?}; ignoring"
+                    );
+                }
+            } else {
                 // assign special-peer name if this peer is special
                 for name in
                     special_peers::special_peer_names_from_x509_subject_name(cert.subject_name())
                 {
                     match asm.peer_table.assign_special_name(name, link_id) {
                         Ok(()) => {
-                            info!(target: LINK_STATE, "Link {link_id} assigned special name {name:?} (secure = {is_verified})")
+                            info!(target: LINK_STATE, "Link {link_id} assigned special name {name:?}")
                         }
                         Err(_) => {
                             warn!(target: LINK_STATE, "Unable to assign link {link_id} special name {name:?}")

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -219,10 +219,11 @@ fn main() -> ExitCode {
     } else {
         None
     };
-    // Adapters still need a ca_cert to verify a nodes cert.
-    if ph_mode == PhMode::Adapter && opt_ca_cert.is_none() {
-        error!(target: STARTUP, "adapters require a CA certificate (set ca_cert in config)");
-        return ExitCode::FAILURE;
+    if opt_ca_cert.is_none() {
+        warn!(
+            target: STARTUP,
+            "no ca_file configured; peer certificates will not be verified"
+        );
     }
     certx = KmCertExchange::new(self_cert, opt_ca_cert);
 
@@ -495,8 +496,9 @@ fn main() -> ExitCode {
     let mut vsconn;
 
     if ph_mode == PhMode::Node {
-        // Note that config parsing code ensures that IF node THEN certificate_file is set.
-        let node_name = config::get_noise_cn(config.certificate_file.as_ref().unwrap())
+        // config parsing ensures that IF node THEN certificate_file is set.
+        let node_name = config
+            .get_noise_cn()
             .expect("unable to determine node name: cannot parse CN");
         info!(target: STARTUP, "node CN is \"{node_name}\"");
 

--- a/adapter/ph/src/main_argparse.rs
+++ b/adapter/ph/src/main_argparse.rs
@@ -5,9 +5,8 @@
 //! more details on the configuration.
 
 use clap::Parser;
-use std::fs;
 use std::io::Read;
-use std::path::Path;
+use std::path::{self, Path};
 
 use crate::assembly::PhMode;
 use crate::main_args::{ArgsError, Command, Control};
@@ -47,7 +46,12 @@ pub fn argparse(args: Option<Vec<&str>>) -> std::result::Result<(PhMode, Config)
             let config_file: Option<AdapterConfig> = match config_file {
                 Some(p) => match load_config::<AdapterConfig>(&p) {
                     Ok(mut ac) => {
-                        ac.config_path = fs::canonicalize(p).unwrap();
+                        ac.config_path = path::absolute(&p).or_else(|e| {
+                            Err(ArgsError::PathError(format!(
+                                "path error for config file: {:?}",
+                                e
+                            )))
+                        })?;
                         Some(ac)
                     }
                     Err(e) => {
@@ -67,28 +71,20 @@ pub fn argparse(args: Option<Vec<&str>>) -> std::result::Result<(PhMode, Config)
                 config.node_addr = Some(node_addr);
             }
             if let Some(npkf) = node_public_key_file {
-                if npkf.is_relative() {
-                    let npkf = fs::canonicalize(npkf).or_else(|e| {
-                        Err(ArgsError::PathError(format!(
-                            "path error for node_public_key_file: {:?}",
-                            e
-                        )))
-                    })?;
-                    config.node_public_key_file = Some(npkf);
-                } else {
-                    config.node_public_key_file = Some(npkf);
-                }
+                config.node_public_key_file = Some(path::absolute(npkf).or_else(|e| {
+                    Err(ArgsError::PathError(format!(
+                        "path error for node_public_key_file: {:?}",
+                        e
+                    )))
+                })?);
             }
-            if let Some(mut bootstrap_key) = bootstrap_key {
-                if bootstrap_key.is_relative() {
-                    bootstrap_key = fs::canonicalize(bootstrap_key).or_else(|e| {
-                        Err(ArgsError::PathError(format!(
-                            "path error for bootstrap key: {:?}",
-                            e
-                        )))
-                    })?;
-                }
-                config.bootstrap_key_path = Some(bootstrap_key);
+            if let Some(bootstrap_key) = bootstrap_key {
+                config.bootstrap_key_path = Some(path::absolute(bootstrap_key).or_else(|e| {
+                    Err(ArgsError::PathError(format!(
+                        "path error for bootstrap key: {:?}",
+                        e
+                    )))
+                })?);
             }
         }
 
@@ -101,7 +97,12 @@ pub fn argparse(args: Option<Vec<&str>>) -> std::result::Result<(PhMode, Config)
             let config_file: Option<NodeConfig> = match config_file {
                 Some(p) => match load_config::<NodeConfig>(&p) {
                     Ok(mut ac) => {
-                        ac.config_path = fs::canonicalize(p).unwrap();
+                        ac.config_path = path::absolute(&p).or_else(|e| {
+                            Err(ArgsError::PathError(format!(
+                                "path error for config file: {:?}",
+                                e
+                            )))
+                        })?;
                         Some(ac)
                     }
                     Err(e) => {

--- a/adapter/ph/src/main_argparse.rs
+++ b/adapter/ph/src/main_argparse.rs
@@ -927,8 +927,8 @@ mod test {
     #[test]
     #[parallel(env)]
     fn test_adapter_cli_name_bootstrap_cn_ordering() {
-        let bootstrap_key_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/data/rsa-key.pem");
+        let bootstrap_key_path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/rsa-key.pem");
 
         let mut tomltxt = r#"
         [global]

--- a/adapter/ph/src/main_argparse.rs
+++ b/adapter/ph/src/main_argparse.rs
@@ -10,7 +10,6 @@ use std::io::Read;
 use std::path::Path;
 
 use crate::assembly::PhMode;
-use crate::auth;
 use crate::main_args::{ArgsError, Command, Control};
 
 use crate::config::{AdapterConfig, Config, NodeConfig};
@@ -89,10 +88,7 @@ pub fn argparse(args: Option<Vec<&str>>) -> std::result::Result<(PhMode, Config)
                         )))
                     })?;
                 }
-                config.bootstrap = Some(auth::RsaBootstrapAuth::new(
-                    &config.get_noise_cn()?,
-                    &bootstrap_key,
-                )?);
+                config.bootstrap_key_path = Some(bootstrap_key);
             }
         }
 
@@ -117,6 +113,7 @@ pub fn argparse(args: Option<Vec<&str>>) -> std::result::Result<(PhMode, Config)
             config = Config::new_for_node(config_file, auth_private_key, &common)?;
         }
     }
+    config.finalize()?;
     if let Err(e) = config.check_valid(ph_mode) {
         return Err(e);
     }
@@ -785,5 +782,188 @@ mod test {
             config.noise_private_key_source(),
             format!("key://{}", noise_key)
         )
+    }
+
+    // Adapter without ca_file passes config validation.
+    #[test]
+    #[parallel(env)]
+    fn test_adapter_no_ca_file_passes_validation() {
+        let mut tomltxt = r#"
+        [global]
+        certificate_file = "$CERTFILE"
+        private_key_file = "$PKFILE"
+        control_path = "/tmp/control.sock"
+        capture_path = "/tmp/capture.sock"
+
+        [adapter]
+        node_addr = "192.168.0.2:5000"
+        node_public_key_file = "$NPKFILE"
+        "#;
+
+        let cert_file = TempFile::touch();
+        let pk_file = TempFile::touch();
+        let npk_file = TempFile::touch();
+
+        let tmp = tomltxt
+            .replace("$CERTFILE", cert_file.get_path().to_str().unwrap())
+            .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
+            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap());
+        tomltxt = &tmp;
+
+        let tmpfile = TempFile::new_toml(&tomltxt);
+        let args = vec!["ph", "adapter", "-c", tmpfile.get_path().to_str().unwrap()];
+
+        let (pmode, config) = argparse(Some(args)).unwrap();
+        assert_eq!(pmode, PhMode::Adapter);
+        assert!(config.ca_file.is_none());
+    }
+
+    // Adapter without certificate_file but with name passes config validation.
+    #[test]
+    #[parallel(env)]
+    fn test_adapter_no_cert_with_name_passes_validation() {
+        let mut tomltxt = r#"
+        [global]
+        private_key_file = "$PKFILE"
+        control_path = "/tmp/control.sock"
+        capture_path = "/tmp/capture.sock"
+
+        [adapter]
+        name = "my-adapter"
+        node_addr = "192.168.0.2:5000"
+        node_public_key_file = "$NPKFILE"
+        "#;
+
+        let pk_file = TempFile::touch();
+        let npk_file = TempFile::touch();
+
+        let tmp = tomltxt
+            .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
+            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap());
+        tomltxt = &tmp;
+
+        let tmpfile = TempFile::new_toml(&tomltxt);
+        let args = vec!["ph", "adapter", "-c", tmpfile.get_path().to_str().unwrap()];
+
+        let (pmode, config) = argparse(Some(args)).unwrap();
+        assert_eq!(pmode, PhMode::Adapter);
+        assert!(config.certificate_file.is_none());
+        assert_eq!(config.name, "my-adapter");
+    }
+
+    // Adapter without certificate_file and without name fails config validation, even with private key.
+    #[test]
+    #[parallel(env)]
+    fn test_adapter_no_cert_no_name_fails_validation() {
+        let mut tomltxt = r#"
+        [global]
+        private_key_file = "$PKFILE"
+        control_path = "/tmp/control.sock"
+        capture_path = "/tmp/capture.sock"
+
+        [adapter]
+        node_addr = "192.168.0.2:5000"
+        node_public_key_file = "$NPKFILE"
+        "#;
+
+        let pk_file = TempFile::touch();
+        let npk_file = TempFile::touch();
+
+        let tmp = tomltxt
+            .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
+            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap());
+        tomltxt = &tmp;
+
+        let tmpfile = TempFile::new_toml(&tomltxt);
+        let args = vec!["ph", "adapter", "-c", tmpfile.get_path().to_str().unwrap()];
+
+        match argparse(Some(args)) {
+            Err(ArgsError::Missing(msg)) => {
+                assert!(msg.contains("name"), "expected 'name' in error, got: {msg}");
+            }
+            other => panic!("expected Missing error, got: {:?}", other),
+        }
+    }
+
+    // CLI --name overrides config [adapter].name.
+    #[test]
+    #[parallel(env)]
+    fn test_adapter_cli_name_overrides_config_name() {
+        let mut tomltxt = r#"
+        [global]
+        private_key_file = "$PKFILE"
+        control_path = "/tmp/control.sock"
+        capture_path = "/tmp/capture.sock"
+
+        [adapter]
+        name = "config-name"
+        node_addr = "192.168.0.2:5000"
+        node_public_key_file = "$NPKFILE"
+        "#;
+
+        let pk_file = TempFile::touch();
+        let npk_file = TempFile::touch();
+
+        let tmp = tomltxt
+            .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
+            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap());
+        tomltxt = &tmp;
+
+        let tmpfile = TempFile::new_toml(&tomltxt);
+        let args = vec![
+            "ph",
+            "adapter",
+            "-c",
+            tmpfile.get_path().to_str().unwrap(),
+            "--name",
+            "cli-name",
+        ];
+
+        let (_, config) = argparse(Some(args)).unwrap();
+        assert_eq!(config.name, "cli-name");
+    }
+
+    // CLI --name with config-file bootstrap_key and no certificate_file: bootstrap CN equals CLI name.
+    #[test]
+    #[parallel(env)]
+    fn test_adapter_cli_name_bootstrap_cn_ordering() {
+        let bootstrap_key_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/rsa-key.pem");
+
+        let mut tomltxt = r#"
+        [global]
+        private_key_file = "$PKFILE"
+        control_path = "/tmp/control.sock"
+        capture_path = "/tmp/capture.sock"
+
+        [adapter]
+        node_addr = "192.168.0.2:5000"
+        node_public_key_file = "$NPKFILE"
+        bootstrap_key = "$BSKEY"
+        "#;
+
+        let pk_file = TempFile::touch();
+        let npk_file = TempFile::touch();
+
+        let tmp = tomltxt
+            .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
+            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap())
+            .replace("$BSKEY", bootstrap_key_path.to_str().unwrap());
+        tomltxt = &tmp;
+
+        let tmpfile = TempFile::new_toml(&tomltxt);
+        let args = vec![
+            "ph",
+            "adapter",
+            "-c",
+            tmpfile.get_path().to_str().unwrap(),
+            "--name",
+            "cli-adapter-name",
+        ];
+
+        let (_, config) = argparse(Some(args)).unwrap();
+        assert_eq!(config.name, "cli-adapter-name");
+        let bootstrap = config.bootstrap.as_ref().expect("bootstrap should be set");
+        assert_eq!(bootstrap.cn(), "cli-adapter-name");
     }
 }


### PR DESCRIPTION

- Makes ca_file optional for adapters. Startup now warns when no CA file is configured instead of failing adapter startup.
- Keeps adapter certificate_file optional, but requires name when no certificate is provided so self-signed cert generation has a valid CN.

- Delays bootstrap/BAS auth object construction until after config-file values and CLI overrides are merged, fixing --name precedence for CN-dependent auth setup.

- Tightens special-peer assignment so visa-service peers are recognized only from CA-verified certificates; unverified certs claiming special peer names are logged and ignored.

- Updates README guidance for node/adapter certificate behavior, peer verification, and visa-service certificate requirements.
