### PR TITLE
Minor changes to README after setting up a ZPRnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ matches against.  Generate and sign one:
 
 ### Create a configuration file for the visa service adapter
 
+Sample configuration, place in a file named `adapter-vs-conf.toml`.
+
+
 ```toml
 [global]
 # ca_file is optional for link establishment, but the VS adapter must present

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Using the handy `zpr-pki` script:
 ./integration-test/lib/zpr-pki pubkey <node-noise.key >node-noise-pub.pem
 
 # Then sign the public key
-./zpr-pki gensignedcert authority/auth-ca.crt authority/auth-ca.key \
+./integration-test/zpr-pki gensignedcert authority/auth-ca.crt authority/auth-ca.key \
   /CN=node.zpr.org 365 < node-noise-pub.pem >node-noise.crt
 ```
 
@@ -285,7 +285,7 @@ here:
 # IP configuration for the node.
 sudo ip tuntap add name tun9 mode tun multi_queue
 sudo ip link set tun9 mtu 1400
-sudo addr add fd5a:5052:90de::1/32 dev tun9
+sudo ip addr add fd5a:5052:90de::1/32 dev tun9
 sudo ip link set tun9 up
 ```
 
@@ -304,7 +304,7 @@ need to configure its TUN interface similar to what we did for the node.
 # IP configuration for the visa service adapter.
 sudo ip tuntap add name tun9 mode tun multi_queue
 sudo ip link set tun9 mtu 1400
-sudo addr add fd5a:5052::1/32 dev tun9
+sudo ip addr add fd5a:5052::1/32 dev tun9
 sudo ip link set tun9 up
 ```
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Sample configuration, place in a file named `node-conf.toml`.
 [global]
 # ca_file is needed for the node to verify adapter certificates and recognize
 # the visa-service adapter as special.  Without it, VS routing will not work.
-ca_file = "auth-ca.crt"
+ca_file = "authority/auth-ca.crt"
 certificate_file = "node-noise.crt"
 private_key_file = "node-noise.key"
 self_addr = "129.6.7.1:5000"
@@ -169,7 +169,7 @@ matches against.  Generate and sign one:
 [global]
 # ca_file is optional for link establishment, but the VS adapter must present
 # a CA-signed certificate_file so the node can recognize it as the visa service.
-ca_file = "auth-ca.crt"
+ca_file = "authority/auth-ca.crt"
 certificate_file = "vs-noise.crt"   # CN must be "vs.zpr"
 private_key_file = "vs-noise.key"
 zpr_addr = [ "fd5a:5052::1" ]

--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ matches against.  Generate and sign one:
 
 Sample configuration, place in a file named `adapter-vs-conf.toml`.
 
-
 ```toml
 [global]
 # ca_file is optional for link establishment, but the VS adapter must present


### PR DESCRIPTION
- Corrected command syntax for adding IP addresses in README.
- added `integration-test/` before one of the `zpr-pki` commands for consistency
- added `authority/` before `auth-ca.crt` in conf toml files, because all other commands assume `auth-ca.crt` is in a subdirectory called `authority`
- added name for `adapter-vs-conf.toml`