### PR TITLE
added various rustyline features to CLI to make interactive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,10 +3390,22 @@ dependencies = [
  "memchr",
  "nix 0.30.1",
  "radix_trie",
+ "rustyline-derive",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rustyline-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d66de233f908aebf9cc30ac75ef9103185b4b715c6f2fb7a626aa5e5ede53ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/adapter/cli/Cargo.toml
+++ b/adapter/cli/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 zpr-ext = { workspace = true, features = ["bytes", "tokio", "zerocopy"] }
-rustyline = "17.0.2"
+rustyline = { version = "17.0.2", features = ["derive"] }
 dirs = "6.0.0"
 
 [features]

--- a/adapter/cli/src/main.rs
+++ b/adapter/cli/src/main.rs
@@ -3,6 +3,7 @@
 //! when a command is multiple words, this program assumes the spaces are replaced
 //! with a '-' on the command line
 mod main_args;
+mod rusty_helper;
 
 use crate::main_args::{CaptureCommands, CliCommand, CmdlineArgs, Commands, LinkCommands};
 use admin_api::rpc_commands::RpcCommands;
@@ -11,8 +12,7 @@ use cbpf_rs;
 use clap::Parser;
 use cli::cmd_line_inter as svc;
 use pcap::{Capture, Linktype};
-use rustyline::DefaultEditor;
-use rustyline::error::ReadlineError;
+use rustyline::{CompletionType, Config, Editor, error::ReadlineError, history::FileHistory};
 use std::borrow::Borrow;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
@@ -82,7 +82,13 @@ async fn main() -> Result<(), CliError> {
 }
 
 async fn run_cli(socket: PathBuf, cap_socket: PathBuf) -> Result<(), CliError> {
-    let mut rl = DefaultEditor::new()?;
+    let config = Config::builder()
+        .completion_type(CompletionType::List)
+        .completion_show_all_if_ambiguous(true)
+        .build();
+    let mut rl = Editor::<rusty_helper::RustyHelper, FileHistory>::with_config(config)?;
+
+    rl.set_helper(Some(rusty_helper::RustyHelper));
 
     // Optionally load history from a file, allows for cross sessioin history
     let history_path = dirs::home_dir().map(|p| p.join(".ph_cli_history"));

--- a/adapter/cli/src/rusty_helper.rs
+++ b/adapter/cli/src/rusty_helper.rs
@@ -19,6 +19,7 @@ const COMMANDS: &[&str] = &[
     "logging",
     "addr",
     "quit",
+    "help",
 ];
 
 const CAPTURE_SUBCOMMANDS: &[&str] = &[
@@ -151,28 +152,27 @@ fn candidate_list(head_command: &str) -> &'static [&'static str] {
 // Helper function to get the parameter info for a given command
 fn get_command_parameter_info(command: &str) -> &str {
     match command {
-        "echo" => " : Ping the Packet Handler",
-        "counters" => " -r/--reset : Display all counters + uptime; --reset to zero them instead.",
-        "watch" => " <interval> (secs) : Poll counters every interval seconds and print deltas.",
-        "perf-sample" => " <duration> <frequency> : Performancy sampling",
-        "capture" => " <subcommand>",
-        "link" => " <subcommand>",
-        "logging" => " [<level>=<target>] (>=1 pair) : Change log levels at runtime",
-        "addr" => " : get address of adapter's node (IP + port)",
-        "quit" => " : Exit the CLI",
-        "set-file" => " <file_path> : Set the pcap output file",
-        "close-file" => " : Close the pcap output file",
-        "set-program" => {
-            " [program] : install a BPF filter (default: link[0] == 1 or link[0] == 0)"
-        }
-        "delete-program" => " : delete the BPF filter",
-        "flush-file" => " : Flush outstanding packets to disk",
-        "sequence" => " <file_path> <duration> [program] : open, filter, wait, close",
-        "show" => " [id] : show one link, or summary if no id",
-        "configure" => " <id>",
-        "start" => " <id>",
-        "stop" => " <id>",
-        "reset" => " <id>",
+        "echo" => "",
+        "counters" => " Display or reset counters",
+        "watch" => " Connect to the Packet Handler for periodic counter updates",
+        "perf-sample" => " Start performance sampling",
+        "capture" => " Set up or tear down packet captures",
+        "link" => " Change link state",
+        "logging" => " Change the log level of a node or adapter",
+        "addr" => " Gets the address of an adapter's node",
+        "quit" => " Exit the CLI",
+        "set-file" => " Set a capture file",
+        "close-file" => " Close a capture file",
+        "set-program" => " Set a BPF to filter captured packets",
+        "delete-program" => " Delete any set BPF",
+        "flush-file" => " Flush any outstanding packets to the capture file",
+        "sequence" => " Create a temporary packet capture",
+        "show" => " Show a link's status",
+        "configure" => " Configure a link",
+        "start" => " Start a link",
+        "stop" => " Stop a link",
+        "reset" => " Reset a link. It will require a configure before starting again",
+        "help" => " Display command help information",
         _ => "",
     }
 }

--- a/adapter/cli/src/rusty_helper.rs
+++ b/adapter/cli/src/rusty_helper.rs
@@ -1,0 +1,178 @@
+use rustyline::{
+    Context, Helper,
+    completion::Pair,
+    highlight::CmdKind,
+    validate::{ValidationContext, ValidationResult},
+};
+use std::borrow::Cow;
+
+#[derive(Helper)]
+pub struct RustyHelper;
+
+const COMMANDS: &[&str] = &[
+    "echo",
+    "counters",
+    "watch",
+    "perf-sample",
+    "capture",
+    "link",
+    "logging",
+    "addr",
+    "quit",
+];
+
+const CAPTURE_SUBCOMMANDS: &[&str] = &[
+    "set-file",
+    "close-file",
+    "set-program",
+    "delete-program",
+    "flush-file",
+    "sequence",
+];
+
+const LINK_SUBCOMMANDS: &[&str] = &["show", "configure", "start", "stop", "reset"];
+
+// Implement the Completer trait for RustyHelper
+impl rustyline::completion::Completer for RustyHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        let (start, prefix, head_command): (usize, &str, &str) = get_word_at_cursor(line, pos);
+
+        let matches = candidate_list(head_command)
+            .iter()
+            .filter(|c: &&&str| c.starts_with(prefix.to_lowercase().as_str()))
+            .map(|&c| Pair {
+                display: c.to_string(),
+                replacement: format!("{} ", c),
+            })
+            .collect();
+
+        Ok((start, matches))
+    }
+}
+
+// Implement the Hinter trait for RustyHelper
+impl rustyline::hint::Hinter for RustyHelper {
+    type Hint = String;
+
+    fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<String> {
+        let (_start, prefix, head_command): (usize, &str, &str) = get_word_at_cursor(line, pos);
+
+        if !prefix.is_empty() {
+            if let Some(c) = candidate_list(head_command)
+                .iter()
+                .find(|c: &&&str| c.starts_with(prefix.to_lowercase().as_str()))
+            {
+                if c.len() != prefix.len() {
+                    return Some(c[prefix.len()..].to_string());
+                }
+            }
+        }
+
+        let last_word = line[..pos].split_whitespace().last().unwrap_or("");
+        let info = get_command_parameter_info(last_word);
+        if info.is_empty() {
+            None
+        } else {
+            Some(info.to_string())
+        }
+    }
+}
+
+// Implement the Highlighter trait for RustyHelper
+impl rustyline::highlight::Highlighter for RustyHelper {
+    fn highlight_hint<'h>(&self, hint: &'h str) -> std::borrow::Cow<'h, str> {
+        std::borrow::Cow::Owned(format!("\x1b[90m{}\x1b[0m", hint))
+    }
+
+    fn highlight<'l>(&self, line: &'l str, pos: usize) -> Cow<'l, str> {
+        let (start, prefix, head_command): (usize, &str, &str) = get_word_at_cursor(line, pos);
+
+        if prefix.is_empty() {
+            return Cow::Borrowed(line);
+        }
+
+        let matched = candidate_list(head_command)
+            .iter()
+            .any(|c| c.starts_with(prefix.to_lowercase().as_str()));
+
+        if matched {
+            Cow::Owned(format!(
+                "{}\x1b[32m{}\x1b[0m{}",
+                &line[..start],
+                &line[start..pos],
+                &line[pos..],
+            ))
+        } else {
+            Cow::Borrowed(line)
+        }
+    }
+    fn highlight_char(&self, line: &str, pos: usize, kind: CmdKind) -> bool {
+        let _ = (line, pos, kind);
+        true
+    }
+}
+
+// Implement the Validator trait for RustyHelper
+impl rustyline::validate::Validator for RustyHelper {
+    fn validate(&self, ctx: &mut ValidationContext) -> rustyline::Result<ValidationResult> {
+        if shlex::split(ctx.input()).is_none() {
+            Ok(ValidationResult::Incomplete)
+        } else {
+            Ok(ValidationResult::Valid(None))
+        }
+    }
+}
+
+// Helper function to get, word, cursor position, and leading head command stripping any leading whitespace
+fn get_word_at_cursor(line: &str, pos: usize) -> (usize, &str, &str) {
+    let start: usize = line[..pos].rfind(' ').map_or(0, |i: usize| i + 1);
+    let prefix: &str = &line[start..pos];
+    let head_command: &str = line[..start].split_whitespace().next().unwrap_or("");
+    (start, prefix, head_command)
+}
+
+// Which candidates to offer given the head command:
+fn candidate_list(head_command: &str) -> &'static [&'static str] {
+    match head_command {
+        "capture" => CAPTURE_SUBCOMMANDS,
+        "link" => LINK_SUBCOMMANDS,
+        "" => COMMANDS,
+        _ => &[],
+    }
+}
+
+// Helper function to get the parameter info for a given command
+fn get_command_parameter_info(command: &str) -> &str {
+    match command {
+        "echo" => " : Ping the Packet Handler",
+        "counters" => " -r/--reset : Display all counters + uptime; --reset to zero them instead.",
+        "watch" => " <interval> (secs) : Poll counters every interval seconds and print deltas.",
+        "perf-sample" => " <duration> <frequency> : Performancy sampling",
+        "capture" => " <subcommand>",
+        "link" => " <subcommand>",
+        "logging" => " [<level>=<target>] (>=1 pair) : Change log levels at runtime",
+        "addr" => " : get address of adapter's node (IP + port)",
+        "quit" => " : Exit the CLI",
+        "set-file" => " <file_path> : Set the pcap output file",
+        "close-file" => " : Close the pcap output file",
+        "set-program" => {
+            " [program] : install a BPF filter (default: link[0] == 1 or link[0] == 0)"
+        }
+        "delete-program" => " : delete the BPF filter",
+        "flush-file" => " : Flush outstanding packets to disk",
+        "sequence" => " <file_path> <duration> [program] : open, filter, wait, close",
+        "show" => " [id] : show one link, or summary if no id",
+        "configure" => " <id>",
+        "start" => " <id>",
+        "stop" => " <id>",
+        "reset" => " <id>",
+        _ => "",
+    }
+}


### PR DESCRIPTION
Worked on implementing rustyline in CLI for testing. Features I added

- autocomplete for current commands
- hinting for autocomplete depending on state of command
- pop up descriptions for commands once you finish typing them
- listing for all possible commands at a given point (hit tab when nothing is typed or when the prefix of multiple options has been typed)
- coloring for hints and valid commands show as green until they are fully typed/auto completed
- Validation to continue allowing typing if "" are not closed

I know the original intention for this task was to swap clap out for rustyline but it seemed like the features of rustyline are almost entirely visual so I built it on top of the existing clap structure. If there are other problems with the CLI with its current implementation I am happy to find a different library or continue building the current one out. Hope this helps

