### PR TITLE
use fwd_pep next_hop when routing between nodes

### DIFF
--- a/adapter/ph/src/mgmt/adapter.rs
+++ b/adapter/ph/src/mgmt/adapter.rs
@@ -117,7 +117,7 @@ pub fn install_tether(
 
     // Confirm this TC matches our initial packet.
     if !tc.classify_5t(&five_tuple) {
-        error!(target: FLOW_MGMT, "Bind of {five_tuple} falied: node supplied TC incompatible with initial packet: {tc}");
+        error!(target: FLOW_MGMT, "Bind of {five_tuple} failed: node supplied TC incompatible with initial packet: {tc}");
         asm.elt.remove(&five_tuple).unwrap();
         return Ok(());
     }

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -166,16 +166,21 @@ pub async fn actor_disconnect(asm: Arc<Assembly>, addr: IpAddress) {
 
 /// Insert visa into table.
 pub fn insert_visa(
-    asm: &Arc<Assembly>,
+    asm: &Assembly,
     visa: vsapi_types::Visa,
 ) -> Result<VisaId, visa_table::VisaTableError> {
     if visa.visa_type != vsapi_types::VisaType::Full {
         panic!("Forward only visas not yet supported")
     }
-    let addr = visa.dock_pep.clone().unwrap().dest_addr;
-    if asm.find_egress_link(addr.into()).is_none() {
+    let dest_addr = visa.dock_pep.as_ref().unwrap().dest_addr;
+    let next_hop = visa
+        .fwd_pep
+        .as_ref()
+        .map(|p| p.next_hop)
+        .unwrap_or(dest_addr);
+    if asm.find_egress_link(next_hop.into()).is_none() {
         asm.counters.management[ManagementCounterType::VisaRequestError].increment();
-        return Err(visa_table::VisaTableError::DestNotFound(addr.into()));
+        return Err(visa_table::VisaTableError::DestNotFound(next_hop.into()));
     }
     let visa_id = asm.visa_table.write().unwrap().insert_visa(visa)?;
     Ok(visa_id)
@@ -184,10 +189,14 @@ pub fn insert_visa(
 /// Given a visa ID, look up the visa in our table to find the destination address
 /// then use that to find an egress link.
 pub fn get_egress_link_for_visa(
-    asm: &Arc<Assembly>,
+    asm: &Assembly,
     visa_id: VisaId,
 ) -> Result<NonZero<LinkId>, visa_table::VisaTableError> {
-    let addr = asm.visa_table.read().unwrap().get_visa_dest_addr(visa_id)?;
+    let addr = asm
+        .visa_table
+        .read()
+        .unwrap()
+        .get_visa_next_hop_addr(visa_id)?;
     let Some(link_id) = asm.find_egress_link(addr) else {
         return Err(visa_table::VisaTableError::DestNotFound(addr));
     };
@@ -195,7 +204,7 @@ pub fn get_egress_link_for_visa(
 }
 
 pub fn handle_revocation(
-    asm: &Arc<Assembly>,
+    asm: &Assembly,
     visa_id: VisaId,
 ) -> Result<(), visa_table::VisaTableError> {
     asm.visa_table

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -45,6 +45,7 @@ pub struct Visa {
     pub visa: vsapi_types::Visa,
     streams: Vec<ForwardingEntry>,
     pub ftuple: VsapiFiveTuple,
+    pub next_hop: IpAddress,
 }
 
 impl std::fmt::Debug for Visa {
@@ -92,11 +93,17 @@ impl Visa {
         if visa.visa_type != vsapi_types::VisaType::Full {
             panic!("Forward only visas not yet supported")
         }
-        let ftuple = visa.dock_pep.clone().unwrap().get_five_tuple();
+        let ftuple = visa.dock_pep.as_ref().unwrap().get_five_tuple();
+        let next_hop = visa
+            .fwd_pep
+            .as_ref()
+            .map(|p| p.next_hop.into())
+            .unwrap_or_default();
         Self {
-            visa: visa,
+            visa,
             streams: Vec::new(),
-            ftuple: ftuple,
+            ftuple,
+            next_hop,
         }
     }
 
@@ -354,16 +361,19 @@ impl VisaTable {
         info!(target: VISA_MGMT, "Revoked visa {visa_id}");
         Ok(())
     }
-    /// Given a visa ID, look up the visa and return the destination address.
-    /// If visa is not found or does not have a destination address, return an error.
-    pub fn get_visa_dest_addr(&self, visa_id: VisaId) -> Result<IpAddress, VisaTableError> {
-        let visa_query = self
+
+    /// Given a visa ID, look up the visa and return the next hop address.
+    /// If visa is not found or does not have a next hop address, return an error.
+    pub fn get_visa_next_hop_addr(&self, visa_id: VisaId) -> Result<IpAddress, VisaTableError> {
+        let visa = self
             .table
             .get(&visa_id)
-            .ok_or(VisaTableError::NotFound(visa_id));
-        match visa_query {
-            Ok(visa) => Ok(IpAddress::from(visa.ftuple.dest_addr.clone())),
-            Err(e) => Err(e),
+            .ok_or(VisaTableError::NotFound(visa_id))?;
+
+        if visa.next_hop == IpAddress::UNSPECIFIED {
+            Ok(IpAddress::from(visa.ftuple.dest_addr.clone()))
+        } else {
+            Ok(visa.next_hop)
         }
     }
 


### PR DESCRIPTION
Fix route lookup to correctly heed the `next_hop` value from the `fwd_pep` of a Visa if present.  This is required for multinode.