### PR TITLE
switch KM Noise protocol from IK to XX mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "admin-api"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "capnp",
  "capnpc",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "libnode2"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aws-lc-rs",
  "capnp",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "ph"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "admin-api",
  "arrayref",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "ph-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "admin-api",
  "capnp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 members = ["adapter/admin-api", "adapter/ph", "adapter/cli", "libnode2"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/adapter/ph/example-adapter-config.toml
+++ b/adapter/ph/example-adapter-config.toml
@@ -92,12 +92,3 @@ private_key_file = "tests/private_key.pem"
     #              to.
     # ------------------------------------------------------------------------
 node_addr = "192.168.0.2:5000"
-
-    # ------------------------------------------------------------------------
-    # node_public_key_file
-    #
-    # [required] - Path to the PEM file containing the nodes
-    #              noise public key.
-    # ------------------------------------------------------------------------
-node_public_key_file = "tests/node_public_key.pem"
-

--- a/adapter/ph/src/assembly.rs
+++ b/adapter/ph/src/assembly.rs
@@ -89,7 +89,6 @@ pub struct Assembly {
     pub km_state: KmState,
 
     pub self_noise_keypair: Option<NoiseKeypair>,
-    pub peer_noise_keypair: Option<NoiseKeypair>,
     pub a2a_dh_keypair: ReusableSecret,
     pub certx: Option<KmCertExchange>,
     pub system_start_time: std::time::Instant,
@@ -549,7 +548,6 @@ pub mod test {
             adapter_manager_factory,
             km_state,
             self_noise_keypair: None,
-            peer_noise_keypair: None,
             a2a_dh_keypair: ReusableSecret::random(),
             certx: None,
             system_start_time: std::time::Instant::now(),

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -158,9 +158,6 @@ pub struct Config {
     /// Required for node, optional for adapter - the ZPR address (no port) of the adapter.
     pub zpr_addr: Vec<IpAddr>,
 
-    /// Required for adapter - the path to the PEM file containing the nodes noise public key (not a certificate).
-    pub node_public_key_file: Option<PathBuf>,
-
     /// Ignored for node, optional for adapter - Only set if the adapter is configured for bootstrap authentication.
     pub bootstrap: Option<RsaBootstrapAuth>,
 
@@ -356,14 +353,6 @@ impl Config {
                 if self.node_addr.is_none() {
                     return Err("node_addr".arg_missing());
                 }
-                if self.node_public_key_file.is_none() {
-                    return Err("node_public_key_file".arg_missing());
-                } else {
-                    check_file_exists(
-                        "node public key file",
-                        &self.node_public_key_file.as_ref().unwrap(),
-                    )?;
-                }
                 if self.certificate_file.is_none() && self.name.is_empty() {
                     return Err("name (required when certificate_file is absent)".arg_missing());
                 }
@@ -452,13 +441,6 @@ impl Config {
         }
         if let Some(node_addr) = &config.node_addr {
             self.node_addr = Some(*node_addr);
-        }
-        if let Some(node_public_key_file) = &config.node_public_key_file {
-            if node_public_key_file.is_relative() {
-                self.node_public_key_file = Some(base_dir.join(node_public_key_file));
-            } else {
-                self.node_public_key_file = Some(node_public_key_file.clone());
-            }
         }
 
         if let Some(bootstrap_key_file) = &config.bootstrap_key {
@@ -597,7 +579,6 @@ impl Default for Config {
             logging: Vec::new(),
             node_addr: None,
             zpr_addr: Vec::new(),
-            node_public_key_file: None,
             bootstrap: None,
             rsaoauth: None,
             bootstrap_key_path: None,
@@ -649,7 +630,6 @@ pub struct GlobalConfigSection {
 pub struct AdapterConfigSection {
     pub name: Option<String>,
     pub node_addr: Option<SocketAddr>,
-    pub node_public_key_file: Option<PathBuf>,
     pub bootstrap_key: Option<PathBuf>,
 }
 
@@ -739,7 +719,6 @@ mod test {
     fn test_deserialize_adapter_config() {
         let toml_str = r#"
             node_addr = "10.0.0.1:5000"
-            node_public_key_file = "node_pubkey.pem"
             bootstrap_key = "rsa_key.pem"
             "#;
         let _config: AdapterConfigSection = toml::from_str(toml_str).unwrap();

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -117,8 +117,13 @@ impl PeerCertificate {
             PeerCertificate::Unverified(cert) => cert,
         }
     }
+
     pub fn common_name(&self) -> Option<String> {
         pki::common_name(self.get_cert())
+    }
+
+    pub fn is_verified(&self) -> bool {
+        matches!(self, Self::Verified(_))
     }
 }
 

--- a/adapter/ph/src/km_cert_exchange.rs
+++ b/adapter/ph/src/km_cert_exchange.rs
@@ -167,6 +167,12 @@ impl KmCertExchange {
         };
         return Ok(peer_result);
     }
+
+    /// Do we require certificate verification?
+    /// (That is, are we configured with an authority certificate?)
+    pub fn requires_verification(&self) -> bool {
+        self.authority_cert.is_some()
+    }
 }
 
 #[cfg(test)]

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -206,7 +206,7 @@ pub fn add_adapter_link(
     local_noise_key: NoiseKeypair,
     certx: KmCertExchange,
 ) -> Result<(), KmSetupError> {
-    let noise = match KmNoise::new(true, Some(local_noise_key), recv_zpis, certx) {
+    let noise = match KmNoise::new(true, true, Some(local_noise_key), recv_zpis, certx) {
         Ok(n) => n,
         Err(e) => {
             return Err(KmSetupError::InitializationError(e));
@@ -229,7 +229,7 @@ pub fn add_node_link(
     local_noise_key: NoiseKeypair,
     certx: KmCertExchange,
 ) -> Result<(), KmSetupError> {
-    let noise = match KmNoise::new(false, Some(local_noise_key), recv_zpis, certx) {
+    let noise = match KmNoise::new(false, false, Some(local_noise_key), recv_zpis, certx) {
         Ok(n) => n,
         Err(e) => return Err(KmSetupError::InitializationError(e)),
     };
@@ -443,8 +443,14 @@ mod test {
                 }
 
                 // Pretend to be a node and send back a valid reply.
-                let mut responder =
-                    KmNoise::new(false, Some(node_kp), ZPIPair::new(3, 4), node_exchanger).unwrap();
+                let mut responder = KmNoise::new(
+                    false,
+                    false,
+                    Some(node_kp),
+                    ZPIPair::new(3, 4),
+                    node_exchanger,
+                )
+                .unwrap();
                 match responder.reset() {
                     Ok(Some(_m)) => panic!("unexpected message from responder.reset!"),
                     Ok(None) => {} // good

--- a/adapter/ph/src/km_multiplexor.rs
+++ b/adapter/ph/src/km_multiplexor.rs
@@ -194,7 +194,6 @@ pub async fn launch_message_worker(
 ///
 ///
 /// - `link_id` is the link to the peer, in this case better be a link to a node.
-/// - `peer_noise_key` is the public noise key for the node/dock.
 ///
 /// Note that the link must already have a peer_table entry.
 ///
@@ -205,16 +204,9 @@ pub fn add_adapter_link(
     link_id: LinkId,
     recv_zpis: ZPIPair,
     local_noise_key: NoiseKeypair,
-    peer_noise_key: [u8; 32],
     certx: KmCertExchange,
 ) -> Result<(), KmSetupError> {
-    let noise = match KmNoise::new(
-        true,
-        Some(peer_noise_key.into()),
-        Some(local_noise_key),
-        recv_zpis,
-        certx,
-    ) {
+    let noise = match KmNoise::new(true, Some(local_noise_key), recv_zpis, certx) {
         Ok(n) => n,
         Err(e) => {
             return Err(KmSetupError::InitializationError(e));
@@ -237,7 +229,7 @@ pub fn add_node_link(
     local_noise_key: NoiseKeypair,
     certx: KmCertExchange,
 ) -> Result<(), KmSetupError> {
-    let noise = match KmNoise::new(false, None, Some(local_noise_key), recv_zpis, certx) {
+    let noise = match KmNoise::new(false, Some(local_noise_key), recv_zpis, certx) {
         Ok(n) => n,
         Err(e) => return Err(KmSetupError::InitializationError(e)),
     };
@@ -351,16 +343,17 @@ mod test {
 
     #[tokio::test]
     async fn test_km_multiplexor_updates_assembly_state() {
-        let node_kp = NoiseKeypair::new(
+        let adapter_kp = NoiseKeypair::new(
             BASE64_STANDARD
-                .decode(NODE_NOISE_KEY)
+                .decode(ADAPTER_NOISE_KEY)
                 .unwrap()
                 .try_into()
                 .unwrap(),
         );
-        let adapter_kp = NoiseKeypair::new(
+
+        let node_kp = NoiseKeypair::new(
             BASE64_STANDARD
-                .decode(ADAPTER_NOISE_KEY)
+                .decode(NODE_NOISE_KEY)
                 .unwrap()
                 .try_into()
                 .unwrap(),
@@ -417,7 +410,6 @@ mod test {
                     adapter_link_id,
                     ZPIPair::new(1, 2),
                     adapter_kp,
-                    node_kp.public.clone(),
                     adapter_exchanger,
                 )
                 .unwrap();
@@ -434,7 +426,7 @@ mod test {
                     Ok(resp) => match resp {
                         Some(KmLinkMsg { link_id, msg }) => {
                             assert_eq!(link_id, adapter_link_id);
-                            assert_eq!(msg.len(), 913); // should be a KM payload
+                            assert_eq!(msg.len(), 32);
                             handshake_req = msg;
                         }
                         None => panic!("Expected KMLinkMessage message"),
@@ -451,14 +443,8 @@ mod test {
                 }
 
                 // Pretend to be a node and send back a valid reply.
-                let mut responder = KmNoise::new(
-                    false,
-                    None,
-                    Some(node_kp),
-                    ZPIPair::new(3, 4),
-                    node_exchanger,
-                )
-                .unwrap();
+                let mut responder =
+                    KmNoise::new(false, Some(node_kp), ZPIPair::new(3, 4), node_exchanger).unwrap();
                 match responder.reset() {
                     Ok(Some(_m)) => panic!("unexpected message from responder.reset!"),
                     Ok(None) => {} // good
@@ -482,6 +468,28 @@ mod test {
                 handle_inbound_km_msg(&asm, adapter_link_id, &handshake_reply).unwrap();
 
                 yield_now().await;
+
+                // The adapter should now reply.
+                let handshake_req2: Bytes;
+                match timeout(Duration::from_secs(2), km_rx.recv()).await {
+                    Ok(resp) => match resp {
+                        Some(KmLinkMsg { link_id, msg }) => {
+                            assert_eq!(link_id, adapter_link_id);
+                            assert_eq!(msg.len(), 881); // should be a KM payload
+                            handshake_req2 = msg;
+                        }
+                        None => panic!("Expected KMLinkMessage message"),
+                    },
+                    Err(_) => panic!("Timed out waiting for KM message"),
+                }
+
+                match responder.handle_message(&handshake_req2, KM_ID_NOISE) {
+                    Ok(Some(_)) => panic!("unexpected additional handshake message from responder"),
+                    Ok(None) => {} // good
+                    Err(e) => {
+                        panic!("responder handle_message failed on handshake-req: {:?}", e);
+                    }
+                };
 
                 // The KM on the link will process the message and transition to established-state.
                 // It will send two signals - SaIdChange followed by SaEstablished.  Both signals

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -72,6 +72,9 @@ pub struct KmNoise {
     /// which message in the handshake sequence is next to send or receive
     msg_nr: u8,
     initiate: bool,
+    /// Should we abort if we cannot verify the certificate received from the peer?
+    /// (Has no effect if the KmCertificateExchange is not configured for validation.)
+    verify_cert: bool,
     local_keypair: NoiseKeypair,
     hs_sent_t: Option<Instant>,
     hs_state: Option<snow::HandshakeState>,
@@ -189,6 +192,7 @@ impl KmNoise {
     /// - `certx` is the certificate exchange creator/verifier.
     pub fn new(
         initiate: bool,
+        verify_cert: bool,
         local_keypair: Option<NoiseKeypair>,
         zpis: ZPIPair,
         certx: KmCertExchange,
@@ -211,6 +215,7 @@ impl KmNoise {
             state: KmSMState::Configuring,
             msg_nr: 0,
             initiate,
+            verify_cert,
             local_keypair: kp,
             hs_sent_t: None,
             hs_state: None,
@@ -507,7 +512,18 @@ impl KeyManagerStateMachine for KmNoise {
                         }
                     };
                     match self.parse_km_payload(&payload[..len], peer_pubkey) {
-                        Ok(_) => {}
+                        Ok(_) => {
+                            if self.verify_cert
+                                && self.certx.requires_verification()
+                                && !self.peer_cert.as_ref().is_some_and(|c| c.is_verified())
+                            {
+                                error!(target: KEY_MGMT, "noise: unable to verify remote certificate; aborting handshake");
+                                self.state = KmSMState::Error;
+                                self.hs_state = Some(hs);
+                                return Err(KmError::CertExchangeError);
+                            }
+                        }
+
                         Err(_) => {
                             self.state = KmSMState::Error;
                             self.hs_state = Some(hs);
@@ -644,6 +660,7 @@ mod test {
 
         let mut initiator = KmNoise::new(
             true,
+            true,
             Some(initiator_keypair),
             ZPIPair::new(1, 2),
             initiator_exchanger,
@@ -655,6 +672,7 @@ mod test {
             KmCertExchange::new_from_pem(NODE_CERT_DATA, CA_CERT_DATA).unwrap();
 
         let mut responder = KmNoise::new(
+            false,
             false,
             Some(node_kp),
             ZPIPair::new(3, 4),
@@ -868,6 +886,7 @@ mod test {
 
         let initiator = KmNoise::new(
             true,
+            true,
             Some(adapter_kp),
             ZPIPair::new(1, 2),
             initiator_exchanger,
@@ -875,6 +894,7 @@ mod test {
         .unwrap();
 
         let responder = KmNoise::new(
+            false,
             false,
             Some(node_kp),
             ZPIPair::new(3, 4),

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -1,9 +1,11 @@
 //! KeyManager implementation using Noise protocol.
 //!
-//! Configured to use the "IK" pattern (see Noise paper).  This is same as what wireguard uses
-//! and requires that initiators know the 25519 public key of the responder.  The idea here
-//! is that an adapter wanting to connect to a remote node will have access to this key.
-//! Maybe through a special DNS record.
+//! Configured to use the "XX" pattern (see Noise paper).  This does not
+//! require that initiators know the 25519 public key of the responder.  The
+//! idea here is that an adapter wanting to connect to a remote node will
+//! validate the certificate which the node sends against a well-known CA
+//! certificate and confirm that the certificate's public key matches that
+//! exchanged by Noise.
 //!
 //! The key management messages are all handled by the noise protocol.
 //!
@@ -44,7 +46,7 @@ use std::fmt::{self, Display, Formatter};
 use std::sync::atomic::AtomicU64;
 use std::time::{Duration, Instant};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
-static PATTERN: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
+static PATTERN: &str = "Noise_XX_25519_ChaChaPoly_BLAKE2s";
 
 const MSG_BUF_SIZE: usize = 4096;
 
@@ -67,18 +69,32 @@ impl From<snow::Error> for KmError {
 pub struct KmNoise {
     settings: KmSettings,
     state: KmSMState,
+    /// which message in the handshake sequence is next to send or receive
+    msg_nr: u8,
     initiate: bool,
-    peer_pub_key: Option<Vec<u8>>, // required if initiator
     local_keypair: NoiseKeypair,
     hs_sent_t: Option<Instant>,
     hs_state: Option<snow::HandshakeState>,
     //t_state: Option<snow::TransportState>,
-    recv_hmac_key: [u8; HMAC_KEY_LEN], // messages sent to us from peer will use this key (we create this)
-    send_hmac_key: Option<[u8; HMAC_KEY_LEN]>, // messages sent to peer will use this key (peers creates this)
+    /// messages sent to us from peer will use this key (we create this)
+    recv_hmac_key: [u8; HMAC_KEY_LEN],
+    /// messages sent to peer will use this key (peers creates this)
+    send_hmac_key: Option<[u8; HMAC_KEY_LEN]>,
     recv_zpis: ZPIPair,
     send_zpis: Option<ZPIPair>,
     certx: KmCertExchange,
-    peer_cert: Option<PeerCertificate>, // result of key exchange
+    /// result of key exchange
+    peer_cert: Option<PeerCertificate>,
+}
+
+/// Should this message number in the Noise handshake sequence carry a ZPI
+/// parameter payload.  Which message(s) this is varies by Noise pattern
+/// chosen.
+fn msg_carries_zpi_payload(msg_nr: u8) -> bool {
+    // Our XX pattern has three handshake messages.  We only expect to find
+    // a KeyMsg in the payload of the 2nd and 3rd messages: the 1st message
+    // is not encrypted.  (Note, msg_nr is 0-based).
+    msg_nr == 1 || msg_nr == 2
 }
 
 /// Holds a noise keypair.
@@ -162,29 +178,21 @@ struct KeyMsg {
 impl KmNoise {
     /// Create the Noise KeyManager.
     ///
-    /// This requires Noise keys.  Eventually (TODO) we will also pass certificates through here
+    /// This requires Noise keys.  We also pass certificates through here
     /// so that each side can check for certificate authority signautre.
-    /// (<https://github.com/org-zpr/zpr-core/issues/419>)
     ///
     /// The ZPI stuff here is definately first pass. Currently there is no way to change the
     /// ZPI values.  The ZPIs passed in here are sent to the peer for use in messages sent to us.
     ///
-    /// - `peer_pub_key` is required for initiator, and should match the `local_keypair` of the responder.
     /// - `local_keypair` is optional. If not provided, a new keypair will be generated.
     /// - `zpis` are the ZPI values that the peer should use for messages.
     /// - `certx` is the certificate exchange creator/verifier.
     pub fn new(
         initiate: bool,
-        peer_pub_key: Option<Vec<u8>>,
         local_keypair: Option<NoiseKeypair>,
         zpis: ZPIPair,
         certx: KmCertExchange,
     ) -> Result<Self, KmError> {
-        if initiate && peer_pub_key.is_none() {
-            error!(target: KEY_MGMT, "noise: peer public key required for initiator");
-            return Err(KmError::ConfigurationError);
-        }
-
         let settings = KmSettings {
             zdp_km_type: KM_ID_NOISE,
             padlen: NOISE_PADLEN,
@@ -201,8 +209,8 @@ impl KmNoise {
         Ok(KmNoise {
             settings,
             state: KmSMState::Configuring,
+            msg_nr: 0,
             initiate,
-            peer_pub_key,
             local_keypair: kp,
             hs_sent_t: None,
             hs_state: None,
@@ -217,25 +225,30 @@ impl KmNoise {
 
     /// Create a noise handshake message with our KeyMsg payload.
     /// Returns a [KmError::HandshakeError] if there is a problem.
-    fn create_hs_message(&self, hs: &mut snow::HandshakeState) -> Result<Bytes, KmError> {
-        let payload = KeyMsg {
-            zpi_full_encr: self.recv_zpis.encr,
-            zpi_transit_hmac: self.recv_zpis.hmac,
-            hmac_key: self.recv_hmac_key,
-        };
-
+    fn create_hs_message(&mut self, hs: &mut snow::HandshakeState) -> Result<Bytes, KmError> {
         let mut payload_buf = BytesMut::with_capacity(MSG_BUF_SIZE);
-        payload_buf.put_slice(payload.as_bytes());
-        match self.certx.write_payload(&mut payload_buf) {
-            Ok(_) => {}
-            Err(e) => {
-                error!(target: KEY_MGMT, "noise: error writing certificate exchange payload: {e:?}");
-                return Err(KmError::CertExchangeError);
-            }
-        };
+
+        if msg_carries_zpi_payload(self.msg_nr) {
+            let payload = KeyMsg {
+                zpi_full_encr: self.recv_zpis.encr,
+                zpi_transit_hmac: self.recv_zpis.hmac,
+                hmac_key: self.recv_hmac_key,
+            };
+
+            payload_buf.put_slice(payload.as_bytes());
+            match self.certx.write_payload(&mut payload_buf) {
+                Ok(_) => {}
+                Err(e) => {
+                    error!(target: KEY_MGMT, "noise: error writing certificate exchange payload: {e:?}");
+                    return Err(KmError::CertExchangeError);
+                }
+            };
+        }
+
         let mut buf = BytesMut::zeroed(MSG_BUF_SIZE);
         match hs.write_message(&payload_buf.freeze(), &mut buf) {
             Ok(len) => {
+                self.msg_nr += 1;
                 buf.truncate(len);
                 Ok(buf.freeze())
             }
@@ -263,7 +276,7 @@ impl KmNoise {
         });
         self.send_hmac_key = Some(km.hmac_key);
 
-        // The key exchange payload follows the KeyMsg.'
+        // The key exchange payload follows the KeyMsg.
         let peer_cert = match self
             .certx
             .process_payload(&payload[std::mem::size_of::<KeyMsg>()..], peer_public_key)
@@ -400,6 +413,7 @@ impl KeyManagerStateMachine for KmNoise {
 
     fn reset(&mut self) -> Result<Option<Bytes>, KmError> {
         self.state = KmSMState::Configuring;
+        self.msg_nr = 0;
         let np: snow::params::NoiseParams = match PATTERN.parse() {
             Ok(p) => p,
             Err(e) => {
@@ -411,11 +425,8 @@ impl KeyManagerStateMachine for KmNoise {
         aws_lc_rs::rand::fill(&mut self.recv_hmac_key).expect("OS RNG Failed"); // generate an HMAC key
         self.send_hmac_key = None;
         if self.initiate {
-            let rpk = self.peer_pub_key.as_ref().unwrap();
             let mut initiator = match snow::Builder::new(np)
                 .local_private_key(self.local_keypair.private.as_ref())
-                .unwrap()
-                .remote_public_key(rpk)
                 .unwrap()
                 .build_initiator()
             {
@@ -456,6 +467,7 @@ impl KeyManagerStateMachine for KmNoise {
                 }
             };
             self.hs_state = Some(responder);
+            self.hs_sent_t = None;
             Ok(None)
         }
     }
@@ -475,26 +487,32 @@ impl KeyManagerStateMachine for KmNoise {
         }
         assert!(self.hs_state.is_some()); // or a programming error has occurred
 
+        // message received; clear timeout
+        self.hs_sent_t = None;
+
         let mut hs = self.hs_state.take().unwrap();
         let mut payload = BytesMut::zeroed(MSG_BUF_SIZE);
-        // Our IK pattern has two handshake messages. In each we expect to find a KeyMsg in the payload.
         match hs.read_message(&message[..], &mut payload) {
             Ok(len) => {
-                let peer_pubkey = match hs.get_remote_static() {
-                    Some(p) => p,
-                    None => {
-                        error!(target: KEY_MGMT, "noise: no remote public key - cannot do cert exchange");
-                        self.state = KmSMState::Error;
-                        self.hs_state = Some(hs);
-                        return Err(KmError::CertExchangeError);
-                    }
-                };
-                match self.parse_km_payload(&payload[..len], peer_pubkey) {
-                    Ok(_) => {}
-                    Err(_) => {
-                        self.state = KmSMState::Error;
-                        self.hs_state = Some(hs);
-                        return Err(KmError::HandshakeError);
+                let msg_nr = self.msg_nr;
+                self.msg_nr += 1;
+                if msg_carries_zpi_payload(msg_nr) {
+                    let peer_pubkey = match hs.get_remote_static() {
+                        Some(p) => p,
+                        None => {
+                            error!(target: KEY_MGMT, "noise: no remote public key - cannot do cert exchange");
+                            self.state = KmSMState::Error;
+                            self.hs_state = Some(hs);
+                            return Err(KmError::CertExchangeError);
+                        }
+                    };
+                    match self.parse_km_payload(&payload[..len], peer_pubkey) {
+                        Ok(_) => {}
+                        Err(_) => {
+                            self.state = KmSMState::Error;
+                            self.hs_state = Some(hs);
+                            return Err(KmError::HandshakeError);
+                        }
                     }
                 }
             }
@@ -509,8 +527,11 @@ impl KeyManagerStateMachine for KmNoise {
         let mut hs_msg: Option<Bytes> = None;
 
         if !hs.is_handshake_finished() {
-            hs_msg = match self.create_hs_message(&mut hs) {
-                Ok(m) => Some(m),
+            match self.create_hs_message(&mut hs) {
+                Ok(m) => {
+                    self.hs_sent_t = Some(Instant::now());
+                    hs_msg = Some(m);
+                }
                 Err(_) => {
                     self.hs_state = Some(hs);
                     self.state = KmSMState::Error;
@@ -567,6 +588,8 @@ impl KeyManagerStateMachine for KmNoise {
                     return Err(KmError::HandshakeError);
                 }
             };
+        } else {
+            self.hs_state = Some(hs);
         }
         return Ok(hs_msg);
     }
@@ -574,7 +597,6 @@ impl KeyManagerStateMachine for KmNoise {
     fn tick(&mut self) -> Result<Option<Bytes>, KmError> {
         if self.state == KmSMState::Configuring
             && self.hs_state.is_some()
-            && self.initiate
             && self.hs_sent_t.is_some()
             && Instant::now().duration_since(self.hs_sent_t.unwrap()) > HANDSHAKE_TIMEOUT
         {
@@ -600,8 +622,7 @@ mod test {
     use crate::km_testdata::test::*;
     use crate::pki;
 
-    #[test]
-    fn test_noise_handshake_manually_1() {
+    fn test_noise_handshake_common() -> (km::KmTransportSA, km::KmTransportSA) {
         let node_kp = NoiseKeypair::new(
             BASE64_STANDARD
                 .decode(NODE_NOISE_KEY)
@@ -623,7 +644,6 @@ mod test {
 
         let mut initiator = KmNoise::new(
             true,
-            Some(node_kp.public.to_vec()),
             Some(initiator_keypair),
             ZPIPair::new(1, 2),
             initiator_exchanger,
@@ -636,7 +656,6 @@ mod test {
 
         let mut responder = KmNoise::new(
             false,
-            None,
             Some(node_kp),
             ZPIPair::new(3, 4),
             responder_exchanger,
@@ -653,10 +672,10 @@ mod test {
                 panic!("error resetting initiator: {:?}", e);
             }
         };
-        assert!(
-            handshake_msg_0.len() == 913,
-            "unexpected handshake message-0 length, got {}",
-            handshake_msg_0.len()
+        assert_eq!(
+            handshake_msg_0.len(),
+            32,
+            "unexpected handshake message-0 length",
         );
         assert!(initiator.get_state() == KmSMState::Configuring);
 
@@ -668,7 +687,7 @@ mod test {
             }
         };
 
-        // -> e, es, s, ss
+        // -> e
         let handshake_msg_1 = match responder.handle_message(&handshake_msg_0, KM_ID_NOISE) {
             Ok(Some(m)) => m,
             Ok(None) => {
@@ -678,31 +697,56 @@ mod test {
                 panic!("responder handle_message failed on handshake-0: {:?}", e);
             }
         };
-        assert!(
-            handshake_msg_1.len() == 862,
-            "unexpected handshake message-1 length, got {}",
-            handshake_msg_1.len()
+        assert_eq!(
+            handshake_msg_1.len(),
+            910,
+            "unexpected handshake message-1 length",
         );
-        assert!(matches!(responder.get_state(), KmSMState::Transport { .. }));
+        assert!(matches!(responder.get_state(), KmSMState::Configuring));
 
-        // <- e, ee, se
-        match initiator.handle_message(&handshake_msg_1, KM_ID_NOISE) {
-            Ok(Some(_)) => panic!("unexpected additional handshake message from initiator"),
-            Ok(None) => {} // good
+        // <- e, ee, s, es
+        let handshake_msg_2 = match initiator.handle_message(&handshake_msg_1, KM_ID_NOISE) {
+            Ok(Some(m)) => m,
+            Ok(None) => {
+                panic!("expected handshake-2 message, got nothing!");
+            }
             Err(e) => {
                 panic!("initiator.handle_message failed on handshake-1: {:?}", e);
             }
         };
+        assert_eq!(
+            handshake_msg_2.len(),
+            881,
+            "unexpected handshake message-2 length",
+        );
         assert!(matches!(initiator.get_state(), KmSMState::Transport { .. }));
 
-        // Handshake complete, now we can encrypt/decrypt
-
-        let i_transport = match initiator.get_state() {
-            KmSMState::Transport(t) => t,
-            _ => {
-                panic!("unexpected state after handshake");
+        // -> s, se
+        match responder.handle_message(&handshake_msg_2, KM_ID_NOISE) {
+            Ok(Some(_)) => panic!("unexpected additional handshake message from responder"),
+            Ok(None) => {} // good
+            Err(e) => {
+                panic!("responder.handle_message failed on handshake-2: {:?}", e);
             }
         };
+        assert!(matches!(responder.get_state(), KmSMState::Transport { .. }));
+
+        let KmSMState::Transport(i_transport) = initiator.get_state() else {
+            panic!("unexpected state after handshake");
+        };
+
+        let KmSMState::Transport(r_transport) = responder.get_state() else {
+            panic!("unexpected state after handshake");
+        };
+
+        (i_transport, r_transport)
+    }
+
+    #[test]
+    fn test_noise_handshake_manually_1() {
+        let (i_transport, r_transport) = test_noise_handshake_common();
+
+        // Handshake complete, now we can encrypt/decrypt
 
         let plaintext = b"hello world";
 
@@ -724,13 +768,6 @@ mod test {
             "unexpected encrypted message length, got {}",
             out_len
         );
-
-        let r_transport = match responder.get_state() {
-            KmSMState::Transport(t) => t,
-            _ => {
-                panic!("unexpected state after handshake");
-            }
-        };
 
         let mut in_buf = [0u8; 4096];
         let in_len = match r_transport
@@ -790,112 +827,9 @@ mod test {
     // Just make sure that our b64 keys work with the code.
     #[test]
     fn test_noise_handshake_manually_static_node_key() {
-        let node_kp = NoiseKeypair::new(
-            BASE64_STANDARD
-                .decode(NODE_NOISE_KEY)
-                .unwrap()
-                .try_into()
-                .unwrap(),
-        );
-        let adapter_kp = NoiseKeypair::new(
-            BASE64_STANDARD
-                .decode(ADAPTER_NOISE_KEY)
-                .unwrap()
-                .try_into()
-                .unwrap(),
-        );
-
-        let initiator_exchanger =
-            KmCertExchange::new_from_pem(ADAPTER_CERT_DATA, CA_CERT_DATA).unwrap();
-        let responder_exchanger =
-            KmCertExchange::new_from_pem(NODE_CERT_DATA, CA_CERT_DATA).unwrap();
-
-        let mut initiator = KmNoise::new(
-            true,
-            Some(node_kp.public.to_vec()),
-            Some(adapter_kp),
-            ZPIPair::new(1, 2),
-            initiator_exchanger,
-        )
-        .unwrap();
-        assert!(initiator.get_state() == KmSMState::Configuring);
-
-        let mut responder = KmNoise::new(
-            false,
-            None,
-            Some(node_kp),
-            ZPIPair::new(3, 4),
-            responder_exchanger,
-        )
-        .unwrap();
-        assert!(responder.get_state() == KmSMState::Configuring);
-
-        let handshake_msg_0 = match initiator.reset() {
-            Ok(Some(m)) => m,
-            Ok(None) => {
-                panic!("expected handshake message");
-            }
-            Err(e) => {
-                panic!("error resetting initiator: {:?}", e);
-            }
-        };
-        assert!(
-            handshake_msg_0.len() == 913,
-            "unexpected handshake message-0 length, got {}",
-            handshake_msg_0.len()
-        );
-        assert!(initiator.get_state() == KmSMState::Configuring);
-
-        match responder.reset() {
-            Ok(Some(_m)) => panic!("unexpected message from responder.reset!"),
-            Ok(None) => {} // good
-            Err(e) => {
-                panic!("error resetting responder: {:?}", e);
-            }
-        };
-
-        // -> e, es, s, ss
-        let handshake_msg_1 = match responder.handle_message(&handshake_msg_0, KM_ID_NOISE) {
-            Ok(Some(m)) => m,
-            Ok(None) => {
-                panic!("expected handshake-1 message, got nothing!");
-            }
-            Err(e) => {
-                panic!("responder handle_message failed on handshake-0: {:?}", e);
-            }
-        };
-        assert!(
-            handshake_msg_1.len() == 862,
-            "unexpected handshake message-1 length, got {}",
-            handshake_msg_1.len()
-        );
-        assert!(matches!(responder.get_state(), KmSMState::Transport { .. }));
-
-        // <- e, ee, se
-        match initiator.handle_message(&handshake_msg_1, KM_ID_NOISE) {
-            Ok(Some(_)) => panic!("unexpected additional handshake message from initiator"),
-            Ok(None) => {} // good
-            Err(e) => {
-                panic!("initiator.handle_message failed on handshake-1: {:?}", e);
-            }
-        };
-        assert!(matches!(initiator.get_state(), KmSMState::Transport { .. }));
+        let (initiator_sa, responder_sa) = test_noise_handshake_common();
 
         // At this point each side should know the others hmac key, and the ZPIs should have been exchanged.
-
-        let initiator_sa = match initiator.get_state() {
-            KmSMState::Transport(t) => t,
-            _ => {
-                panic!("unexpected state after handshake");
-            }
-        };
-
-        let responder_sa = match responder.get_state() {
-            KmSMState::Transport(t) => t,
-            _ => {
-                panic!("unexpected state after handshake");
-            }
-        };
 
         assert!(initiator_sa.recv_hmac_key != [0u8; HMAC_KEY_LEN]);
         assert!(responder_sa.recv_hmac_key != [0u8; HMAC_KEY_LEN]);
@@ -934,7 +868,6 @@ mod test {
 
         let initiator = KmNoise::new(
             true,
-            Some(node_kp.public.to_vec()),
             Some(adapter_kp),
             ZPIPair::new(1, 2),
             initiator_exchanger,
@@ -943,7 +876,6 @@ mod test {
 
         let responder = KmNoise::new(
             false,
-            None,
             Some(node_kp),
             ZPIPair::new(3, 4),
             responder_exchanger,
@@ -1049,6 +981,23 @@ mod test {
             },
             Err(_) => {
                 panic!("timed out waiting for handshake message from node");
+            }
+        }
+
+        // and finally, the adapter responds to the node
+        match timeout(Duration::from_secs(2), a_km_rx.recv()).await {
+            Ok(resp) => match resp {
+                Some(linkmsg) => {
+                    n_km_payload_tx.send(linkmsg.msg).await.unwrap();
+                }
+                None => {
+                    panic!(
+                        "timed out or failed waiting for handshake message response from adapter"
+                    );
+                }
+            },
+            Err(_) => {
+                panic!("timed out waiting for handshake message from adapter");
             }
         }
 

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -1,6 +1,6 @@
 use crate::auth::{self, AUTH_KEY_SIZE_BYTES, AuthBlob, ZdpAuthCodeBlob, ZdpSelfSignedBlob};
 use crate::counters::ManagementCounterType;
-use crate::km::{PeerCertificate, ZPIPair};
+use crate::km::ZPIPair;
 use crate::km_multiplexor;
 use crate::mgmt;
 use crate::mgmt::core::{MgmtSendError, PacketStatus};
@@ -580,40 +580,19 @@ impl LinkStateWrapper {
         };
 
         if let Some(ref peer_cert) = sa.peer_cert {
-            let require_ca_signature = asm.config.get().ca_file.is_some();
-            let (cert, is_verified) = match peer_cert {
-                PeerCertificate::Unverified(cert) => {
-                    warn!(target: LINK_STATE, "{} has unverified name {}", asm.formatted_link_id(link_id), pki::subject_name(cert));
-                    if require_ca_signature {
-                        // If this node has been configured with a CA certificate for checking these things
-                        // then these rules kick in:
-                        //
-                        // - Nodes should accept unverified certs from adapters.
-                        // - Nodes should not accept unverified certs from other nodes.
-                        // - Adapters should not accept unverified certs from nodes.
-                        match self.link_type {
-                            LinkType::AdapterToNode => {
-                                return Err(LinkStateError::InvalidOperation(
-                                    "adapter received unverified certificate from node".to_string(),
-                                ));
-                            }
-                            LinkType::NodeToAdapter => (), // OK
-                            LinkType::NodeToNode => {
-                                return Err(LinkStateError::InvalidOperation(
-                                    "node received unverified certificate from peer node"
-                                        .to_string(),
-                                ));
-                            }
-                            _ => (),
-                        }
-                    }
-                    (cert, false)
-                }
-                PeerCertificate::Verified(cert) => {
-                    info!(target: LINK_STATE, "{} has verified name {}", asm.formatted_link_id(link_id), pki::subject_name(cert));
-                    (cert, true)
-                }
-            };
+            let cert = peer_cert.get_cert();
+            let is_verified = peer_cert.is_verified();
+
+            // Note, keying will have failed if we requested verification (i.e. were
+            // connecting to node) but the cert couldn't be verified.  So here,
+            // we only need to verify the case that we are only conditionally verifying
+            // (i.e., we are being connected to by a special adapter).
+
+            if is_verified {
+                info!(target: LINK_STATE, "{} has verified name {}", asm.formatted_link_id(link_id), pki::subject_name(cert));
+            } else {
+                warn!(target: LINK_STATE, "{} has unverified name {}", asm.formatted_link_id(link_id), pki::subject_name(cert));
+            }
 
             let subject_der = match pki::subject_der(cert) {
                 Ok(der) => der,

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -527,7 +527,6 @@ impl LinkStateWrapper {
                     link_id,
                     ZPIPair::new(ZPI_ENCRYPTED_HEADER_FLAG | 5, 6),
                     asm.self_noise_keypair.clone().unwrap(),
-                    asm.peer_noise_keypair.clone().unwrap().public,
                     asm.certx.clone().unwrap(),
                 )
                 .unwrap();

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -6,7 +6,6 @@ use std::default::Default;
 use std::fs;
 use std::io::ErrorKind;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
-use std::path::Path;
 use std::process;
 use std::process::ExitCode;
 use std::sync::{Arc, Mutex};
@@ -83,7 +82,7 @@ use flow_control::FlowControl;
 use km_multiplexor::KmState;
 use km_noise::NoiseKeypair;
 use logging::targets::STARTUP;
-use pki::{generate_self_signed_noise_cert, load_cert, load_noise_public_key};
+use pki::{generate_self_signed_noise_cert, load_cert};
 use queues::*;
 use sys::ZprTun;
 use tun_ctl::TunCtl;
@@ -145,7 +144,6 @@ fn main() -> ExitCode {
     //
 
     let self_noise_keypair;
-    let peer_noise_keypair;
     let certx;
 
     let maybe_private_key = match config.get_noise_private_key_data() {
@@ -166,22 +164,8 @@ fn main() -> ExitCode {
             error!(target: STARTUP, "nodes require a noise private key to be specified");
             return ExitCode::FAILURE;
         };
-        peer_noise_keypair = None;
         self_noise_keypair = NoiseKeypair::new(private_key);
     } else {
-        let public_key = match load_noise_public_key(&Path::new(
-            &config.node_public_key_file.clone().unwrap(),
-        )) {
-            Ok(key) => key,
-            Err(e) => {
-                error!(target: STARTUP, "failed to load node public key file: {e:?}");
-                return ExitCode::FAILURE;
-            }
-        };
-        peer_noise_keypair = Some(NoiseKeypair {
-            public: public_key,
-            private: [0u8; 32], // unknown
-        });
         self_noise_keypair = match maybe_private_key {
             Some(private_key) => NoiseKeypair::new(private_key),
             None => NoiseKeypair::generate(),
@@ -557,7 +541,6 @@ fn main() -> ExitCode {
         adapter_manager_factory: AdapterManagerFactory::new(am_inq_factory),
         km_state: KmState::new(km_inq, km_sig_inq),
         self_noise_keypair: Some(self_noise_keypair),
-        peer_noise_keypair,
         a2a_dh_keypair: x25519_dalek::ReusableSecret::random(),
         certx: Some(certx),
         system_start_time,

--- a/adapter/ph/src/main_argparse.rs
+++ b/adapter/ph/src/main_argparse.rs
@@ -39,7 +39,6 @@ pub fn argparse(args: Option<Vec<&str>>) -> std::result::Result<(PhMode, Config)
             config_file,
             common,
             node_addr,
-            node_public_key_file,
             bootstrap_key,
         } => {
             ph_mode = PhMode::Adapter;
@@ -69,14 +68,6 @@ pub fn argparse(args: Option<Vec<&str>>) -> std::result::Result<(PhMode, Config)
             }
             if let Some(node_addr) = node_addr {
                 config.node_addr = Some(node_addr);
-            }
-            if let Some(npkf) = node_public_key_file {
-                config.node_public_key_file = Some(path::absolute(npkf).or_else(|e| {
-                    Err(ArgsError::PathError(format!(
-                        "path error for node_public_key_file: {:?}",
-                        e
-                    )))
-                })?);
             }
             if let Some(bootstrap_key) = bootstrap_key {
                 config.bootstrap_key_path = Some(path::absolute(bootstrap_key).or_else(|e| {
@@ -216,7 +207,6 @@ mod test {
 
         [adapter]
         node_addr = "192.168.0.2:5000"
-        node_public_key_file = "tests/node_public_key.pem"
         "#;
 
         let tmpfile = TempFile::new_toml(&tomltxt);
@@ -260,10 +250,6 @@ mod test {
             Some(Vec::from([IpAddr::V4(std::net::Ipv4Addr::new(
                 10, 0, 0, 1
             ))]))
-        );
-        assert_eq!(
-            config.adapter.node_public_key_file,
-            Some(PathBuf::from("tests/node_public_key.pem"))
         );
     }
 
@@ -330,7 +316,6 @@ mod test {
 
         [adapter]
         node_addr = "192.168.0.2:5000"
-        node_public_key_file = "$NPKFILE"
         "#;
 
         let ca_file = TempFile::touch();
@@ -338,14 +323,12 @@ mod test {
         let capture_file = TempFile::touch();
         let cert_file = TempFile::touch();
         let pk_file = TempFile::touch();
-        let npk_file = TempFile::touch();
 
         let tmp = tomltxt
             .replace("$CERTFILE", cert_file.get_path().to_str().unwrap())
             .replace("$CONTROLFILE", control_file.get_path().to_str().unwrap())
             .replace("$CAPTUREFILE", capture_file.get_path().to_str().unwrap())
             .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
-            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap())
             .replace("$CAFILE", ca_file.get_path().to_str().unwrap());
         tomltxt = &tmp;
 
@@ -384,10 +367,6 @@ mod test {
         assert_eq!(
             config.zpr_addr,
             Vec::from([IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1))])
-        );
-        assert_eq!(
-            config.node_public_key_file,
-            Some(npk_file.get_path().into())
         );
     }
 
@@ -443,9 +422,6 @@ mod test {
 
         let tmpfile = TempFile::new_toml(&tomltxt);
 
-        let node_pk_file = TempFile::touch();
-        let node_pk_fname = String::from(node_pk_file.get_path().to_str().unwrap());
-
         let args = vec![
             "ph",
             "adapter",
@@ -455,8 +431,6 @@ mod test {
             "192.168.0.2:5000",
             "--zpr-addr",
             "10.0.0.1",
-            "--node-public-key-file",
-            &node_pk_fname,
         ];
 
         let (pmode, config) = argparse(Some(args)).unwrap();
@@ -473,10 +447,6 @@ mod test {
         assert_eq!(
             config.zpr_addr,
             Vec::from([IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1))])
-        );
-        assert_eq!(
-            config.node_public_key_file,
-            Some(PathBuf::from(&node_pk_fname))
         );
     }
 
@@ -495,7 +465,6 @@ mod test {
 
         [adapter]
         node_addr = "192.168.0.2:5000"
-        node_public_key_file = "$NPKFILE"
         "#;
 
         let ca_file = TempFile::touch();
@@ -503,14 +472,12 @@ mod test {
         let control_file = TempFile::touch();
         let capture_file = TempFile::touch();
         let pk_file = TempFile::touch();
-        let npk_file = TempFile::touch();
 
         let tmp = tomltxt
             .replace("$CERTFILE", cert_file.get_path().to_str().unwrap())
             .replace("$CONTROLFILE", control_file.get_path().to_str().unwrap())
             .replace("$CAPTUREFILE", capture_file.get_path().to_str().unwrap())
             .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
-            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap())
             .replace("$CAFILE", ca_file.get_path().to_str().unwrap());
         tomltxt = &tmp;
 
@@ -564,10 +531,6 @@ mod test {
             config.zpr_addr,
             Vec::from([IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1))])
         );
-        assert_eq!(
-            config.node_public_key_file,
-            Some(npk_file.get_path().into())
-        );
     }
 
     #[test]
@@ -585,18 +548,15 @@ mod test {
 
         [adapter]
         node_addr = "192.168.0.2:5000"
-        node_public_key_file = "$NPKFILE"
         "#;
 
         let ca_file = TempFile::touch();
         let cert_file = TempFile::touch();
         let pk_file = TempFile::touch();
-        let npk_file = TempFile::touch();
 
         let tmp = tomltxt
             .replace("$CERTFILE", cert_file.get_path().to_str().unwrap())
             .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
-            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap())
             .replace("$CAFILE", ca_file.get_path().to_str().unwrap());
         tomltxt = &tmp;
 
@@ -632,10 +592,6 @@ mod test {
         assert_eq!(
             config.zpr_addr,
             Vec::from([IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1))])
-        );
-        assert_eq!(
-            config.node_public_key_file,
-            Some(npk_file.get_path().into())
         );
     }
 
@@ -749,16 +705,13 @@ mod test {
 
         [adapter]
         node_addr = "192.168.0.2:5000"
-        node_public_key_file = "$NPKFILE"
         "#;
 
         let ca_file = TempFile::touch();
         let cert_file = TempFile::touch();
-        let npk_file = TempFile::touch();
 
         let tmp = tomltxt
             .replace("$CERTFILE", cert_file.get_path().to_str().unwrap())
-            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap())
             .replace("$CAFILE", ca_file.get_path().to_str().unwrap());
         tomltxt = &tmp;
 
@@ -798,17 +751,14 @@ mod test {
 
         [adapter]
         node_addr = "192.168.0.2:5000"
-        node_public_key_file = "$NPKFILE"
         "#;
 
         let cert_file = TempFile::touch();
         let pk_file = TempFile::touch();
-        let npk_file = TempFile::touch();
 
         let tmp = tomltxt
             .replace("$CERTFILE", cert_file.get_path().to_str().unwrap())
-            .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
-            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap());
+            .replace("$PKFILE", pk_file.get_path().to_str().unwrap());
         tomltxt = &tmp;
 
         let tmpfile = TempFile::new_toml(&tomltxt);
@@ -832,15 +782,11 @@ mod test {
         [adapter]
         name = "my-adapter"
         node_addr = "192.168.0.2:5000"
-        node_public_key_file = "$NPKFILE"
         "#;
 
         let pk_file = TempFile::touch();
-        let npk_file = TempFile::touch();
 
-        let tmp = tomltxt
-            .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
-            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap());
+        let tmp = tomltxt.replace("$PKFILE", pk_file.get_path().to_str().unwrap());
         tomltxt = &tmp;
 
         let tmpfile = TempFile::new_toml(&tomltxt);
@@ -864,15 +810,11 @@ mod test {
 
         [adapter]
         node_addr = "192.168.0.2:5000"
-        node_public_key_file = "$NPKFILE"
         "#;
 
         let pk_file = TempFile::touch();
-        let npk_file = TempFile::touch();
 
-        let tmp = tomltxt
-            .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
-            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap());
+        let tmp = tomltxt.replace("$PKFILE", pk_file.get_path().to_str().unwrap());
         tomltxt = &tmp;
 
         let tmpfile = TempFile::new_toml(&tomltxt);
@@ -899,15 +841,11 @@ mod test {
         [adapter]
         name = "config-name"
         node_addr = "192.168.0.2:5000"
-        node_public_key_file = "$NPKFILE"
         "#;
 
         let pk_file = TempFile::touch();
-        let npk_file = TempFile::touch();
 
-        let tmp = tomltxt
-            .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
-            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap());
+        let tmp = tomltxt.replace("$PKFILE", pk_file.get_path().to_str().unwrap());
         tomltxt = &tmp;
 
         let tmpfile = TempFile::new_toml(&tomltxt);
@@ -939,16 +877,13 @@ mod test {
 
         [adapter]
         node_addr = "192.168.0.2:5000"
-        node_public_key_file = "$NPKFILE"
         bootstrap_key = "$BSKEY"
         "#;
 
         let pk_file = TempFile::touch();
-        let npk_file = TempFile::touch();
 
         let tmp = tomltxt
             .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
-            .replace("$NPKFILE", npk_file.get_path().to_str().unwrap())
             .replace("$BSKEY", bootstrap_key_path.to_str().unwrap());
         tomltxt = &tmp;
 

--- a/adapter/ph/src/main_args.rs
+++ b/adapter/ph/src/main_args.rs
@@ -144,10 +144,6 @@ pub enum Command {
         #[arg(long, short = 'N', value_name = "ADDR:PORT", value_parser = parse_socket_addr_or_scoped_ip_addr)]
         node_addr: Option<SocketAddr>,
 
-        /// PEM file holding the nodes noise public key
-        #[arg(long, short = 'b', value_name = "PATH")]
-        node_public_key_file: Option<PathBuf>, // noise public key for node (only specified when starting an adapter)
-
         /// PEM file holding the boostrap RSA private key
         #[arg(long, value_name = "PATH")]
         bootstrap_key: Option<PathBuf>,

--- a/adapter/ph/src/pki.rs
+++ b/adapter/ph/src/pki.rs
@@ -200,6 +200,7 @@ pub fn load_noise_private_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseE
     })
 }
 
+#[cfg(test)]
 /// Load a public X22519 key from a PEM file
 pub fn load_noise_public_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseError> {
     let contents = fs::read(path)?;

--- a/integration-test/capture-test.sh
+++ b/integration-test/capture-test.sh
@@ -182,7 +182,6 @@ sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --bootstrap-key actorvs-rsa.key \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_VS":12345 \
-  --node-public-key-file node.pubkey \
   --zpr-addr "$VS_ZPR_ADDR" 2>&1 | tee adapter-vs.log | prefix_log zpr-vs &
 
 sleep 5
@@ -199,8 +198,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --bootstrap-key actor1-rsa.key \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_A":12345 \
-  --zpr-addr "$A_ZPR_ADDR" \
-  --node-public-key-file node.pubkey 2>&1 | tee adapter1.log | prefix_log zpr-a &
+  --zpr-addr "$A_ZPR_ADDR" 2>&1 | tee adapter1.log | prefix_log zpr-a &
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   adapter \
@@ -214,8 +212,7 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --bootstrap-key actor2-rsa.key \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_B":12345 \
-  --zpr-addr "$B_ZPR_ADDR" \
-  --node-public-key-file node.pubkey 2>&1 | tee adapter2.log | prefix_log zpr-b &
+  --zpr-addr "$B_ZPR_ADDR" 2>&1 | tee adapter2.log | prefix_log zpr-b &
 
 if [[ "$NUM_ACTORS" -ge 3 ]]; then
   sudo -E ip netns exec zpr-c sudo -E -u "$ZPR_USER" "$PH_BIN" \
@@ -230,7 +227,6 @@ if [[ "$NUM_ACTORS" -ge 3 ]]; then
     --bootstrap-key actor3-rsa.key \
     --tun-if tun0 \
     --node-addr "$NODE_SUBSTRATE_ADDR_C":12345 \
-    --node-public-key-file node.pubkey \
     --zpr-addr "$C_ZPR_ADDR" 2>&1 | tee adapter3.log | prefix_log zpr-c &
 fi
 

--- a/integration-test/one-node-test.sh
+++ b/integration-test/one-node-test.sh
@@ -197,7 +197,6 @@ sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --tun-if tun0 \
   --io-engine auto \
   --node-addr "$NODE_SUBSTRATE_ADDR_VS" \
-  --node-public-key-file node.pubkey \
   --zpr-addr "$VS_ZPR_ADDR" 2>&1 | tee adapter-vs.log | prefix_log zpr-vs &
 
 sleep 5
@@ -216,7 +215,6 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --tun-if tun0 \
   --io-engine io_uring \
   --node-addr "$NODE_SUBSTRATE_ADDR_A" \
-  --node-public-key-file node.pubkey \
   --zpr-addr "$A_ZPR_ADDR" 2>&1 | tee adapter1.log | prefix_log zpr-a &
 
 sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
@@ -233,7 +231,6 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --tun-if tun0 \
   --io-engine posix_unbatched \
   --node-addr "$NODE_SUBSTRATE_ADDR_B" \
-  --node-public-key-file node.pubkey \
   --zpr-addr "$B_ZPR_ADDR" 2>&1 | tee adapter2.log | prefix_log zpr-b &
 
 if [[ "$NUM_ACTORS" -ge 3 ]]; then
@@ -252,7 +249,6 @@ if [[ "$NUM_ACTORS" -ge 3 ]]; then
     --km-impl "$KM_IMPL" \
     --tun-if tun0 \
     --node-addr "$NODE_SUBSTRATE_ADDR_C_ALT" \
-    --node-public-key-file node.pubkey \
     --zpr-addr "$C_ZPR_ADDR" 2>&1 | tee adapter3.log | prefix_log zpr-c &
 fi
 


### PR DESCRIPTION
Since adapters validate the node's certificate, we have no need for adapters to validate the node's public key directly, or to have it beforehand.

To support this, we must switch Noise from an ?K mode to a ?X mode.  NX would be sufficient for most adapters, but not for the VS adapter which needs to authenticate itself to the node, and not for upcoming node-node authentication.  IX saves one message on paper, but (like XX) cannot encrypt the KM payload before the 1st message, which is necessary to hide the HMAC, so a 3rd message is needed anyway.  XX is 3 messages, but encrypts the 2nd and 3rd so we can piggyback on both to exchange KM payloads, and it provides better identity hiding than IX which may be desirable.

If we change the KM payload exchange so that only the responder generates HMAC keying material, we could use IX if we want to save one message, at the expense of identity hiding.  Link establishment isn't necessarily latency-sensitive so for now XX is the best option.

This required also changing the KM payload mechanism to understand that there are now 3 messages, and that the 1st isn't to be used to send a payload.

Also remove no-longer-needed --node-public-key-file argument.

This of course removes the ability for adapters to ensure that they're connecting to a _specific_ node, but we should do that by allowing adapters to specify a CN they are expecting, if this is desired.

Closes #1286.