### PR TITLE
migrating towards new capnproto admin interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,9 +374,8 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "capnp"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63da65e5e9ffc3b8f993d4ad222a548152549351a643f6b850a7773cb6ff2809"
+version = "0.25.5"
+source = "git+https://github.com/emilazy/capnproto-rust.git?rev=cfbcb9b#cfbcb9bf2b620db96cffdfd4bb09af4837093bab"
 dependencies = [
  "embedded-io",
 ]
@@ -384,30 +383,32 @@ dependencies = [
 [[package]]
 name = "capnp-futures"
 version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b69dfddccc57844f9a90f9d72b44b97c326914851ea94fb7da40ef9cad6e8d"
+source = "git+https://github.com/emilazy/capnproto-rust.git?rev=cfbcb9b#cfbcb9bf2b620db96cffdfd4bb09af4837093bab"
 dependencies = [
  "capnp",
  "futures-channel",
- "futures-util",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "tokio",
 ]
 
 [[package]]
 name = "capnp-rpc"
 version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c74c337e87f75f3174ffb3513738ab0acc631c04f64cc33b867c60f84771da"
+source = "git+https://github.com/emilazy/capnproto-rust.git?rev=cfbcb9b#cfbcb9bf2b620db96cffdfd4bb09af4837093bab"
 dependencies = [
  "capnp",
  "capnp-futures",
- "futures",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
 ]
 
 [[package]]
 name = "capnpc"
 version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca02be865c8c5a78bfc24b9819006ab6b59bef238467203928e26459557af93"
+source = "git+https://github.com/emilazy/capnproto-rust.git?rev=cfbcb9b#cfbcb9bf2b620db96cffdfd4bb09af4837093bab"
 dependencies = [
  "capnp",
 ]
@@ -2613,6 +2614,7 @@ dependencies = [
  "blake3",
  "bytes",
  "capnp",
+ "capnp-futures",
  "capnp-rpc",
  "cbpf-rs",
  "chrono",
@@ -2665,6 +2667,7 @@ version = "0.6.0"
 dependencies = [
  "admin-api",
  "capnp",
+ "capnp-futures",
  "capnp-rpc",
  "cbpf-rs",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 capnp = { version = "0.25.0", features = ["sync_reader"] }
+capnp-futures = "0.25"
 capnp-rpc = "0.25.0"
 cbpf-rs = { git = "https://github.com/org-zpr/zpr-utils.git", tag = "cbpf-rs-v0.2.0"}
 clap = { version = "4.5.23", features = ["derive"] }
@@ -29,3 +30,9 @@ zpr-ext = { git = "https://github.com/org-zpr/zpr-utils.git", tag = "zpr-ext-v0.
 
 [profile.release]
 panic = "abort"
+
+[patch.crates-io]
+capnp = { git = "https://github.com/emilazy/capnproto-rust.git", rev = "cfbcb9b" }
+capnp-futures = { git = "https://github.com/emilazy/capnproto-rust.git", rev = "cfbcb9b" }
+capnp-rpc = { git = "https://github.com/emilazy/capnproto-rust.git", rev = "cfbcb9b" }
+capnpc = { git = "https://github.com/emilazy/capnproto-rust.git", rev = "cfbcb9b" }

--- a/adapter/admin-api/cli.capnp
+++ b/adapter/admin-api/cli.capnp
@@ -4,7 +4,7 @@ interface CmdLineInter {
     echo                 @0 () -> ();
     resetCounters        @1 () -> ();
     counters             @2 () -> (counts: Counters);
-    setCaptureFile       @3 (filePath: Text) -> (result: SuccessOrError);
+    setCaptureFile       @3 (captureFile: CaptureFile) -> (result: SuccessOrError);
     closeCaptureFile     @4 () -> ();
     flushCaptureFile     @5 () -> ();
     setCaptureProgram    @6 (program: Program) -> (result: SuccessOrError);
@@ -18,6 +18,10 @@ interface CmdLineInter {
     resetLink            @14 (id: UInt32) -> ();
     changeLogging        @15 (logs: List(Log)) -> (result: LogsApplied);
     getNodeInfo          @16 () -> (result: SuccessOrError);
+}
+
+interface CaptureFile {
+    # expects an FD to be passed as ancillary data
 }
 
 struct SuccessOrError {

--- a/adapter/cli/Cargo.toml
+++ b/adapter/cli/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 admin-api = { path = "../admin-api" }
 capnp = { workspace = true }
+capnp-futures = { workspace = true, optional = true } 
 capnp-rpc = { workspace = true }
 cbpf-rs = { workspace = true, features = ["pcap"]}
 clap = { workspace = true }
@@ -25,6 +26,7 @@ dirs = "6.0.0"
 
 [features]
 complete = ["clap_complete"]
+capnp-ancillary = ["dep:capnp-futures", "capnp-futures/tokio-unix-fd-stream"]
 
 [[bin]]
 name = "ph-cli"

--- a/adapter/cli/src/main.rs
+++ b/adapter/cli/src/main.rs
@@ -19,10 +19,13 @@ use std::io::prelude::*;
 use std::io::{BufReader, Error, IoSlice};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::os::fd::AsFd;
+#[cfg(feature = "capnp-ancillary")]
+use std::os::fd::{BorrowedFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use thiserror::Error;
 use tokio::time::{Duration, sleep};
+#[cfg(not(feature = "capnp-ancillary"))]
 use tokio_util::compat::*;
 use zpr_ext::std::os::unix::net::{SocketAncillary, UnixStreamExt};
 
@@ -160,9 +163,19 @@ async fn process_command(
     let sock = tokio::net::UnixStream::connect(socket).await?;
     let (reader, writer) = sock.into_split();
 
+    #[cfg(not(feature = "capnp-ancillary"))]
     let network = capnp_rpc::twoparty::VatNetwork::new(
         tokio::io::BufReader::new(reader).compat(),
         tokio::io::BufWriter::new(writer).compat_write(),
+        capnp_rpc::rpc_twoparty_capnp::Side::Client,
+        capnp::message::ReaderOptions::new(),
+    );
+
+    #[cfg(feature = "capnp-ancillary")]
+    let network = capnp_rpc::twoparty::io::VatNetwork::new_with_fds(
+        capnp_futures::io::tokio::UnixFdStream::new(reader),
+        capnp_futures::io::tokio::UnixFdStream::new(writer),
+        1,
         capnp_rpc::rpc_twoparty_capnp::Side::Client,
         capnp::message::ReaderOptions::new(),
     );
@@ -187,7 +200,10 @@ async fn process_command(
                 }
                 Commands::Capture(capture) => match capture.command {
                     CaptureCommands::SetFile { file_path } => {
-                        handle_set_capture_file(file_path, cap_socket)?
+                        #[cfg(not(feature = "capnp-ancillary"))]
+                        handle_set_capture_file(file_path, cap_socket)?;
+                        #[cfg(feature = "capnp-ancillary")]
+                        set_capture_file_task(service, file_path).await?;
                     }
                     CaptureCommands::CloseFile => close_capture_file_task(service).await?,
                     CaptureCommands::FlushFile => flush_capture_file_task(service).await?,
@@ -276,27 +292,46 @@ async fn counters_task(service: svc::Client) -> Result<(), CliError> {
     Ok(())
 }
 
-// TODO determine if possible to send FD through capnp or by some side channel
-#[allow(dead_code)]
-async fn set_capture_file_task(_service: svc::Client, _file_path: String) -> Result<(), CliError> {
-    // let mut request = service.set_capture_file_request();
-    // request
-    //     .get()
-    //     .init_file_path(file_path.len() as u32)
-    //     .push_str(&file_path);
+// This struct is used to implement the capture_file interface for the RPC worker.
+// It is only used when the capnp-ancillary feature is enabled, which allows for file descriptor passing over Unix sockets.
+#[cfg(feature = "capnp-ancillary")]
+struct CaptureFileImpl {
+    fd: OwnedFd,
+}
 
-    // let response = request.send().promise.await?;
-    // let results = response.get()?;
-    // match results.get_result()?.which()? {
-    //     cli::success_or_error::Which::Success(_) => {
-    //         println!("Capture file set")
-    //     }
-    //     cli::success_or_error::Which::Error(e) => {
-    //         let result = e.unwrap().get_txt()?.to_string()?;
-    //         return Err(capnp::Error::failed(result));
-    //     }
-    // };
-    Ok(())
+#[cfg(feature = "capnp-ancillary")]
+impl cli::capture_file::Server for CaptureFileImpl {
+    fn get_fd(&self) -> Option<BorrowedFd<'_>> {
+        Some(self.fd.as_fd())
+    }
+}
+
+/// Opens the named capture file and passes its FD to the PH as a CaptureFile to set_capture_file_request.  This is only used when the capnp-ancillary feature is enabled, which allows for file descriptor passing over Unix sockets.
+#[cfg(feature = "capnp-ancillary")]
+async fn set_capture_file_task(service: svc::Client, file_path: String) -> Result<(), CliError> {
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(file_path)?;
+
+    let mut request = service.set_capture_file_request();
+    request
+        .get()
+        .set_capture_file(capnp_rpc::new_client(CaptureFileImpl { fd: file.into() }));
+    let response = request.send().promise.await?;
+
+    match response.get()?.get_result()?.which()? {
+        cli::success_or_error::Which::Success(_) => {
+            println!("Capture file opened");
+            Ok(())
+        }
+        cli::success_or_error::Which::Error(e) => {
+            let result = e?.get_txt()?.to_string()?;
+            println!("{result}");
+            Err(CliError::RpcError(result))
+        }
+    }
 }
 
 async fn close_capture_file_task(service: svc::Client) -> Result<(), CliError> {
@@ -365,6 +400,7 @@ async fn delete_capture_program_task(service: svc::Client) -> Result<(), CliErro
     Ok(())
 }
 
+#[cfg_attr(feature = "capnp-ancillary", allow(unused_variables))]
 async fn capture_sequence_task(
     service: svc::Client,
     file_path: String,
@@ -373,7 +409,10 @@ async fn capture_sequence_task(
     cap_socket: &PathBuf,
 ) -> Result<(), CliError> {
     let sleep_time = Duration::new(time, 0);
+    #[cfg(not(feature = "capnp-ancillary"))]
     handle_set_capture_file(file_path, cap_socket)?;
+    #[cfg(feature = "capnp-ancillary")]
+    set_capture_file_task(service.clone(), file_path).await?;
     set_capture_program_task(service.clone(), program).await?;
 
     let handler = Arc::new(CtrlcHandle::new());

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.22.1"
 blake3 = { version = "1.5.4" }
 bytes = { version = "1.11.1" }
 capnp = { workspace = true }
+capnp-futures = { workspace = true, optional = true }
 capnp-rpc = { workspace = true }
 cbpf-rs = { workspace = true }
 chrono = "0.4.39"
@@ -70,6 +71,7 @@ rcu-crossbeam-epoch = ["rcu/rcu-crossbeam-epoch", "zpr/rcu-crossbeam-epoch"]
 rcu-mutex-arc = ["rcu/rcu-mutex-arc", "zpr/rcu-mutex-arc"]
 rcu-rwlock = ["rcu/rcu-rwlock", "zpr/rcu-rwlock"]
 complete = ["clap_complete"]
+capnp-ancillary = ["dep:capnp-futures", "capnp-futures/tokio-unix-fd-stream"]
 
 [[bin]]
 name = "ph"

--- a/adapter/ph/src/admin_worker.rs
+++ b/adapter/ph/src/admin_worker.rs
@@ -44,9 +44,21 @@ pub async fn launch_capnp(
         let (sock, _addr) = listener.accept().await?;
 
         let (reader, writer) = sock.into_split();
+
+        #[cfg(not(feature = "capnp-ancillary"))]
         let network = capnp_rpc::twoparty::VatNetwork::new(
             tokio::io::BufReader::new(reader).compat(),
             tokio::io::BufWriter::new(writer).compat_write(),
+            capnp_rpc::rpc_twoparty_capnp::Side::Server,
+            capnp::message::ReaderOptions::new(),
+        );
+
+        //use an FD-passing transport instead of a plain byte stream.
+        #[cfg(feature = "capnp-ancillary")]
+        let network = capnp_rpc::twoparty::io::VatNetwork::new_with_fds(
+            capnp_futures::io::tokio::UnixFdStream::new(reader),
+            capnp_futures::io::tokio::UnixFdStream::new(writer),
+            1,
             capnp_rpc::rpc_twoparty_capnp::Side::Server,
             capnp::message::ReaderOptions::new(),
         );
@@ -149,6 +161,7 @@ impl svc::Server for AdminServiceImpl {
         Ok(())
     }
 
+    #[cfg(not(feature = "capnp-ancillary"))]
     async fn set_capture_file(
         self: Rc<Self>,
         _: svc::SetCaptureFileParams,
@@ -157,6 +170,48 @@ impl svc::Server for AdminServiceImpl {
         Err(capnp::Error::unimplemented(
             "method cmd_line_inter::Server::set_capture_file not implemented".to_string(),
         ))
+    }
+
+    /// Opens the capture file from an FD received as ancillary data.
+    #[cfg(feature = "capnp-ancillary")]
+    async fn set_capture_file(
+        self: Rc<Self>,
+        params: svc::SetCaptureFileParams,
+        mut results: svc::SetCaptureFileResults,
+    ) -> Result<(), capnp::Error> {
+        info!(target: RPC, "Set capture file procedure initiated");
+        let capture_file = params.get()?.get_capture_file()?;
+        let fd = capture_file.client.get_fd().await?;
+        let results_builder = results.get().init_result();
+
+        match fd {
+            Some(fd) => {
+                let owned_fd = fd.try_clone_to_owned().map_err(|e| {
+                    capnp::Error::failed(format!("failed to clone capture file fd: {e}"))
+                })?;
+                let file = File::from(std::fs::File::from(owned_fd));
+                match self.asm.capture_worker.open_capture_file(file).await {
+                    Ok(()) => {
+                        debug!(target: RPC, "Capture file opened");
+                        results_builder.init_success().set_none(());
+                    }
+                    Err(err) => {
+                        debug!(target: RPC, "Error opening capture file: {err}");
+                        results_builder
+                            .init_error()
+                            .set_txt(format!("Error opening capture file: {err}").as_str());
+                    }
+                }
+            }
+            None => {
+                debug!(target: RPC, "Error opening capture file: no file descriptor received");
+                results_builder
+                    .init_error()
+                    .set_txt("Error opening capture file: no file descriptor received");
+            }
+        }
+
+        Ok(())
     }
 
     async fn close_capture_file(

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -70,6 +70,7 @@ pub const ACTOR_AUTHENTICATION_TIMEOUT: std::time::Duration = std::time::Duratio
 /// How long to wait when we expect the VS to have to talk to external auth services.
 pub const VS_AUTHENTICATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+#[cfg(not(feature = "capnp-ancillary"))]
 pub const ANCILLARY_BUFFER_SIZE: usize = 128;
 
 const DEFAULT_BUFFER_COUNT: usize = 512; // should be at least 5x batch size; see fastpath_worker.rs for explanation

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -53,6 +53,7 @@ mod pki;
 mod prelude;
 mod queues;
 mod sample_ring;
+#[cfg(not(feature = "capnp-ancillary"))]
 mod set_capture_file_worker;
 mod signal_worker;
 mod special_peers;
@@ -271,19 +272,23 @@ fn main() -> ExitCode {
         UnixListener::bind(&config.control_path).expect("failed to bind to control socket");
     info!(target: STARTUP, "control socket bound to {:?}", config.control_path);
 
-    fs::remove_file(&config.capture_path)
-        .or_else(|e| {
-            if e.kind() == ErrorKind::NotFound {
-                Ok(())
-            } else {
-                Err(e)
-            }
-        })
-        .unwrap();
-    let capture_socket = Arc::new(
-        UnixListener::bind(&config.capture_path).expect("failed to bind to capture socket"),
-    );
-    info!(target: STARTUP, "capture socket bound to {:?}", config.capture_path);
+    #[cfg(not(feature = "capnp-ancillary"))]
+    let capture_socket = {
+        fs::remove_file(&config.capture_path)
+            .or_else(|e| {
+                if e.kind() == ErrorKind::NotFound {
+                    Ok(())
+                } else {
+                    Err(e)
+                }
+            })
+            .unwrap();
+        let capture_socket = Arc::new(
+            UnixListener::bind(&config.capture_path).expect("failed to bind to capture socket"),
+        );
+        info!(target: STARTUP, "capture socket bound to {:?}", config.capture_path);
+        capture_socket
+    };
 
     //
     // open TUN devices and actor requeue sockets
@@ -620,6 +625,7 @@ fn main() -> ExitCode {
     js.spawn_local(signal_worker::launch(asm.clone()));
     js.spawn_local(mgmt_dispatch_worker::launch(asm.clone(), md_outq));
     js.spawn_local(adapter_manager_worker::launch(asm.clone(), am_outq));
+    #[cfg(not(feature = "capnp-ancillary"))]
     js.spawn_local(set_capture_file_worker::launch(
         asm.clone(),
         capture_socket.clone(),


### PR DESCRIPTION
Added all changes as outline in task. One note: Instead of deleting old implementation added "capnp-ancillary" gate to not interfere with original code base before the demo