### PR TITLE
Ic/a2 a final steps

### DIFF
--- a/adapter/ph/src/adapter_tables.rs
+++ b/adapter/ph/src/adapter_tables.rs
@@ -10,6 +10,7 @@ use crate::defs::FiveTuple;
 use crate::mgmt::txn_mgr::TxnHandle;
 use crate::packet::Packet;
 use crate::tc;
+use crate::zdp;
 use cslab::{RcuCslab, RcuCslabReader};
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry as DashMapEntry;
@@ -20,10 +21,29 @@ use zpr::packet_info::{CompressionMode, StreamId};
 
 const DOCK_LOOKUP_TABLE_SIZE: usize = 1 << 20; // 1 million
 
-#[derive(Clone, Copy)]
 pub struct EltPep {
     pub compression_mode: CompressionMode,
     pub tether_id: StreamId,
+    pub a2a_shared_secret: Option<x25519_dalek::SharedSecret>,
+    pub a2a_micv_key: Option<[u8; blake3::KEY_LEN]>,
+}
+
+impl EltPep {
+    pub fn new(
+        compression_mode: CompressionMode,
+        tether_id: StreamId,
+        a2a_shared_secret: Option<x25519_dalek::SharedSecret>,
+    ) -> Self {
+        let a2a_micv_key = a2a_shared_secret
+            .as_ref()
+            .map(|secret| blake3::derive_key(zdp::ZDP_A2A_MICV_KEY_CONTEXT, secret.as_bytes()));
+        Self {
+            compression_mode,
+            tether_id,
+            a2a_shared_secret,
+            a2a_micv_key,
+        }
+    }
 }
 
 pub enum EltEntry {
@@ -179,6 +199,21 @@ impl EndpointLookupTable {
 
 pub struct DltPep {
     pub tc: tc::Ip5TupleTc,
+    pub a2a_shared_secret: Option<x25519_dalek::SharedSecret>,
+    pub a2a_micv_key: Option<[u8; blake3::KEY_LEN]>,
+}
+
+impl DltPep {
+    pub fn new(tc: tc::Ip5TupleTc, a2a_shared_secret: Option<x25519_dalek::SharedSecret>) -> Self {
+        let a2a_micv_key = a2a_shared_secret
+            .as_ref()
+            .map(|secret| blake3::derive_key(zdp::ZDP_A2A_MICV_KEY_CONTEXT, secret.as_bytes()));
+        Self {
+            tc,
+            a2a_shared_secret,
+            a2a_micv_key,
+        }
+    }
 }
 
 /// The Dock Lookup Table (DLT) holds all state of inbound tethers.

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -310,14 +310,17 @@ impl FastpathWorker {
         match &*entry {
             EltEntry::Active(pep) => {
                 // compute A2A MAC
-                // TODO: use actual A2A SAID & keyed hash
+                // TODO: use actual A2A SAID
                 // See https://github.com/org-zpr/zpr-core/issues/1349
                 let a2a_said: A2aSaid = 0;
                 let a2a_mac_size = zdp::ZDP_A2A_MAC_SIZE; // TODO: may be smaller depending on A2A SAID
                 let mut a2a_mac = [0u8; zdp::ZDP_A2A_MAC_SIZE];
+                let a2a_micv = match pep.a2a_micv_key {
+                    Some(micv_key) => blake3::keyed_hash(&micv_key, pkt.body()),
+                    None => blake3::hash(pkt.body()),
+                };
                 // SECURITY: truncating BLAKE3 is safe
-                a2a_mac[..a2a_mac_size]
-                    .copy_from_slice(&blake3::hash(pkt.body()).as_bytes()[..a2a_mac_size]);
+                a2a_mac[..a2a_mac_size].copy_from_slice(&a2a_micv.as_bytes()[..a2a_mac_size]);
 
                 // compress packet
                 compress::compress(
@@ -431,8 +434,12 @@ impl FastpathWorker {
         compress::expand(pep.tc.compression_mode(), &pep.tc.five_tuple(), &mut pkt);
 
         // check A2A MAC
-        // TODO: use actual A2A SAID & keyed hash
-        if blake3::hash(pkt.body()).as_bytes()[..a2a_mac_size] != a2a_mac[..a2a_mac_size] {
+        // TODO: use actual A2A SAID
+        let a2a_micv = match pep.a2a_micv_key {
+            Some(micv_key) => blake3::keyed_hash(&micv_key, pkt.body()),
+            None => blake3::hash(pkt.body()),
+        };
+        if a2a_micv.as_bytes()[..a2a_mac_size] != a2a_mac[..a2a_mac_size] {
             drop(pep);
             return self.drop_and_count(pkt, FastpathCounterType::MicvFailure);
         }

--- a/adapter/ph/src/mgmt/adapter.rs
+++ b/adapter/ph/src/mgmt/adapter.rs
@@ -45,8 +45,17 @@ pub fn bind_egress_stream(
         "bind_egress_stream(dock_link_id={}, txn_id={txn_id}, tc={tc}, peer_a2a_dh_pubkey={peer_a2a_dh_pubkey:?})",
         asm.formatted_link_id(dock_link_id.get()));
 
+    let a2a_shared_secret = match &peer_a2a_dh_pubkey {
+        Some(pubkey) => Some(asm.a2a_dh_keypair.diffie_hellman(pubkey)),
+        None => {
+            warn!(target: FLOW_MGMT, "{}: bind of {tc}: peer A2A public key not provided",
+                asm.formatted_link_id(dock_link_id.get()));
+            None
+        }
+    };
+
     // form PEP
-    let pep = DltPep { tc };
+    let pep = DltPep::new(tc, a2a_shared_secret);
 
     // TODO: reverse path
 
@@ -128,10 +137,15 @@ pub fn install_tether(
     // Bind succeeded; add to ELT.
     debug!(target: FLOW_MGMT, "Bind of {five_tuple} succeeded: {tether_id} (peer_a2a_dh_pubkey={peer_a2a_dh_pubkey:?})");
 
-    let pep = EltPep {
-        compression_mode: tc.compression_mode(),
-        tether_id,
+    let a2a_shared_secret = match &peer_a2a_dh_pubkey {
+        Some(pubkey) => Some(asm.a2a_dh_keypair.diffie_hellman(pubkey)),
+        None => {
+            warn!(target: FLOW_MGMT, "Bind of {five_tuple}: peer A2A public key not provided");
+            None
+        }
     };
+
+    let pep = EltPep::new(tc.compression_mode(), tether_id, a2a_shared_secret);
 
     let Ok(initial_packet) = asm.elt.set_active(&five_tuple, pep) else {
         // The only way for a transaction to have exited pending (i.e.,

--- a/adapter/ph/src/mgmt/node.rs
+++ b/adapter/ph/src/mgmt/node.rs
@@ -431,10 +431,12 @@ fn requested_visa_granted(
 
     // adapter next-hops require the TC; node next-hops require the visa ID
     let tc;
+    let peer_a2a_dh_pubkey;
 
     match egress_peer_state.peer_type() {
         PeerType::Node => {
             tc = None;
+            peer_a2a_dh_pubkey = None;
         }
 
         PeerType::Adapter => {
@@ -446,6 +448,7 @@ fn requested_visa_granted(
                 return requested_visa_denied(asm, ingress_link_id, txn_id);
             };
             tc = Some(visa.get_tc());
+            peer_a2a_dh_pubkey = visa.get_ingress_a2a_dh_pubkey();
         }
 
         PeerType::Dock | PeerType::Unknown => {
@@ -503,7 +506,7 @@ fn requested_visa_granted(
                 egress_link_id.get(),
                 egress_bind_txn_id,
                 tc,
-                None,
+                peer_a2a_dh_pubkey.as_ref(),
             )
             .enqueue();
         }
@@ -609,14 +612,17 @@ fn requested_tether_granted(
 
     // adapter requestors require the TC; node requestors do not
     let tc;
+    let peer_a2a_dh_pubkey;
 
     match ingress_peer_state.peer_type() {
         PeerType::Node => {
             tc = None;
+            peer_a2a_dh_pubkey = None;
         }
 
         PeerType::Adapter => {
             tc = Some(visa.get_tc());
+            peer_a2a_dh_pubkey = visa.get_egress_a2a_dh_pubkey();
         }
 
         PeerType::Dock | PeerType::Unknown => {
@@ -653,7 +659,7 @@ fn requested_tether_granted(
             txn_id,
             ingress_tether_id,
             tc,
-            None,
+            peer_a2a_dh_pubkey.as_ref(),
         )
         .enqueue(),
     }

--- a/adapter/ph/src/visa_table.rs
+++ b/adapter/ph/src/visa_table.rs
@@ -135,6 +135,20 @@ impl Visa {
         tc::Ip5TupleTc::new(self.visa.dock_pep.as_ref().unwrap().get_five_tuple().into())
     }
 
+    pub fn get_ingress_a2a_dh_pubkey(&self) -> Option<x25519_dalek::PublicKey> {
+        let key = &self.visa.dock_pep.as_ref()?.session_key.ingress_key;
+        <[u8; 32]>::try_from(key.as_slice())
+            .ok()
+            .map(x25519_dalek::PublicKey::from)
+    }
+
+    pub fn get_egress_a2a_dh_pubkey(&self) -> Option<x25519_dalek::PublicKey> {
+        let key = &self.visa.dock_pep.as_ref()?.session_key.egress_key;
+        <[u8; 32]>::try_from(key.as_slice())
+            .ok()
+            .map(x25519_dalek::PublicKey::from)
+    }
+
     pub fn unlink_forwarding_entry(&mut self, forwarding_entry: &ForwardingEntry) -> bool {
         let idx = self.streams.iter().position(|fe| forwarding_entry == fe);
 

--- a/adapter/ph/src/zdp.rs
+++ b/adapter/ph/src/zdp.rs
@@ -302,6 +302,9 @@ pub mod traffic_classifier_flags {
 /// Config-specified size of A2A MAC.  Algorithm-specified MAC may be smaller (but not larger).
 pub const ZDP_A2A_MAC_SIZE: usize = 8;
 
+/// BLAKE3 key-derivation context for the A2A MICV key.
+pub const ZDP_A2A_MICV_KEY_CONTEXT: &str = "org-zpr zpr-core 2026-08-21 a2a micv key";
+
 /// Size of the ZDP "link" HMAC which is set link-by-link for transit packets.
 /// This HMAC is tacked on to the end of the packet (following the A2A HMAC).
 pub const ZDP_PACKET_MAC_SIZE: usize = 8;


### PR DESCRIPTION
Final steps of A2APubKey! 

Step 13: Stored A2A key material is adapter_tables. When using blake3::derive_key() I wasn't sure what to use for the context parameter so I added a const to zdp.rs based on the derive_key() specs

Step 14: Grabbed key from visa and passed it to send_bind_actor_address_success_response() (did similar for egress side). Performed diffie_hellman. I also added in two helpers into visa_table.rs to assist in grabbing from visa. 

Step 15:  Added the blake3::keyed_hash() to both sides if a key is present and if None defaults back to the blake3::hash() code