### PR TITLE
Ssl fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
+ "digest 0.11.3",
  "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
@@ -2197,7 +2198,6 @@ dependencies = [
  "capnp-rpc",
  "clap",
  "crossterm",
- "rand 0.9.4",
  "ratatui",
  "rcgen",
  "rustls",
@@ -2208,7 +2208,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-input",
- "x509-parser",
+ "x509-cert",
  "zpr 0.20.0",
 ]
 
@@ -2723,7 +2723,6 @@ dependencies = [
  "nix 0.29.0",
  "open-enum",
  "pkcs8",
- "rand 0.9.4",
  "rcu 0.1.1",
  "replace_with",
  "reqwest",
@@ -2742,6 +2741,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "x25519-dalek",
+ "x509-cert",
  "zerocopy",
  "zpr 0.20.0",
  "zpr-ext",
@@ -2917,15 +2917,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,16 +3034,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
@@ -3063,29 +3044,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
 
 [[package]]
 name = "rand_core"
@@ -5190,6 +5152,20 @@ dependencies = [
  "getrandom 0.4.2",
  "rand_core 0.10.1",
  "zeroize",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
+dependencies = [
+ "const-oid",
+ "der",
+ "sha1",
+ "signature",
+ "spki",
+ "tls_codec",
 ]
 
 [[package]]

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -32,7 +32,6 @@ libnode = { package = "libnode2", path = "../../libnode2" }
 nix = { version = "0.29.0", features = ["fs", "ioctl", "net", "poll", "uio"] }
 open-enum = { version = "0.5.1" }
 pkcs8 = "0.11"
-rand = "0.9.3"
 rcu = { git = "https://github.com/org-zpr/zpr-utils.git", tag = "rcu-v0.1.1", default-features = false }
 replace_with = "0.1.8"
 reqwest = { version = "0.13.1", features = ["json", "query"] }

--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -54,7 +54,6 @@ zpr = { workspace = true }
 zpr-ext = { workspace = true, features = ["bytes", "tokio", "socket2", "zerocopy"] }
 zpr-utils = { git = "https://github.com/org-zpr/zpr-utils.git", tag = "zpr-utils-v0.2.0"}
 x509-cert = { version = "0.3.0", features = ["builder"] }
-x509-parser = "0.18"
 ed25519-dalek = { version = "3.0.0", features = ["pkcs8", "alloc"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/adapter/ph/src/address_pool.rs
+++ b/adapter/ph/src/address_pool.rs
@@ -1,5 +1,4 @@
 use ipnet::Ipv6Net;
-use rand::{TryRngCore, rngs::OsRng};
 use std::collections::HashSet;
 use std::net::Ipv6Addr;
 use thiserror::Error;
@@ -69,7 +68,7 @@ impl AddressPool {
         addr_bytes[..6].copy_from_slice(&base_addr.segments()[..6]);
 
         let mut buf = [0u8; 8];
-        OsRng.try_fill_bytes(&mut buf).expect("OS RNG Failed");
+        aws_lc_rs::rand::fill(&mut buf).expect("OS RNG Failed");
         let mut this_id = u64::from_be_bytes(buf) & MAX_AAA_ID;
         while !self.active.insert(this_id) {
             this_id = (this_id.wrapping_add(1)) % MAX_AAA_ID;

--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -326,8 +326,10 @@ impl RsaBootstrapAuth {
     /// The visa service (policy) must be configured with the corresponding public key.
     pub fn new(cn: &str, rsa_keyfile: &Path) -> Result<Self, AuthError> {
         let pemdata = std::fs::read(rsa_keyfile)?;
-        let pkey = load_rsa_key(&pemdata)
-            .map_err(|e| AuthError::OpenSSLError(format!("Failed to load RSA key: {}", e)))?;
+        let pkey = Arc::new(
+            load_rsa_key(&pemdata)
+                .map_err(|e| AuthError::OpenSSLError(format!("Failed to load RSA key: {}", e)))?,
+        );
         Ok(RsaBootstrapAuth {
             pkey,
             cn: cn.to_string(),

--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -13,7 +13,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use zerocopy::byteorder::network_endian::*;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
-use rand::{TryRngCore, rngs::OsRng};
 use reqwest::StatusCode;
 use reqwest::header;
 use reqwest::redirect::Policy;
@@ -279,9 +278,7 @@ impl ZdpInitAuthenticationPayload {
             .as_secs() as u64;
         let be_time = ctime.to_be_bytes();
         let mut nonce = [0u8; 8];
-        OsRng
-            .try_fill_bytes(&mut nonce)
-            .expect("failed to generate random bytes for nonce");
+        aws_lc_rs::rand::fill(&mut nonce).expect("failed to generate random bytes for nonce");
         let mut hasher = blake3::Hasher::new_keyed(&key);
         hasher.update(&nonce);
         hasher.update(&be_time);

--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -24,8 +24,10 @@ use thiserror::Error;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use x509_cert::Certificate as X509Certificate;
 
-use crate::pki::{Cert, get_cn_from_cert};
+use crate::pki;
+use crate::pki::get_cn_from_cert;
 
 /// When a node signs a challenge for an adapter it uses this sort of key.
 pub const AUTH_KEY_SIZE_BYTES: usize = 32; // blake3 256bit key
@@ -213,7 +215,7 @@ impl ZdpSelfSignedBlob {
     ///   - The blob is not older than `MAX_BLOB_AGE_SECONDS`.
     pub fn verify_blob_challenge(
         &self,
-        peer_cert: &Cert,
+        peer_cert: &X509Certificate,
         key: &[u8; AUTH_KEY_SIZE_BYTES],
     ) -> Result<(), AuthError> {
         if let Some(link_cn) = get_cn_from_cert(peer_cert) {
@@ -442,10 +444,11 @@ impl OAuthRsa {
     pub async fn authenticate(
         &self,
         service_addr: SocketAddr,
-        tls_cert: Cert,
+        tls_cert: X509Certificate,
     ) -> Result<ZdpAuthCodeBlob, AuthError> {
-        let der = tls_cert.to_der();
-        let tls_cert = Certificate::from_der(der).unwrap();
+        let der = pki::to_der(&tls_cert)
+            .map_err(|e| AuthError::FormatError(format!("cannot encode TLS certificate: {e}")))?;
+        let tls_cert = Certificate::from_der(&der).unwrap();
 
         let nonce_buf = self.preauthorize(service_addr, &tls_cert).await?;
 

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{self, Path, PathBuf};
+use std::sync::Arc;
 use zpr::packet_info::{KM_ID_NOISE, KM_ID_NULL, KmId};
 
 use admin_api::get_data_home;
@@ -296,7 +297,7 @@ impl Config {
                     e
                 ))
             })?;
-            self.rsaoauth = Some(OAuthRsa::new(&cn, priv_key));
+            self.rsaoauth = Some(OAuthRsa::new(&cn, Arc::new(priv_key)));
         }
         Ok(())
     }

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -8,7 +8,7 @@
 //! of a [KeyManagerStateMachine] which does the actual work of creating and
 //! parsing key management ZDP messages.
 
-use crate::pki::Cert;
+use crate::pki;
 use crate::prelude::*;
 use crate::zdp::{ZdpBaseHeader, ZdpPacketType, ZdpZpiHeader};
 use bytes::Bytes;
@@ -21,6 +21,7 @@ use thiserror::Error;
 use tokio::sync::mpsc;
 use tokio::time;
 use tokio_util::sync::CancellationToken;
+use x509_cert::Certificate;
 
 #[derive(Debug, Error)]
 #[allow(dead_code)]
@@ -89,21 +90,35 @@ pub enum DecryptionError {
 /// The key exchange process always swaps certificates, but they may or may not
 /// be signed by our trusted CA. In particular, adapters may create self-signed
 /// certificates.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum PeerCertificate {
-    Verified(Cert),
-    Unverified(Cert),
+    Verified(Certificate),
+    Unverified(Certificate),
+}
+
+/// only prints subject name instead of the whole cert for simpler debug output
+impl fmt::Debug for PeerCertificate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let state = match self {
+            PeerCertificate::Verified(_) => "Verified",
+            PeerCertificate::Unverified(_) => "Unverified",
+        };
+        f.debug_struct("PeerCertificate")
+            .field("state", &state)
+            .field("subject", &pki::subject_name(self.get_cert()).to_string())
+            .finish()
+    }
 }
 
 impl PeerCertificate {
-    pub fn get_cert(&self) -> &Cert {
+    pub fn get_cert(&self) -> &Certificate {
         match self {
             PeerCertificate::Verified(cert) => cert,
             PeerCertificate::Unverified(cert) => cert,
         }
     }
     pub fn common_name(&self) -> Option<String> {
-        self.get_cert().common_name()
+        pki::common_name(self.get_cert())
     }
 }
 

--- a/adapter/ph/src/km_cert_exchange.rs
+++ b/adapter/ph/src/km_cert_exchange.rs
@@ -18,12 +18,13 @@
 //!
 
 use tracing::{error, warn};
+use x509_cert::Certificate;
 use zerocopy::byteorder::network_endian::*;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::km::PeerCertificate;
 use crate::logging::targets::KEY_MGMT;
-use crate::pki::{Cert, ParseError};
+use crate::pki::{self, ParseError};
 
 #[derive(Debug)]
 pub enum CertExchangeError {
@@ -46,14 +47,14 @@ struct CertExchgHdr {
 /// and the certificate for our trusted signing authority.
 #[derive(Clone)]
 pub struct KmCertExchange {
-    local_cert: Cert,
-    authority_cert: Option<Cert>,
+    local_cert: Certificate,
+    authority_cert: Option<Certificate>,
 }
 
 impl KmCertExchange {
     /// - `cert` - the certificate of the initiator.
     /// - `authority_cert` - the certificate of the authority that is expected to have signed the responders certificate.
-    pub fn new(cert: Cert, authority_cert: Option<Cert>) -> Self {
+    pub fn new(cert: Certificate, authority_cert: Option<Certificate>) -> Self {
         KmCertExchange {
             local_cert: cert,
             authority_cert,
@@ -63,8 +64,8 @@ impl KmCertExchange {
     /// Like [KmCertExchange::new] but takes the contents of the various PEM files.
     #[allow(dead_code)]
     pub fn new_from_pem(cert_pem: &str, authority_cert_pem: &str) -> Result<Self, ParseError> {
-        let cert = Cert::from_pem(cert_pem.as_bytes())?;
-        let authority_cert = Cert::from_pem(authority_cert_pem.as_bytes())?;
+        let cert = pki::from_pem(cert_pem.as_bytes())?;
+        let authority_cert = pki::from_pem(authority_cert_pem.as_bytes())?;
         Ok(KmCertExchange::new(cert, Some(authority_cert)))
     }
 
@@ -74,7 +75,8 @@ impl KmCertExchange {
     /// - [CertExchangeError::BufferSizeError] - the buffer is too short to hold the payload.
     /// - [CertExchangeError::CertificateFormatError] - the certificate is too large to be encoded in the payload.
     pub fn write_payload(&self, buf: &mut impl bytes::BufMut) -> Result<(), CertExchangeError> {
-        let cert_der = self.local_cert.to_der();
+        let cert_der =
+            pki::to_der(&self.local_cert).map_err(|_| CertExchangeError::CertificateFormatError)?;
         if cert_der.len() > u16::MAX as usize {
             return Err(CertExchangeError::CertificateFormatError);
         }
@@ -88,7 +90,7 @@ impl KmCertExchange {
             cert_len: sz.into(),
         };
         buf.put(msg.as_bytes());
-        buf.put_slice(cert_der);
+        buf.put_slice(&cert_der);
         Ok(())
     }
 
@@ -126,7 +128,7 @@ impl KmCertExchange {
         }
 
         let cert_offset = std::mem::size_of::<CertExchgHdr>();
-        let initiator_cert = match Cert::from_der(&payload[cert_offset..]) {
+        let initiator_cert = match pki::from_der(&payload[cert_offset..cert_offset + cert_len]) {
             Ok(c) => c,
             Err(e) => {
                 error!(target: KEY_MGMT, "error constructing cert from DER data: {e}");
@@ -135,8 +137,7 @@ impl KmCertExchange {
         };
 
         let is_verified = if let Some(authority_cert) = &self.authority_cert {
-            let authority_pkey = authority_cert.public_key().unwrap(); // TODO: check this unwrap in ctor
-            match initiator_cert.verify(&authority_pkey) {
+            match pki::verify(&initiator_cert, pki::public_key(authority_cert)) {
                 Ok(true) => true,
                 Ok(false) => {
                     warn!(target: KEY_MGMT, "cert failed signature verification");
@@ -151,16 +152,11 @@ impl KmCertExchange {
             false
         };
 
-        // Extract the public key from the cert and check it against expected
-        let initiator_public_key = match initiator_cert.public_key() {
-            Ok(p) => p,
-            Err(e) => {
-                error!(target: KEY_MGMT, "error extracting public key from cert: {e}");
-                return Err(CertExchangeError::CertificateFormatError);
-            }
-        };
-
-        if initiator_public_key.raw_public_key() != expected_peer_public_key {
+        if pki::public_key(&initiator_cert)
+            .subject_public_key
+            .raw_bytes()
+            != expected_peer_public_key
+        {
             return Err(CertExchangeError::KeyMismatchError);
         }
         let peer_result = if is_verified {
@@ -222,7 +218,7 @@ mod test {
         };
 
         // Node emits the initiator cert on success:
-        let adapter_cert = Cert::from_pem(ADAPTER_CERT_DATA.as_bytes()).unwrap();
+        let adapter_cert = pki::from_pem(ADAPTER_CERT_DATA.as_bytes()).unwrap();
         assert_eq!(PeerCertificate::Verified(adapter_cert), i_cert);
     }
 
@@ -255,8 +251,7 @@ mod test {
         let keypair = NoiseKeypair::generate();
 
         let self_signed_cert = generate_self_signed_noise_cert("foo.zpl", &keypair).unwrap();
-        let self_signed_cert_pem = self_signed_cert.to_pem();
-        let self_signed_cert_pem_str = String::from_utf8(self_signed_cert_pem).unwrap();
+        let self_signed_cert_pem_str = pki::to_pem(&self_signed_cert).unwrap();
 
         let adapter_exchanger =
             KmCertExchange::new_from_pem(&self_signed_cert_pem_str, CA_CERT_DATA).unwrap();

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -40,7 +40,6 @@ use crate::prelude::*;
 use base64::prelude::*;
 use bytes::{BufMut, Bytes, BytesMut};
 use curve25519_dalek::montgomery::MontgomeryPoint;
-use rand::{TryRngCore, rngs::OsRng};
 use std::fmt::{self, Display, Formatter};
 use std::sync::atomic::AtomicU64;
 use std::time::{Duration, Instant};
@@ -409,9 +408,7 @@ impl KeyManagerStateMachine for KmNoise {
                 return Err(KmError::ConfigurationError);
             }
         };
-        OsRng
-            .try_fill_bytes(&mut self.recv_hmac_key)
-            .expect("OS RNG Failed"); // generate an HMAC key
+        aws_lc_rs::rand::fill(&mut self.recv_hmac_key).expect("OS RNG Failed"); // generate an HMAC key
         self.send_hmac_key = None;
         if self.initiate {
             let rpk = self.peer_pub_key.as_ref().unwrap();

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -601,7 +601,7 @@ mod test {
 
     use crate::km;
     use crate::km_testdata::test::*;
-    use crate::pki::Cert;
+    use crate::pki;
 
     #[test]
     fn test_noise_handshake_manually_1() {
@@ -760,7 +760,7 @@ mod test {
         assert!(i_transport.peer_cert.is_some());
 
         {
-            let actual_i_cert = match Cert::from_pem(ADAPTER_CERT_DATA.as_bytes()) {
+            let actual_i_cert = match pki::from_pem(ADAPTER_CERT_DATA.as_bytes()) {
                 Ok(cert) => cert,
                 Err(e) => {
                     panic!("error constructing cert from PEM data: {}", e);
@@ -775,7 +775,7 @@ mod test {
         }
 
         {
-            let actual_r_cert = match Cert::from_pem(NODE_CERT_DATA.as_bytes()) {
+            let actual_r_cert = match pki::from_pem(NODE_CERT_DATA.as_bytes()) {
                 Ok(cert) => cert,
                 Err(e) => {
                     panic!("error constructing cert from PEM data: {}", e);

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -4,7 +4,7 @@ use crate::km::{PeerCertificate, ZPIPair};
 use crate::km_multiplexor;
 use crate::mgmt;
 use crate::mgmt::core::{MgmtSendError, PacketStatus};
-use crate::pki::Cert;
+use crate::pki;
 use crate::prelude::*;
 use crate::sample_ring::SampleRing;
 use crate::special_peers;
@@ -584,7 +584,7 @@ impl LinkStateWrapper {
             let require_ca_signature = asm.config.get().ca_file.is_some();
             let (cert, is_verified) = match peer_cert {
                 PeerCertificate::Unverified(cert) => {
-                    warn!(target: LINK_STATE, "{} has unverified name {:?}", asm.formatted_link_id(link_id), cert.common_name());
+                    warn!(target: LINK_STATE, "{} has unverified name {}", asm.formatted_link_id(link_id), pki::subject_name(cert));
                     if require_ca_signature {
                         // If this node has been configured with a CA certificate for checking these things
                         // then these rules kick in:
@@ -611,13 +611,14 @@ impl LinkStateWrapper {
                     (cert, false)
                 }
                 PeerCertificate::Verified(cert) => {
-                    info!(target: LINK_STATE, "{} has verified name {:?}", asm.formatted_link_id(link_id), cert.common_name());
+                    info!(target: LINK_STATE, "{} has verified name {}", asm.formatted_link_id(link_id), pki::subject_name(cert));
                     (cert, true)
                 }
             };
 
             if !is_verified {
-                for name in special_peers::special_peer_names_from_subject_der(&cert.subject_der())
+                for name in
+                    special_peers::special_peer_names_from_subject_der(&pki::subject_der(cert))
                 {
                     warn!(
                         target: LINK_STATE,
@@ -626,7 +627,8 @@ impl LinkStateWrapper {
                 }
             } else {
                 // assign special-peer name if this peer is special
-                for name in special_peers::special_peer_names_from_subject_der(&cert.subject_der())
+                for name in
+                    special_peers::special_peer_names_from_subject_der(&pki::subject_der(cert))
                 {
                     match asm.peer_table.assign_special_name(name, link_id) {
                         Ok(()) => {
@@ -1359,7 +1361,7 @@ impl LinkStateWrapper {
         }
         let service_addr = asa_addrs[0];
 
-        let tls_cert = Cert::from_pem(auth::HARD_CODED_BAS_TLS_CERT_PEM.as_bytes()).unwrap();
+        let tls_cert = pki::from_pem(auth::HARD_CODED_BAS_TLS_CERT_PEM.as_bytes()).unwrap();
         let task_asm = asm.clone();
 
         tokio::task::spawn_local(async move {

--- a/adapter/ph/src/main_argparse.rs
+++ b/adapter/ph/src/main_argparse.rs
@@ -152,7 +152,6 @@ where
 mod test {
 
     use super::*;
-    use rand::Rng;
     use serial_test::{parallel, serial};
     use std::env;
     use std::fs;
@@ -172,13 +171,14 @@ mod test {
 
     impl TempFile {
         fn new_toml(contents: &str) -> TempFile {
-            let mut rng = rand::rng();
             let tstamp = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_millis();
             let dir = env::temp_dir();
-            let num: u32 = rng.random();
+            let mut buf = [0u8; 4];
+            aws_lc_rs::rand::fill(&mut buf).unwrap();
+            let num = u32::from_be_bytes(buf);
             let path = dir.join(format!("org_zpr_ph_test_main_{}_{}.toml", num, tstamp));
             fs::write(&path, contents).expect("Unable to write file");
             TempFile {

--- a/adapter/ph/src/peer_table.rs
+++ b/adapter/ph/src/peer_table.rs
@@ -12,7 +12,6 @@ use bytes::Bytes;
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::DashMap;
 use enum_map::EnumMap;
-use rand::{TryRngCore, rngs::OsRng};
 use rcu::{RcuBox, RcuCslabEntryGuard, RcuOptionGuard};
 use std::default::Default;
 use std::future::Future;
@@ -92,8 +91,7 @@ impl PeerState {
 
         let mut key = [0u8; AUTH_KEY_SIZE_BYTES];
         if link_type == LinkType::NodeToAdapter {
-            OsRng
-                .try_fill_bytes(&mut key)
+            aws_lc_rs::rand::fill(&mut key)
                 .expect("failed to generate random bytes for peer auth key");
         }
         Self {

--- a/adapter/ph/src/pki.rs
+++ b/adapter/ph/src/pki.rs
@@ -137,17 +137,25 @@ pub fn verify(cert: &Certificate, key: &SubjectPublicKeyInfoOwned) -> Result<boo
         ParseError::DecodeError
     })?;
     let sig = cert.signature().raw_bytes();
-    let alg = &cert.signature_algorithm().oid;
+    let sig_alg = &cert.signature_algorithm().oid;
+    let key_alg = &key.algorithm.oid;
     let raw_key = key.subject_public_key.raw_bytes();
-
-    if *alg == OID_SHA256_WITH_RSA {
+    if *key_alg == OID_RSA_ENCRYPTION {
+        if *sig_alg != OID_SHA256_WITH_RSA {
+            error!(target: KEY_MGMT, "signature algorithm {sig_alg} is not valid for an RSA issuer key");
+            return Err(ParseError::KeyError);
+        }
         let vk = UnparsedPublicKey::new(&signature::RSA_PKCS1_2048_8192_SHA256, raw_key);
         Ok(vk.verify(&tbs, sig).is_ok())
-    } else if *alg == OID_ED25519 {
+    } else if *key_alg == OID_ED25519 {
+        if *sig_alg != OID_ED25519 {
+            error!(target: KEY_MGMT, "signature algorithm {sig_alg} is not valid for an Ed25519 issuer key");
+            return Err(ParseError::KeyError);
+        }
         let vk = UnparsedPublicKey::new(&signature::ED25519, raw_key);
         Ok(vk.verify(&tbs, sig).is_ok())
     } else {
-        error!(target: KEY_MGMT, "unsupported certificate signature algorithm: {alg}");
+        error!(target: KEY_MGMT, "unsupported issuer public key algorithm: {key_alg}");
         Err(ParseError::KeyError)
     }
 }
@@ -254,7 +262,8 @@ pub fn get_cn_from_cert(cert: &Certificate) -> Option<String> {
     common_name(cert)
 }
 
-const ID_X25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.110");
+const OID_X25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.110");
+const OID_RSA_ENCRYPTION: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
 const OID_SHA256_WITH_RSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11");
 const OID_ED25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
 
@@ -299,7 +308,7 @@ pub fn generate_self_signed_noise_cert(
 
     let spki = SubjectPublicKeyInfoOwned {
         algorithm: AlgorithmIdentifierOwned {
-            oid: ID_X25519,
+            oid: OID_X25519,
             parameters: None,
         },
         subject_public_key: BitString::from_bytes(&keypair.public)?,

--- a/adapter/ph/src/pki.rs
+++ b/adapter/ph/src/pki.rs
@@ -1,22 +1,22 @@
 //! Collection of PKI related utility functions.
 use aws_lc_rs::signature::{self, UnparsedPublicKey};
-use base64::prelude::{BASE64_STANDARD, Engine as _};
 use ed25519_dalek::{Signature as EdSignature, SigningKey as EdSigningKey};
 use rand::{TryRngCore, rngs::OsRng};
 use std::fs;
-use std::io::Cursor;
 use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
 use thiserror::Error;
 use tracing::error;
 use x509_cert::{
+    Certificate,
     builder::{Builder, CertificateBuilder, profile::BuilderProfile},
     certificate::TbsCertificate,
     der::{
-        Decode, Encode,
+        Decode, Encode, EncodePem,
         asn1::{BitString, OctetStringRef},
         oid::ObjectIdentifier,
+        pem::{self, LineEnding},
     },
     ext::{
         Extension,
@@ -28,11 +28,8 @@ use x509_cert::{
     time::Validity,
 };
 
+use libnode::pki::first_pem_block;
 use pkcs8::PrivateKeyInfoRef;
-use x509_parser::certificate::X509Certificate;
-use x509_parser::oid_registry::{OID_PKCS1_SHA256WITHRSA, OID_SIG_ED25519};
-use x509_parser::pem::Pem;
-use x509_parser::prelude::FromDer;
 
 use crate::km_noise::NoiseKeypair;
 use crate::logging::targets::KEY_MGMT; // TODO: eliminate logging from this module
@@ -61,125 +58,98 @@ pub enum ParseError {
     IOError(#[from] std::io::Error),
 }
 
-///Public key extracted from a certificate.
-pub struct PubKey {
-    key: Vec<u8>,
+/// Construct from DER bytes
+pub fn from_der(der: &[u8]) -> Result<Certificate, ParseError> {
+    Certificate::from_der(der).map_err(|e| {
+        error!(target: KEY_MGMT, "error parsing DER certificate: {e}");
+        ParseError::DecodeError
+    })
 }
 
-impl PubKey {
-    pub fn raw_public_key(&self) -> &[u8] {
-        &self.key
-    }
+/// Construct from PEM bytes
+pub fn from_pem(pem_data: &[u8]) -> Result<Certificate, ParseError> {
+    let text = std::str::from_utf8(pem_data).map_err(|e| {
+        error!(target: KEY_MGMT, "certificate PEM data is not valid UTF-8: {e}");
+        ParseError::PEMFormatError
+    })?;
+    let block = first_pem_block(text).ok_or_else(|| {
+        error!(target: KEY_MGMT, "no PEM block found in certificate data");
+        ParseError::PEMCertNotFound
+    })?;
+    let (_, der) = pem::decode_vec(block.as_bytes()).map_err(|e| {
+        error!(target: KEY_MGMT, "error parsing PEM certificate: {e}");
+        ParseError::PEMFormatError
+    })?;
+    from_der(&der)
 }
 
-// An X.509 certificate, stored as its DER encoding.
-#[derive(Clone, PartialEq, Eq)]
-pub struct Cert {
-    der: Vec<u8>,
+/// The DER encoding of the certificate.
+pub fn to_der(cert: &Certificate) -> Result<Vec<u8>, ParseError> {
+    cert.to_der().map_err(|e| {
+        error!(target: KEY_MGMT, "error encoding certificate: {e}");
+        ParseError::DecodeError
+    })
 }
 
-impl std::fmt::Debug for Cert {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Cert")
-            .field("cn", &self.common_name())
-            .finish()
-    }
+/// The PEM encoding of the certificate. (Used in tests)
+#[allow(dead_code)]
+pub fn to_pem(cert: &Certificate) -> Result<String, ParseError> {
+    EncodePem::to_pem(cert, LineEnding::LF).map_err(|e| {
+        error!(target: KEY_MGMT, "error encoding certificate as PEM: {e}");
+        ParseError::DecodeError
+    })
 }
 
-impl Cert {
-    /// Construct from DER bytes
-    pub fn from_der(der: &[u8]) -> Result<Cert, ParseError> {
-        X509Certificate::from_der(der).map_err(|e| {
-            error!(target: KEY_MGMT, "error parsing DER certificate: {e}");
-            ParseError::DecodeError
-        })?;
-        Ok(Cert { der: der.to_vec() })
-    }
+/// The certificate subject's Common Name
+pub fn common_name(cert: &Certificate) -> Option<String> {
+    cert.tbs_certificate()
+        .subject()
+        .common_name()
+        .ok()?
+        .map(|cn| cn.value().to_string())
+}
 
-    /// Construct from PEM bytes
-    pub fn from_pem(pem: &[u8]) -> Result<Cert, ParseError> {
-        let (_, pem) = x509_parser::pem::parse_x509_pem(pem).map_err(|e| {
-            error!(target: KEY_MGMT, "error parsing PEM certificate: {e}");
-            ParseError::PEMFormatError
-        })?;
-        Cert::from_der(&pem.contents)
-    }
+/// The certificate subject's full distinguished name
+pub fn subject_name(cert: &Certificate) -> &Name {
+    cert.tbs_certificate().subject()
+}
 
-    /// The DER encoding of the certificate.
-    pub fn to_der(&self) -> &[u8] {
-        &self.der
-    }
-
-    /// The PEM encoding of the certificate. (Used in tests)
-    #[allow(dead_code)]
-    pub fn to_pem(&self) -> Vec<u8> {
-        let b64 = BASE64_STANDARD.encode(&self.der);
-        let mut out = String::with_capacity(b64.len() + 64);
-        out.push_str(PEM_BEGIN_CERTIFICATE);
-        out.push('\n');
-        for chunk in b64.as_bytes().chunks(64) {
-            out.push_str(std::str::from_utf8(chunk).unwrap());
-            out.push('\n');
-        }
-        out.push_str(PEM_END_CERTIFICATE);
-        out.push('\n');
-        out.into_bytes()
-    }
-
-    /// The certificate subject's Common Name
-    pub fn common_name(&self) -> Option<String> {
-        let (_, cert) = X509Certificate::from_der(&self.der).ok()?;
-        cert.subject()
-            .iter_common_name()
-            .next()
-            .and_then(|attr| attr.as_str().ok())
-            .map(|s| s.to_string())
-    }
-
-    /// The DER encoding of the subject distinguished name
-    pub fn subject_der(&self) -> Vec<u8> {
-        match X509Certificate::from_der(&self.der) {
-            Ok((_, cert)) => cert.subject().as_raw().to_vec(),
-            Err(e) => {
-                error!(target: KEY_MGMT, "error extracting subject DN: {e}");
-                Vec::new()
-            }
+/// The DER encoding of the subject distinguished name
+pub fn subject_der(cert: &Certificate) -> Vec<u8> {
+    match cert.tbs_certificate().subject().to_der() {
+        Ok(der) => der,
+        Err(e) => {
+            error!(target: KEY_MGMT, "error encoding subject DN: {e}");
+            Vec::new()
         }
     }
+}
 
-    /// Extract the certificate's public key.
-    pub fn public_key(&self) -> Result<PubKey, ParseError> {
-        let (_, cert) = X509Certificate::from_der(&self.der).map_err(|e| {
-            error!(target: KEY_MGMT, "error parsing certificate: {e}");
-            ParseError::DecodeError
-        })?;
-        let key = cert.public_key().subject_public_key.data.to_vec();
-        Ok(PubKey { key })
-    }
+/// Extract the certificate's public key.
+pub fn public_key(cert: &Certificate) -> &SubjectPublicKeyInfoOwned {
+    cert.tbs_certificate().subject_public_key_info()
+}
 
-    /// Verify this certificate's signature against the presumed issuer's
-    /// public key
-    pub fn verify(&self, key: &PubKey) -> Result<bool, ParseError> {
-        let (_, cert) = X509Certificate::from_der(&self.der).map_err(|e| {
-            error!(target: KEY_MGMT, "error parsing certificate for verify: {e}");
-            ParseError::DecodeError
-        })?;
+/// Verify a certificate's signature against the presumed issuer's
+/// public key
+pub fn verify(cert: &Certificate, key: &SubjectPublicKeyInfoOwned) -> Result<bool, ParseError> {
+    let tbs = cert.tbs_certificate().to_der().map_err(|e| {
+        error!(target: KEY_MGMT, "error re-encoding TBS certificate: {e}");
+        ParseError::DecodeError
+    })?;
+    let sig = cert.signature().raw_bytes();
+    let alg = &cert.signature_algorithm().oid;
+    let raw_key = key.subject_public_key.raw_bytes();
 
-        let tbs = cert.tbs_certificate.as_ref();
-        let sig = cert.signature_value.data.as_ref();
-        let alg = &cert.signature_algorithm.algorithm;
-
-        if *alg == OID_PKCS1_SHA256WITHRSA {
-            let vk =
-                UnparsedPublicKey::new(&signature::RSA_PKCS1_2048_8192_SHA256, key.key.as_slice());
-            Ok(vk.verify(tbs, sig).is_ok())
-        } else if *alg == OID_SIG_ED25519 {
-            let vk = UnparsedPublicKey::new(&signature::ED25519, key.key.as_slice());
-            Ok(vk.verify(tbs, sig).is_ok())
-        } else {
-            error!(target: KEY_MGMT, "unsupported certificate signature algorithm: {alg}");
-            Err(ParseError::KeyError)
-        }
+    if *alg == OID_SHA256_WITH_RSA {
+        let vk = UnparsedPublicKey::new(&signature::RSA_PKCS1_2048_8192_SHA256, raw_key);
+        Ok(vk.verify(&tbs, sig).is_ok())
+    } else if *alg == OID_ED25519 {
+        let vk = UnparsedPublicKey::new(&signature::ED25519, raw_key);
+        Ok(vk.verify(&tbs, sig).is_ok())
+    } else {
+        error!(target: KEY_MGMT, "unsupported certificate signature algorithm: {alg}");
+        Err(ParseError::KeyError)
     }
 }
 
@@ -215,20 +185,24 @@ fn extract_cert_pem_data(textdata: &str) -> Result<String, ParseError> {
 }
 
 /// Load a certificate from a file.
-pub fn load_cert(path: &Path) -> Result<Cert, ParseError> {
+pub fn load_cert(path: &Path) -> Result<Certificate, ParseError> {
     let contents = fs::read_to_string(path)?;
     let cert_pem_data = extract_cert_pem_data(&contents)?;
-    Cert::from_pem(cert_pem_data.as_bytes())
+    from_pem(cert_pem_data.as_bytes())
 }
 
 /// Load a private X22519 key from a PEM file
 pub fn load_noise_private_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseError> {
     let contents = fs::read_to_string(path)?;
-    let (block, _) = Pem::read(Cursor::new(contents.as_bytes())).map_err(|e| {
+    let block = first_pem_block(&contents).ok_or_else(|| {
+        error!(target: KEY_MGMT, "no PEM block found in key file");
+        ParseError::PEMFormatError
+    })?;
+    let (_, der) = pem::decode_vec(block.as_bytes()).map_err(|e| {
         error!(target: KEY_MGMT, "error reading key from PEM data: {e}");
         ParseError::PEMFormatError
     })?;
-    let pki = PrivateKeyInfoRef::try_from(block.contents.as_slice()).map_err(|e| {
+    let pki = PrivateKeyInfoRef::try_from(der.as_slice()).map_err(|e| {
         error!(target: KEY_MGMT, "error parsing PKCS#8 private key: {e}");
         ParseError::KeyError
     })?;
@@ -251,11 +225,15 @@ pub fn load_noise_private_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseE
 /// Load a public X22519 key from a PEM file
 pub fn load_noise_public_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseError> {
     let contents = fs::read_to_string(path)?;
-    let (block, _) = Pem::read(Cursor::new(contents.as_bytes())).map_err(|e| {
+    let block = first_pem_block(&contents).ok_or_else(|| {
+        error!(target: KEY_MGMT, "no PEM block found in key file");
+        ParseError::PEMFormatError
+    })?;
+    let (_, der) = pem::decode_vec(block.as_bytes()).map_err(|e| {
         error!(target: KEY_MGMT, "error reading key from PEM data: {e}");
         ParseError::PEMFormatError
     })?;
-    let spki = SubjectPublicKeyInfoOwned::from_der(block.contents.as_slice()).map_err(|e| {
+    let spki = SubjectPublicKeyInfoOwned::from_der(&der).map_err(|e| {
         error!(target: KEY_MGMT, "error parsing SubjectPublicKeyInfo: {e}");
         ParseError::KeyError
     })?;
@@ -273,11 +251,13 @@ pub fn load_noise_public_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseEr
 
 /// Get the CN value as a string out of the certificate. If not found or any
 /// other issue, returns None.
-pub fn get_cn_from_cert(cert: &Cert) -> Option<String> {
-    cert.common_name()
+pub fn get_cn_from_cert(cert: &Certificate) -> Option<String> {
+    common_name(cert)
 }
 
 const ID_X25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.110");
+const OID_SHA256_WITH_RSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11");
+const OID_ED25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
 
 struct NoiseCertProfile {
     name: Name,
@@ -304,7 +284,7 @@ impl BuilderProfile for NoiseCertProfile {
 pub fn generate_self_signed_noise_cert(
     cn: &str,
     keypair: &NoiseKeypair,
-) -> Result<Cert, Box<dyn std::error::Error>> {
+) -> Result<Certificate, Box<dyn std::error::Error>> {
     if cn.is_empty() {
         return Err("CN (common name) must be non-empty".into());
     }
@@ -337,9 +317,8 @@ pub fn generate_self_signed_noise_cert(
     builder.add_extension((false, &key_usage))?;
 
     let cert = builder.build::<_, EdSignature>(&signer)?;
-    let der = cert.to_der()?;
 
-    Ok(Cert { der })
+    Ok(cert)
 }
 
 #[cfg(test)]
@@ -347,9 +326,7 @@ mod test {
 
     use super::*;
 
-    #[test]
-    fn test_extract_cert_pem_data() {
-        let cert_pem_data = r#"-----BEGIN CERTIFICATE-----
+    const TEST_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
 MIIDWzCCAUOgAwIBAgIURkj38EC8A6U5BF8Ue/ZWxz/+SLcwDQYJKoZIhvcNAQEL
 BQAwYjELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAk1BMQ8wDQYDVQQHDAZCb3N0b24x
 CzAJBgNVBAoMAkFJMQwwCgYDVQQLDANaUFIxGjAYBgNVBAMMEWF1dGhvcml0eS56
@@ -371,7 +348,9 @@ n5ystfC9RDOzkrR8ICLvoWBQ52ctmNH3oWs1p1DT3uL6k3QMnNlejIkUqAY51aI=
 -----END CERTIFICATE-----
 "#;
 
-        let cert = Cert::from_pem(cert_pem_data.as_bytes()).unwrap();
+    #[test]
+    fn test_extract_cert_pem_data() {
+        let cert = from_pem(TEST_CERT_PEM.as_bytes()).unwrap();
         let cns = get_cn_from_cert(&cert);
         assert!(cns.is_some());
         let cns = cns.unwrap();
@@ -437,17 +416,15 @@ n5ystfC9RDOzkrR8ICLvoWBQ52ctmNH3oWs1p1DT3uL6k3QMnNlejIkUqAY51aI=
         };
         let builder =
             CertificateBuilder::new(NoiseCertProfile { name }, serial, validity, spki).unwrap();
-        let built = builder.build::<_, EdSignature>(&signer).unwrap();
-        let cert = Cert {
-            der: built.to_der().unwrap(),
-        };
+        let cert = builder.build::<_, EdSignature>(&signer).unwrap();
 
-        let pubkey = cert.public_key().unwrap();
         // The correct Ed25519 key verifies the signature.
-        assert!(cert.verify(&pubkey).unwrap());
+        assert!(verify(&cert, public_key(&cert)).unwrap());
         // A tampered key does not.
-        let mut other = pubkey.raw_public_key().to_vec();
-        other[0] ^= 0xff;
-        assert!(!cert.verify(&PubKey { key: other }).unwrap());
+        let mut tampered = public_key(&cert).clone();
+        let mut raw_tampered = tampered.subject_public_key.raw_bytes().to_vec();
+        raw_tampered[0] ^= 0xff;
+        tampered.subject_public_key = BitString::from_bytes(&raw_tampered).unwrap();
+        assert!(!verify(&cert, &tampered).unwrap());
     }
 }

--- a/adapter/ph/src/pki.rs
+++ b/adapter/ph/src/pki.rs
@@ -1,7 +1,6 @@
 //! Collection of PKI related utility functions.
 use aws_lc_rs::signature::{self, UnparsedPublicKey};
 use ed25519_dalek::{Signature as EdSignature, SigningKey as EdSigningKey};
-use rand::{TryRngCore, rngs::OsRng};
 use std::fs;
 use std::path::Path;
 use std::str::FromStr;
@@ -292,7 +291,7 @@ pub fn generate_self_signed_noise_cert(
     let name = Name::from_str(&format!("CN={cn}"))?;
 
     let mut serial_bytes = [0u8; 16];
-    OsRng.try_fill_bytes(&mut serial_bytes)?;
+    aws_lc_rs::rand::fill(&mut serial_bytes)?;
     serial_bytes[0] &= 0x7f;
     let serial = SerialNumber::new(&serial_bytes)?;
 
@@ -307,7 +306,7 @@ pub fn generate_self_signed_noise_cert(
     };
 
     let mut seed = [0u8; 32];
-    OsRng.try_fill_bytes(&mut seed)?;
+    aws_lc_rs::rand::fill(&mut seed)?;
 
     let signer = EdSigningKey::from_bytes(&seed);
 
@@ -397,13 +396,13 @@ n5ystfC9RDOzkrR8ICLvoWBQ52ctmNH3oWs1p1DT3uL6k3QMnNlejIkUqAY51aI=
         const ID_ED25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
 
         let mut seed = [0u8; 32];
-        OsRng.try_fill_bytes(&mut seed).unwrap();
+        aws_lc_rs::rand::fill(&mut seed).unwrap();
         let signer = EdSigningKey::from_bytes(&seed);
         let verifying = signer.verifying_key();
 
         let name = Name::from_str("CN=ed25519.test").unwrap();
         let mut serial_bytes = [0u8; 16];
-        OsRng.try_fill_bytes(&mut serial_bytes).unwrap();
+        aws_lc_rs::rand::fill(&mut serial_bytes).unwrap();
         serial_bytes[0] &= 0x7f;
         let serial = SerialNumber::new(&serial_bytes).unwrap();
         let validity = Validity::from_now(Duration::from_hours(24)).unwrap();

--- a/adapter/ph/src/special_peers.rs
+++ b/adapter/ph/src/special_peers.rs
@@ -22,15 +22,15 @@ pub fn special_peer_names_from_subject_der(dn_der: &[u8]) -> EnumSet<SpecialPeer
 mod test {
     use super::*;
     use crate::km_noise::NoiseKeypair;
-    use crate::pki::generate_self_signed_noise_cert;
+    use crate::pki::{self, generate_self_signed_noise_cert};
     use zpr::dn::VISA_SERVICE_CN;
 
     #[test]
     fn matches_visa_service_dn() {
         let keypair = NoiseKeypair::generate();
         let cert = generate_self_signed_noise_cert(VISA_SERVICE_CN, &keypair).unwrap();
-        assert_eq!(cert.subject_der().as_slice(), VISA_SERVICE_DN);
-        let names = special_peer_names_from_subject_der(&cert.subject_der());
+        assert_eq!(pki::subject_der(&cert).as_slice(), VISA_SERVICE_DN);
+        let names = special_peer_names_from_subject_der(&pki::subject_der(&cert));
         assert!(names.contains(SpecialPeerName::VisaServiceAdapter));
     }
 
@@ -38,6 +38,6 @@ mod test {
     fn ignores_other_dn() {
         let keypair = NoiseKeypair::generate();
         let cert = generate_self_signed_noise_cert("not-special.zpr", &keypair).unwrap();
-        assert!(special_peer_names_from_subject_der(&cert.subject_der()).is_empty());
+        assert!(special_peer_names_from_subject_der(&pki::subject_der(&cert)).is_empty());
     }
 }

--- a/libnode2/Cargo.toml
+++ b/libnode2/Cargo.toml
@@ -16,7 +16,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
 zpr = { workspace = true }
 rand = "0.9.3"
-x509-parser = "0.18"
+x509-cert = "0.3.0"
 
 crossterm = { version = "0.29", optional = true } # lnt
 ratatui = { version = "0.30", optional = true } # lnt

--- a/libnode2/Cargo.toml
+++ b/libnode2/Cargo.toml
@@ -15,7 +15,6 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
 zpr = { workspace = true }
-rand = "0.9.3"
 x509-cert = "0.3.0"
 
 crossterm = { version = "0.29", optional = true } # lnt

--- a/libnode2/src/cli/crypto.rs
+++ b/libnode2/src/cli/crypto.rs
@@ -2,7 +2,6 @@
 
 use crate::rsa_sign::{load_rsa_key, sign_rsa_key};
 use aws_lc_rs::signature::RsaKeyPair;
-use rand::{TryRngCore, rngs::OsRng};
 use std::fs;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -18,7 +17,7 @@ pub fn build_self_signed_blob(
     private_key: &RsaKeyPair,
 ) -> Result<SelfSignedBlob, Box<dyn std::error::Error>> {
     let mut challenge = vec![0u8; 32];
-    OsRng.try_fill_bytes(&mut challenge)?;
+    aws_lc_rs::rand::fill(&mut challenge)?;
 
     let timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/libnode2/src/cli/crypto.rs
+++ b/libnode2/src/cli/crypto.rs
@@ -5,7 +5,6 @@ use aws_lc_rs::signature::RsaKeyPair;
 use rand::{TryRngCore, rngs::OsRng};
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use zpr::vsapi_types::{ChallengeAlg, SelfSignedBlob};
 
@@ -45,7 +44,7 @@ pub fn build_self_signed_blob(
 /// Load an RSA private key from a PEM file.
 pub fn load_private_key(
     keyfile: &Path,
-) -> Result<Arc<RsaKeyPair>, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<RsaKeyPair, Box<dyn std::error::Error + Send + Sync>> {
     let key_data = fs::read(keyfile)?;
     Ok(load_rsa_key(&key_data)?)
 }

--- a/libnode2/src/cli/handler.rs
+++ b/libnode2/src/cli/handler.rs
@@ -4,7 +4,6 @@
 //! processes lifecycle events, user commands, and incoming VSS messages until
 //! the user disconnects.
 
-use rand::{TryRngCore, rngs::OsRng};
 use std::net::{IpAddr, Ipv4Addr};
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::AbortHandle;
@@ -168,7 +167,7 @@ pub async fn run_handler(
                             };
 
                             let mut rand_octets = [0u8; 3];
-                            OsRng.try_fill_bytes(&mut rand_octets).expect("OS RNG Failed");
+                            aws_lc_rs::rand::fill(&mut rand_octets).expect("OS RNG Failed");
                             let substrate_addr = IpAddr::V4(Ipv4Addr::new(
                                 10, rand_octets[0], rand_octets[1], rand_octets[2],
                             ));

--- a/libnode2/src/pki.rs
+++ b/libnode2/src/pki.rs
@@ -1,8 +1,8 @@
 use std::fs;
 use std::path::Path;
 use thiserror::Error;
-use x509_parser::certificate::X509Certificate;
-use x509_parser::prelude::FromDer;
+use x509_cert::Certificate;
+use x509_cert::der::{Decode, pem};
 
 const PEM_BEGIN_CERTIFICATE: &str = "-----BEGIN CERTIFICATE-----";
 const PEM_END_CERTIFICATE: &str = "-----END CERTIFICATE-----";
@@ -19,14 +19,26 @@ pub enum ParseError {
     IOError(#[from] std::io::Error),
 }
 
+/// Isolate the first PEM block
+pub fn first_pem_block(text: &str) -> Option<&str> {
+    let begin = text.find("-----BEGIN ")?;
+    let rest = &text[begin..];
+    let end = rest.find("-----END ")?;
+    let line_end = rest[end..]
+        .find('\n')
+        .map(|i| end + i + 1)
+        .unwrap_or(rest.len());
+    Some(&rest[..line_end])
+}
+
 /// Get the CN from DER-encoded certificate
 pub fn get_cn_from_cert(der: &[u8]) -> Option<String> {
-    let (_, cert) = X509Certificate::from_der(der).ok()?;
-    cert.subject()
-        .iter_common_name()
-        .next()
-        .and_then(|attr| attr.as_str().ok())
-        .map(|s| s.to_string())
+    let cert = Certificate::from_der(der).ok()?;
+    cert.tbs_certificate()
+        .subject()
+        .common_name()
+        .ok()?
+        .map(|cn| cn.value().to_string())
 }
 
 /// Load a certificate from a file.
@@ -36,9 +48,9 @@ pub fn load_cert(path: &Path) -> Result<Vec<u8>, ParseError> {
         Err(e) => return Err(ParseError::IOError(e)),
     };
     let cert_pem_data = extract_cert_pem_data(&contents)?;
-    let (_, pem) = x509_parser::pem::parse_x509_pem(cert_pem_data.as_bytes())
+    let (_, der) = pem::decode_vec(cert_pem_data.as_bytes())
         .map_err(|e| ParseError::PEMFormatError(e.to_string()))?;
-    Ok(pem.contents)
+    Ok(der)
 }
 
 /// Look for first instance of "-----BEGIN CERTIFICATE-----" and return that up to and

--- a/libnode2/src/rsa_sign.rs
+++ b/libnode2/src/rsa_sign.rs
@@ -1,19 +1,22 @@
-//! RSA signinging helpers using aws-lc-rs
+//! RSA signing helpers using aws-lc-rs
 
 use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::signature::{RSA_PKCS1_SHA256, RsaKeyPair};
-use std::io::Cursor;
-use x509_parser::pem::Pem;
+use x509_cert::der::pem;
+
+use crate::pki::first_pem_block;
 
 //Wrapped potential errors
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 //Parses to create RSA key pair
 pub fn load_rsa_key(pem_bytes: &[u8]) -> Result<RsaKeyPair, BoxError> {
-    let (block, _) = Pem::read(Cursor::new(pem_bytes))?;
-    let key = match block.label.as_str() {
-        "RSA PRIVATE KEY" => RsaKeyPair::from_der(block.contents.as_slice())?,
-        "PRIVATE KEY" => RsaKeyPair::from_pkcs8(block.contents.as_slice())?,
+    let text = std::str::from_utf8(pem_bytes)?;
+    let pem_block = first_pem_block(text).ok_or("no PEM block found")?;
+    let (label, der) = pem::decode_vec(pem_block.as_bytes())?;
+    let key = match label {
+        "RSA PRIVATE KEY" => RsaKeyPair::from_der(&der)?,
+        "PRIVATE KEY" => RsaKeyPair::from_pkcs8(&der)?,
         other => return Err(format!("unsupported PEM tag: {other}").into()),
     };
     Ok(key)

--- a/libnode2/src/rsa_sign.rs
+++ b/libnode2/src/rsa_sign.rs
@@ -3,21 +3,20 @@
 use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::signature::{RSA_PKCS1_SHA256, RsaKeyPair};
 use std::io::Cursor;
-use std::sync::Arc;
 use x509_parser::pem::Pem;
 
 //Wrapped potential errors
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 //Parses to create RSA key pair
-pub fn load_rsa_key(pem_bytes: &[u8]) -> Result<Arc<RsaKeyPair>, BoxError> {
+pub fn load_rsa_key(pem_bytes: &[u8]) -> Result<RsaKeyPair, BoxError> {
     let (block, _) = Pem::read(Cursor::new(pem_bytes))?;
     let key = match block.label.as_str() {
         "RSA PRIVATE KEY" => RsaKeyPair::from_der(block.contents.as_slice())?,
         "PRIVATE KEY" => RsaKeyPair::from_pkcs8(block.contents.as_slice())?,
         other => return Err(format!("unsupported PEM tag: {other}").into()),
     };
-    Ok(Arc::new(key))
+    Ok(key)
 }
 
 //Signs RSA key pair padded with aws_lc_rs::rand random bytes

--- a/libnode2/src/vsconn.rs
+++ b/libnode2/src/vsconn.rs
@@ -125,7 +125,7 @@ pub struct VSConn {
     cmd_rx: mpsc::Receiver<VS2Command>,
     vs_addr: SocketAddr,
     node_cn: String,
-    node_private_key: Arc<RsaKeyPair>,
+    node_private_key: RsaKeyPair,
     life_tx: broadcast::Sender<VSConnLifecycleEvent>,
     connect_fn: ConnectFn,
 }
@@ -194,7 +194,7 @@ impl VSConn {
         buffer_size: usize,
         vs_addr: SocketAddr,
         node_cn: String,
-        node_private_key: Arc<RsaKeyPair>,
+        node_private_key: RsaKeyPair,
     ) -> Self {
         let (cmd_tx, cmd_rx) = mpsc::channel(buffer_size);
         let (life_tx, _) = broadcast::channel(LIFECYCLE_EVENT_BUFFER_SIZE);
@@ -663,12 +663,7 @@ impl VSConn {
                     alg
                 )));
             }
-            sign_payload(
-                timestamp,
-                &self.node_cn,
-                chal_data,
-                self.node_private_key.clone(),
-            )
+            sign_payload(timestamp, &self.node_cn, chal_data, &self.node_private_key)
         };
 
         // Now authenticate with the gate.
@@ -1032,14 +1027,14 @@ fn sign_payload(
     timestamp: u64,
     cn: &str,
     challenge_data: &[u8],
-    private_key: Arc<RsaKeyPair>,
+    private_key: &RsaKeyPair,
 ) -> Vec<u8> {
     let mut data = Vec::new();
     data.extend_from_slice(&timestamp.to_be_bytes());
     data.extend_from_slice(cn.as_bytes());
     data.extend_from_slice(challenge_data);
 
-    sign_rsa_key(&private_key, &data)
+    sign_rsa_key(private_key, &data)
 }
 
 /// Wrap a Cap'n Proto RPC future with a timeout, mapping errors to VSApiError.
@@ -1138,7 +1133,7 @@ mod tests {
         fn new_for_test(
             vs_addr: SocketAddr,
             node_cn: String,
-            node_private_key: Arc<RsaKeyPair>,
+            node_private_key: RsaKeyPair,
             connect_fn: ConnectFn,
         ) -> Self {
             let (cmd_tx, cmd_rx) = mpsc::channel(16);
@@ -1155,8 +1150,8 @@ mod tests {
         }
     }
 
-    fn test_key() -> Arc<RsaKeyPair> {
-        Arc::new(RsaKeyPair::generate(KeySize::Rsa2048).unwrap())
+    fn test_key() -> RsaKeyPair {
+        RsaKeyPair::generate(KeySize::Rsa2048).unwrap()
     }
 
     /// Connect function that always fails immediately with ConnectionRefused.


### PR DESCRIPTION
Addresses all review comments on the opensslswitch pr request. I branched off, fixed everything, and than split into three commits. 1. Dropped the Arc around RSA private key everywhere Clone wasn't derived. 2. Removed x509-parser (functionality replaced with x509-cert) and removed custom Pubkey and Cert structs for x509_cert::Certificate and spki::SubjectPublicKeyInfoOwned. 3. Swapped out OsRNg with aws_lc_s::rand::fill. 