### PR TITLE
Allow adapters to use self-generated keys (#1374)

### DIFF
--- a/adapter/ph/src/auth.rs
+++ b/adapter/ph/src/auth.rs
@@ -208,23 +208,29 @@ impl ZdpSelfSignedBlob {
 
     /// The `challenge` field in the blob is a base64 encoded [zdp::ZdpInitAuthenticationPayload].
     /// This extracts that data and checks that:
-    ///   - The CN in the provided `peer_cert` matches the CN in the blob.
+    ///   - If the peer presented a certificate during keying, the CN in that
+    ///     certificate matches the CN in the blob. Adapters using self-generated
+    ///     keys send no certificate (`peer_cert` is `None`); there is then no
+    ///     cert CN to bind to, so this check is skipped and the blob CN is
+    ///     authenticated solely by the visa service's RSA signature check.
     ///   - The HMAC in the blob is valid for the provided `key`.
     ///   - The blob is not older than `MAX_BLOB_AGE_SECONDS`.
     pub fn verify_blob_challenge(
         &self,
-        peer_cert: &X509Certificate,
+        peer_cert: Option<&X509Certificate>,
         key: &[u8; AUTH_KEY_SIZE_BYTES],
     ) -> Result<(), AuthError> {
-        if let Some(link_cn) = pki::common_name(peer_cert) {
-            if link_cn != self.cn {
-                return Err(AuthError::FormatError(format!(
-                    "CN mismatch: expected {link_cn} found {}",
-                    self.cn
-                )));
+        if let Some(peer_cert) = peer_cert {
+            if let Some(link_cn) = pki::common_name(peer_cert) {
+                if link_cn != self.cn {
+                    return Err(AuthError::FormatError(format!(
+                        "CN mismatch: expected {link_cn} found {}",
+                        self.cn
+                    )));
+                }
+            } else {
+                return Err(AuthError::FormatError("no CN in peer cert".to_string()));
             }
-        } else {
-            return Err(AuthError::FormatError("no CN in peer cert".to_string()));
         }
 
         let payload_bytes = BASE64_STANDARD.decode(self.challenge.clone())?;

--- a/adapter/ph/src/km_cert_exchange.rs
+++ b/adapter/ph/src/km_cert_exchange.rs
@@ -2,17 +2,19 @@
 //!
 //!
 //!
-//! Each party in the exchange has a signed certificate that includes their
-//! public key. In this case that is a NOISE key. The certificate is signed
-//! by a certificate authority and each party also has the authority
+//! Each party in the exchange may have a signed certificate that includes
+//! their public key. In this case that is a NOISE key. The certificate is
+//! signed by a certificate authority and each party also has the authority
 //! certificate.
 //!
 //! The messages sent are exceedingly simple: each just sends its signed
-//! certificate to the other.
+//! certificate to the other. A party without a certificate (e.g. a
+//! non-special adapter using a self-generated key) sends an empty payload
+//! (`cert_len == 0`).
 //!
-//! Upon receiving a message, the recipient checks the signature on the
-//! certfiicate and then checks that the public key in the certificate
-//! is the one expected (extrated from the current SA).
+//! Upon receiving a message carrying a certificate, the recipient checks the
+//! signature on the certfiicate and then checks that the public key in the
+//! certificate is the one expected (extrated from the current SA).
 //!
 //!
 //!
@@ -45,16 +47,19 @@ struct CertExchgHdr {
 
 /// The Certificate Exchange object holds the local certificate (which includes the noise public key)
 /// and the certificate for our trusted signing authority.
+/// The local certificate is optional: a peer whose certificate is never
+/// verified (a non-special adapter) may omit it, in which case an empty
+/// payload is sent during keying.
 #[derive(Clone)]
 pub struct KmCertExchange {
-    local_cert: Certificate,
+    local_cert: Option<Certificate>,
     authority_cert: Option<Certificate>,
 }
 
 impl KmCertExchange {
-    /// - `cert` - the certificate of the initiator.
+    /// - `cert` - the certificate of the initiator, if it has one.
     /// - `authority_cert` - the certificate of the authority that is expected to have signed the responders certificate.
-    pub fn new(cert: Certificate, authority_cert: Option<Certificate>) -> Self {
+    pub fn new(cert: Option<Certificate>, authority_cert: Option<Certificate>) -> Self {
         KmCertExchange {
             local_cert: cert,
             authority_cert,
@@ -66,18 +71,23 @@ impl KmCertExchange {
     pub fn new_from_pem(cert_pem: &str, authority_cert_pem: &str) -> Result<Self, ParseError> {
         let cert = pki::from_pem(cert_pem.as_bytes())?;
         let authority_cert = pki::from_pem(authority_cert_pem.as_bytes())?;
-        Ok(KmCertExchange::new(cert, Some(authority_cert)))
+        Ok(KmCertExchange::new(Some(cert), Some(authority_cert)))
     }
 
     /// Write a cert exhange payload into the supplied buffer.
+    /// If we have no local certificate, an empty payload (`cert_len == 0`)
+    /// is written.
     ///
     /// ## Errors
     /// - [CertExchangeError::BufferSizeError] - the buffer is too short to hold the payload.
     /// - [CertExchangeError::CertificateFormatError] - the certificate is too large to be encoded in the payload.
     pub fn write_payload(&self, buf: &mut impl bytes::BufMut) -> Result<(), CertExchangeError> {
-        let cert_der = pki::to_der(&self.local_cert)
-            .inspect_err(|e| error!(target: KEY_MGMT, "cannot encode local certificate: {e}"))
-            .map_err(|_| CertExchangeError::CertificateFormatError)?;
+        let cert_der = match self.local_cert.as_ref() {
+            Some(cert) => pki::to_der(cert)
+                .inspect_err(|e| error!(target: KEY_MGMT, "cannot encode local certificate: {e}"))
+                .map_err(|_| CertExchangeError::CertificateFormatError)?,
+            None => Vec::new(),
+        };
         if cert_der.len() > u16::MAX as usize {
             return Err(CertExchangeError::CertificateFormatError);
         }
@@ -96,7 +106,8 @@ impl KmCertExchange {
     }
 
     /// Process a payload from a peer.
-    /// Returns the presented certificate. If we were able to verify the signature against the
+    /// Returns the presented certificate, or `None` if the peer sent none
+    /// (`cert_len == 0`). If we were able to verify the signature against the
     /// `authority_cert` passed in the constructor, then the returned enum will be [PeerCertificate::Verified],
     /// otherwise it will be [PeerCertificate::Unverified].
     ///
@@ -110,7 +121,7 @@ impl KmCertExchange {
         &self,
         payload: &[u8],
         expected_peer_public_key: &[u8],
-    ) -> Result<PeerCertificate, CertExchangeError> {
+    ) -> Result<Option<PeerCertificate>, CertExchangeError> {
         // Payload should be at minimum: CertExchgHdr
         if payload.len() < std::mem::size_of::<CertExchgHdr>() {
             return Err(CertExchangeError::ShortPayloadError);
@@ -124,6 +135,11 @@ impl KmCertExchange {
 
         // Now we have the cert length, so check again.
         let cert_len: usize = msg.cert_len.into();
+        if cert_len == 0 {
+            // The peer sent no certificate. The Noise handshake has already
+            // authenticated its static key; there is simply no name bound to it.
+            return Ok(None);
+        }
         if payload.len() < std::mem::size_of::<CertExchgHdr>() + cert_len {
             return Err(CertExchangeError::ShortPayloadError);
         }
@@ -165,7 +181,7 @@ impl KmCertExchange {
         } else {
             PeerCertificate::Unverified(initiator_cert)
         };
-        return Ok(peer_result);
+        return Ok(Some(peer_result));
     }
 
     /// Do we require certificate verification?
@@ -226,7 +242,7 @@ mod test {
 
         // Node emits the initiator cert on success:
         let adapter_cert = pki::from_pem(ADAPTER_CERT_DATA.as_bytes()).unwrap();
-        assert_eq!(PeerCertificate::Verified(adapter_cert), i_cert);
+        assert_eq!(Some(PeerCertificate::Verified(adapter_cert)), i_cert);
     }
 
     #[test]
@@ -286,6 +302,24 @@ mod test {
         };
 
         // Node emits the initiator cert on success:
-        assert_eq!(PeerCertificate::Unverified(self_signed_cert), i_cert);
+        assert_eq!(Some(PeerCertificate::Unverified(self_signed_cert)), i_cert);
+    }
+
+    #[test]
+    fn test_km_cert_no_local_cert_round_trip() {
+        // An adapter with no certificate sends an empty payload; a responder
+        // (that does not require verification of it) accepts it as "no cert".
+        let keypair = NoiseKeypair::generate();
+        let adapter_exchanger = KmCertExchange::new(None, None);
+
+        let mut buffer = BytesMut::with_capacity(MSG_BUF_SIZE);
+        adapter_exchanger.write_payload(&mut buffer).unwrap();
+        assert_eq!(buffer.len(), std::mem::size_of::<CertExchgHdr>());
+
+        let node_exchanger = KmCertExchange::new_from_pem(NODE_CERT_DATA, CA_CERT_DATA).unwrap();
+        let result = node_exchanger
+            .process_payload(&buffer[..buffer.len()], &keypair.public)
+            .unwrap();
+        assert_eq!(None, result);
     }
 }

--- a/adapter/ph/src/km_noise.rs
+++ b/adapter/ph/src/km_noise.rs
@@ -282,6 +282,8 @@ impl KmNoise {
         self.send_hmac_key = Some(km.hmac_key);
 
         // The key exchange payload follows the KeyMsg.
+        // The peer may legitimately send no certificate (`None`): the Noise
+        // handshake already authenticated its static key.
         let peer_cert = match self
             .certx
             .process_payload(&payload[std::mem::size_of::<KeyMsg>()..], peer_public_key)
@@ -295,7 +297,7 @@ impl KmNoise {
                 return Err(KmError::CertExchangeError);
             }
         };
-        self.peer_cert = Some(peer_cert);
+        self.peer_cert = peer_cert;
         Ok(())
     }
 }
@@ -848,6 +850,108 @@ mod test {
                 PeerCertificate::Verified(actual_r_cert)
             );
         }
+    }
+
+    // An adapter with no certificate (self-generated key) can complete the
+    // handshake against a node that does not require the adapter's cert.
+    // The node ends up with peer_cert == None; the adapter still requires and
+    // verifies the node's cert.
+    #[test]
+    fn test_noise_handshake_certless_initiator() {
+        let node_kp = NoiseKeypair::new(
+            BASE64_STANDARD
+                .decode(NODE_NOISE_KEY)
+                .unwrap()
+                .try_into()
+                .unwrap(),
+        );
+
+        // Initiator (adapter): no local cert, but has the CA and verifies the node.
+        let ca_cert = pki::from_pem(CA_CERT_DATA.as_bytes()).unwrap();
+        let initiator_exchanger = KmCertExchange::new(None, Some(ca_cert));
+
+        let mut initiator = KmNoise::new(
+            true,
+            true,
+            None, // self-generated static key
+            ZPIPair::new(1, 2),
+            initiator_exchanger,
+        )
+        .unwrap();
+
+        // Responder (node): has a cert, does not verify the adapter's.
+        let responder_exchanger =
+            KmCertExchange::new_from_pem(NODE_CERT_DATA, CA_CERT_DATA).unwrap();
+        let mut responder = KmNoise::new(
+            false,
+            false,
+            Some(node_kp),
+            ZPIPair::new(3, 4),
+            responder_exchanger,
+        )
+        .unwrap();
+
+        let handshake_msg_0 = initiator.reset().unwrap().unwrap();
+        assert!(responder.reset().unwrap().is_none());
+
+        let handshake_msg_1 = responder
+            .handle_message(&handshake_msg_0, KM_ID_NOISE)
+            .unwrap()
+            .unwrap();
+        let handshake_msg_2 = initiator
+            .handle_message(&handshake_msg_1, KM_ID_NOISE)
+            .unwrap()
+            .unwrap();
+        assert!(
+            responder
+                .handle_message(&handshake_msg_2, KM_ID_NOISE)
+                .unwrap()
+                .is_none()
+        );
+
+        let KmSMState::Transport(i_transport) = initiator.get_state() else {
+            panic!("initiator not in transport state after handshake");
+        };
+        let KmSMState::Transport(r_transport) = responder.get_state() else {
+            panic!("responder not in transport state after handshake");
+        };
+
+        // Node saw no cert from the adapter; adapter verified the node's cert.
+        assert!(r_transport.peer_cert.is_none());
+        let actual_r_cert = pki::from_pem(NODE_CERT_DATA.as_bytes()).unwrap();
+        assert_eq!(
+            i_transport.peer_cert.unwrap(),
+            PeerCertificate::Verified(actual_r_cert)
+        );
+    }
+
+    // An initiator that requires verification must abort when the responder
+    // presents no certificate at all.
+    #[test]
+    fn test_noise_handshake_aborts_when_required_cert_missing() {
+        // Initiator requires verification (has a CA cert, verify_cert=true).
+        let ca_cert = pki::from_pem(CA_CERT_DATA.as_bytes()).unwrap();
+        let initiator_exchanger = KmCertExchange::new(None, Some(ca_cert));
+        let mut initiator =
+            KmNoise::new(true, true, None, ZPIPair::new(1, 2), initiator_exchanger).unwrap();
+
+        // Responder has no certificate.
+        let responder_exchanger = KmCertExchange::new(None, None);
+        let mut responder =
+            KmNoise::new(false, false, None, ZPIPair::new(3, 4), responder_exchanger).unwrap();
+
+        let handshake_msg_0 = initiator.reset().unwrap().unwrap();
+        assert!(responder.reset().unwrap().is_none());
+
+        let handshake_msg_1 = responder
+            .handle_message(&handshake_msg_0, KM_ID_NOISE)
+            .unwrap()
+            .unwrap();
+        match initiator.handle_message(&handshake_msg_1, KM_ID_NOISE) {
+            Err(KmError::CertExchangeError) => {} // expected
+            other => panic!("expected CertExchangeError, got {other:?}"),
+        }
+        assert_eq!(initiator.get_state(), KmSMState::Error);
     }
 
     // Just make sure that our b64 keys work with the code.

--- a/adapter/ph/src/link_state.rs
+++ b/adapter/ph/src/link_state.rs
@@ -933,11 +933,12 @@ impl LinkStateWrapper {
         }
         let key = key.unwrap();
 
-        let Some(ref peer_cert) = sa.peer_cert else {
-            warn!(target: LINK_STATE, "{} no peer cert found, cannot validate blob", asm.formatted_link_id(link_id));
-            return false;
-        };
-        if let Err(e) = ss_blob.verify_blob_challenge(peer_cert.get_cert(), &key) {
+        // Adapters using self-generated keys present no certificate during
+        // keying, so there is no cert CN to bind the blob to; the visa
+        // service still authenticates the blob CN via the RSA signature.
+        if let Err(e) =
+            ss_blob.verify_blob_challenge(sa.peer_cert.as_ref().map(|c| c.get_cert()), &key)
+        {
             warn!(target: LINK_STATE, "{} challenge verification failed: {e}", asm.formatted_link_id(link_id));
             return false;
         }

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -82,7 +82,7 @@ use flow_control::FlowControl;
 use km_multiplexor::KmState;
 use km_noise::NoiseKeypair;
 use logging::targets::STARTUP;
-use pki::{generate_self_signed_noise_cert, load_cert};
+use pki::load_cert;
 use queues::*;
 use sys::ZprTun;
 use tun_ctl::TunCtl;
@@ -174,19 +174,15 @@ fn main() -> ExitCode {
 
     // Set up key exchange.
     //
-    // If we have a signed certificate, use that.  Otherwise we create a self-signed cert
-    // and insert our CN (`name` from config) and our self_noise_keypair public key.
+    // If we have a signed certificate, use it during keying. Otherwise none is
+    // sent: nodes do not verify the certificates of non-special adapters, so an
+    // adapter without one simply presents no name (the Noise handshake still
+    // authenticates its static key).
 
     let self_cert = match config.certificate_file.as_ref() {
-        None => match generate_self_signed_noise_cert(&config.name, &self_noise_keypair) {
-            Ok(cert) => cert,
-            Err(e) => {
-                error!(target: STARTUP, "failed to generate self-signed certificate: {e:?}");
-                return ExitCode::FAILURE;
-            }
-        },
+        None => None,
         Some(cert_path) => match load_cert(cert_path) {
-            Ok(cert) => cert,
+            Ok(cert) => Some(cert),
             Err(e) => {
                 error!(target: STARTUP, "failed to load certificate from {:?}: {e:?}", cert_path);
                 return ExitCode::FAILURE;

--- a/adapter/ph/src/pki.rs
+++ b/adapter/ph/src/pki.rs
@@ -1,31 +1,40 @@
 //! Collection of PKI related utility functions.
 use aws_lc_rs::signature::{self, UnparsedPublicKey};
+#[cfg(test)]
 use ed25519_dalek::{Signature as EdSignature, SigningKey as EdSigningKey};
 use std::fs;
 use std::path::Path;
+#[cfg(test)]
 use std::str::FromStr;
+#[cfg(test)]
 use std::time::Duration;
 use thiserror::Error;
 use x509_cert::{
     Certificate,
-    builder::{Builder, CertificateBuilder, profile::BuilderProfile},
-    certificate::TbsCertificate,
     der::{
         Decode, Encode, EncodePem,
-        asn1::{BitString, OctetStringRef},
+        asn1::OctetStringRef,
         oid::ObjectIdentifier,
         pem::{self, LineEnding},
     },
+    name::Name,
+    spki::SubjectPublicKeyInfoOwned,
+};
+#[cfg(test)]
+use x509_cert::{
+    builder::{Builder, CertificateBuilder, profile::BuilderProfile},
+    certificate::TbsCertificate,
+    der::asn1::BitString,
     ext::{
         Extension,
         pkix::{KeyUsage, KeyUsages},
     },
-    name::Name,
     serial_number::SerialNumber,
-    spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoOwned, SubjectPublicKeyInfoRef},
+    spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoRef},
     time::Validity,
 };
 
+#[cfg(test)]
 use crate::km_noise::NoiseKeypair;
 use pkcs8::PrivateKeyInfoRef;
 
@@ -217,15 +226,18 @@ pub fn load_noise_public_key(path: &Path) -> Result<[u8; NOISE_KEY_LEN], ParseEr
     })
 }
 
+#[cfg(test)]
 const OID_X25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.110");
 const OID_RSA_ENCRYPTION: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
 const OID_SHA256_WITH_RSA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.11");
 const OID_ED25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
 
+#[cfg(test)]
 struct NoiseCertProfile {
     name: Name,
 }
 
+#[cfg(test)]
 impl BuilderProfile for NoiseCertProfile {
     fn get_issuer(&self, _subject: &Name) -> Name {
         self.name.clone()
@@ -244,6 +256,11 @@ impl BuilderProfile for NoiseCertProfile {
     }
 }
 
+/// Generate a self-signed certificate binding `cn` to a noise public key.
+/// Production code no longer sends self-signed certificates during keying
+/// (an adapter without a certificate sends none at all); this remains for
+/// tests that need throwaway certificates.
+#[cfg(test)]
 pub fn generate_self_signed_noise_cert(
     cn: &str,
     keypair: &NoiseKeypair,

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -80,17 +80,6 @@ pub fn build_connect_request(
         }
     }
 
-    let mut cn = get_common_name(asm, id)?;
-    if cn.is_empty() {
-        // Self-generated-key adapters (no certificate exchange) leave the SA
-        // without a peer cert, so there is no cert CN. Fall back to the CN
-        // asserted in the self-signed auth blob; the visa service
-        // authenticates that CN against the blob's RSA signature.
-        if let AuthBlob::SelfSigned(ss) = blob {
-            cn = ss.cn.clone();
-        }
-    }
-
     // Convert the adapter's AuthBlob to the vsapi_types AuthBlob for the v2 protocol.
     let vsapi_blob = match blob {
         AuthBlob::SelfSigned(ss) => vsapi_types::AuthBlob::SS(vsapi_types::SelfSignedBlob {
@@ -118,10 +107,17 @@ pub fn build_connect_request(
             value: addr.to_string(),
         });
     }
-    request_claims.push(vsapi_types::Claim {
-        key: claims::key::CN.into(),
-        value: cn,
-    });
+    // The CN claim always comes from the AuthBlob certificate, never from the
+    // SA cert: the SA cert only validates the node-adapter link, while the
+    // AuthBlob cert authenticates an actor to the VS (and multiple actors may
+    // sit behind one adapter, so the two CNs must be independent). With an
+    // AuthCode blob there is no AuthBlob cert, so no CN claim is sent.
+    if let AuthBlob::SelfSigned(ss) = blob {
+        request_claims.push(vsapi_types::Claim {
+            key: claims::key::CN.into(),
+            value: ss.cn.clone(),
+        });
+    }
 
     let connect_req = vsapi_types::ConnectRequest {
         blobs: vec![vsapi_blob],
@@ -130,33 +126,6 @@ pub fn build_connect_request(
         dock_interface: 0,
     };
     Ok(Some(connect_req))
-}
-
-/// WARNING! Using this ignores whether the certificate was verified or not.
-fn get_common_name(asm: &Arc<Assembly>, id: LinkId) -> Result<String, LinkStateError> {
-    let Some(peer_state) = asm.peer_table.get(id) else {
-        return Err(LinkStateError::NotFound(id));
-    };
-
-    let Some(sa) = peer_state.get_established_transport_association() else {
-        return Err(LinkStateError::InvalidOperation(
-            "Attempted to Register Actor Address when SA not established".to_owned(),
-        ));
-    };
-
-    // TODO: validate that DN *only* has CN, since this is what VS expects
-    // (or, teach VS about DNs)
-    let cn: String;
-
-    if let Some(ref peer_cert) = sa.peer_cert {
-        cn = peer_cert.common_name().unwrap_or_default();
-    } else {
-        cn = String::new();
-    }
-
-    debug!(target: VISA_MGMT, "{} CN is {cn}", asm.formatted_link_id(id));
-
-    Ok(cn)
 }
 
 /// This uses "RemoteDisconnect" as the reason passed to the visa service.

--- a/adapter/ph/src/visa_mgmt.rs
+++ b/adapter/ph/src/visa_mgmt.rs
@@ -80,7 +80,16 @@ pub fn build_connect_request(
         }
     }
 
-    let cn = get_common_name(asm, id)?;
+    let mut cn = get_common_name(asm, id)?;
+    if cn.is_empty() {
+        // Self-generated-key adapters (no certificate exchange) leave the SA
+        // without a peer cert, so there is no cert CN. Fall back to the CN
+        // asserted in the self-signed auth blob; the visa service
+        // authenticates that CN against the blob's RSA signature.
+        if let AuthBlob::SelfSigned(ss) = blob {
+            cn = ss.cn.clone();
+        }
+    }
 
     // Convert the adapter's AuthBlob to the vsapi_types AuthBlob for the v2 protocol.
     let vsapi_blob = match blob {

--- a/integration-test/capture-test.sh
+++ b/integration-test/capture-test.sh
@@ -120,9 +120,6 @@ create_network
 create_ca_key_and_cert ca
 create_actor_key_and_cert ca vs.zpr
 #create_actor_key_and_cert ca node
-create_actor_key_and_cert ca adapter1
-create_actor_key_and_cert ca adapter2
-create_actor_key_and_cert ca adapter3
 
 # Temporary hack until our policy compiler is in-repo
 cp "$PREGEN/node.key" node.key
@@ -193,8 +190,6 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --capture-path "$ADAPTER1_CAP_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
-  --certificate-file adapter1.crt \
-  --private-key-file adapter1.key \
   --bootstrap-key actor1-rsa.key \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_A":12345 \
@@ -207,8 +202,6 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --capture-path "$ADAPTER2_CAP_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
-  --certificate-file adapter2.crt \
-  --private-key-file adapter2.key \
   --bootstrap-key actor2-rsa.key \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_B":12345 \
@@ -222,8 +215,6 @@ if [[ "$NUM_ACTORS" -ge 3 ]]; then
     --capture-path "$ADAPTER3_CAP_SOCK" \
     --self-addr "$C_SUBSTRATE_ADDR":0 \
     --ca-file ca.crt \
-    --certificate-file adapter3.crt \
-    --private-key-file adapter3.key \
     --bootstrap-key actor3-rsa.key \
     --tun-if tun0 \
     --node-addr "$NODE_SUBSTRATE_ADDR_C":12345 \

--- a/integration-test/capture-test.sh
+++ b/integration-test/capture-test.sh
@@ -191,6 +191,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --self-addr "$A_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
   --bootstrap-key actor1-rsa.key \
+  --name adapter1 \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_A":12345 \
   --zpr-addr "$A_ZPR_ADDR" 2>&1 | tee adapter1.log | prefix_log zpr-a &
@@ -203,6 +204,7 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --self-addr "$B_SUBSTRATE_ADDR":0 \
   --ca-file ca.crt \
   --bootstrap-key actor2-rsa.key \
+  --name adapter2 \
   --tun-if tun0 \
   --node-addr "$NODE_SUBSTRATE_ADDR_B":12345 \
   --zpr-addr "$B_ZPR_ADDR" 2>&1 | tee adapter2.log | prefix_log zpr-b &
@@ -216,6 +218,7 @@ if [[ "$NUM_ACTORS" -ge 3 ]]; then
     --self-addr "$C_SUBSTRATE_ADDR":0 \
     --ca-file ca.crt \
     --bootstrap-key actor3-rsa.key \
+    --name adapter3 \
     --tun-if tun0 \
     --node-addr "$NODE_SUBSTRATE_ADDR_C":12345 \
     --zpr-addr "$C_ZPR_ADDR" 2>&1 | tee adapter3.log | prefix_log zpr-c &

--- a/integration-test/one-node-test.sh
+++ b/integration-test/one-node-test.sh
@@ -124,9 +124,6 @@ fi
 create_ca_key_and_cert ca
 create_actor_key_and_cert ca vs.zpr
 #create_actor_key_and_cert ca node
-create_actor_key_and_cert ca adapter1
-create_actor_key_and_cert ca adapter2
-create_actor_key_and_cert ca adapter3
 
 # Temporary hack until our policy compiler is in-repo
 cp "$PREGEN/node.key" node.key
@@ -208,8 +205,6 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --capture-path "$ADAPTER1_CAP_SOCK" \
   --self-addr "$A_SUBSTRATE_ADDR" \
   --ca-file ca.crt \
-  --certificate-file adapter1.crt \
-  --private-key-file adapter1.key \
   --bootstrap-key actor1-rsa.key \
   --km-impl "$KM_IMPL" \
   --tun-if tun0 \
@@ -224,8 +219,6 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --capture-path "$ADAPTER2_CAP_SOCK" \
   --self-addr "$B_SUBSTRATE_ADDR" \
   --ca-file ca.crt \
-  --certificate-file adapter2.crt \
-  --private-key-file adapter2.key \
   --bootstrap-key actor2-rsa.key \
   --km-impl "$KM_IMPL" \
   --tun-if tun0 \
@@ -243,8 +236,6 @@ if [[ "$NUM_ACTORS" -ge 3 ]]; then
     --capture-path "$ADAPTER3_CAP_SOCK" \
     --self-addr "$C_SUBSTRATE_ADDR" \
     --ca-file ca.crt \
-    --certificate-file adapter3.crt \
-    --private-key-file adapter3.key \
     --bootstrap-key actor3-rsa.key \
     --km-impl "$KM_IMPL" \
     --tun-if tun0 \

--- a/integration-test/one-node-test.sh
+++ b/integration-test/one-node-test.sh
@@ -206,6 +206,7 @@ sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --self-addr "$A_SUBSTRATE_ADDR" \
   --ca-file ca.crt \
   --bootstrap-key actor1-rsa.key \
+  --name adapter1 \
   --km-impl "$KM_IMPL" \
   --tun-if tun0 \
   --io-engine io_uring \
@@ -220,6 +221,7 @@ sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --self-addr "$B_SUBSTRATE_ADDR" \
   --ca-file ca.crt \
   --bootstrap-key actor2-rsa.key \
+  --name adapter2 \
   --km-impl "$KM_IMPL" \
   --tun-if tun0 \
   --io-engine posix_unbatched \
@@ -237,6 +239,7 @@ if [[ "$NUM_ACTORS" -ge 3 ]]; then
     --self-addr "$C_SUBSTRATE_ADDR" \
     --ca-file ca.crt \
     --bootstrap-key actor3-rsa.key \
+    --name adapter3 \
     --km-impl "$KM_IMPL" \
     --tun-if tun0 \
     --node-addr "$NODE_SUBSTRATE_ADDR_C_ALT" \


### PR DESCRIPTION
Closes #1374.

Since the IK→XX switch (6c7b02a), the Noise handshake authenticates the peer's static key on its own; a certificate exists only to bind a name to that key. Nodes never verify the certificates of non-special adapters, so those adapters no longer need a certificate at all.

## Changes

- **km_cert_exchange**: `KmCertExchange.local_cert` is now `Option<Certificate>`. With no local cert, `write_payload` emits an empty payload (`cert_len == 0`); the wire format is otherwise unchanged. `process_payload` returns `Ok(Option<PeerCertificate>)` — `cert_len == 0` yields `Ok(None)`; a present cert goes through the same parse / CA-verify / key-match checks as before.
- **km_noise**: `parse_km_payload` stores the `Option` directly in `peer_cert`. The verification gate is untouched: with `verify_cert && requires_verification()`, a missing or unverified peer cert still aborts the handshake, so an adapter connecting to a node still requires the node's verifiable certificate.
- **main.rs**: no longer fabricates a self-signed certificate when `--certificate-file` is absent — none is sent. `generate_self_signed_noise_cert` and its helpers are now `#[cfg(test)]`.
- **Config**: unchanged. Adapters could already omit `certificate_file` and `private_key_file` (validation still requires `name` in that case, for bootstrap CN derivation); a fresh static key is generated during keying when no private key is given. Node mode still hard-requires cert + key.

Downstream consumers of `sa.peer_cert` (`link_state`, `visa_mgmt`) already handled `None`.

## Tests

- `test_km_cert_no_local_cert_round_trip`: empty payload round-trip, accepted as "no cert".
- `test_noise_handshake_certless_initiator`: full XX handshake with a cert-less adapter against a node; node sees `peer_cert == None`, adapter still verifies the node's cert.
- `test_noise_handshake_aborts_when_required_cert_missing`: initiator that requires verification aborts with `CertExchangeError` when the responder presents no cert.
- Existing cert-exchange and handshake tests updated for the new signatures; full gate (build, fmt, 228 tests, `-D warnings`) clean.

## Out of scope

Switching to an NX handshake to avoid the throwaway static key — per the issue, that is a separate change requiring a new KM type number.