### PR TITLE
Encrypt short packets in place, into their own tailroom (#385)

### DIFF
--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -600,8 +600,12 @@ pub fn encrypt_hmac(send_hmac_key: [u8; 32], pkt: &mut Packet) {
 ///
 /// ```text
 /// before:  [ metadata ][ headroom ][ ZPI ][ plaintext ][ tailroom ........... ]
-/// after:   [ metadata ][ .............. dead .......... ][ ZPI ][ ciphertext  ]
+/// after:   [ metadata ][ ....... dead .........][ ZPI ][ ciphertext ][ tail.. ]
 /// ```
+///
+/// The ciphertext starts exactly where the old tailroom started, the relocated
+/// ZPI byte overwrites the tail of the old plaintext, and whatever tailroom the
+/// ciphertext (plaintext + AEAD overhead) does not consume remains after it.
 ///
 /// Only the one-byte ZPI header is moved.  Packets too large for their own
 /// tailroom to hold the ciphertext fall back to the scratch-buffer path; for

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -592,17 +592,48 @@ pub fn encrypt_hmac(send_hmac_key: [u8; 32], pkt: &mut Packet) {
     pkt.put(&link_mac[..zdp::ZDP_PACKET_MAC_SIZE]);
 }
 
-pub fn encrypt_full(
-    _asm: &Assembly,
-    codec: &dyn Codec,
-    pkt: &mut Packet,
-) -> Result<(), km::EncryptionError> {
+/// Encrypt the body of a ZDP packet in place, leaving the ZPI header intact.
+///
+/// The ciphertext is written into the packet's own tailroom rather than into a
+/// scratch buffer, which avoids both a `PACKET_BUFFER_SIZE` stack zeroing and a
+/// copy of the ciphertext back into the packet:
+///
+/// ```text
+/// before:  [ metadata ][ headroom ][ ZPI ][ plaintext ][ tailroom ........... ]
+/// after:   [ metadata ][ .............. dead .......... ][ ZPI ][ ciphertext  ]
+/// ```
+///
+/// Only the one-byte ZPI header is moved.  Packets too large for their own
+/// tailroom to hold the ciphertext fall back to the scratch-buffer path; for
+/// the packet sizes seen in practice the fast path always applies.
+pub fn encrypt_full(codec: &dyn Codec, pkt: &mut Packet) -> Result<(), km::EncryptionError> {
     // TODO: Could do some length checks here on the packet body.  Is it too short? Too long? Etc.
 
     let zpi_hdr_len = std::mem::size_of::<zdp::ZdpZpiHeader>(); // = 1
 
-    let mut enc_buf = [0u8; config::PACKET_BUFFER_SIZE];
+    if pkt.body().len() < zpi_hdr_len {
+        return Err(km::EncryptionError::ParseError);
+    }
+
     let encr_len = pkt.body().len() - zpi_hdr_len; // Everything except the ZPI byte
+
+    // Can the ciphertext fit in this packet's own tailroom?  If so we can
+    // encrypt straight into the backing buffer.
+    if pkt.tailroom_available() >= encr_len + codec.max_overhead() {
+        let len = {
+            let (body, tailroom) = pkt.body_and_tailroom_mut();
+            codec.encrypt_transport_stateless(&body[zpi_hdr_len..], tailroom)?
+        };
+
+        // The ciphertext sits where the tailroom was; move the ZPI header down
+        // in front of it and make that the new body.
+        pkt.adopt_tailroom_with_header(zpi_hdr_len, len);
+
+        return Ok(());
+    }
+
+    // Fallback: the packet is too big to encrypt into its own tailroom.
+    let mut enc_buf = [0u8; config::PACKET_BUFFER_SIZE];
 
     match codec.encrypt_transport_stateless(
         &pkt.body()[zpi_hdr_len..encr_len + zpi_hdr_len],
@@ -672,12 +703,7 @@ fn decrypt_hmac(recv_hmac_key: [u8; 32], pkt: &mut Packet) -> Result<(), Decrypt
 }
 
 /// Decrypt a packet using the given encryption codec.
-fn decrypt_full(
-    _asm: &Assembly,
-    codec: &dyn Codec,
-    padlen: usize,
-    pkt: &mut Packet,
-) -> Result<(), DecryptError> {
+fn decrypt_full(codec: &dyn Codec, padlen: usize, pkt: &mut Packet) -> Result<(), DecryptError> {
     if pkt.body().len() < 1 {
         return Err(DecryptError::BadStructure);
     }
@@ -714,9 +740,9 @@ fn decrypt_with_sa(
     } else if zpi_hdr.zpi == transport_sa.recv_zpis.encr {
         // TODO: Put padlen in state somewhere too
         if asm.config.get().km_impl == KM_ID_NOISE {
-            return decrypt_full(asm, &*transport_sa.codec, NOISE_PADLEN, pkt);
+            return decrypt_full(&*transport_sa.codec, NOISE_PADLEN, pkt);
         } else {
-            return decrypt_full(asm, &*transport_sa.codec, 0, pkt);
+            return decrypt_full(&*transport_sa.codec, 0, pkt);
         }
     } else {
         // We have an SA and ZPI does not match.
@@ -847,7 +873,7 @@ fn substrate_egress_common(
             if transit {
                 encrypt_hmac(transport_sa.send_hmac_key, pkt);
             } else {
-                match encrypt_full(asm, &*transport_sa.codec, pkt) {
+                match encrypt_full(&*transport_sa.codec, pkt) {
                     Ok(()) => (),
                     Err(err) => return Err(err),
                 }
@@ -936,6 +962,200 @@ mod test {
         assert!(res.is_ok());
 
         assert!(pkt.body().len() == orig_len); // did remove checksum
+    }
+
+    /// A codec that expands its input, like a real AEAD does: an 8-byte
+    /// counter prefix, the (trivially transformed) body, and a 16-byte trailing
+    /// tag.  Enough to catch offset and overlap mistakes that a copy codec
+    /// would hide.
+    struct ExpandingCodec;
+
+    impl ExpandingCodec {
+        const NONCE: usize = 8;
+        const TAG: usize = 16;
+    }
+
+    impl km::Codec for ExpandingCodec {
+        fn max_overhead(&self) -> usize {
+            Self::NONCE + Self::TAG
+        }
+
+        fn encrypt_transport_stateless(
+            &self,
+            payload: &[u8],
+            message: &mut [u8],
+        ) -> Result<usize, km::EncryptionError> {
+            let out_len = payload.len() + self.max_overhead();
+            if message.len() < out_len {
+                return Err(km::EncryptionError::MessageTooLarge);
+            }
+            message[..Self::NONCE].copy_from_slice(&[0x5a_u8; ExpandingCodec::NONCE]);
+            for (i, b) in payload.iter().enumerate() {
+                message[Self::NONCE + i] = b ^ 0xa5;
+            }
+            message[Self::NONCE + payload.len()..out_len].fill(0xee);
+            Ok(out_len)
+        }
+
+        fn decrypt_transport_stateless(
+            &self,
+            payload: &[u8],
+            message: &mut [u8],
+        ) -> Result<usize, km::DecryptionError> {
+            if payload.len() < self.max_overhead() {
+                return Err(km::DecryptionError::MessageTooShort);
+            }
+            let body = &payload[Self::NONCE..payload.len() - Self::TAG];
+            if message.len() < body.len() {
+                return Err(km::DecryptionError::ParseError);
+            }
+            for (i, b) in body.iter().enumerate() {
+                message[i] = b ^ 0xa5;
+            }
+            Ok(body.len())
+        }
+    }
+
+    /// What `encrypt_full` should produce for a given cleartext body,
+    /// independent of which code path it took.
+    fn expected_ciphertext(body: &[u8]) -> Vec<u8> {
+        let mut out = vec![body[0]]; // ZPI byte, unencrypted
+        out.extend_from_slice(&[0x5a_u8; ExpandingCodec::NONCE]);
+        out.extend(body[1..].iter().map(|b| b ^ 0xa5));
+        out.extend_from_slice(&[0xee_u8; ExpandingCodec::TAG]);
+        out
+    }
+
+    fn packet_with_body(buf_size: usize, headroom: usize, body: &[u8]) -> Packet {
+        let mut pkt = Packet::new(vec![0u8; buf_size].into_boxed_slice(), headroom);
+        pkt.put(body);
+        pkt
+    }
+
+    #[test]
+    fn test_encrypt_full_uses_tailroom_in_place() {
+        let body: Vec<u8> = (0..60u8).collect(); // body[0] is the ZPI byte
+        let mut pkt = packet_with_body(config::PACKET_BUFFER_SIZE, 64, &body);
+
+        let cleartext_end = pkt.body_offset() + pkt.len();
+
+        assert!(encrypt_full(&ExpandingCodec, &mut pkt).is_ok());
+
+        assert_eq!(pkt.body(), expected_ciphertext(&body).as_slice());
+
+        // The ciphertext must live in what used to be tailroom -- that is the
+        // whole point -- with only the one-byte ZPI header relocated.
+        assert_eq!(pkt.body_offset(), cleartext_end - 1);
+    }
+
+    #[test]
+    fn test_encrypt_full_falls_back_when_tailroom_too_small() {
+        let body: Vec<u8> = (0..60u8).collect();
+        // Tailroom of 40 bytes cannot hold 59 + 24 bytes of ciphertext.
+        let buf_size = Packet::MIN_BODY_OFFSET + body.len() + 40;
+        let mut pkt = packet_with_body(buf_size, 0, &body);
+
+        let cleartext_offset = pkt.body_offset();
+
+        assert!(encrypt_full(&ExpandingCodec, &mut pkt).is_ok());
+
+        // Same bytes as the in-place path, but written back over the original
+        // body rather than into the tailroom.
+        assert_eq!(pkt.body(), expected_ciphertext(&body).as_slice());
+        assert_eq!(pkt.body_offset(), cleartext_offset);
+    }
+
+    #[test]
+    fn test_encrypt_full_decrypt_full_round_trip() {
+        let body: Vec<u8> = (0..60u8).collect();
+        let mut pkt = packet_with_body(config::PACKET_BUFFER_SIZE, 64, &body);
+
+        assert!(encrypt_full(&ExpandingCodec, &mut pkt).is_ok());
+        assert_ne!(pkt.body(), body.as_slice());
+
+        assert!(decrypt_full(&ExpandingCodec, ExpandingCodec.max_overhead(), &mut pkt).is_ok());
+        assert_eq!(pkt.body(), body.as_slice());
+    }
+
+    /// The pre-#385 implementation, kept in the test module so the benchmark
+    /// below compares old and new on identical packets.
+    fn encrypt_full_via_scratch_buffer(
+        codec: &dyn Codec,
+        pkt: &mut Packet,
+    ) -> Result<(), km::EncryptionError> {
+        let zpi_hdr_len = std::mem::size_of::<zdp::ZdpZpiHeader>();
+        let mut enc_buf = [0u8; config::PACKET_BUFFER_SIZE];
+        let encr_len = pkt.body().len() - zpi_hdr_len;
+
+        match codec.encrypt_transport_stateless(
+            &pkt.body()[zpi_hdr_len..encr_len + zpi_hdr_len],
+            &mut enc_buf,
+        ) {
+            Ok(len) => {
+                pkt.shrink_by(encr_len);
+                pkt.put(&enc_buf[0..len]);
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn bench_encrypt_full_paths() {
+        use std::time::Instant;
+
+        const ITERS: u32 = 500_000;
+        let body: Vec<u8> = (0..64u8).collect();
+
+        // One buffer, reused, so buffer allocation is not part of either
+        // measurement.
+        let mut buf = vec![0u8; config::PACKET_BUFFER_SIZE].into_boxed_slice();
+
+        let run = |f: &dyn Fn(&dyn Codec, &mut Packet) -> Result<(), km::EncryptionError>,
+                   buf: &mut Box<[u8]>| {
+            let t = Instant::now();
+            for _ in 0..ITERS {
+                let owned = std::mem::replace(buf, Box::new([]));
+                let mut pkt = Packet::new(owned, 64);
+                pkt.put(body.as_slice());
+                f(&ExpandingCodec, &mut pkt).unwrap();
+                std::hint::black_box(pkt.body()[0]);
+                *buf = pkt.destroy();
+            }
+            t.elapsed()
+        };
+
+        // Warm up, then measure each twice and keep the faster run.
+        run(&encrypt_full, &mut buf);
+        run(&encrypt_full_via_scratch_buffer, &mut buf);
+
+        let new = run(&encrypt_full, &mut buf).min(run(&encrypt_full, &mut buf));
+        let old = run(&encrypt_full_via_scratch_buffer, &mut buf)
+            .min(run(&encrypt_full_via_scratch_buffer, &mut buf));
+
+        println!(
+            "encrypt_full 64B body: in-place {:?}/pkt, scratch-buffer {:?}/pkt",
+            new / ITERS,
+            old / ITERS
+        );
+    }
+
+    #[test]
+    fn test_encrypt_full_rejects_empty_packet() {
+        let mut pkt = packet_with_body(config::PACKET_BUFFER_SIZE, 64, &[]);
+        assert!(encrypt_full(&ExpandingCodec, &mut pkt).is_err());
+    }
+
+    #[test]
+    fn test_encrypt_full_zpi_only_packet() {
+        // Degenerate case: body is nothing but the ZPI byte, so the header
+        // relocation is a self-copy.
+        let body = [0x07u8];
+        let mut pkt = packet_with_body(config::PACKET_BUFFER_SIZE, 64, &body);
+
+        assert!(encrypt_full(&ExpandingCodec, &mut pkt).is_ok());
+        assert_eq!(pkt.body(), expected_ciphertext(&body).as_slice());
     }
 
     #[test]

--- a/adapter/ph/src/km.rs
+++ b/adapter/ph/src/km.rs
@@ -839,6 +839,14 @@ pub enum KmSMState {
 /// and decrypt entire buffers.  It is up to implemnentor to make sure that things like
 /// "ZPI" are left alone.
 pub trait Codec: Send + Sync {
+    /// The maximum number of bytes by which a ciphertext may exceed the
+    /// plaintext it was produced from (nonce, authentication tag, padding).
+    /// Callers use this to size, or to prove the sufficiency of, the output
+    /// buffer they hand to `encrypt_transport_stateless()`, and as the minimum
+    /// plausible length of a ciphertext handed to
+    /// `decrypt_transport_stateless()`.
+    fn max_overhead(self: &Self) -> usize;
+
     /// Encrypt `payload` into `message`.
     fn encrypt_transport_stateless(
         self: &Self,
@@ -863,6 +871,11 @@ impl UnimplCodec {
 }
 
 impl Codec for UnimplCodec {
+    /// No encryption is ever performed, so there is no overhead.
+    fn max_overhead(self: &Self) -> usize {
+        0
+    }
+
     /// Function is not implemented so always returns an error.
     fn encrypt_transport_stateless(
         self: &Self,
@@ -978,6 +991,10 @@ mod test {
     struct CopyCodec;
 
     impl Codec for CopyCodec {
+        fn max_overhead(self: &Self) -> usize {
+            0
+        }
+
         fn encrypt_transport_stateless(
             self: &Self,
             payload: &[u8],

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -322,6 +322,10 @@ impl NoiseCodec {
 }
 
 impl Codec for NoiseCodec {
+    fn max_overhead(self: &Self) -> usize {
+        NOISE_PADLEN
+    }
+
     fn encrypt_transport_stateless(
         self: &Self,
         payload: &[u8],
@@ -380,6 +384,10 @@ impl NullCodec {
 }
 
 impl Codec for NullCodec {
+    fn max_overhead(self: &Self) -> usize {
+        0
+    }
+
     fn encrypt_transport_stateless(
         self: &Self,
         payload: &[u8],

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -529,8 +529,10 @@ impl Packet {
         let output_offset = old_offset + self.metadata().len;
         let new_offset = output_offset - header_len;
 
-        // Regions cannot overlap unless the body is entirely header, in which
-        // case source and destination coincide and the copy is a no-op.
+        // The source and destination regions overlap whenever the header is
+        // more than half the length of the old body (new_offset < old_offset +
+        // header_len iff len < 2 * header_len). That is fine: `copy_within`
+        // handles overlapping regions correctly (it is a `memmove`).
         self.buf
             .copy_within(old_offset..old_offset + header_len, new_offset);
 

--- a/adapter/ph/src/packet.rs
+++ b/adapter/ph/src/packet.rs
@@ -476,6 +476,67 @@ impl Packet {
         &mut self.buf[offset..offset + len]
     }
 
+    /// Offset of the packet body within the backing buffer.
+    pub fn body_offset(&self) -> usize {
+        self.metadata().offset
+    }
+
+    /// The amount of space available for extension of the end of the packet.
+    pub fn tailroom_available(&self) -> usize {
+        let md = self.metadata();
+        self.buf.len() - (md.offset + md.len)
+    }
+
+    /// Returns the packet body and the tailroom following it as two disjoint
+    /// slices.  This allows a transform (e.g. encryption) to read the body and
+    /// write its output into the tailroom of the same backing buffer, without
+    /// an intermediate scratch buffer.  Use `set_body_extent()` afterwards to
+    /// make the written region the new packet body.
+    pub fn body_and_tailroom_mut(&mut self) -> (&[u8], &mut [u8]) {
+        let offset = self.metadata().offset;
+        let len = self.metadata().len;
+        let (head, tail) = self.buf.split_at_mut(offset + len);
+        (&head[offset..], tail)
+    }
+
+    /// Redefine the packet body to be the `len` bytes at `offset` in the
+    /// backing buffer.  The data itself is not touched; only the metadata
+    /// describing where the body lives is updated.  Intended for transforms
+    /// that write their result elsewhere in the buffer (see
+    /// `body_and_tailroom_mut()`).
+    pub fn set_body_extent(&mut self, offset: usize, len: usize) {
+        assert!(offset >= Self::MIN_BODY_OFFSET);
+        assert!(len <= self.buf.len());
+        assert!(offset <= self.buf.len() - len);
+        let md = self.metadata_mut();
+        md.offset = offset;
+        md.len = len;
+    }
+
+    /// Completes an in-place transform that read the current body and wrote
+    /// `written` bytes of output into the tailroom (see
+    /// `body_and_tailroom_mut()`).  The leading `header_len` bytes of the
+    /// current body are preserved: they are relocated to sit immediately in
+    /// front of the transform's output, and the body is redefined to be that
+    /// header followed by the output.
+    ///
+    /// Panics if the tailroom does not actually hold `written` bytes.
+    pub fn adopt_tailroom_with_header(&mut self, header_len: usize, written: usize) {
+        assert!(header_len <= self.metadata().len);
+        assert!(written <= self.tailroom_available());
+
+        let old_offset = self.metadata().offset;
+        let output_offset = old_offset + self.metadata().len;
+        let new_offset = output_offset - header_len;
+
+        // Regions cannot overlap unless the body is entirely header, in which
+        // case source and destination coincide and the copy is a no-op.
+        self.buf
+            .copy_within(old_offset..old_offset + header_len, new_offset);
+
+        self.set_body_extent(new_offset, header_len + written);
+    }
+
     /// Returns mutable references to both the packet metadata and body.
     pub fn metadata_mut_and_body_mut(&mut self) -> (&mut PacketMetadata, &mut [u8]) {
         let (md, bd) = self.buf.split_at_mut(size_of::<PacketMetadata>());
@@ -620,8 +681,7 @@ unsafe impl buf::BufMut for Packet {
 
     /// This indicates how much tailroom is remaining.
     fn remaining_mut(&self) -> usize {
-        let md = self.metadata();
-        self.buf.len() - (md.offset + md.len)
+        self.tailroom_available()
     }
 
     /// Provides a reference to a portion of the remaining tailroom.


### PR DESCRIPTION
Closes #385.

`encrypt_full()` allocated a 12 KiB zeroed stack buffer (`PACKET_BUFFER_SIZE`) per packet, encrypted into it, then copied the ciphertext back over the packet body. Both costs are avoidable for any packet whose own tailroom can hold the ciphertext — which, as the issue notes, is practically all of them.

The ciphertext is now written directly into the packet's tailroom and the one-byte ZPI header is relocated in front of it; nothing else moves:

```
before:  [ metadata ][ headroom ][ ZPI ][ plaintext ][ tailroom ........... ]
after:   [ metadata ][ .............. dead .......... ][ ZPI ][ ciphertext  ]
```

Packets too large for their own tailroom keep the old scratch-buffer path, and a test asserts both paths produce byte-identical output.

Measured on a 64-byte body with a codec that expands by 24 bytes (release build, buffer allocation excluded from both paths):

```
in-place        28 ns/pkt
scratch buffer 192 ns/pkt
```

### Supporting changes

- `Codec` gains `max_overhead()` — the bound on how much a ciphertext may exceed its plaintext. Callers previously had no way to size an output buffer; `decrypt_with_sa()` works around that today by hardcoding `NOISE_PADLEN` behind a `km_impl == KM_ID_NOISE` check, which breaks the moment another codec exists. (That hardcode is left in place here; removing it is a natural follow-up.)
- `Packet` gains `body_offset()`, `tailroom_available()`, `body_and_tailroom_mut()`, `set_body_extent()` and `adopt_tailroom_with_header()` to express the read-body/write-tailroom transform safely (the body and tailroom are disjoint `split_at_mut` halves of the backing buffer, so plaintext/ciphertext overlap is impossible by construction).
- `encrypt_full()` / `decrypt_full()` lose their unused `&Assembly` parameter.
- `encrypt_full()` now rejects a body shorter than the ZPI header instead of underflowing on the length subtraction.

### Deviations from the plan posted on the issue

None of substance. The plan's open question (does anything downstream of egress rely on the packet retaining tailroom/offset?) got no answer; I proceeded on 'no' — `substrate_egress()` queues the packet and only `body()` is written to the socket. Flagging it here for review attention.

### Deliberately out of scope

`decrypt_full()` and `km::encrypt_transport_zdp()`/`decrypt_transport_zdp()` carry the identical 12 KiB scratch buffer. The issue is scoped to encryption; the decrypt side is a follow-up.

### Testing

- `test_encrypt_full_uses_tailroom_in_place` — ciphertext lands in the former tailroom, ZPI byte survives, offset moved as expected.
- `test_encrypt_full_falls_back_when_tailroom_too_small` — fallback fires and produces byte-identical output to the in-place path.
- `test_encrypt_full_decrypt_full_round_trip` — with an expanding codec (8-byte nonce + 16-byte tag).
- `test_encrypt_full_rejects_empty_packet`, `test_encrypt_full_zpi_only_packet` — edge cases, including the header self-copy degenerate case.
- `bench_encrypt_full_paths` (`#[ignore]`, run with `--ignored --nocapture`) — source of the numbers above; keeps the old implementation in the test module for comparison.

Full gate: `cargo build --all-targets`, `cargo fmt --check`, `cargo test` (222 passed), `-D warnings` clean.