### PR TITLE
step 12

### DIFF
--- a/adapter/ph/src/mgmt/adapter.rs
+++ b/adapter/ph/src/mgmt/adapter.rs
@@ -38,10 +38,12 @@ pub fn bind_egress_stream(
     dock_link_id: NonZero<LinkId>,
     txn_id: txn_mgr::TxnId,
     tc: tc::Ip5TupleTc,
+    peer_a2a_dh_pubkey: Option<x25519_dalek::PublicKey>,
 ) {
     debug!(
         target: FLOW_MGMT,
-        "bind_egress_stream(dock_link_id={}, txn_id={txn_id}, tc={tc})", asm.formatted_link_id(dock_link_id.get()));
+        "bind_egress_stream(dock_link_id={}, txn_id={txn_id}, tc={tc}, peer_a2a_dh_pubkey={peer_a2a_dh_pubkey:?})",
+        asm.formatted_link_id(dock_link_id.get()));
 
     // form PEP
     let pep = DltPep { tc };
@@ -109,6 +111,7 @@ pub fn install_tether(
     txn: &txn_mgr::TxnHandle,
     tether_id: StreamId,
     tc: tc::Ip5TupleTc,
+    peer_a2a_dh_pubkey: Option<x25519_dalek::PublicKey>,
 ) -> Result<(), InstallTetherError> {
     let five_tuple = asm
         .elt
@@ -123,7 +126,7 @@ pub fn install_tether(
     }
 
     // Bind succeeded; add to ELT.
-    debug!(target: FLOW_MGMT, "Bind of {five_tuple} succeeded: {tether_id}");
+    debug!(target: FLOW_MGMT, "Bind of {five_tuple} succeeded: {tether_id} (peer_a2a_dh_pubkey={peer_a2a_dh_pubkey:?})");
 
     let pep = EltPep {
         compression_mode: tc.compression_mode(),

--- a/adapter/ph/src/mgmt/handlers.rs
+++ b/adapter/ph/src/mgmt/handlers.rs
@@ -46,6 +46,8 @@ pub enum HandleMgmtError {
     LinkClosed,
 }
 
+const X25519_KEY_LEN: usize = 32;
+
 impl From<&HandleMgmtError> for counters::ManagementCounterType {
     fn from(err: &HandleMgmtError) -> Self {
         match err {
@@ -679,6 +681,26 @@ pub async fn handle_bind_egress_stream_request(
         return Err(HandleMgmtError::BadStructure);
     };
 
+    if pkt.remaining() < size_of::<u16>() {
+        return Err(HandleMgmtError::BadStructure);
+    }
+
+    let key_len = pkt.get_u16() as usize;
+
+    let peer_a2a_dh_pubkey = if key_len == 0 {
+        None
+    } else {
+        if pkt.remaining() < key_len {
+            return Err(HandleMgmtError::BadStructure);
+        }
+
+        let Ok(key_bytes) = <[u8; X25519_KEY_LEN]>::try_from(&pkt.body()[..key_len]) else {
+            return Err(HandleMgmtError::BadStructure);
+        };
+
+        Some(x25519_dalek::PublicKey::from(key_bytes))
+    };
+
     let Some(ingress_link_id) = NonZero::new(pkt.metadata().ingress_link_id) else {
         // who sent this??
         error!(target: FLOW_MGMT, "coding error: stray packet from unknown source; dropping");
@@ -698,7 +720,7 @@ pub async fn handle_bind_egress_stream_request(
         asm.formatted_link_id(ingress_link_id.get()), tc.five_tuple()
     );
 
-    adapter::bind_egress_stream(asm, ingress_link_id, txn_id, tc);
+    adapter::bind_egress_stream(asm, ingress_link_id, txn_id, tc, peer_a2a_dh_pubkey);
 
     Ok(())
 }
@@ -739,7 +761,27 @@ pub async fn handle_bind_actor_address_response(
                 return Err(HandleMgmtError::BadStructure);
             };
 
-            adapter::install_tether(&asm, &txn, stream_id, tc)?;
+            if pkt.remaining() < size_of::<u16>() {
+                return Err(HandleMgmtError::BadStructure);
+            }
+
+            let key_len = pkt.get_u16() as usize;
+
+            let peer_a2a_dh_pubkey = if key_len == 0 {
+                None
+            } else {
+                if pkt.remaining() < key_len {
+                    return Err(HandleMgmtError::BadStructure);
+                }
+
+                let Ok(key_bytes) = <[u8; X25519_KEY_LEN]>::try_from(&pkt.body()[..key_len]) else {
+                    return Err(HandleMgmtError::BadStructure);
+                };
+
+                Some(x25519_dalek::PublicKey::from(key_bytes))
+            };
+
+            adapter::install_tether(&asm, &txn, stream_id, tc, peer_a2a_dh_pubkey)?;
             Ok(())
         }
 

--- a/adapter/ph/src/mgmt/node.rs
+++ b/adapter/ph/src/mgmt/node.rs
@@ -503,6 +503,7 @@ fn requested_visa_granted(
                 egress_link_id.get(),
                 egress_bind_txn_id,
                 tc,
+                None,
             )
             .enqueue();
         }
@@ -652,6 +653,7 @@ fn requested_tether_granted(
             txn_id,
             ingress_tether_id,
             tc,
+            None,
         )
         .enqueue(),
     }

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -296,6 +296,7 @@ pub fn send_bind_actor_address_success_response<'a>(
     txn_id: TxnId,
     tether_id: StreamId,
     tc: tc::Ip5TupleTc,
+    peer_a2a_dh_pubkey: Option<&x25519_dalek::PublicKey>,
 ) -> Sent<'a> {
     debug!(target: ZDP, "{}: sending BindActorAddressResponse [success] for {txn_id}", asm.formatted_link_id(link_id));
 
@@ -310,7 +311,13 @@ pub fn send_bind_actor_address_success_response<'a>(
 
     Tcst::Ip5Tuple.write_to_buf(&mut rsp_pkt).unwrap();
     tc.serialize(&mut rsp_pkt);
-
+    match peer_a2a_dh_pubkey {
+        Some(key) => {
+            rsp_pkt.put_u16(key.as_bytes().len() as u16);
+            rsp_pkt.put_slice(key.as_bytes());
+        }
+        None => rsp_pkt.put_u16(0)
+    }
     super::core::send_per_flow_txn_mgmt(
         asm,
         link_id,
@@ -436,6 +443,7 @@ pub fn send_bind_egress_stream_request<'a>(
     link_id: LinkId,
     txn_id: TxnId,
     tc: tc::Ip5TupleTc,
+    peer_a2a_dh_pubkey: Option<&x25519_dalek::PublicKey>,
 ) -> Sent<'a> {
     debug!(target: ZDP, "{}: sending BindEgressStreamRequest for {tc}", asm.formatted_link_id(link_id));
 
@@ -443,6 +451,13 @@ pub fn send_bind_egress_stream_request<'a>(
     let bind_req_hdr = req.alloc_zeroed_header::<zdp::ZdpBindEgressStreamRequestHeader>();
     bind_req_hdr.tcst = Tcst::Ip5Tuple;
     tc.serialize(&mut req);
+    match peer_a2a_dh_pubkey {
+        Some(key) => {
+            req.put_u16(key.as_bytes().len() as u16);
+            req.put_slice(key.as_bytes());
+        }
+        None => req.put_u16(0),
+    }
 
     core::send_per_flow_txn_mgmt(
         asm,

--- a/adapter/ph/src/mgmt/requests.rs
+++ b/adapter/ph/src/mgmt/requests.rs
@@ -316,7 +316,7 @@ pub fn send_bind_actor_address_success_response<'a>(
             rsp_pkt.put_u16(key.as_bytes().len() as u16);
             rsp_pkt.put_slice(key.as_bytes());
         }
-        None => rsp_pkt.put_u16(0)
+        None => rsp_pkt.put_u16(0),
     }
     super::core::send_per_flow_txn_mgmt(
         asm,

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -218,6 +218,7 @@ pub struct ZdpBindActorAddressResponseHeader {
     // followed by `info_len` octets of Optional Additional Status Information
     // followed by 8-bit TCST
     // followed by traffic classifier
+    // followed by A2A pubkey as a big-endian u16 indicating length followed by key itself
 }
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]
@@ -239,6 +240,7 @@ pub struct ZdpStreamIdResponseHeader {
 pub struct ZdpBindEgressStreamRequestHeader {
     pub tcst: Tcst,
     // followed by traffic classifier
+    // followed by A2A pubkey as a big-endian u16 indicating length followed by key itself
 }
 
 #[derive(FromBytes, IntoBytes, Immutable, KnownLayout, Unaligned)]


### PR DESCRIPTION
Step 12 of A2A PubKey. 

Ingress and egress node need to share these keys with their respective adapters. On both ingress and egress side, added ZDP protocol changes. In mgmt::requests::send_bind_actor_address_success_response() (and egress equivalent), added an extra parameter peer_a2a_dh_pubkey: Option<&x25519_dalek::PublicKey>. Wrote this to the end of the packet with first key len and then key itself. 

In mgmt::handlers::handle_bind_actor_address_response() (and egress equivalent), deserialized the key.  Pass the key as a new argument to adapter::install_tether(). 