### PR TITLE
Mgmt traffic hairpinning

### DIFF
--- a/adapter/ph/src/adapter_manager_worker.rs
+++ b/adapter/ph/src/adapter_manager_worker.rs
@@ -4,7 +4,6 @@ use crate::mgmt::{self, core::MgmtSendError, core::PacketStatus};
 use crate::prelude::*;
 use crate::queues::AdapterManagerMessage;
 use crate::two_way_queue;
-use std::num::NonZero;
 use tokio;
 
 pub async fn launch(
@@ -78,47 +77,31 @@ fn do_request_tether_id(asm: &Arc<Assembly>, pkt: Packet) {
 
     debug!(target: FLOW_MGMT, "{}: Issuing bind request for {five_tuple} (is now set PENDING)", asm.formatted_link_id(dock_link_id));
 
-    match asm.ph_mode {
-        PhMode::Adapter => {
-            let task_asm = asm.clone();
-            tokio::task::spawn_local(async move {
-                // Bind requests are "large", since they contain packet
-                // bodies, and may be manifestly undeliverable by the
-                // network due to MTU or middleware issues.  So we allow
-                // them to deterministically time out, returning an error
-                // to the requestor.
-                match mgmt::requests::send_bind_actor_address_request(
-                    &task_asm,
-                    dock_link_id,
-                    txn_id,
-                    five_tuple.l3_type,
-                    &packet_body,
-                )
-                .limit_retries(config::DEFAULT_ZDPR_RETRY_LIMIT)
-                .await
-                {
-                    Ok(PacketStatus::Acked) => (),
-
-                    Ok(PacketStatus::Canceled) => {
-                        mgmt::adapter::deny_tether(
-                            &task_asm,
-                            &txn,
-                            "Network error issuing bind request",
-                        )
-                        .unwrap();
-                    }
-
-                    Err(MgmtSendError::LinkClosed) => (),
-                }
-            });
-        }
-
-        PhMode::Node => mgmt::dock::bind_actor_address(
-            asm,
-            NonZero::new(LOCAL_ACTOR_LINK_ID).unwrap(),
+    let task_asm = asm.clone();
+    tokio::task::spawn_local(async move {
+        // Bind requests are "large", since they contain packet
+        // bodies, and may be manifestly undeliverable by the
+        // network due to MTU or middleware issues.  So we allow
+        // them to deterministically time out, returning an error
+        // to the requestor.
+        match mgmt::requests::send_bind_actor_address_request(
+            &task_asm,
+            dock_link_id,
             txn_id,
             five_tuple.l3_type,
             &packet_body,
-        ),
-    }
+        )
+        .limit_retries(config::DEFAULT_ZDPR_RETRY_LIMIT)
+        .await
+        {
+            Ok(PacketStatus::Acked) => (),
+
+            Ok(PacketStatus::Canceled) => {
+                mgmt::adapter::deny_tether(&task_asm, &txn, "Network error issuing bind request")
+                    .unwrap();
+            }
+
+            Err(MgmtSendError::LinkClosed) => (),
+        }
+    });
 }

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -83,6 +83,7 @@ pub struct Assembly {
     pub dlt: adapter_tables::DockLookupTable,
 
     pub mgmt_dispatch_factory: MgmtDispatchFactory,
+    pub mgmt_hairpin_dispatch: MgmtHairpinDispatch,
     pub adapter_manager_factory: AdapterManagerFactory,
     pub km_state: KmState,
 
@@ -333,7 +334,10 @@ impl Assembly {
         interface_addr: &ScopedIpAddr,
         link_type: LinkType,
     ) -> Result<NonZero<LinkId>, PeerInsertError> {
-        assert!(link_type != LinkType::NodeToNode);
+        assert!(matches!(
+            link_type,
+            LinkType::NodeToAdapter | LinkType::AdapterToNode
+        ));
         debug!(target: PEER_MGMT, "Starting tether with {adapter_addr} connected to {interface_addr}");
         let peer_id = self.add_peer(link_type, adapter_addr, interface_addr)?;
 
@@ -427,6 +431,7 @@ pub mod test {
         pub elt: Option<adapter_tables::EndpointLookupTable>,
         pub dlt: Option<adapter_tables::DockLookupTable>,
         pub mgmt_dispatch_factory: Option<MgmtDispatchFactory>,
+        pub mgmt_hairpin_dispatch: Option<MgmtHairpinDispatch>,
         pub adapter_manager_factory: Option<AdapterManagerFactory>,
         pub km_state: Option<KmState>,
         pub system_start_time: Option<std::time::Instant>,
@@ -495,6 +500,10 @@ pub mod test {
             let (md_inq_factory, _md_outq) = two_way_queue::two_way_queue(1);
             MgmtDispatchFactory::new(md_inq_factory)
         });
+        let mgmt_hairpin_dispatch = builder.mgmt_hairpin_dispatch.unwrap_or_else(|| {
+            let (mhd_inq, _mhd_outq) = mpsc::channel(1);
+            MgmtHairpinDispatch::new(mhd_inq)
+        });
         let adapter_manager_factory = builder.adapter_manager_factory.unwrap_or_else(|| {
             let (am_inq_factory, _am_outq) = two_way_queue::two_way_queue(1);
             AdapterManagerFactory::new(am_inq_factory)
@@ -534,6 +543,7 @@ pub mod test {
             elt,
             dlt,
             mgmt_dispatch_factory,
+            mgmt_hairpin_dispatch,
             adapter_manager_factory,
             km_state,
             self_noise_keypair: None,

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -180,6 +180,7 @@ pub enum LinkStateError {
 pub enum LinkType {
     Internal,
     AdapterToNode,
+    #[allow(dead_code)]
     NodeToNode, // Currently unsupported
     NodeToAdapter,
 }

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -14,6 +14,7 @@ use crate::zdp::{self, ResponseCode, TerminateReason};
 use openssl::x509::X509;
 use std::fmt::{Display, Formatter};
 use std::net::{IpAddr, SocketAddr};
+use std::num::NonZero;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 use thiserror::Error;
@@ -316,6 +317,9 @@ pub struct LinkStateWrapper {
     link_type: LinkType,
     locked_fsm: Mutex<LinkStateMachine>,
     pub locked_data: Mutex<LinkData>,
+    /// Internal links _may_ be associated with another internal link
+    /// representing its remote side.
+    pub internal_peer_id: Option<NonZero<LinkId>>,
 }
 
 impl LinkStateWrapper {
@@ -333,6 +337,7 @@ impl LinkStateWrapper {
             link_type: new_link_type,
             locked_fsm: Mutex::new(lsm),
             locked_data: Mutex::new(LinkData::new()),
+            internal_peer_id: None,
         }
     }
 

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -563,6 +563,7 @@ fn main() -> ExitCode {
         logging: Mutex::new(logging_map),
         reload_handle,
     });
+
     //
     // create a Tokio "local set" to schedule all our management workers on
     //
@@ -572,36 +573,19 @@ fn main() -> ExitCode {
     let _local_set_guard = local_set.enter();
 
     //
-    // instantiate the "fake" local actor link
-    //
-
-    assert_eq!(
-        asm.peer_table.insert_internal_peer().get(),
-        LOCAL_ACTOR_LINK_ID
-    );
-
-    if matches!(ph_mode, PhMode::Node) {
-        // Nodes use this link as the source of bind requests from the
-        // internal adapter, which require that the originator has a valid
-        // actor address (which matches the requested source address).
-
-        for addr in &asm.config.get().zpr_addr {
-            asm.peer_table
-                .get(LOCAL_ACTOR_LINK_ID)
-                .unwrap()
-                .link_state_machine
-                .add_internal_actor_address(addr.into());
-        }
-    }
-
-    //
-    // instantiate tether if we're an adapter,
-    // or "fake" internal dock link if we're a node
+    // instantiate local actor and tether links
     // NOTE: must occur before we start any other workers!
     //
 
     match ph_mode {
         PhMode::Adapter => {
+            // instantiate the "fake" local actor link
+            assert_eq!(
+                asm.peer_table.insert_internal_peer().get(),
+                LOCAL_ACTOR_LINK_ID
+            );
+
+            // instantiate tether
             let dsid = asm
                 .start_tether(
                     asm.config.get().node_addr.as_ref().unwrap(),
@@ -613,7 +597,24 @@ fn main() -> ExitCode {
             assert_eq!(dsid.get(), DOCK_LINK_ID);
         }
 
-        PhMode::Node => assert_eq!(asm.peer_table.insert_internal_peer().get(), DOCK_LINK_ID),
+        PhMode::Node => {
+            // instantiate the "fake" local actor and dock links
+
+            let (lalid, dlid) = asm.peer_table.insert_internal_peer_pair();
+            assert_eq!(lalid.get(), LOCAL_ACTOR_LINK_ID);
+            assert_eq!(dlid.get(), DOCK_LINK_ID);
+
+            // Nodes use the local actor link as the source of bind requests from the
+            // internal adapter, which require that the originator has a valid
+            // actor address (which matches the requested source address).
+            for addr in &asm.config.get().zpr_addr {
+                asm.peer_table
+                    .get(LOCAL_ACTOR_LINK_ID)
+                    .unwrap()
+                    .link_state_machine
+                    .add_internal_actor_address(addr.into());
+            }
+        }
     }
 
     //

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -239,6 +239,7 @@ fn main() -> ExitCode {
         packet_buffer_socket_pair(topology_config.capture_queue_size).unwrap();
     let (md_inq_factory, md_outq) =
         two_way_queue::two_way_queue(topology_config.mgmt_dispatch_queue_size);
+    let (mhd_inq, mhd_outq) = mpsc::channel(topology_config.mgmt_dispatch_queue_size);
     let (am_inq_factory, am_outq) =
         two_way_queue::two_way_queue(topology_config.adapter_manager_queue_size);
     let (km_sig_inq, km_sig_outq) = mpsc::channel(topology_config.km_signal_queue_size);
@@ -552,6 +553,7 @@ fn main() -> ExitCode {
         elt: adapter_tables::EndpointLookupTable::new(),
         dlt: adapter_tables::DockLookupTable::new(),
         mgmt_dispatch_factory: MgmtDispatchFactory::new(md_inq_factory),
+        mgmt_hairpin_dispatch: MgmtHairpinDispatch::new(mhd_inq),
         adapter_manager_factory: AdapterManagerFactory::new(am_inq_factory),
         km_state: KmState::new(km_inq, km_sig_inq),
         self_noise_keypair: Some(self_noise_keypair),
@@ -600,9 +602,19 @@ fn main() -> ExitCode {
         PhMode::Node => {
             // instantiate the "fake" local actor and dock links
 
-            let (lalid, dlid) = asm.peer_table.insert_internal_peer_pair();
+            let (lalid, dlid) = asm.peer_table.insert_internal_peer_pair(|link_id, q| {
+                mgmt_processor_worker::launch(
+                    mgmt_processor_worker::Config { link_id },
+                    asm.clone(),
+                    q,
+                )
+            });
             assert_eq!(lalid.get(), LOCAL_ACTOR_LINK_ID);
             assert_eq!(dlid.get(), DOCK_LINK_ID);
+
+            // For now, we use ZDPR for flow control on internal mgmt links.
+            tokio::task::spawn_local(zdpr_worker::launch(asm.clone(), lalid.get()));
+            tokio::task::spawn_local(zdpr_worker::launch(asm.clone(), dlid.get()));
 
             // Nodes use the local actor link as the source of bind requests from the
             // internal adapter, which require that the originator has a valid
@@ -624,7 +636,7 @@ fn main() -> ExitCode {
     let mut js = JoinSet::new();
 
     js.spawn_local(signal_worker::launch(asm.clone()));
-    js.spawn_local(mgmt_dispatch_worker::launch(asm.clone(), md_outq));
+    js.spawn_local(mgmt_dispatch_worker::launch(asm.clone(), md_outq, mhd_outq));
     js.spawn_local(adapter_manager_worker::launch(asm.clone(), am_outq));
     #[cfg(not(feature = "capnp-ancillary"))]
     js.spawn_local(set_capture_file_worker::launch(

--- a/adapter/ph/src/mgmt/adapter.rs
+++ b/adapter/ph/src/mgmt/adapter.rs
@@ -6,7 +6,7 @@
 //! adapter in response to a message from a node, or directly by a node
 //! managing its local adapter.
 
-use super::{dock, txn_mgr};
+use super::txn_mgr;
 use crate::adapter_tables::{DltPep, EltPep};
 use crate::counters::ManagementCounterType;
 use crate::prelude::*;
@@ -52,58 +52,26 @@ pub fn bind_egress_stream(
     match asm.dlt.insert(pep) {
         Ok(tid) => {
             // TODO: maybe tick a counter somewhere?
-            match asm.ph_mode {
-                PhMode::Node => {
-                    // we're a node operating on our internal adapter; "respond" directly to local dock
-                    let dock_peer_state = asm.peer_table.get(LOCAL_ACTOR_LINK_ID).unwrap();
-                    let txn = dock_peer_state
-                        .txn_mgr
-                        .get(txn_id)
-                        .expect("local dock lost transaction");
-                    dock::install_tether(
-                        asm,
-                        NonZero::new(LOCAL_ACTOR_LINK_ID).unwrap(),
-                        &txn,
-                        tid,
-                    )
-                    .expect("local dock rejected tether response");
-                }
-
-                PhMode::Adapter => super::requests::send_bind_egress_stream_success_response(
-                    asm,
-                    dock_link_id.get(),
-                    txn_id,
-                    tid,
-                )
-                .enqueue(),
-            }
+            super::requests::send_bind_egress_stream_success_response(
+                asm,
+                dock_link_id.get(),
+                txn_id,
+                tid,
+            )
+            .enqueue();
         }
 
         Err(()) => {
             // DLT full; respond with error message
             let msg = "DLT full";
             // TODO: maybe tick a counter somewhere?
-
-            match asm.ph_mode {
-                PhMode::Node => {
-                    // we're a node operating on our internal adapter; "respond" directly to local dock
-                    let dock_peer_state = asm.peer_table.get(LOCAL_ACTOR_LINK_ID).unwrap();
-                    let txn = dock_peer_state
-                        .txn_mgr
-                        .get(txn_id)
-                        .expect("local dock lost transaction");
-                    dock::deny_tether(asm, NonZero::new(LOCAL_ACTOR_LINK_ID).unwrap(), &txn, msg)
-                        .expect("local dock rejected tether response");
-                }
-
-                PhMode::Adapter => super::requests::send_bind_egress_stream_error_response(
-                    asm,
-                    dock_link_id.get(),
-                    txn_id,
-                    msg,
-                )
-                .enqueue(),
-            }
+            super::requests::send_bind_egress_stream_error_response(
+                asm,
+                dock_link_id.get(),
+                txn_id,
+                msg,
+            )
+            .enqueue();
         }
     }
 }

--- a/adapter/ph/src/mgmt/core.rs
+++ b/adapter/ph/src/mgmt/core.rs
@@ -109,20 +109,18 @@ fn send_zdpr_common(
     // TODO: just allocate this on the stack, pending #985.
     let mut packet = new_tiny_heap_packet();
 
-    let mgmt_hdr = packet.alloc_zeroed_header::<zdp::ZdpMgmtHeader>();
-    mgmt_hdr.sequence_number = sequence_number.into();
-
+    let _mgmt_hdr = packet.alloc_zeroed_header::<zdp::ZdpMgmtHeader>();
     let base_hdr = packet.alloc_zeroed_header::<zdp::ZdpBaseHeader>();
     base_hdr.packet_type = packet_type;
 
-    // It's possible (but unlikely) the MgmtSubstrateEgress queue fills up.
-    // In that case, just ignore the error; act as if the packet was dropped
-    // by the substrate due to congestion.
-    let _ = asm
-        .mgmt_substrate_egress
-        .try_enqueue_packet(link_id, &mut packet);
+    build_and_egress_packets(
+        asm,
+        link_id,
+        std::iter::once((sequence_number, &mut packet)),
+    );
 }
 
+#[derive(Debug)]
 pub enum MgmtSendError {
     LinkClosed,
 }
@@ -622,6 +620,12 @@ pub fn build_and_egress_packets<'a>(
 ) {
     let mut dropped_backpressure = 0;
 
+    let Some(peer_state) = asm.peer_table.get(link_id) else {
+        return;
+    };
+    let internal_peer_id = peer_state.link_state_machine.internal_peer_id;
+    drop(peer_state);
+
     packets.for_each(|(seq_num, packet)| {
         let (mgmt_hdr, _) = zdp::ZdpMgmtHeader::mut_from_prefix(
             &mut packet.body_mut()[std::mem::size_of::<zdp::ZdpBaseHeader>()..],
@@ -629,14 +633,27 @@ pub fn build_and_egress_packets<'a>(
         .unwrap();
         mgmt_hdr.sequence_number = seq_num.into();
 
-        // It's possible (but unlikely) the MgmtSubstrateEgress queue fills up.
-        // In that case, just ignore the error; act as if the packet was dropped
-        // by the substrate due to congestion.
-        if !asm
-            .mgmt_substrate_egress
-            .try_enqueue_packet(link_id, packet)
-        {
-            dropped_backpressure += 1;
+        if let Some(internal_peer_id) = internal_peer_id {
+            // We are hairpinning this packet.
+            let mut packet = Packet::new_with_existing_metadata(packet.buffer().clone());
+            packet.metadata_mut().ingress_link_id = internal_peer_id.get();
+            if !asm
+                .mgmt_hairpin_dispatch
+                .try_dispatch_mgmt_packet_with_link(packet)
+                .is_ok()
+            {
+                dropped_backpressure += 1;
+            }
+        } else {
+            // It's possible (but unlikely) the MgmtSubstrateEgress queue fills up.
+            // In that case, just ignore the error; act as if the packet was dropped
+            // by the substrate due to congestion.
+            if !asm
+                .mgmt_substrate_egress
+                .try_enqueue_packet(link_id, packet)
+            {
+                dropped_backpressure += 1;
+            }
         }
     });
 

--- a/adapter/ph/src/mgmt/dock.rs
+++ b/adapter/ph/src/mgmt/dock.rs
@@ -12,8 +12,8 @@
 // node->node links, we don't make the distinction (so some terminology
 // choices are weird).
 
+use super::requests;
 use super::txn_mgr::{TxnHandle, TxnId};
-use super::{adapter, requests};
 use crate::classifier;
 use crate::counters::ManagementCounterType;
 use crate::defs::FiveTuple;
@@ -359,22 +359,8 @@ fn requested_visa_granted(
         .awaiting_next_hop_bind_table
         .insert(egress_bind_txn, (ingress_link_id, txn_id));
 
-    if egress_link_id.get() == LOCAL_ACTOR_LINK_ID {
-        adapter::bind_egress_stream(
-            asm,
-            NonZero::new(DOCK_LINK_ID).unwrap(),
-            egress_bind_txn_id,
-            tc,
-        );
-    } else {
-        requests::send_bind_egress_stream_request(
-            asm,
-            egress_link_id.get(),
-            egress_bind_txn_id,
-            tc,
-        )
+    requests::send_bind_egress_stream_request(asm, egress_link_id.get(), egress_bind_txn_id, tc)
         .enqueue();
-    }
 }
 
 /// Notify the bind-request state machine that the visa it requested
@@ -488,25 +474,14 @@ fn requested_tether_granted(
     let ingress_tether_id = ingress_tether_entry.insert(pep);
 
     // Send a success response to the requestor with the tether ID.
-
-    if ingress_peer_state.is_internal() {
-        let adapter_peer_state = asm.peer_table.get(DOCK_LINK_ID).unwrap();
-        let txn = adapter_peer_state
-            .txn_mgr
-            .get(txn_id)
-            .expect("local adapter lost transaction");
-        adapter::install_tether(asm, &txn, ingress_tether_id, tc)
-            .expect("local adapter rejected tether response");
-    } else {
-        requests::send_bind_actor_address_success_response(
-            asm,
-            ingress_link_id.get(),
-            txn_id,
-            ingress_tether_id,
-            tc,
-        )
-        .enqueue();
-    }
+    requests::send_bind_actor_address_success_response(
+        asm,
+        ingress_link_id.get(),
+        txn_id,
+        ingress_tether_id,
+        tc,
+    )
+    .enqueue();
 }
 
 /// Common functionality for exiting the bind request state machine with an error.
@@ -562,23 +537,8 @@ fn bind_actor_address_reject(
     }
 
     // Send an error response to the requestor.
-
-    if ingress_peer_state.is_internal() {
-        let adapter_peer_state = asm.peer_table.get(DOCK_LINK_ID).unwrap();
-        let txn = adapter_peer_state
-            .txn_mgr
-            .get(txn_id)
-            .expect("local adapter lost transaction");
-        adapter::deny_tether(asm, &txn, reason).expect("local adapter rejected tether response");
-    } else {
-        requests::send_bind_actor_address_error_response(
-            asm,
-            ingress_link_id.get(),
-            txn_id,
-            reason,
-        )
+    requests::send_bind_actor_address_error_response(asm, ingress_link_id.get(), txn_id, reason)
         .enqueue();
-    }
 }
 
 #[derive(Debug)]
@@ -742,9 +702,5 @@ pub fn unbind_stream(asm: &Arc<Assembly>, ingress_link_id: NonZero<LinkId>, stre
     }
 
     // Issue unbind request to next hop
-    if pft_pep.next_hop.0 == LOCAL_ACTOR_LINK_ID {
-        adapter::unbind_stream(asm, NonZero::new(DOCK_LINK_ID).unwrap(), stream_id);
-    } else {
-        requests::send_unbind_egress_stream_request(asm, pft_pep.next_hop.0, stream_id).enqueue();
-    }
+    requests::send_unbind_egress_stream_request(asm, pft_pep.next_hop.0, stream_id).enqueue();
 }

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -16,6 +16,7 @@ use crate::zdp;
 use std::net::SocketAddr;
 use std::num::NonZero;
 use thiserror::Error;
+use zpr::packet_info::DOCK_LINK_ID;
 use zpr_ext::zerocopy::FromBytesExt;
 use zpr_utils::net_defs::IpAddress;
 
@@ -590,8 +591,9 @@ pub async fn handle_bind_actor_address_request(
     txn_id: TxnId,
     mut pkt: Packet,
 ) -> HandleMgmtResult {
-    if !matches!(asm.ph_mode, PhMode::Node) {
-        error!(target: ZDP, "{}: received BindActorAddress message on adapter", asm.formatted_link_id(pkt.metadata().ingress_link_id));
+    // must not come from a dock
+    if pkt.metadata().ingress_link_id == DOCK_LINK_ID {
+        error!(target: ZDP, "{}: received BindActorAddress message on dock link", asm.formatted_link_id(pkt.metadata().ingress_link_id));
         return Err(HandleMgmtError::MessageNotPermitted);
     }
 
@@ -627,8 +629,9 @@ pub async fn handle_bind_egress_stream_request(
     txn_id: TxnId,
     mut pkt: Packet,
 ) -> HandleMgmtResult {
-    if !matches!(asm.ph_mode, PhMode::Adapter) {
-        error!(target: ZDP, "{}: received BindEgressStream message on node", asm.formatted_link_id(pkt.metadata().ingress_link_id));
+    // must come from an dock
+    if pkt.metadata().ingress_link_id != DOCK_LINK_ID {
+        error!(target: ZDP, "{}: received BindEgressStream message on non-dock link", asm.formatted_link_id(pkt.metadata().ingress_link_id));
         return Err(HandleMgmtError::MessageNotPermitted);
     }
 

--- a/adapter/ph/src/mgmt_dispatch_worker.rs
+++ b/adapter/ph/src/mgmt_dispatch_worker.rs
@@ -1,26 +1,40 @@
 //! Code which handles dispatching management packets from fastpath.
+//! There is only one of these in the system.
 
 use crate::mgmt::dispatch;
 use crate::prelude::*;
 use crate::queues::MgmtDispatchMessage;
 use crate::two_way_queue;
+use tokio::select;
+use tokio::sync::mpsc;
 
 pub async fn launch(
     asm: Arc<Assembly>,
     mut queue: two_way_queue::Receiver<MgmtDispatchMessage, PacketBuffer>,
+    mut hairpin_queue: mpsc::Receiver<Packet>,
 ) {
-    while let Some(mut msg) = queue.recv().await {
-        match &mut *msg {
-            MgmtDispatchMessage::WithLink(pkt) => {
-                dispatch::dispatch_mgmt_packet_with_link(&asm, pkt);
-            }
-            MgmtDispatchMessage::WithAddr {
-                peer_sa,
-                interface_addr,
-                packet,
-            } => {
-                dispatch::dispatch_mgmt_packet_with_addr(&asm, *peer_sa, *interface_addr, packet);
-            }
+    loop {
+        select! {
+            Some(mut msg) = queue.recv() => {
+                match &mut *msg {
+                    MgmtDispatchMessage::WithLink(pkt) => {
+                        dispatch::dispatch_mgmt_packet_with_link(&asm, pkt);
+                    }
+
+                    MgmtDispatchMessage::WithAddr {
+                        peer_sa,
+                        interface_addr,
+                        packet,
+                    } => {
+                        dispatch::dispatch_mgmt_packet_with_addr(&asm, *peer_sa, *interface_addr, packet);
+                    }
+                }
+            },
+
+            Some(mut pkt) = hairpin_queue.recv() =>
+                dispatch::dispatch_mgmt_packet_with_link(&asm, &mut pkt),
+
+            else => break,
         }
     }
 }

--- a/adapter/ph/src/mgmt_processor_worker.rs
+++ b/adapter/ph/src/mgmt_processor_worker.rs
@@ -1,3 +1,8 @@
+//! The management process worker pulls management messages
+//! (that is, excluding ZDPR control messages) for a specific link,
+//! pulled from that link's management processor queue, and
+//! handles them via the management handlers.
+
 use crate::counters::ManagementCounterType;
 use crate::link_state::LinkEvent;
 use crate::mgmt;

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -121,14 +121,16 @@ impl PeerState {
     }
 
     /// Creates a "dummy" peer for referencing internal links.
-    pub fn new_internal_peer(link_id: NonZero<LinkId>) -> Self {
-        PeerState::new(
+    pub fn new_internal_peer(link_id: NonZero<LinkId>, peer_id: Option<NonZero<LinkId>>) -> Self {
+        let mut ps = PeerState::new(
             link_id,
             LinkType::Internal,
             std::net::SocketAddrV6::new(std::net::Ipv6Addr::from_bits(0), 0, 0, 0).into(),
             ScopedIpv6Addr::new(std::net::Ipv6Addr::from_bits(0), 0).into(),
             |_| std::future::pending(),
-        )
+        );
+        ps.link_state_machine.internal_peer_id = peer_id;
+        ps
     }
 
     pub fn is_internal(&self) -> bool {
@@ -180,8 +182,21 @@ impl PeerTable {
     /// at startup, before dynamic entries have been added.)
     pub fn insert_internal_peer(&self) -> NonZero<LinkId> {
         let entry = self.vacant_entry().unwrap();
-        let peer = PeerState::new_internal_peer(entry.key());
+        let peer = PeerState::new_internal_peer(entry.key(), None);
         entry.insert(peer)
+    }
+
+    pub fn insert_internal_peer_pair(&self) -> (NonZero<LinkId>, NonZero<LinkId>) {
+        let entry1 = self.vacant_entry().unwrap();
+        // we have to "guess" at the next slot, since we can't hold two vacant entries open concurrently
+        let link_id2 = entry1.key().checked_add(1).unwrap();
+        let peer1 = PeerState::new_internal_peer(entry1.key(), Some(link_id2));
+        let link_id1 = entry1.insert(peer1);
+
+        let entry2 = self.vacant_entry().unwrap();
+        let peer2 = PeerState::new_internal_peer(entry2.key(), Some(link_id1));
+        assert_eq!(link_id2, entry2.insert(peer2));
+        (link_id1, link_id2)
     }
 
     pub fn vacant_entry(&self) -> Result<VacantPeerTableEntry<'_>, PeerInsertError> {

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -121,13 +121,22 @@ impl PeerState {
     }
 
     /// Creates a "dummy" peer for referencing internal links.
-    pub fn new_internal_peer(link_id: NonZero<LinkId>, peer_id: Option<NonZero<LinkId>>) -> Self {
+    pub fn new_internal_peer<Worker>(
+        link_id: NonZero<LinkId>,
+        peer_id: Option<NonZero<LinkId>>,
+        launch_mgmt_processor_worker: impl FnOnce(
+            mpsc::Receiver<queues::MgmtProcessorMessage>,
+        ) -> Worker,
+    ) -> Self
+    where
+        Worker: Future<Output = ()> + 'static,
+    {
         let mut ps = PeerState::new(
             link_id,
             LinkType::Internal,
             std::net::SocketAddrV6::new(std::net::Ipv6Addr::from_bits(0), 0, 0, 0).into(),
             ScopedIpv6Addr::new(std::net::Ipv6Addr::from_bits(0), 0).into(),
-            |_| std::future::pending(),
+            launch_mgmt_processor_worker,
         );
         ps.link_state_machine.internal_peer_id = peer_id;
         ps
@@ -182,20 +191,36 @@ impl PeerTable {
     /// at startup, before dynamic entries have been added.)
     pub fn insert_internal_peer(&self) -> NonZero<LinkId> {
         let entry = self.vacant_entry().unwrap();
-        let peer = PeerState::new_internal_peer(entry.key(), None);
+        let peer = PeerState::new_internal_peer(entry.key(), None, |_| std::future::pending());
         entry.insert(peer)
     }
 
-    pub fn insert_internal_peer_pair(&self) -> (NonZero<LinkId>, NonZero<LinkId>) {
+    pub fn insert_internal_peer_pair<Worker>(
+        &self,
+        launch_mgmt_processor_worker: impl Fn(
+            NonZero<LinkId>,
+            mpsc::Receiver<queues::MgmtProcessorMessage>,
+        ) -> Worker,
+    ) -> (NonZero<LinkId>, NonZero<LinkId>)
+    where
+        Worker: Future<Output = ()> + 'static,
+    {
         let entry1 = self.vacant_entry().unwrap();
         // we have to "guess" at the next slot, since we can't hold two vacant entries open concurrently
-        let link_id2 = entry1.key().checked_add(1).unwrap();
-        let peer1 = PeerState::new_internal_peer(entry1.key(), Some(link_id2));
-        let link_id1 = entry1.insert(peer1);
+        let link_id1 = entry1.key();
+        let link_id2 = link_id1.checked_add(1).unwrap();
+        let peer1 = PeerState::new_internal_peer(link_id1, Some(link_id2), |q| {
+            launch_mgmt_processor_worker(link_id1, q)
+        });
+        entry1.insert(peer1);
 
         let entry2 = self.vacant_entry().unwrap();
-        let peer2 = PeerState::new_internal_peer(entry2.key(), Some(link_id1));
-        assert_eq!(link_id2, entry2.insert(peer2));
+        assert_eq!(entry2.key(), link_id2);
+        let peer2 = PeerState::new_internal_peer(link_id2, Some(link_id1), |q| {
+            launch_mgmt_processor_worker(link_id2, q)
+        });
+        entry2.insert(peer2);
+
         (link_id1, link_id2)
     }
 

--- a/adapter/ph/src/queues.rs
+++ b/adapter/ph/src/queues.rs
@@ -288,6 +288,30 @@ impl MgmtDispatchFactory {
     }
 }
 
+pub struct MgmtHairpinDispatch {
+    sender: mpsc::Sender<Packet>,
+}
+
+impl MgmtHairpinDispatch {
+    pub fn new(sender: mpsc::Sender<Packet>) -> Self {
+        Self { sender }
+    }
+
+    pub fn try_dispatch_mgmt_packet_with_link(
+        &self,
+        packet: Packet,
+    ) -> Result<(), TryEnqueueError<Packet>> {
+        debug_assert_ne!(packet.metadata().ingress_link_id, 0);
+        match self.sender.try_send(packet) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                panic!("mgmt hairpin dispatch channel closed")
+            }
+            Err(mpsc::error::TrySendError::Full(pkt)) => Err(TryEnqueueError::Full(pkt)),
+        }
+    }
+}
+
 pub enum AdapterManagerMessage {
     RequestTetherId(Packet),
 }


### PR DESCRIPTION
This change adds a mgmt->mgmt queue for ZDP traffic.  The intended use case is for the node to be able to control its internal adapter without making direct function calls (which complicates the internal API structure and poses several deadlocks which need care to resolve).

I tried various iterations of cutting this queueing path short (e.g. by avoiding ZDPR control flow messaging) but each attempt became more complicated than it was worth.  So for now we use full ZDPR signalling rather than implementing a parallel control flow mechanism.

Also, this adds the notion of an "internal link peer".  This is only used for the dock<->internal adapter link on nodes.  This is needed simply so that packets egressed from an internal link find their way to the correct peered link.

We do NOT however run the link state machine on internal links.  Only the ZDPR and dispatch mechanisms.

Finally, we eliminate the existing direct internal calls which can now be mgmt messages.