### PR TITLE
Mk/1321 - adds the VSAPI "open" call to libnode2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,7 +2095,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-input",
- "zpr 0.18.0",
+ "zpr 0.18.1",
 ]
 
 [[package]]
@@ -2645,7 +2654,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "zerocopy",
- "zpr 0.18.0",
+ "zpr 0.18.1",
  "zpr-ext",
  "zpr-utils",
 ]
@@ -5139,17 +5148,21 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.18.0"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.18.0#fa1af9ea6808706516054b78667964664df55791"
+version = "0.18.1"
 dependencies = [
+ "base64 0.22.1",
+ "bytes",
  "capnp",
  "capnpc",
+ "colored",
  "criterion",
+ "flate2",
  "ip_network_table-deps-treebitmap",
  "open-enum",
  "rand 0.10.1",
  "range-set-blaze",
  "rcu 0.1.0",
+ "serde",
  "thiserror 1.0.69",
  "url",
  "zerocopy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ tokio = { version = "1.48.0", features = ["full"] }
 tokio-util = { version = "0.7.17", features = ["rt", "compat"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
-#zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.18.0", features = ["vsapi", "policy"] }
-zpr = { path = "../zpr-common", features = ["vsapi", "policy"] }
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.19.0", features = ["vsapi", "policy"] }
 zpr-ext = { git = "https://github.com/org-zpr/zpr-utils.git", tag = "zpr-ext-v0.5.3" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ tokio = { version = "1.48.0", features = ["full"] }
 tokio-util = { version = "0.7.17", features = ["rt", "compat"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.18.0", features = ["vsapi", "policy"] }
+#zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.18.0", features = ["vsapi", "policy"] }
+zpr = { path = "../zpr-common", features = ["vsapi", "policy"] }
 zpr-ext = { git = "https://github.com/org-zpr/zpr-utils.git", tag = "zpr-ext-v0.5.3" }
 
 [profile.release]

--- a/adapter/ph/src/vs_worker.rs
+++ b/adapter/ph/src/vs_worker.rs
@@ -9,8 +9,8 @@ use crate::logging::targets::STARTUP;
 use crate::vss_worker;
 
 use libnode::error::VSApiError;
-use libnode::vsconn::{VSConnHandle, VSConnLifecycleEvent};
-use zpr::vsapi_types::{DisconnectNotice, DisconnectReason, ErrorCode, NodeConnect, StateFlag};
+use libnode::vsconn::{NodeConnect, StateFlag, VSConnHandle, VSConnLifecycleEvent};
+use zpr::vsapi_types::{DisconnectNotice, DisconnectReason, ErrorCode};
 
 pub async fn launch(
     asm: Arc<Assembly>,

--- a/libnode2/src/cli/handler.rs
+++ b/libnode2/src/cli/handler.rs
@@ -9,12 +9,12 @@ use std::net::{IpAddr, Ipv4Addr};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::AbortHandle;
 use tracing::{error, info, warn};
-use zpr::vsapi_types::{AuthBlob, CommFlag, ConnectRequest, DisconnectReason, PacketDesc, VisaOp};
-
-use crate::vsconn::{
-    StateFlag, VSConnHandle, VSConnLifecycleEvent, VSConnectRequest, VSDisconnectNotice,
-    VSVisaRequest,
+use zpr::vsapi_types::{
+    AuthBlob, CommFlag, ConnectRequest, DisconnectNotice, DisconnectReason, NodeConnect,
+    PacketDesc, StateFlag, VisaOp, VisaRequest,
 };
+
+use crate::vsconn::{VSConnHandle, VSConnLifecycleEvent};
 use crate::vss::{ListProcessingResponse, VSSMessage};
 
 use super::cmd::Cmd;
@@ -41,7 +41,7 @@ pub async fn run_handler(
     info!("allowing VSConn to start up...");
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-    let request = VSConnectRequest {
+    let request = NodeConnect {
         zpr_addr: node_zpr_addr,
         state: StateFlag::NoState,
     };
@@ -93,7 +93,7 @@ pub async fn run_handler(
                                 five_tuple,
                                 comm_flags: CommFlag::BiDirectional,
                             };
-                            let req = VSVisaRequest {
+                            let req = VisaRequest {
                                 pdesc,
                                 previous_id: None,
                             };
@@ -129,7 +129,7 @@ pub async fn run_handler(
                             }
                         }
                         Cmd::NotifyDisconnect(zpr_addr) => {
-                            let notice = VSDisconnectNotice {
+                            let notice = DisconnectNotice {
                                 zpr_addr: Some(zpr_addr),
                                 reason: DisconnectReason::Admin,
                             };
@@ -212,6 +212,12 @@ pub async fn run_handler(
                         VSSMessage::SetServices(services, resp_tx) => {
                             let _ = output_tx.send(format!(
                                 "[VSS incoming] SetServices with {} services", services.len()
+                            ));
+                            let _ = resp_tx.send(Ok(()));
+                        }
+                        VSSMessage::SetTopology(links, resp_tx) => {
+                            let _ = output_tx.send(format!(
+                                "[VSS incoming] SetTopology with {} links", links.len()
                             ));
                             let _ = resp_tx.send(Ok(()));
                         }

--- a/libnode2/src/cli/handler.rs
+++ b/libnode2/src/cli/handler.rs
@@ -10,11 +10,11 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::task::AbortHandle;
 use tracing::{error, info, warn};
 use zpr::vsapi_types::{
-    AuthBlob, CommFlag, ConnectRequest, DisconnectNotice, DisconnectReason, NodeConnect,
-    PacketDesc, StateFlag, VisaOp, VisaRequest,
+    AuthBlob, CommFlag, ConnectRequest, DisconnectNotice, DisconnectReason, PacketDesc, VisaOp,
+    VisaRequest,
 };
 
-use crate::vsconn::{VSConnHandle, VSConnLifecycleEvent};
+use crate::vsconn::{NodeConnect, StateFlag, VSConnHandle, VSConnLifecycleEvent};
 use crate::vss::{ListProcessingResponse, VSSMessage};
 
 use super::cmd::Cmd;

--- a/libnode2/src/vsconn.rs
+++ b/libnode2/src/vsconn.rs
@@ -2,7 +2,6 @@ use zpr::vsapi::v1 as vsapi2;
 use zpr::vsapi_types::ApiResponseError;
 
 use std::future::Future;
-use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -22,8 +21,8 @@ use tracing::*;
 use crate::error::VSApiError;
 use crate::logging::targets::VS_RPC;
 use zpr::vsapi_types::{
-    ConnectRequest, Connection, DisconnectNotice, NodeConnect, StateFlag, Visa, VisaDecision,
-    VisaOp, VisaRequest, VisaResponse,
+    ConnectRequest, ConnectType, Connection, DisconnectNotice, NodeConnect, NodeOpen, Param,
+    StateFlag, VSConnectRequest, Visa, VisaDecision, VisaOp, VisaRequest, VisaResponse, pname,
 };
 use zpr::write_to::WriteTo;
 
@@ -32,8 +31,6 @@ use zpr::write_to::WriteTo;
 type ConnectFn = Box<
     dyn Fn(SocketAddr) -> Pin<Box<dyn Future<Output = std::io::Result<tokio::net::TcpStream>>>>,
 >;
-
-const PARAM_ZPR_ADDR: &str = "zpr_addr";
 
 const LIFECYCLE_EVENT_BUFFER_SIZE: usize = 64;
 
@@ -65,8 +62,12 @@ enum VS2Command {
     /// Stop the local vs-api run loop, optionally de-register from the visa service first.
     Stop(bool),
 
-    /// Run through the connect sequence. If connect succeeds the VSHandle is kept internally.
+    /// Run through the "bootstrap" connect sequence. If connect succeeds the VSHandle is kept internally.
     Connect(NodeConnect, oneshot::Sender<VSConnectResponse>),
+
+    /// Run through the "open" sequence for an already authenticated (via [VS2Command::AuthorizeConnect]) node.
+    /// If connect succeeds the VSHandle is kept internally. No `params` are required.
+    Open(NodeOpen, oneshot::Sender<VSConnectResponse>),
 
     VisaRequest(VisaRequest, oneshot::Sender<VSVisaResponse>),
 
@@ -423,6 +424,38 @@ impl VSConn {
                 Ok(())
             }
 
+            VS2Command::Open(req, resp_tx) => {
+                debug!(target: VS_RPC, "VSConn: open");
+                let stateflag = req.state.clone();
+                let resp = if cmd_state.is_connected() {
+                    Err(VSApiError::CommandFailed(
+                        "open called but already connected to VS-API".to_string(),
+                    ))
+                } else {
+                    self.do_open(&cmd_state.vs_service, req).await
+                };
+
+                let retval = match resp {
+                    Ok(handle) => {
+                        info!(target: VS_RPC, "VS API open succeeded");
+                        cmd_state.vs_handle = Some(handle);
+                        self.send_lifecycle_event(VSConnLifecycleEvent::ConnectedToVsApi(
+                            stateflag,
+                        ));
+                        Ok(())
+                    }
+                    Err(e) => {
+                        error!(target: VS_RPC, "VS API open failed: {:?}", e);
+                        Err(e)
+                    }
+                };
+
+                if let Err(e) = resp_tx.send(retval) {
+                    error!(target: VS_RPC, "failed to send open response: {:?}", e);
+                }
+                Ok(())
+            }
+
             VS2Command::VisaRequest(req, resp_tx) => {
                 debug!(target: VS_RPC, "VSConn: visa_request");
                 let resp = if !cmd_state.is_connected() {
@@ -540,35 +573,21 @@ impl VSConn {
         vs_service: &vsapi2::visa_service::Client,
         req: NodeConnect,
     ) -> Result<vsapi2::v_s_handle::Client, VSApiError> {
-        let mut vs_request = vs_service.connect_request();
-
-        let mut vscr_bldr = vs_request.get().init_req();
-        vscr_bldr.set_cn(&self.node_cn);
-
-        let ctype = match req.state {
-            StateFlag::HasState => vsapi2::VSConnT::Reconnect,
-            StateFlag::NoState => vsapi2::VSConnT::Reset,
+        let vs_cr = VSConnectRequest {
+            cn: self.node_cn.clone(),
+            ctype: match req.state {
+                StateFlag::HasState => ConnectType::Reconnect,
+                StateFlag::NoState => ConnectType::Reset,
+            },
+            // We set one param: the zpr_address for the node.
+            params: vec![Param::new_ip(pname::ZPR_ADDR.into(), req.zpr_addr)],
         };
-        vscr_bldr.set_ctype(ctype);
 
-        // We set one param: the zpr_address for the node.
-        let mut params_bldr = vscr_bldr.init_params(1);
-        {
-            let mut param0 = params_bldr.reborrow().get(0);
-            param0.set_name(PARAM_ZPR_ADDR);
-            match req.zpr_addr {
-                IpAddr::V4(av4) => {
-                    param0.set_ptype(vsapi2::ParamT::Ipv4);
-                    param0.set_value_data(&av4.octets());
-                }
-                IpAddr::V6(av6) => {
-                    param0.set_ptype(vsapi2::ParamT::Ipv6);
-                    param0.set_value_data(&av6.octets());
-                }
-            }
-        }
+        debug!(target: VS_RPC, "VS-API -> connect (type = {:?})", vs_cr.ctype);
 
-        debug!(target: VS_RPC, "VS-API -> connect (type = {:?})", ctype);
+        let mut vs_request = vs_service.connect_request();
+        let mut vscr_bldr = vs_request.get().init_req();
+        vs_cr.write_to(&mut vscr_bldr);
 
         let vs_request_response = rpc_with_timeout(
             "connect",
@@ -642,6 +661,48 @@ impl VSConn {
         };
 
         // Ok we now have an authenticated handle to the VS.
+        Ok(vs_handle_svc)
+    }
+
+    /// Compared to VSAPI "connect", VSAPI "open" is far simpler. The VS already knows the node
+    /// (detected based on source address) is authtenticated and so a successful call just reutrns
+    /// the handle directly.
+    async fn do_open(
+        &self,
+        vs_service: &vsapi2::visa_service::Client,
+        oreq: NodeOpen,
+    ) -> Result<vsapi2::v_s_handle::Client, VSApiError> {
+        debug!(target: VS_RPC, "VS-API -> open (type = {:?})", oreq.state);
+
+        let req = VSConnectRequest {
+            cn: self.node_cn.clone(),
+            ctype: match oreq.state {
+                StateFlag::HasState => ConnectType::Reconnect,
+                StateFlag::NoState => ConnectType::Reset,
+            },
+            params: Vec::new(), // TODO: params should be optional
+        };
+
+        let mut vs_request = vs_service.open_request();
+        let mut vscr_bldr = vs_request.get().init_req();
+        req.write_to(&mut vscr_bldr);
+
+        let vs_request_response = rpc_with_timeout(
+            "open",
+            DEFAULT_CONNECT_RPC_TIMEOUT,
+            vs_request.send().promise,
+        )
+        .await?;
+
+        let handle_or_error = vs_request_response.get()?.get_resp()?;
+
+        let vs_handle_svc: vsapi2::v_s_handle::Client = match handle_or_error.which()? {
+            vsapi2::result::Which::Ok(vs_handle_obj) => vs_handle_obj?,
+            vsapi2::result::Which::Error(err_obj) => {
+                let err_obj = err_obj?;
+                return Err(ApiResponseError::try_from(err_obj)?.into());
+            }
+        };
         Ok(vs_handle_svc)
     }
 
@@ -857,6 +918,13 @@ impl VSConnHandle {
     pub async fn connect(&self, req: NodeConnect) -> Result<(), VSApiError> {
         let (resp_tx, resp_rx) = oneshot::channel();
         let cmd = VS2Command::Connect(req, resp_tx);
+        self.send_command(cmd).await?;
+        resp_rx.await.map_err(|_| VSApiError::ConnClosed)?
+    }
+
+    pub async fn open(&self, req: NodeOpen) -> Result<(), VSApiError> {
+        let (resp_tx, resp_rx) = oneshot::channel();
+        let cmd = VS2Command::Open(req, resp_tx);
         self.send_command(cmd).await?;
         resp_rx.await.map_err(|_| VSApiError::ConnClosed)?
     }

--- a/libnode2/src/vsconn.rs
+++ b/libnode2/src/vsconn.rs
@@ -2,7 +2,7 @@ use zpr::vsapi::v1 as vsapi2;
 use zpr::vsapi_types::ApiResponseError;
 
 use std::future::Future;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -21,8 +21,8 @@ use tracing::*;
 use crate::error::VSApiError;
 use crate::logging::targets::VS_RPC;
 use zpr::vsapi_types::{
-    ConnectRequest, ConnectType, Connection, DisconnectNotice, NodeConnect, NodeOpen, Param,
-    StateFlag, VSConnectRequest, Visa, VisaDecision, VisaOp, VisaRequest, VisaResponse, pname,
+    ConnectRequest, ConnectType, Connection, DisconnectNotice, Param, VSConnectRequest, Visa,
+    VisaDecision, VisaOp, VisaRequest, VisaResponse, pname,
 };
 use zpr::write_to::WriteTo;
 
@@ -55,6 +55,28 @@ type VSNotifyDisconnectResponse = Result<(), VSApiError>;
 type VSPingResponse = Result<(), VSApiError>;
 type VSVisaIdsResponse = Result<Vec<u64>, VSApiError>;
 type VSVisaByIdResponse = Result<Vec<Visa>, VSApiError>;
+
+#[derive(Debug)]
+pub struct NodeConnect {
+    /// Connect will fail if this does not match policy.
+    pub zpr_addr: IpAddr,
+    pub state: StateFlag,
+}
+
+#[derive(Debug)]
+pub struct NodeOpen {
+    pub state: StateFlag,
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateFlag {
+    /// Visa service / node has no state for this connection.
+    #[default]
+    NoState,
+
+    /// Visa service / node has existing state for this connection.
+    HasState,
+}
 
 // The async "commands" that can be sent into the running visa service client.
 #[derive(Debug)]
@@ -140,6 +162,24 @@ impl VSCommandState {
     /// we are currently connected to the VS API.
     fn is_connected(&self) -> bool {
         self.vs_handle.is_some()
+    }
+}
+
+impl NodeConnect {
+    fn connect_type(&self) -> ConnectType {
+        match self.state {
+            StateFlag::NoState => ConnectType::Reset,
+            StateFlag::HasState => ConnectType::Reconnect,
+        }
+    }
+}
+
+impl NodeOpen {
+    fn connect_type(&self) -> ConnectType {
+        match self.state {
+            StateFlag::NoState => ConnectType::Reset,
+            StateFlag::HasState => ConnectType::Reconnect,
+        }
     }
 }
 
@@ -575,12 +615,8 @@ impl VSConn {
     ) -> Result<vsapi2::v_s_handle::Client, VSApiError> {
         let vs_cr = VSConnectRequest {
             cn: self.node_cn.clone(),
-            ctype: match req.state {
-                StateFlag::HasState => ConnectType::Reconnect,
-                StateFlag::NoState => ConnectType::Reset,
-            },
-            // We set one param: the zpr_address for the node.
-            params: vec![Param::new_ip(pname::ZPR_ADDR.into(), req.zpr_addr)],
+            ctype: req.connect_type(),
+            params: Some(vec![Param::new_ip(pname::ZPR_ADDR.into(), req.zpr_addr)]),
         };
 
         debug!(target: VS_RPC, "VS-API -> connect (type = {:?})", vs_cr.ctype);
@@ -676,11 +712,8 @@ impl VSConn {
 
         let req = VSConnectRequest {
             cn: self.node_cn.clone(),
-            ctype: match oreq.state {
-                StateFlag::HasState => ConnectType::Reconnect,
-                StateFlag::NoState => ConnectType::Reset,
-            },
-            params: Vec::new(), // TODO: params should be optional
+            ctype: oreq.connect_type(),
+            params: None,
         };
 
         let mut vs_request = vs_service.open_request();


### PR DESCRIPTION
- Add the `open` command (similar to the `connect` command).
- Minor refactor - uses some new types in `zpr-common`, moves some types out of common

Requires latest common PR to go through first.