### PR TITLE
Node sends its advertised substrate address to the VS on connect/open (#1375)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -641,7 +641,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1153,7 +1153,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1311,7 +1311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2208,7 +2208,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-input",
- "zpr 0.25.0",
+ "zpr 0.25.1",
  "zpr-utils",
 ]
 
@@ -2427,7 +2427,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2743,7 +2743,7 @@ dependencies = [
  "x25519-dalek",
  "x509-cert",
  "zerocopy",
- "zpr 0.25.0",
+ "zpr 0.25.1",
  "zpr-ext",
  "zpr-utils",
 ]
@@ -3361,7 +3361,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3419,7 +3419,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3812,7 +3812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4743,7 +4743,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5334,8 +5334,8 @@ dependencies = [
 
 [[package]]
 name = "zpr"
-version = "0.25.0"
-source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.25.0#06b5813f95444008b0a662cf7bb3839703d98807"
+version = "0.25.1"
+source = "git+https://github.com/org-zpr/zpr-common.git?tag=v0.25.1#104c8112cdf0eb780e2be7c0ad30cbe31e155fa5"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio-util = { version = "0.7.17", features = ["rt", "compat"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 x509-cert = "0.3.0"
-zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.25.0", features = ["vsapi", "policy"] }
+zpr = { git = "https://github.com/org-zpr/zpr-common.git", tag = "v0.25.1", features = ["vsapi", "policy"] }
 zpr-ext = { git = "https://github.com/org-zpr/zpr-utils.git", tag = "zpr-ext-v0.5.3" }
 zpr-utils = { git = "https://github.com/org-zpr/zpr-utils.git", tag = "zpr-utils-v0.2.1" }
 

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -640,7 +640,7 @@ pub struct NodeConfig {
 #[derive(Deserialize, Debug, Clone)]
 pub struct NodeConfigSection {
     /// The substrate address this node advertises to the visa service, as a
-    /// `"host:port"` string. Hostnames are resolved once at parse time.
+    /// literal `"IP:port"` string (IPv6 in square-bracket notation).
     pub advertised_substrate_addr: Option<String>,
 }
 
@@ -734,25 +734,19 @@ fn check_file_exists(desc: &str, path: &Path) -> Result<(), ArgsError> {
     }
 }
 
-/// Resolve an `advertised_substrate_addr` config string (`"host:port"`, host may be a
-/// hostname or an IP) to a concrete [SocketAddr]. Resolution happens once, here at
-/// config-parse time. Unresolvable strings, unspecified IPs (e.g. `0.0.0.0`) and
-/// port 0 are rejected: the value is what peers dial, so it must be concrete.
+/// Parse an `advertised_substrate_addr` config string to a concrete [SocketAddr].
+/// The value must be a literal `IP:port` — IPv6 in square-bracket notation, e.g.
+/// `"[2001:db8::1]:5000"`. Hostnames are deliberately not accepted: substrate
+/// claims are always for a specific IP address and adapters dial nodes by IP, so
+/// the advertised value must be the concrete address itself. Unspecified IPs
+/// (e.g. `0.0.0.0`) and port 0 are rejected: the value is what peers dial.
 fn resolve_advertised_addr(addr_str: &str) -> Result<SocketAddr, ArgsError> {
-    use std::net::ToSocketAddrs;
-    let resolved = addr_str
-        .to_socket_addrs()
-        .map_err(|e| {
-            ArgsError::ParseError(format!(
-                "failed to resolve advertised_substrate_addr {addr_str:?}: {e}"
-            ))
-        })?
-        .next()
-        .ok_or_else(|| {
-            ArgsError::ParseError(format!(
-                "advertised_substrate_addr {addr_str:?} resolved to no addresses"
-            ))
-        })?;
+    let resolved: SocketAddr = addr_str.parse().map_err(|e| {
+        ArgsError::ParseError(format!(
+            "advertised_substrate_addr {addr_str:?} is not a literal IP:port \
+             (IPv6 in square brackets, e.g. \"[2001:db8::1]:5000\"): {e}"
+        ))
+    })?;
     if resolved.ip().is_unspecified() {
         return Err(ArgsError::ParseError(format!(
             "advertised_substrate_addr {addr_str:?} is an unspecified address; peers cannot dial it"
@@ -837,15 +831,27 @@ mod test {
             resolve_advertised_addr("203.0.113.7:5000").unwrap(),
             "203.0.113.7:5000".parse::<SocketAddr>().unwrap()
         );
-        // Hostname resolves (localhost is safe to assume in CI).
-        let resolved = resolve_advertised_addr("localhost:5000").unwrap();
-        assert_eq!(resolved.port(), 5000);
-        assert!(resolved.ip().is_loopback());
+        // V6 in square-bracket notation passes through.
+        assert_eq!(
+            resolve_advertised_addr("[2001:db8::7]:5000").unwrap(),
+            "[2001:db8::7]:5000".parse::<SocketAddr>().unwrap()
+        );
+        // V6 with a scope-free full form.
+        assert_eq!(
+            resolve_advertised_addr("[2001:db8:0:0:0:0:0:9]:6000").unwrap(),
+            "[2001:db8::9]:6000".parse::<SocketAddr>().unwrap()
+        );
+        // V6 without brackets rejected.
+        assert!(resolve_advertised_addr("2001:db8::7:5000").is_err());
+        // Hostnames rejected: the claim is always for a specific IP address.
+        assert!(resolve_advertised_addr("localhost:5000").is_err());
+        assert!(resolve_advertised_addr("node1.example.com:5000").is_err());
         // Unspecified IP rejected.
         assert!(resolve_advertised_addr("0.0.0.0:5000").is_err());
         assert!(resolve_advertised_addr("[::]:5000").is_err());
-        // Port 0 rejected.
+        // Port 0 rejected (V4 and V6).
         assert!(resolve_advertised_addr("203.0.113.7:0").is_err());
+        assert!(resolve_advertised_addr("[2001:db8::7]:0").is_err());
         // Garbage rejected.
         assert!(resolve_advertised_addr("not an address").is_err());
         assert!(resolve_advertised_addr("203.0.113.7").is_err());

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -126,6 +126,11 @@ pub struct Config {
     /// For a node this is the nodes dock listening address.
     pub self_addr: SocketAddr,
 
+    /// Node only, optional - the substrate address this node advertises to the visa
+    /// service (the address peers dial). Needed when it differs from the bind address,
+    /// e.g. behind NAT. Resolved from the config-file string at parse time.
+    pub advertised_substrate_addr: Option<SocketAddr>,
+
     /// Path to a PEM file containing the Certificate Authority certificate.
     /// Optional and if present is used by the link management system to verify passed noise certificates.
     pub ca_file: Option<PathBuf>,
@@ -251,6 +256,7 @@ impl Config {
             let base_dir = config_file.config_path.parent().unwrap();
             config.set_from_globals(&config_file.global, base_dir)?;
             config.set_from_authentication(&config_file.authentication, base_dir)?;
+            config.set_from_node(&config_file.node)?;
         }
         Ok(config)
     }
@@ -478,6 +484,17 @@ impl Config {
         Ok(())
     }
 
+    // Overwrite our internal state with the values present in the node section
+    // of TOML config.
+    fn set_from_node(&mut self, config: &Option<NodeConfigSection>) -> Result<(), ArgsError> {
+        if let Some(config) = config {
+            if let Some(advertised) = &config.advertised_substrate_addr {
+                self.advertised_substrate_addr = Some(resolve_advertised_addr(advertised)?);
+            }
+        }
+        Ok(())
+    }
+
     // Overwrite our internal state with the values present in the CommonArgs (from command line)
     fn set_from_common(&mut self, common: &CommonArgs) -> Result<(), ArgsError> {
         if let Some(control_path) = &common.control_path {
@@ -574,6 +591,7 @@ impl Default for Config {
             certificate_file: None,
             private_key_file: None,
             private_key_data: None,
+            advertised_substrate_addr: None,
             auth_private_key: None,
             tun_if: None,
             logging: Vec::new(),
@@ -607,7 +625,16 @@ pub struct NodeConfig {
     pub config_path: PathBuf,
 
     pub global: GlobalConfigSection,
+    pub node: Option<NodeConfigSection>,
     pub authentication: Option<AuthenticationConfigSection>,
+}
+
+// Node only bits.
+#[derive(Deserialize, Debug, Clone)]
+pub struct NodeConfigSection {
+    /// The substrate address this node advertises to the visa service, as a
+    /// `"host:port"` string. Hostnames are resolved once at parse time.
+    pub advertised_substrate_addr: Option<String>,
 }
 
 // Global section is shared by nodes and adapters.
@@ -700,6 +727,38 @@ fn check_file_exists(desc: &str, path: &Path) -> Result<(), ArgsError> {
     }
 }
 
+/// Resolve an `advertised_substrate_addr` config string (`"host:port"`, host may be a
+/// hostname or an IP) to a concrete [SocketAddr]. Resolution happens once, here at
+/// config-parse time. Unresolvable strings, unspecified IPs (e.g. `0.0.0.0`) and
+/// port 0 are rejected: the value is what peers dial, so it must be concrete.
+fn resolve_advertised_addr(addr_str: &str) -> Result<SocketAddr, ArgsError> {
+    use std::net::ToSocketAddrs;
+    let resolved = addr_str
+        .to_socket_addrs()
+        .map_err(|e| {
+            ArgsError::ParseError(format!(
+                "failed to resolve advertised_substrate_addr {addr_str:?}: {e}"
+            ))
+        })?
+        .next()
+        .ok_or_else(|| {
+            ArgsError::ParseError(format!(
+                "advertised_substrate_addr {addr_str:?} resolved to no addresses"
+            ))
+        })?;
+    if resolved.ip().is_unspecified() {
+        return Err(ArgsError::ParseError(format!(
+            "advertised_substrate_addr {addr_str:?} is an unspecified address; peers cannot dial it"
+        )));
+    }
+    if resolved.port() == 0 {
+        return Err(ArgsError::ParseError(format!(
+            "advertised_substrate_addr {addr_str:?} has port 0; peers cannot dial it"
+        )));
+    }
+    Ok(resolved)
+}
+
 /// Parse the `certificate_file` (a noise certificate) and return the CN value found within.
 ///
 /// TODO: This has nothing to do with noise.  And nothing to do with km_cert_exchange.  Move to a pki util file.
@@ -722,5 +781,66 @@ mod test {
             bootstrap_key = "rsa_key.pem"
             "#;
         let _config: AdapterConfigSection = toml::from_str(toml_str).unwrap();
+    }
+
+    #[test]
+    fn test_deserialize_node_config_section() {
+        let toml_str = r#"
+            advertised_substrate_addr = "203.0.113.7:5000"
+            "#;
+        let config: NodeConfigSection = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.advertised_substrate_addr.as_deref(),
+            Some("203.0.113.7:5000")
+        );
+    }
+
+    #[test]
+    fn test_node_config_advertised_substrate_addr() {
+        let toml_str = r#"
+            [global]
+            self_addr = "10.0.0.1:5000"
+
+            [node]
+            advertised_substrate_addr = "203.0.113.7:6000"
+            "#;
+        let file_config: NodeConfig = toml::from_str(toml_str).unwrap();
+        let mut config = Config::default();
+        config.set_from_node(&file_config.node).unwrap();
+        assert_eq!(
+            config.advertised_substrate_addr,
+            Some("203.0.113.7:6000".parse().unwrap())
+        );
+
+        // Without a [node] section the option stays unset.
+        let toml_str = r#"
+            [global]
+            self_addr = "10.0.0.1:5000"
+            "#;
+        let file_config: NodeConfig = toml::from_str(toml_str).unwrap();
+        let mut config = Config::default();
+        config.set_from_node(&file_config.node).unwrap();
+        assert_eq!(config.advertised_substrate_addr, None);
+    }
+
+    #[test]
+    fn test_resolve_advertised_addr() {
+        // Plain IP:port passes through.
+        assert_eq!(
+            resolve_advertised_addr("203.0.113.7:5000").unwrap(),
+            "203.0.113.7:5000".parse::<SocketAddr>().unwrap()
+        );
+        // Hostname resolves (localhost is safe to assume in CI).
+        let resolved = resolve_advertised_addr("localhost:5000").unwrap();
+        assert_eq!(resolved.port(), 5000);
+        assert!(resolved.ip().is_loopback());
+        // Unspecified IP rejected.
+        assert!(resolve_advertised_addr("0.0.0.0:5000").is_err());
+        assert!(resolve_advertised_addr("[::]:5000").is_err());
+        // Port 0 rejected.
+        assert!(resolve_advertised_addr("203.0.113.7:0").is_err());
+        // Garbage rejected.
+        assert!(resolve_advertised_addr("not an address").is_err());
+        assert!(resolve_advertised_addr("203.0.113.7").is_err());
     }
 }

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -495,6 +495,13 @@ impl Config {
         Ok(())
     }
 
+    /// Set the advertised substrate address from a command-line string,
+    /// applying the same resolution/validation as the config-file path.
+    pub fn set_advertised_substrate_addr(&mut self, addr_str: &str) -> Result<(), ArgsError> {
+        self.advertised_substrate_addr = Some(resolve_advertised_addr(addr_str)?);
+        Ok(())
+    }
+
     // Overwrite our internal state with the values present in the CommonArgs (from command line)
     fn set_from_common(&mut self, common: &CommonArgs) -> Result<(), ArgsError> {
         if let Some(control_path) = &common.control_path {

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -504,8 +504,10 @@ fn main() -> ExitCode {
         //   1. advertised_substrate_addr config, if set.
         //   2. self_addr, if its IP is specified (common LAN/single-host case).
         // A wildcard self_addr with no configured advertised address is a startup
-        // error: the VSAPI socket traverses the ZPR network, so its local IP is the
-        // node's ZPR/TUN address and cannot serve as a substrate fallback.
+        // error: a wildcard binds every local IP (including ones added later), of
+        // which the machine may have several, but we can advertise only one —
+        // there is no sound way to pick it automatically, so the operator must
+        // choose via advertised_substrate_addr.
         let advertised_substrate = config
             .advertised_substrate_addr
             .or_else(|| {

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -507,34 +507,30 @@ fn main() -> ExitCode {
         // Advertised substrate address resolution, in order:
         //   1. advertised_substrate_addr config, if set.
         //   2. self_addr, if its IP is specified (common LAN/single-host case).
-        //   3. Deferred: VSConn derives it from the VSAPI socket's local IP + the dock
-        //      port on connect (wildcard binds only; requires a concrete dock port).
-        let advertised_substrate = config.advertised_substrate_addr.or_else(|| {
-            if config.self_addr.ip().is_unspecified() {
-                None
-            } else {
-                Some(config.self_addr)
-            }
-        });
-        let dock_port = config.self_addr.port();
-        match advertised_substrate {
-            Some(addr) => {
-                info!(target: STARTUP, "advertising substrate address {addr} to the visa service")
-            }
-            None => {
-                assert!(
-                    dock_port != 0,
-                    "cannot determine an advertised substrate address: self_addr \
-                     {} has an unspecified IP and no dock port; set \
-                     advertised_substrate_addr in the [node] config section",
+        // A wildcard self_addr with no configured advertised address is a startup
+        // error: the VSAPI socket traverses the ZPR network, so its local IP is the
+        // node's ZPR/TUN address and cannot serve as a substrate fallback.
+        let advertised_substrate = config
+            .advertised_substrate_addr
+            .or_else(|| {
+                if config.self_addr.ip().is_unspecified() {
+                    None
+                } else {
+                    Some(config.self_addr)
+                }
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "cannot determine an advertised substrate address: self_addr {} \
+                     has an unspecified IP; set advertised_substrate_addr in the \
+                     [node] config section",
                     config.self_addr
-                );
-                info!(
-                    target: STARTUP,
-                    "advertised substrate address will be derived from the VSAPI socket (dock port {dock_port})"
-                );
-            }
-        }
+                )
+            });
+        info!(
+            target: STARTUP,
+            "advertising substrate address {advertised_substrate} to the visa service"
+        );
 
         vsconn = Some(libnode::vsconn::VSConn::new(
             topology_config.vs_queue_size,
@@ -542,7 +538,6 @@ fn main() -> ExitCode {
             node_name,
             auth_private_key,
             advertised_substrate,
-            dock_port,
         ));
     } else {
         vsconn = None;

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -504,11 +504,45 @@ fn main() -> ExitCode {
         let auth_private_key = zpr_utils::rsa_sign::load_rsa_key(auth_key_pem.as_bytes())
             .unwrap_or_else(|e| panic!("failed to parse auth_private_key {auth_key_path:?}: {e}"));
 
+        // Advertised substrate address resolution, in order:
+        //   1. advertised_substrate_addr config, if set.
+        //   2. self_addr, if its IP is specified (common LAN/single-host case).
+        //   3. Deferred: VSConn derives it from the VSAPI socket's local IP + the dock
+        //      port on connect (wildcard binds only; requires a concrete dock port).
+        let advertised_substrate = config.advertised_substrate_addr.or_else(|| {
+            if config.self_addr.ip().is_unspecified() {
+                None
+            } else {
+                Some(config.self_addr)
+            }
+        });
+        let dock_port = config.self_addr.port();
+        match advertised_substrate {
+            Some(addr) => {
+                info!(target: STARTUP, "advertising substrate address {addr} to the visa service")
+            }
+            None => {
+                assert!(
+                    dock_port != 0,
+                    "cannot determine an advertised substrate address: self_addr \
+                     {} has an unspecified IP and no dock port; set \
+                     advertised_substrate_addr in the [node] config section",
+                    config.self_addr
+                );
+                info!(
+                    target: STARTUP,
+                    "advertised substrate address will be derived from the VSAPI socket (dock port {dock_port})"
+                );
+            }
+        }
+
         vsconn = Some(libnode::vsconn::VSConn::new(
             topology_config.vs_queue_size,
             SocketAddr::new(VISA_SERVICE_ADDR, VISA_SERVICE_PORT),
             node_name,
             auth_private_key,
+            advertised_substrate,
+            dock_port,
         ));
     } else {
         vsconn = None;

--- a/adapter/ph/src/main_argparse.rs
+++ b/adapter/ph/src/main_argparse.rs
@@ -697,6 +697,147 @@ mod test {
         assert!(config.logging.is_empty());
     }
 
+    // CLI --advertised-substrate-addr sets the advertised address with no config file.
+    #[test]
+    #[parallel(env)]
+    fn test_main_args_argparse_node_advertised_addr_cli_only() {
+        let ca_file = TempFile::touch();
+        let ca_file_fname = String::from(ca_file.get_path().to_str().unwrap());
+        let cert_file = TempFile::touch();
+        let cert_file_fname = String::from(cert_file.get_path().to_str().unwrap());
+        let pk_file = TempFile::touch();
+        let pk_file_fname = String::from(pk_file.get_path().to_str().unwrap());
+
+        let args = vec![
+            "ph",
+            "node",
+            "--ca-file",
+            &ca_file_fname,
+            "--certificate-file",
+            &cert_file_fname,
+            "--private-key-file",
+            &pk_file_fname,
+            "--control-path",
+            "/tmp/control.sock",
+            "--capture-path",
+            "/tmp/capture.sock",
+            "--zpr-addr",
+            "10.0.0.1",
+            "--self-addr",
+            "0.0.0.0:12345",
+            "--advertised-substrate-addr",
+            "203.0.113.7:12345",
+        ];
+
+        let (pmode, config) = argparse(Some(args)).unwrap();
+
+        assert_eq!(pmode, PhMode::Node);
+        // The bind address stays wildcard; only the advertised address is concrete.
+        assert_eq!(
+            config.self_addr,
+            SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)), 12345)
+        );
+        assert_eq!(
+            config.advertised_substrate_addr,
+            Some(SocketAddr::new(
+                IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 7)),
+                12345
+            ))
+        );
+    }
+
+    // CLI --advertised-substrate-addr wins over [node] advertised_substrate_addr.
+    #[test]
+    #[parallel(env)]
+    fn test_main_args_argparse_node_advertised_addr_cli_overrides_config() {
+        let mut tomltxt = r#"
+        [global]
+        ca_file = "$CAFILE"
+        certificate_file = "$CERTFILE"
+        private_key_file = "$PKFILE"
+        control_path = "/tmp/control.sock"
+        capture_path = "/tmp/capture.sock"
+        self_addr = "0.0.0.0:12345"
+        zpr_addr = [ "10.0.0.1" ]
+
+        [node]
+        advertised_substrate_addr = "203.0.113.7:6000"
+        "#;
+
+        let ca_file = TempFile::touch();
+        let cert_file = TempFile::touch();
+        let pk_file = TempFile::touch();
+
+        let tmp = tomltxt
+            .replace("$CERTFILE", cert_file.get_path().to_str().unwrap())
+            .replace("$PKFILE", pk_file.get_path().to_str().unwrap())
+            .replace("$CAFILE", ca_file.get_path().to_str().unwrap());
+        tomltxt = &tmp;
+
+        let tmpfile = TempFile::new_toml(&tomltxt);
+
+        let args = vec![
+            "ph",
+            "node",
+            "-c",
+            tmpfile.get_path().to_str().unwrap(),
+            "--advertised-substrate-addr",
+            "198.51.100.9:7000",
+        ];
+
+        let (_, config) = argparse(Some(args)).unwrap();
+
+        assert_eq!(
+            config.advertised_substrate_addr,
+            Some(SocketAddr::new(
+                IpAddr::V4(std::net::Ipv4Addr::new(198, 51, 100, 9)),
+                7000
+            ))
+        );
+    }
+
+    // The CLI value goes through the same validation as the config-file value:
+    // an unspecified IP is rejected because peers cannot dial it.
+    #[test]
+    #[parallel(env)]
+    fn test_main_args_argparse_node_advertised_addr_cli_rejects_unspecified() {
+        let ca_file = TempFile::touch();
+        let ca_file_fname = String::from(ca_file.get_path().to_str().unwrap());
+        let cert_file = TempFile::touch();
+        let cert_file_fname = String::from(cert_file.get_path().to_str().unwrap());
+        let pk_file = TempFile::touch();
+        let pk_file_fname = String::from(pk_file.get_path().to_str().unwrap());
+
+        let args = vec![
+            "ph",
+            "node",
+            "--ca-file",
+            &ca_file_fname,
+            "--certificate-file",
+            &cert_file_fname,
+            "--private-key-file",
+            &pk_file_fname,
+            "--control-path",
+            "/tmp/control.sock",
+            "--capture-path",
+            "/tmp/capture.sock",
+            "--zpr-addr",
+            "10.0.0.1",
+            "--advertised-substrate-addr",
+            "0.0.0.0:12345",
+        ];
+
+        match argparse(Some(args)) {
+            Err(ArgsError::ParseError(msg)) => {
+                assert!(
+                    msg.contains("unspecified"),
+                    "expected 'unspecified' in error, got: {msg}"
+                );
+            }
+            other => panic!("expected ParseError, got: {:?}", other),
+        }
+    }
+
     #[test]
     #[serial(env)] // serialize with other tests because we modify process environment
     fn test_main_args_argparse_adapter_key_in_env() {

--- a/adapter/ph/src/main_argparse.rs
+++ b/adapter/ph/src/main_argparse.rs
@@ -82,6 +82,7 @@ pub fn argparse(args: Option<Vec<&str>>) -> std::result::Result<(PhMode, Config)
         Command::Node {
             config_file,
             auth_private_key,
+            advertised_substrate_addr,
             common,
         } => {
             ph_mode = PhMode::Node;
@@ -103,6 +104,10 @@ pub fn argparse(args: Option<Vec<&str>>) -> std::result::Result<(PhMode, Config)
                 None => None,
             };
             config = Config::new_for_node(config_file, auth_private_key, &common)?;
+            // Command line overrides the config file.
+            if let Some(advertised) = advertised_substrate_addr {
+                config.set_advertised_substrate_addr(&advertised)?;
+            }
         }
     }
     config.finalize()?;

--- a/adapter/ph/src/main_args.rs
+++ b/adapter/ph/src/main_args.rs
@@ -159,9 +159,10 @@ pub enum Command {
         #[arg(long, value_name = "PATH")]
         auth_private_key: Option<PathBuf>,
 
-        /// Substrate address to advertise to the visa service (host:port; host may be
-        /// a hostname). Required when self_addr has an unspecified IP (e.g. 0.0.0.0),
-        /// since a wildcard address cannot be dialed by peers.
+        /// Substrate address to advertise to the visa service, as a literal
+        /// IP:port (IPv6 in square brackets, e.g. [2001:db8::1]:5000). Required
+        /// when self_addr has an unspecified IP (e.g. 0.0.0.0), since a wildcard
+        /// address cannot be dialed by peers.
         #[arg(long, value_name = "ADDR:PORT")]
         advertised_substrate_addr: Option<String>,
 

--- a/adapter/ph/src/main_args.rs
+++ b/adapter/ph/src/main_args.rs
@@ -159,6 +159,12 @@ pub enum Command {
         #[arg(long, value_name = "PATH")]
         auth_private_key: Option<PathBuf>,
 
+        /// Substrate address to advertise to the visa service (host:port; host may be
+        /// a hostname). Required when self_addr has an unspecified IP (e.g. 0.0.0.0),
+        /// since a wildcard address cannot be dialed by peers.
+        #[arg(long, value_name = "ADDR:PORT")]
+        advertised_substrate_addr: Option<String>,
+
         #[command(flatten)]
         common: CommonArgs,
     },

--- a/integration-test/capture-test.sh
+++ b/integration-test/capture-test.sh
@@ -161,6 +161,7 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --control-path "$NODE_SOCK" \
   --capture-path "$NODE_CAP_SOCK" \
   --self-addr 0.0.0.0:12345 \
+  --advertised-substrate-addr "$NODE_SUBSTRATE_ADDR_VS":12345 \
   --ca-file ca.crt \
   --certificate-file node.crt \
   --private-key-file node.key \

--- a/integration-test/one-node-test.sh
+++ b/integration-test/one-node-test.sh
@@ -171,6 +171,7 @@ sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
   --logging "$DEBUG_TARGETS" \
   --control-path "$NODE_SOCK" \
   --capture-path "$NODE_CAP_SOCK" \
+  --advertised-substrate-addr "$NODE_SUBSTRATE_ADDR_VS":5000 \
   --ca-file ca.crt \
   --certificate-file node.crt \
   --private-key-file node.key \

--- a/libnode2/README.md
+++ b/libnode2/README.md
@@ -28,7 +28,8 @@ Then launch lntest:
 
 ```bash
 ./target/degug/lntest -a \[::1\]:5002 -n node.zpr.org \
-  -p test-data/include/node-private-key.pem
+  -p test-data/include/node-private-key.pem \
+  --substrate-addr 127.0.0.1:5000
 ```
 
 Hit return a few times becuase the REPL loop get clobbered by the logging

--- a/libnode2/src/bin/lntest.rs
+++ b/libnode2/src/bin/lntest.rs
@@ -27,7 +27,7 @@ async fn main() {
     let private_key = libnode2::cli::crypto::load_private_key(&args.private_key)
         .expect("failed to load private key");
 
-    let mut vsc = VSConn::new(8, vs_sa, args.node_cn, private_key);
+    let mut vsc = VSConn::new(8, vs_sa, args.node_cn, private_key, None, 0);
     let life_rx = vsc.subscribe_lifecycle_events();
     let handle = vsc.handle();
 

--- a/libnode2/src/bin/lntest.rs
+++ b/libnode2/src/bin/lntest.rs
@@ -19,6 +19,14 @@ async fn main() {
 
     let vs_sa: SocketAddr = args.vs_addr.parse().expect("failed to parse vs-addr");
     let node_zpr_addr: IpAddr = args.self_addr.parse().expect("failed to parse self_addr");
+    let substrate_addr: SocketAddr = args
+        .substrate_addr
+        .parse()
+        .expect("failed to parse substrate_addr");
+    assert!(
+        !substrate_addr.ip().is_unspecified() && substrate_addr.port() != 0,
+        "substrate_addr must be a concrete address peers could dial"
+    );
     let cfg = Config { node_zpr_addr };
 
     let log_buf = LogBuffer::default();
@@ -27,7 +35,7 @@ async fn main() {
     let private_key = libnode2::cli::crypto::load_private_key(&args.private_key)
         .expect("failed to load private key");
 
-    let mut vsc = VSConn::new(8, vs_sa, args.node_cn, private_key, None, 0);
+    let mut vsc = VSConn::new(8, vs_sa, args.node_cn, private_key, substrate_addr);
     let life_rx = vsc.subscribe_lifecycle_events();
     let handle = vsc.handle();
 

--- a/libnode2/src/cli/args.rs
+++ b/libnode2/src/cli/args.rs
@@ -27,6 +27,12 @@ pub struct Args {
     /// Nodes ZPR address to present to the visa service.
     #[arg(long, default_value = "fd5a:5052:90de::1")]
     pub self_addr: String,
+
+    /// Substrate address ('HOST:PORT') to advertise to the visa service — the
+    /// endpoint peers would dial. lntest carries no substrate traffic, so any
+    /// concrete, policy-acceptable address works; it must not be unspecified.
+    #[arg(long)]
+    pub substrate_addr: String,
 }
 
 /// Runtime configuration derived from parsed CLI arguments.

--- a/libnode2/src/vsconn.rs
+++ b/libnode2/src/vsconn.rs
@@ -129,6 +129,19 @@ pub struct VSConn {
     node_private_key: RsaKeyPair,
     life_tx: broadcast::Sender<VSConnLifecycleEvent>,
     connect_fn: ConnectFn,
+    /// The substrate address this node advertises to the VS, when configured
+    /// (operator config; required behind NAT). When `None`, the effective value
+    /// is derived from the VSAPI TCP socket's local IP plus `dock_port` on each
+    /// (re)connect — correct only when node and peers share a network.
+    advertised_substrate: Option<SocketAddr>,
+    /// The node's dock (substrate listening) port, used by the socket-derived
+    /// fallback above. A value of 0 means "use the TCP source port instead"
+    /// (test tooling only; a real node always has a concrete dock port).
+    dock_port: u16,
+    /// Effective substrate address, computed in [VSConn::run] once the VSAPI
+    /// TCP connection is up. Sent as the `substrate_addr` param on both
+    /// `connect` and `open` (the VS requires it on both).
+    substrate_addr: std::cell::Cell<Option<SocketAddr>>,
 }
 
 /// Handle for sending commands to a running [VSConn].
@@ -191,11 +204,16 @@ impl VSConn {
     ///
     /// `buffer_size` determines how many commands can be buffered to send to the run loop before
     /// [VSConnHandle] starts blocking.
+    ///
+    /// `advertised_substrate` is the substrate address this node advertises to the VS
+    /// (`None` = derive from the VSAPI socket's local IP + `dock_port`; see the field docs).
     pub fn new(
         buffer_size: usize,
         vs_addr: SocketAddr,
         node_cn: String,
         node_private_key: RsaKeyPair,
+        advertised_substrate: Option<SocketAddr>,
+        dock_port: u16,
     ) -> Self {
         let (cmd_tx, cmd_rx) = mpsc::channel(buffer_size);
         let (life_tx, _) = broadcast::channel(LIFECYCLE_EVENT_BUFFER_SIZE);
@@ -207,6 +225,9 @@ impl VSConn {
             node_private_key,
             life_tx,
             connect_fn: Box::new(|addr| Box::pin(tokio::net::TcpStream::connect(addr))),
+            advertised_substrate,
+            dock_port,
+            substrate_addr: std::cell::Cell::new(None),
         }
     }
 
@@ -294,6 +315,23 @@ impl VSConn {
             }
         };
         sock.set_nodelay(true)?;
+
+        // Compute the effective substrate address we advertise to the VS: the configured
+        // value when present, otherwise the socket's local IP plus the dock port (last
+        // resort for wildcard binds — correct only when node and peers share a network).
+        let effective_substrate = match self.advertised_substrate {
+            Some(addr) => addr,
+            None => {
+                let local = sock.local_addr()?;
+                let port = if self.dock_port != 0 {
+                    self.dock_port
+                } else {
+                    local.port()
+                };
+                SocketAddr::new(local.ip(), port)
+            }
+        };
+        self.substrate_addr.set(Some(effective_substrate));
 
         let connector = tls_connect();
         let tls = connector.connect(self.vs_addr.ip().into(), sock).await?;
@@ -608,6 +646,19 @@ impl VSConn {
         }
     }
 
+    /// The `substrate_addr` param the VS requires on both `connect` and `open`.
+    /// Set by [VSConn::run] before any command is processed; the error arm is
+    /// defensive.
+    fn substrate_addr_param(&self) -> Result<Param, VSApiError> {
+        let addr = self.substrate_addr.get().ok_or_else(|| {
+            VSApiError::CommandFailed("substrate address not yet determined".to_string())
+        })?;
+        Ok(Param::new_str(
+            pname::SUBSTRATE_ADDR.into(),
+            addr.to_string(),
+        ))
+    }
+
     async fn do_connect(
         &self,
         vs_service: &vsapi2::visa_service::Client,
@@ -616,7 +667,10 @@ impl VSConn {
         let vs_cr = VSConnectRequest {
             cn: self.node_cn.clone(),
             ctype: req.connect_type(),
-            params: Some(vec![Param::new_ip(pname::ZPR_ADDR.into(), req.zpr_addr)]),
+            params: Some(vec![
+                Param::new_ip(pname::ZPR_ADDR.into(), req.zpr_addr),
+                self.substrate_addr_param()?,
+            ]),
         };
 
         debug!(target: VS_RPC, "VS-API -> connect (type = {:?})", vs_cr.ctype);
@@ -708,7 +762,7 @@ impl VSConn {
         let req = VSConnectRequest {
             cn: self.node_cn.clone(),
             ctype: oreq.connect_type(),
-            params: None,
+            params: Some(vec![self.substrate_addr_param()?]),
         };
 
         let mut vs_request = vs_service.open_request();
@@ -1147,6 +1201,9 @@ mod tests {
                 node_private_key,
                 life_tx,
                 connect_fn,
+                advertised_substrate: None,
+                dock_port: 0,
+                substrate_addr: std::cell::Cell::new(None),
             }
         }
     }

--- a/libnode2/src/vsconn.rs
+++ b/libnode2/src/vsconn.rs
@@ -129,19 +129,14 @@ pub struct VSConn {
     node_private_key: RsaKeyPair,
     life_tx: broadcast::Sender<VSConnLifecycleEvent>,
     connect_fn: ConnectFn,
-    /// The substrate address this node advertises to the VS, when configured
-    /// (operator config; required behind NAT). When `None`, the effective value
-    /// is derived from the VSAPI TCP socket's local IP plus `dock_port` on each
-    /// (re)connect — correct only when node and peers share a network.
-    advertised_substrate: Option<SocketAddr>,
-    /// The node's dock (substrate listening) port, used by the socket-derived
-    /// fallback above. A value of 0 means "use the TCP source port instead"
-    /// (test tooling only; a real node always has a concrete dock port).
-    dock_port: u16,
-    /// Effective substrate address, computed in [VSConn::run] once the VSAPI
-    /// TCP connection is up. Sent as the `substrate_addr` param on both
-    /// `connect` and `open` (the VS requires it on both).
-    substrate_addr: std::cell::Cell<Option<SocketAddr>>,
+    /// The substrate address this node advertises to the VS (operator config;
+    /// the address peers dial, which may differ from the bind address behind
+    /// NAT). Sent as the `substrate_addr` param on both `connect` and `open`
+    /// (the VS requires it on both). Callers must resolve a concrete,
+    /// reachable address before constructing a [VSConn]: the VSAPI TCP socket
+    /// traverses the ZPR network, so its local IP is the node's ZPR/TUN
+    /// address and can never serve as a substrate fallback.
+    substrate_addr: SocketAddr,
 }
 
 /// Handle for sending commands to a running [VSConn].
@@ -205,15 +200,15 @@ impl VSConn {
     /// `buffer_size` determines how many commands can be buffered to send to the run loop before
     /// [VSConnHandle] starts blocking.
     ///
-    /// `advertised_substrate` is the substrate address this node advertises to the VS
-    /// (`None` = derive from the VSAPI socket's local IP + `dock_port`; see the field docs).
+    /// `substrate_addr` is the substrate address this node advertises to the VS — the
+    /// address peers dial (see the field docs). It must be concrete and reachable;
+    /// there is deliberately no auto-derivation fallback.
     pub fn new(
         buffer_size: usize,
         vs_addr: SocketAddr,
         node_cn: String,
         node_private_key: RsaKeyPair,
-        advertised_substrate: Option<SocketAddr>,
-        dock_port: u16,
+        substrate_addr: SocketAddr,
     ) -> Self {
         let (cmd_tx, cmd_rx) = mpsc::channel(buffer_size);
         let (life_tx, _) = broadcast::channel(LIFECYCLE_EVENT_BUFFER_SIZE);
@@ -225,9 +220,7 @@ impl VSConn {
             node_private_key,
             life_tx,
             connect_fn: Box::new(|addr| Box::pin(tokio::net::TcpStream::connect(addr))),
-            advertised_substrate,
-            dock_port,
-            substrate_addr: std::cell::Cell::new(None),
+            substrate_addr,
         }
     }
 
@@ -316,33 +309,10 @@ impl VSConn {
         };
         sock.set_nodelay(true)?;
 
-        // Compute the effective substrate address we advertise to the VS: the configured
-        // value when present, otherwise the socket's local IP plus the dock port (last
-        // resort for wildcard binds — correct only when node and peers share a network).
-        let effective_substrate = match self.advertised_substrate {
-            Some(addr) => {
-                debug!(
-                    target: VS_RPC,
-                    "advertising configured substrate address {addr} to the VS"
-                );
-                addr
-            }
-            None => {
-                let local = sock.local_addr()?;
-                let port = if self.dock_port != 0 {
-                    self.dock_port
-                } else {
-                    local.port()
-                };
-                let addr = SocketAddr::new(local.ip(), port);
-                debug!(
-                    target: VS_RPC,
-                    "advertising substrate address {addr} to the VS (derived from local socket {local} and dock port {port}; no configured address)"
-                );
-                addr
-            }
-        };
-        self.substrate_addr.set(Some(effective_substrate));
+        debug!(
+            target: VS_RPC,
+            "advertising substrate address {} to the VS", self.substrate_addr
+        );
 
         let connector = tls_connect();
         let tls = connector.connect(self.vs_addr.ip().into(), sock).await?;
@@ -658,16 +628,11 @@ impl VSConn {
     }
 
     /// The `substrate_addr` param the VS requires on both `connect` and `open`.
-    /// Set by [VSConn::run] before any command is processed; the error arm is
-    /// defensive.
-    fn substrate_addr_param(&self) -> Result<Param, VSApiError> {
-        let addr = self.substrate_addr.get().ok_or_else(|| {
-            VSApiError::CommandFailed("substrate address not yet determined".to_string())
-        })?;
-        Ok(Param::new_str(
+    fn substrate_addr_param(&self) -> Param {
+        Param::new_str(
             pname::SUBSTRATE_ADDR.into(),
-            addr.to_string(),
-        ))
+            self.substrate_addr.to_string(),
+        )
     }
 
     async fn do_connect(
@@ -680,7 +645,7 @@ impl VSConn {
             ctype: req.connect_type(),
             params: Some(vec![
                 Param::new_ip(pname::ZPR_ADDR.into(), req.zpr_addr),
-                self.substrate_addr_param()?,
+                self.substrate_addr_param(),
             ]),
         };
 
@@ -773,7 +738,7 @@ impl VSConn {
         let req = VSConnectRequest {
             cn: self.node_cn.clone(),
             ctype: oreq.connect_type(),
-            params: Some(vec![self.substrate_addr_param()?]),
+            params: Some(vec![self.substrate_addr_param()]),
         };
 
         let mut vs_request = vs_service.open_request();
@@ -1212,9 +1177,7 @@ mod tests {
                 node_private_key,
                 life_tx,
                 connect_fn,
-                advertised_substrate: None,
-                dock_port: 0,
-                substrate_addr: std::cell::Cell::new(None),
+                substrate_addr: "127.0.0.1:5000".parse().unwrap(),
             }
         }
     }

--- a/libnode2/src/vsconn.rs
+++ b/libnode2/src/vsconn.rs
@@ -134,9 +134,10 @@ pub struct VSConn {
     /// the address peers dial, which may differ from the bind address behind
     /// NAT). Sent as the `substrate_addr` param on both `connect` and `open`
     /// (the VS requires it on both). Callers must resolve a concrete,
-    /// reachable address before constructing a [VSConn]: the VSAPI TCP socket
-    /// traverses the ZPR network, so its local IP is the node's ZPR/TUN
-    /// address and can never serve as a substrate fallback.
+    /// reachable address before constructing a [VSConn]: the node may have
+    /// several local IPs (a wildcard bind covers all of them, present and
+    /// future) but only one can be advertised, so the choice belongs to the
+    /// operator, not to a socket-derived guess.
     substrate_addr: SocketAddr,
 }
 

--- a/libnode2/src/vsconn.rs
+++ b/libnode2/src/vsconn.rs
@@ -320,7 +320,13 @@ impl VSConn {
         // value when present, otherwise the socket's local IP plus the dock port (last
         // resort for wildcard binds — correct only when node and peers share a network).
         let effective_substrate = match self.advertised_substrate {
-            Some(addr) => addr,
+            Some(addr) => {
+                debug!(
+                    target: VS_RPC,
+                    "advertising configured substrate address {addr} to the VS"
+                );
+                addr
+            }
             None => {
                 let local = sock.local_addr()?;
                 let port = if self.dock_port != 0 {
@@ -328,7 +334,12 @@ impl VSConn {
                 } else {
                     local.port()
                 };
-                SocketAddr::new(local.ip(), port)
+                let addr = SocketAddr::new(local.ip(), port);
+                debug!(
+                    target: VS_RPC,
+                    "advertising substrate address {addr} to the VS (derived from local socket {local} and dock port {port}; no configured address)"
+                );
+                addr
             }
         };
         self.substrate_addr.set(Some(effective_substrate));


### PR DESCRIPTION
Implements org-zpr/zpr-core#1375 (node side of org-zpr/zpr-visaservice#299). The VS side is merged and requires the `substrate_addr` param on both `connect` and `open`, so node and VS must deploy together once this lands.

## Changes

- **Dep bump**: `zpr` v0.25.0 → v0.25.1 (picks up `pname::SUBSTRATE_ADDR` from zpr-common#65). `cargo update -p zpr@0.25.0 --precise 0.25.1`; the lockfile also deduped a few `windows-sys` entries as a side effect (Windows-only, no Linux build impact).
- **New config option** `advertised_substrate_addr` (optional, `"host:port"` string) in a new `[node]` section of the node config file, per the issue follow-up comment. Hostnames accepted; resolved once at config-parse time via `ToSocketAddrs`. Unresolvable values, unspecified IPs, and port 0 are rejected at startup.
- **Resolution order** (computed once at node startup in `adapter/ph/src/main.rs`):
  1. `advertised_substrate_addr`, if set;
  2. `self_addr`, if its IP is specified (common LAN/single-host case);
  3. deferred to `VSConn`: local address of the VSAPI TCP socket + the dock port, captured on each (re)connect. Correct only when node and peers share a network; a NAT'd node must use the config option.
  Startup fails (with a message pointing at the config option) when `self_addr` is wildcard **and** its port is 0, since fallback 3 could never form a usable address.
- **libnode2**: `VSConn::new` gains `advertised_substrate: Option<SocketAddr>` and `dock_port: u16`; the run loop computes the effective substrate after TCP connect; `do_connect` sends `Param::new_str(pname::SUBSTRATE_ADDR, ...)` alongside `ZPR_ADDR`; `do_open` now sends `params: Some(vec![substrate_addr])` instead of `None`.
- `lntest` passes `(None, 0)` → advertises its own socket address (test harness).

## Deviation from the issue text (flagged in the plan comment before implementing)

The issue wires `substrate_addr: SocketAddr` through `NodeConnect` and its construction sites (`vs_worker.rs`, `cli/handler.rs`). Instead the value is held inside `VSConn`, set at construction:

- `do_open` needs the same value and `NodeOpen` carries nothing;
- fallback 3 needs the TCP stream's `local_addr()`, which the `NodeConnect` construction sites don't have;
- keeping it in one place guarantees connect and open advertise the same address.

`NodeConnect`/`NodeOpen` and their construction sites are unchanged. Happy to rework to the issue's wiring if preferred.

## Verification

- `cargo build --all-targets`, `cargo build -p libnode2 --all-features`, `cargo fmt --check`, `cargo test` (229 passed + new config tests), `-D warnings` build: all clean.
- New unit tests: `[node]` section TOML parsing, `resolve_advertised_addr` (IP pass-through, hostname resolution, rejection of unspecified/port-0/garbage).
- End-to-end checks from the issue (VS stores dock `ip:port`; advertised ≠ bind honored; policy mismatch → `paramError`) need a node+VS deploy, which this environment doesn't have — they should be covered when this and the VS side are deployed together.
