### PR TITLE
bump zpr-common dependency to v0.18.0; VisaId is now u64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,7 +2086,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-input",
- "zpr 0.17.0",
+ "zpr 0.18.0",
 ]
 
 [[package]]
@@ -2644,7 +2644,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "zerocopy",
- "zpr 0.17.0",
+ "zpr 0.18.0",
  "zpr-ext",
  "zpr-utils",
 ]
@@ -5132,8 +5132,8 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.17.0"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.17.0#ec73d3ec6169e2111ff85c2e7b44535f0b619ff8"
+version = "0.18.0"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.18.0#fa1af9ea6808706516054b78667964664df55791"
 dependencies = [
  "capnp",
  "capnpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1.48.0", features = ["full"] }
 tokio-util = { version = "0.7.17", features = ["rt", "compat"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.17.0", features = ["vsapi", "policy"] }
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.18.0", features = ["vsapi", "policy"] }
 zpr-ext = { git = "https://github.com/org-zpr/zpr-utils.git", tag = "zpr-ext-v0.5.3" }
 
 [profile.release]

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -198,8 +198,8 @@ impl VisaTable {
             0,
             &vs_zpr_addr,
             VISA_SERVICE_PORT,
-            expires_ms,
             VS_VISAS_CONFIG_ID,
+            expires_ms,
         );
         let vs2node = make_tcp_visa(
             2,
@@ -207,8 +207,8 @@ impl VisaTable {
             VISA_SERVICE_PORT,
             &node_zpr_addr,
             0,
-            expires_ms,
             VS_VISAS_CONFIG_ID,
+            expires_ms,
         );
 
         let mut visa_table = Self::new();
@@ -745,8 +745,8 @@ mod tests {
             + Duration::from_secs(3600))
         .as_millis() as i64;
 
-        let visa1_raw = make_tcp_visa(4000, &client1_addr, 0, &service_addr, 80, expires_ms, 100);
-        let visa2_raw = make_tcp_visa(4001, &client2_addr, 0, &service_addr, 80, expires_ms, 100);
+        let visa1_raw = make_tcp_visa(4000, &client1_addr, 0, &service_addr, 80, 100, expires_ms);
+        let visa2_raw = make_tcp_visa(4001, &client2_addr, 0, &service_addr, 80, 100, expires_ms);
 
         let mut visa_table = asm.visa_table.write().unwrap();
         let visa1_id = visa_table.insert_visa(visa1_raw).unwrap();
@@ -811,8 +811,8 @@ mod tests {
             + Duration::from_millis(10000))
         .as_millis() as i64;
 
-        let visa1 = make_tcp_visa(1000, &client1_addr, 0, &service_addr, 80, expires_ms, 100);
-        let visa2 = make_tcp_visa(1001, &client2_addr, 0, &service_addr, 80, expires_ms, 100);
+        let visa1 = make_tcp_visa(1000, &client1_addr, 0, &service_addr, 80, 100, expires_ms);
+        let visa2 = make_tcp_visa(1001, &client2_addr, 0, &service_addr, 80, 100, expires_ms);
         let v1 = new_vsapi_visa_tcp_default(12345, DateTime::<Utc>::MAX_UTC.into());
         let _ = visa_table.insert_visa(v1);
 

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -220,16 +220,14 @@ impl VisaTable {
             .expect("Failed to insert visa->node visa into table");
 
         visa_table.lookup_table = FiveTupleLookupTable::new();
-        visa_table
-            .lookup_table
-            .build_table_from_hash(&visa_table.table);
+        visa_table.lookup_table.add_hash_to_table(&visa_table.table);
 
         visa_table
     }
 
     /// Insert a visa from the Visa Service into the Visa Table
     pub fn insert_visa(&mut self, visa: vsapi_types::Visa) -> Result<VisaId, VisaTableError> {
-        let visa_id = visa.issuer_id as i32;
+        let visa_id = visa.issuer_id;
 
         let expiration = DateTime::from(visa.expires);
 
@@ -280,7 +278,7 @@ impl VisaTable {
     ) -> Result<(), VisaTableError> {
         self.revoke_no_rebuild(peer_table, visa_id)?;
         self.lookup_table = FiveTupleLookupTable::new();
-        self.lookup_table.build_table_from_hash(&self.table);
+        self.lookup_table.add_hash_to_table(&self.table);
 
         Ok(())
     }
@@ -298,7 +296,7 @@ impl VisaTable {
             let _ = self.revoke_no_rebuild(peer_table, timeout_entry.id);
         }
         self.lookup_table = FiveTupleLookupTable::new();
-        self.lookup_table.build_table_from_hash(&self.table);
+        self.lookup_table.add_hash_to_table(&self.table);
     }
 
     /// Revoke all visas that have any forwarding entry referencing `link_id`.
@@ -324,7 +322,7 @@ impl VisaTable {
             .table
             .iter()
             .filter_map(|(visa_id, visa)| {
-                if *visa_id >= config::MIN_VISA_ID as i32
+                if *visa_id >= config::MIN_VISA_ID
                     && visa.streams.iter().any(|entry| entry.0 == link_id)
                 {
                     Some(*visa_id)
@@ -341,7 +339,7 @@ impl VisaTable {
                 let _ = self.revoke_no_rebuild(peer_table, visa_id);
             }
             self.lookup_table = FiveTupleLookupTable::new();
-            self.lookup_table.build_table_from_hash(&self.table);
+            self.lookup_table.add_hash_to_table(&self.table);
         }
     }
 
@@ -384,7 +382,7 @@ impl VisaTable {
 }
 
 fn make_tcp_visa(
-    visa_id: i32,
+    visa_id: u64,
     source: &Ipv6Addr,
     source_port: u16,
     dest: &Ipv6Addr,
@@ -407,7 +405,7 @@ fn make_tcp_visa(
     };
 
     vsapi_types::Visa {
-        issuer_id: visa_id as u64,
+        issuer_id: visa_id,
         config: configuration,
         expires: UNIX_EPOCH + dur,
         visa_type: vsapi_types::VisaType::Full,


### PR DESCRIPTION
Now matches Cap'n Proto definition.

Also, fix arg order in calls to make_tcp_visa (per @mkolehmainen request).