### PR TITLE
A2A pubkey testing

### DIFF
--- a/adapter/ph/Cargo.toml
+++ b/adapter/ph/Cargo.toml
@@ -67,6 +67,7 @@ tokio = { workspace = true, features = ["test-util"] }
 [features]
 default = ["io-uring", "rcu-crossbeam-epoch"]
 ci = []
+enable-security-testing = []
 rcu-aarc = ["rcu/rcu-aarc", "zpr/rcu-aarc"]
 rcu-arc-swap = ["rcu/rcu-arc-swap", "zpr/rcu-arc-swap"]
 rcu-crossbeam-epoch = ["rcu/rcu-crossbeam-epoch", "zpr/rcu-crossbeam-epoch"]

--- a/adapter/ph/src/config.rs
+++ b/adapter/ph/src/config.rs
@@ -180,6 +180,18 @@ pub struct Config {
 
     /// Type of key manager implementation
     pub km_impl: KmId,
+
+    /// Security testing for A2A Pubkeys
+    #[cfg(feature = "enable-security-testing")]
+    pub security_testing_mangle_forwarded_pings: bool,
+
+    /// Security testing: force old-style unkeyed A2A MICVs.
+    #[cfg(feature = "enable-security-testing")]
+    pub security_testing_unkeyed_a2a_micv: bool,
+
+    /// Security testing: recompute the A2A MICV after mangling (vs. reuse it).
+    #[cfg(feature = "enable-security-testing")]
+    pub security_testing_recompute_micvs: bool,
 }
 
 impl Config {
@@ -583,6 +595,14 @@ impl Config {
             }
         };
 
+        #[cfg(feature = "enable-security-testing")]
+        {
+            self.security_testing_mangle_forwarded_pings =
+                common.security_testing_mangle_forwarded_pings;
+            self.security_testing_unkeyed_a2a_micv = common.security_testing_unkeyed_a2a_micv;
+            self.security_testing_recompute_micvs = common.security_testing_recompute_micvs;
+        }
+
         Ok(())
     }
 }
@@ -610,6 +630,12 @@ impl Default for Config {
             bas_key_path: None,
             batch_io_engine: batch_io::AUTO_ENGINE_NAME.to_owned(),
             km_impl: KM_ID_NOISE,
+            #[cfg(feature = "enable-security-testing")]
+            security_testing_mangle_forwarded_pings: false,
+            #[cfg(feature = "enable-security-testing")]
+            security_testing_unkeyed_a2a_micv: false,
+            #[cfg(feature = "enable-security-testing")]
+            security_testing_recompute_micvs: true,
         }
     }
 }

--- a/adapter/ph/src/fastpath.rs
+++ b/adapter/ph/src/fastpath.rs
@@ -47,6 +47,18 @@ pub struct FastpathWorkerConfig {
     pub batch_io_engine: &'static BatchIoEngine,
     pub buffer_count: usize,
     pub batch_size: usize,
+
+    /// Security Testing: node corrupts forwarded ICMP echo requests.
+    #[cfg(feature = "enable-security-testing")]
+    pub mangle_forwarded_pings: bool,
+
+    /// Security Testing: force old-style unkeyed A2A MICVs.
+    #[cfg(feature = "enable-security-testing")]
+    pub unkeyed_a2a_micv: bool,
+
+    /// Security Testing: recompute the A2A MICV after mangling (vs. reuse it).
+    #[cfg(feature = "enable-security-testing")]
+    pub recompute_micvs: bool,
 }
 
 pub struct QueuedEgressPacket {
@@ -315,6 +327,8 @@ impl FastpathWorker {
                 let a2a_mac_size = zdp::ZDP_A2A_MAC_SIZE; // TODO: may be smaller depending on A2A SAID
                 let mut a2a_mac = [0u8; zdp::ZDP_A2A_MAC_SIZE];
                 let a2a_micv = match pep.a2a_micv_key {
+                    #[cfg(feature = "enable-security-testing")]
+                    Some(_) if self.config.unkeyed_a2a_micv => blake3::hash(pkt.body()),
                     Some(micv_key) => blake3::keyed_hash(&micv_key, pkt.body()),
                     None => blake3::hash(pkt.body()),
                 };
@@ -379,6 +393,22 @@ impl FastpathWorker {
 
                 egress_link_id = pep.next_hop.0;
                 egress_stream_id = pep.next_hop.1;
+
+                // Security Testing: if this is an adapter-to-adapter transit
+                // stream, corrupt forwarded ICMP echo requests to prove the A2A
+                // MICV catches a malicious node.
+                #[cfg(feature = "enable-security-testing")]
+                if self.config.mangle_forwarded_pings
+                    && matches!(
+                        ingress_peer_state.peer_type(),
+                        crate::peer_table::PeerType::Adapter
+                    )
+                    && self.asm.peer_table.get(egress_link_id).is_some_and(|p| {
+                        matches!(p.peer_type(), crate::peer_table::PeerType::Adapter)
+                    })
+                {
+                    self.security_testing_mangle_ping(&mut pkt, pep.visa_id);
+                }
             }
         }
 
@@ -395,6 +425,117 @@ impl FastpathWorker {
 
             self.substrate_egress(pkt);
         }
+    }
+
+    /// Security Testing: acting as a malicious node, corrupt the payload of
+    /// a forwarded ICMP echo request and recompute its A2A MICV using a key we
+    /// (the node) are not supposed to possess. If the receiving adapter enforces
+    /// a real keyed MICV, our forged key will not match and it will drop the
+    /// packet; with an unkeyed MICV the forgery succeeds.
+    #[cfg(feature = "enable-security-testing")]
+    fn security_testing_mangle_ping(&self, pkt: &mut Packet, visa_id: VisaId) {
+        const PWNED: &[u8] = b"YOU HAVE BEEN PWNED";
+
+        let a2a_hdr_len = std::mem::size_of::<zdp::ZdpA2aHeader>();
+        let mac_len = zdp::ZDP_A2A_MAC_SIZE;
+
+        // Pull the five-tuple, compression mode, and the egress adapter's A2A
+        // public key out of the visa. (Either adapter's key would do.)
+        let (five_tuple, compression_mode, peer_a2a_pubkey) = {
+            let visa_table = self.asm.visa_table.read().unwrap();
+            let Some(visa) = visa_table.table.get(&visa_id) else {
+                return;
+            };
+            let tc = visa.get_tc();
+            (
+                *tc.five_tuple(),
+                tc.compression_mode(),
+                visa.get_egress_a2a_dh_pubkey(),
+            )
+        };
+
+        // We only handle ICMP echo requests (IPv4 or IPv6).
+        let is_v4_icmp = five_tuple.l3_type == L3Type::Ipv4
+            && five_tuple.l4_protocol == net_defs::ip_number::ICMP;
+        let is_v6_icmp = five_tuple.l3_type == L3Type::Ipv6
+            && five_tuple.l4_protocol == net_defs::ip_number::IPV6_ICMP;
+        if !is_v4_icmp && !is_v6_icmp {
+            return;
+        }
+
+        let body_len = pkt.body().len();
+        if body_len < a2a_hdr_len + mac_len {
+            return;
+        }
+        let compressed = &pkt.body()[a2a_hdr_len..body_len - mac_len];
+
+        // Expand a throwaway copy so we can (a) confirm it's an echo request and
+        // (b) compute the MICV over the same bytes the receiver will.
+        let mut temp = Packet::new(
+            Box::new([0u8; config::PACKET_BUFFER_SIZE]) as PacketBuffer,
+            config::DEFAULT_MESSAGE_HEADROOM,
+        );
+        temp.put(compressed);
+        compress::expand(compression_mode, &five_tuple, &mut temp);
+
+        // Locate the ICMP header in the expanded packet and pick the echo-request
+        // type for this family. (IPv4 header length is variable; the IPv6 header
+        // is a fixed 40 bytes, and our ping carries no extension headers.)
+        let (icmp_off, echo_type) = if is_v4_icmp {
+            (((temp.body()[0] & 0x0f) as usize) * 4, 8u8)
+        } else {
+            (40, 128u8)
+        };
+        let echo_data_off = icmp_off + 8; // ICMP echo header: type/code/csum/id/seq
+        if temp.body().len() < echo_data_off {
+            return;
+        }
+        // Echo Request is type 8 (v4) / 128 (v6), code 0.
+        if temp.body()[icmp_off] != echo_type || temp.body()[icmp_off + 1] != 0 {
+            return;
+        }
+        let echo_data_len = temp.body().len() - echo_data_off;
+        if echo_data_len < PWNED.len() {
+            return; // not enough room; leave the packet alone
+        }
+
+        // Overwrite the echo payload in the real packet -- this is the mangle.
+        let mac_start = body_len - mac_len;
+        let echo_start = mac_start - echo_data_len;
+        pkt.body_mut()[echo_start..echo_start + PWNED.len()].copy_from_slice(PWNED);
+
+        if !self.config.recompute_micvs {
+            // Leave the original MICV in place. A receiver whose MICV actually
+            // covers the payload will reject this regardless of keying -- which
+            // is what proves the MICV covers the payload and not just a prefix.
+            warn!(
+                target: DATAPATH,
+                "SECURITY TESTING: mangled forwarded ping (visa {visa_id}, kept original MICV)"
+            );
+            return;
+        }
+
+        // Recompute the MICV over the mangled packet and forge the trailer.
+        // With --security-testing-unkeyed-a2a-micv, forge with the unkeyed hash
+        // (which needs no secret and will pass an unkeyed verifier).
+        temp.body_mut()[echo_data_off..echo_data_off + PWNED.len()].copy_from_slice(PWNED);
+        let keyed = peer_a2a_pubkey.is_some() && !self.config.unkeyed_a2a_micv;
+        let forged_micv = if keyed {
+            let pubkey = peer_a2a_pubkey.unwrap();
+            // DH between our node key and the adapter's public key, which
+            // yields the WRONG shared secret.
+            let shared = self.asm.a2a_dh_keypair.diffie_hellman(&pubkey);
+            let micv_key = blake3::derive_key(zdp::ZDP_A2A_MICV_KEY_CONTEXT, shared.as_bytes());
+            blake3::keyed_hash(&micv_key, temp.body())
+        } else {
+            blake3::hash(temp.body())
+        };
+        pkt.body_mut()[mac_start..].copy_from_slice(&forged_micv.as_bytes()[..mac_len]);
+
+        warn!(
+            target: DATAPATH,
+            "SECURITY TESTING: mangled forwarded ping (visa {visa_id}, recomputed MICV, keyed={keyed})"
+        );
     }
 
     /// Send a compressed actor packet to the actor.
@@ -435,6 +576,8 @@ impl FastpathWorker {
         // check A2A MAC
         // TODO: use actual A2A SAID
         let a2a_micv = match pep.a2a_micv_key {
+            #[cfg(feature = "enable-security-testing")]
+            Some(_) if self.config.unkeyed_a2a_micv => blake3::hash(pkt.body()),
             Some(micv_key) => blake3::keyed_hash(&micv_key, pkt.body()),
             None => blake3::hash(pkt.body()),
         };

--- a/adapter/ph/src/main.rs
+++ b/adapter/ph/src/main.rs
@@ -139,6 +139,32 @@ fn main() -> ExitCode {
 
     info!(target: STARTUP, "starting with PID {}", process::id());
 
+    #[cfg(feature = "enable-security-testing")]
+    {
+        error!(
+            target: STARTUP,
+            "\n\
+             ################################################################\n\
+             ##                                                            ##\n\
+             ##   W A R N I N G  SECURITY TESTING BUILD                    ##\n\
+             ##                                                            ##\n\
+             ##   Built with the `enable-security-testing` feature, which  ##\n\
+             ##   compiles in code that DELIBERATELY BREAKS the security   ##\n\
+             ##   guarantees of ZPR in order to test them.                 ##\n\
+             ##                                                            ##\n\
+             ##   NEVER RUN THIS BINARY IN A PRODUCTION ENVIRONMENT!       ##\n\
+             ##                                                            ##\n\
+             ################################################################"
+        );
+        error!(
+            target: STARTUP,
+            "security testing: mangle forwarded pings = {}, unkeyed a2a micv = {}, recompute micvs = {}",
+            config.security_testing_mangle_forwarded_pings,
+            config.security_testing_unkeyed_a2a_micv,
+            config.security_testing_recompute_micvs
+        );
+    }
+
     //
     // read key material
     //
@@ -686,6 +712,12 @@ fn main() -> ExitCode {
         batch_io_engine,
         buffer_count: asm.topology_config.buffer_count,
         batch_size: asm.topology_config.fastpath_batch_size,
+        #[cfg(feature = "enable-security-testing")]
+        mangle_forwarded_pings: asm.config.get().security_testing_mangle_forwarded_pings,
+        #[cfg(feature = "enable-security-testing")]
+        unkeyed_a2a_micv: asm.config.get().security_testing_unkeyed_a2a_micv,
+        #[cfg(feature = "enable-security-testing")]
+        recompute_micvs: asm.config.get().security_testing_recompute_micvs,
     };
 
     for (worker_index, socket, tun_dev, requeue_outq) in izip!(

--- a/adapter/ph/src/main_args.rs
+++ b/adapter/ph/src/main_args.rs
@@ -121,6 +121,25 @@ pub struct CommonArgs {
     /// Current supported implementations: noise (default), null
     #[arg(long, default_value = "noise")]
     pub km_impl: String,
+
+    /// Security Testing: corrupt forwarded ICMP echo packets so that a
+    /// correct receiver must reject them.
+    #[cfg(feature = "enable-security-testing")]
+    #[arg(long)]
+    pub security_testing_mangle_forwarded_pings: bool,
+
+    /// Security Testing: fall back to old-style unkeyed A2A MICVs. Adapters
+    /// write and verify with the unkeyed hash; a malicious node forges with it.
+    #[cfg(feature = "enable-security-testing")]
+    #[arg(long)]
+    pub security_testing_unkeyed_a2a_micv: bool,
+
+    /// Security Testing: whether a mangling node recomputes the A2A MICV
+    /// (true, the default) or reuses the original (false). Reusing it proves the
+    /// MICV covers the payload: a mangled ping is then rejected even when unkeyed.
+    #[cfg(feature = "enable-security-testing")]
+    #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
+    pub security_testing_recompute_micvs: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/integration-test/a2a-pubkey-test.sh
+++ b/integration-test/a2a-pubkey-test.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+#
+# SECURITY TESTING integration test.
+#
+# Models a malicious node (a compromised binary) that corrupts forwarded ICMP
+# echo requests and re-forges their A2A MICV.  A correct receiver rejects the
+# forgery, so the mangled ping never reaches zpr-b.  A tcpdump running in the
+# zpr-b namespace watches for the injected "YOU HAVE BEEN PWNED" payload and
+# FAILS the test if it ever arrives.
+#
+# The node is launched with --security-testing-mangle-forwarded-pings, so the
+# PH binaries MUST be built with the `enable-security-testing` feature:
+#   cargo build -p ph --features enable-security-testing
+#
+# Run it several ways to see the A2A MICV do its job:
+#   ./a2a-pubkey-test.sh                     # keyed MICV: PASSES (forgery rejected)
+#   ./a2a-pubkey-test.sh --unkeyed           # unkeyed MICV: FAILS (forgery accepted)
+#   ./a2a-pubkey-test.sh --unkeyed --reuse   # unkeyed, no recompute: PASSES
+#
+# The last case is the key extra evidence: with --reuse the node mangles the
+# payload but keeps the original MICV, so even an unkeyed receiver rejects it --
+# proving the MICV genuinely covers the payload (not just a prefix of it).
+#
+set -euo pipefail
+
+export RUST_BACKTRACE=1
+DEBUG_TARGETS=${DEBUG_TARGETS:-all=INFO}
+KM_IMPL=${KM_IMPL:-noise}
+
+PH_BIN="${PH_BIN:-$(realpath "$(dirname "$0")/../target/debug/ph")}"
+PH_DEBUG_BIN="${PH_DEBUG_BIN:-$(realpath "$(dirname "$0")/../target/debug/ph-cli")}"
+VS_BIN="${VS_BIN:-$(realpath "$(dirname "$0")/vs")}"
+VS_ADMIN_BIN="${VS_ADMIN_BIN:-$(realpath "$(dirname "$0")/vs-admin")}"
+VALKEY_SERVER_BIN="${VALKEY_SERVER_BIN:-$(realpath -s "$(dirname "$0")/valkey-server")}"
+
+PREGEN=$(realpath "$(dirname $0)/pregen")
+NODE_AUTH_PRIVATE_KEY="${NODE_AUTH_PRIVATE_KEY:-$PREGEN/node-rsa-key.pem}"
+
+# The payload the malicious node injects; see security_testing_mangle_ping().
+PWNED_STRING="YOU HAVE BEEN PWNED"
+
+source "$(dirname $0)/lib/common_funcs.sh"
+
+ZPR_USER=$USER
+
+# Optionally force old-style unkeyed A2A MICVs on all PH instances (the "old way"
+# the A2A key replaced).  With this set the forgery succeeds and the test fails.
+UNKEYED_ARG=""
+# By default the node recomputes the MICV after mangling (the forgery). With
+# --reuse it keeps the original MICV instead, so the mangled ping is rejected
+# regardless of keying.
+RECOMPUTE_ARG=""
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --unkeyed)
+      UNKEYED_ARG="--security-testing-unkeyed-a2a-micv"
+      shift
+      ;;
+    --reuse)
+      RECOMPUTE_ARG="--security-testing-recompute-micvs false"
+      shift
+      ;;
+    --help)
+      echo "Usage: $0 [--unkeyed] [--reuse]"
+      exit 1
+      ;;
+    *)
+      echo "Error: unexpected argument $1" >&2
+      echo "Usage: $0 [--unkeyed] [--reuse]"
+      exit 1
+      ;;
+  esac
+done
+
+# Substrate (underlay) addresses.
+NODE_SUBSTRATE_ADDR_VS=10.0.0.1
+NODE_SUBSTRATE_ADDR_A=10.0.1.1
+NODE_SUBSTRATE_ADDR_B=10.0.2.1
+NODE_SUBSTRATE_ADDR_C=10.0.3.1
+NODE_SUBSTRATE_ADDR_C_ALT=10.0.3.129
+VS_SUBSTRATE_ADDR=10.0.0.2
+A_SUBSTRATE_ADDR=10.0.1.2
+B_SUBSTRATE_ADDR=10.0.2.2
+C_SUBSTRATE_ADDR=10.0.3.2
+
+# ZPR (overlay) addresses -- IPv6, matching the v6 ping policy.  create_network
+# sets up a zpr-c namespace unconditionally, so its address must be defined even
+# though this test runs no adapter there.
+NODE_ZPR_ADDR=fd5a:5052::2
+VS_ZPR_ADDR=fd5a:5052::1
+A_ZPR_ADDR=fd00:1:1::1
+B_ZPR_ADDR=fd00:1:2::1
+C_ZPR_ADDR=fd00:1:3::1
+ZPR_SUBNET=fd00:1::0/32
+
+POLICY_BIN="v6-1node-2actor-ping.bin2"
+
+if [ ! -e "$VS_BIN" ]; then
+  echo "vs binary not found, expected it at $VS_BIN"
+  exit 1
+fi
+
+if [ ! -e "$VS_ADMIN_BIN" ]; then
+  echo "vs-admin binary not found, expected it at $VS_ADMIN_BIN"
+  exit 1
+fi
+
+if systemctl is-active --quiet valkey-server 2>/dev/null; then
+  echo "valkey-server system service is running. Please stop it before running this test:"
+  echo "  sudo systemctl stop valkey-server"
+  exit 1
+fi
+
+if [ ! -e "$VALKEY_SERVER_BIN" ]; then
+  echo "valkey-server binary not found, expected it at $VALKEY_SERVER_BIN"
+  exit 1
+fi
+
+if [ ! -e "$PREGEN/$POLICY_BIN" ]; then
+  echo "policy file not found (expected .bin2): $PREGEN/$POLICY_BIN"
+  exit 1
+fi
+
+if [ ! -x "$PH_BIN" ]; then
+  echo "ph binary not found or not executable: $PH_BIN"
+  exit 1
+fi
+
+# The mangle flag only exists in a feature build; bail early with a clear message
+# rather than failing obscurely at node launch.
+if ! "$PH_BIN" node --help 2>&1 | grep -q -- --security-testing-mangle-forwarded-pings; then
+  echo "ph binary was not built with the 'enable-security-testing' feature."
+  echo "Rebuild with: cargo build -p ph --features enable-security-testing"
+  exit 1
+fi
+
+if [ ! -x "$PH_DEBUG_BIN" ]; then
+  echo "ph-cli binary not found or not executable: $PH_DEBUG_BIN"
+  exit 1
+fi
+
+if [ ! -e "$NODE_AUTH_PRIVATE_KEY" ]; then
+  echo "node auth private key not found: $NODE_AUTH_PRIVATE_KEY"
+  exit 1
+fi
+
+if ! command -v tcpdump > /dev/null; then
+  echo "tcpdump not found; it is required to detect the injected payload"
+  exit 1
+fi
+
+NODE_SOCK=node.sock
+VS_SOCK=vs.sock
+ADAPTER1_SOCK=adapter1.sock
+ADAPTER2_SOCK=adapter2.sock
+NODE_CAP_SOCK=node_cap.sock
+VS_CAP_SOCK=vs_cap.sock
+ADAPTER1_CAP_SOCK=adapter1_cap.sock
+ADAPTER2_CAP_SOCK=adapter2_cap.sock
+
+#
+# Set up automatic cleanup
+#
+
+trap cleanup EXIT
+
+TMPDIR=$(mktemp -d)
+pushd "$TMPDIR" > /dev/null
+
+PWNED_PCAP="$TMPDIR/zpr-b-icmp.pcap"
+
+echo "Setting up network"
+
+destroy_network
+create_network
+
+create_ca_key_and_cert ca
+create_actor_key_and_cert ca vs.zpr
+create_actor_key_and_cert ca adapter1
+create_actor_key_and_cert ca adapter2
+
+# Temporary hack until our policy compiler is in-repo
+cp "$PREGEN/node.key" node.key
+cp "$PREGEN/node-cert.pem" node.crt
+cp "$PREGEN/node-pubkey.pem" node.pubkey
+cp "$PREGEN/actor1-rsa.key" actor1-rsa.key
+cp "$PREGEN/actor2-rsa.key" actor2-rsa.key
+cp "$PREGEN/actorvs-rsa.key" actorvs-rsa.key
+
+emit_vs_config ca vs.zpr > vs-config.toml
+
+#
+# Launch ValKey + Visa Service
+#
+
+echo "Launching ValKey"
+
+sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$VALKEY_SERVER_BIN" \
+    --save "" \
+    --appendonly no 2>&1 | tee valkey.log | prefix_log valkey &
+
+wait_for 15 check_vs_valkey_port
+
+echo "Launching Visa Service"
+
+sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" XDG_DATA_HOME=/tmp "$VS_BIN" \
+    -c vs-config.toml \
+    --clear-state \
+    "$PREGEN/$POLICY_BIN" 2>&1 | tee vs.log | prefix_log vs &
+
+sleep 2
+
+#
+# Launch PHs
+#
+
+echo "Launching Node (MALICIOUS: mangling forwarded pings${UNKEYED_ARG:+, unkeyed MICVs}${RECOMPUTE_ARG:+, reusing original MICV})"
+
+sudo -E ip netns exec zpr-node sudo -E -u "$ZPR_USER" "$PH_BIN" \
+  node \
+  --logging "$DEBUG_TARGETS" \
+  --control-path "$NODE_SOCK" \
+  --capture-path "$NODE_CAP_SOCK" \
+  --ca-file ca.crt \
+  --certificate-file node.crt \
+  --private-key-file node.key \
+  --auth-private-key "$NODE_AUTH_PRIVATE_KEY" \
+  --advertised-substrate-addr "$NODE_SUBSTRATE_ADDR_VS":5000 \
+  --km-impl "$KM_IMPL" \
+  --tun-if tun0 \
+  --zpr-addr "$NODE_ZPR_ADDR" \
+  --security-testing-mangle-forwarded-pings \
+  $UNKEYED_ARG $RECOMPUTE_ARG 2>&1 | tee node.log | prefix_log zpr-node &
+
+sleep 2
+
+echo "Launching Adapters"
+
+sudo -E ip netns exec zpr-vs sudo -E -u "$ZPR_USER" "$PH_BIN" \
+  adapter \
+  --logging "$DEBUG_TARGETS" \
+  --control-path "$VS_SOCK" \
+  --capture-path "$VS_CAP_SOCK" \
+  --self-addr "$VS_SUBSTRATE_ADDR" \
+  --ca-file ca.crt \
+  --certificate-file vs.zpr.crt \
+  --private-key-file vs.zpr.key \
+  --bootstrap-key actorvs-rsa.key \
+  --km-impl "$KM_IMPL" \
+  --tun-if tun0 \
+  --io-engine auto \
+  --node-addr "$NODE_SUBSTRATE_ADDR_VS" \
+  --zpr-addr "$VS_ZPR_ADDR" \
+  $UNKEYED_ARG 2>&1 | tee adapter-vs.log | prefix_log zpr-vs &
+
+sleep 5
+
+sudo -E ip netns exec zpr-a sudo -E -u "$ZPR_USER" "$PH_BIN" \
+  adapter \
+  --logging "$DEBUG_TARGETS" \
+  --control-path "$ADAPTER1_SOCK" \
+  --capture-path "$ADAPTER1_CAP_SOCK" \
+  --self-addr "$A_SUBSTRATE_ADDR" \
+  --ca-file ca.crt \
+  --bootstrap-key actor1-rsa.key \
+  --name adapter1 \
+  --km-impl "$KM_IMPL" \
+  --tun-if tun0 \
+  --io-engine io_uring \
+  --node-addr "$NODE_SUBSTRATE_ADDR_A" \
+  --zpr-addr "$A_ZPR_ADDR" \
+  $UNKEYED_ARG 2>&1 | tee adapter1.log | prefix_log zpr-a &
+
+sudo -E ip netns exec zpr-b sudo -E -u "$ZPR_USER" "$PH_BIN" \
+  adapter \
+  --logging "$DEBUG_TARGETS" \
+  --control-path "$ADAPTER2_SOCK" \
+  --capture-path "$ADAPTER2_CAP_SOCK" \
+  --self-addr "$B_SUBSTRATE_ADDR" \
+  --ca-file ca.crt \
+  --bootstrap-key actor2-rsa.key \
+  --name adapter2 \
+  --km-impl "$KM_IMPL" \
+  --tun-if tun0 \
+  --io-engine posix_unbatched \
+  --node-addr "$NODE_SUBSTRATE_ADDR_B" \
+  --zpr-addr "$B_ZPR_ADDR" \
+  $UNKEYED_ARG 2>&1 | tee adapter2.log | prefix_log zpr-b &
+
+#
+# Wait for connectivity
+#
+PASS=0
+echo "Wait for TUN carrier..."
+wait_for 15 check_carrier zpr-node tun0 || { PASS=1; }
+if [[ "$PASS" == 0 ]]; then wait_for 15 check_carrier zpr-vs tun0 || { PASS=1; }; fi
+if [[ "$PASS" == 0 ]]; then wait_for 15 check_carrier zpr-a tun0 || { PASS=1; }; fi
+if [[ "$PASS" == 0 ]]; then wait_for 15 check_carrier zpr-b tun0 || { PASS=1; }; fi
+
+if [[ "$PASS" == 0 ]]; then
+  echo "Carrier has arrived."
+  sleep 1
+
+  #
+  # Watch zpr-b for the injected payload.  We capture the decapsulated ICMP the
+  # zpr-b adapter delivers to its TUN: a rejected forgery never reaches here, an
+  # accepted one arrives carrying the PWNED string.
+  #
+  echo "Starting packet capture on zpr-b..."
+  # Safety net: SIGTERM lets tcpdump exit cleanly (and restore the terminal it
+  # touched); --kill-after escalates to SIGKILL only if it's wedged in an idle
+  # poll() ignoring catchable signals. -U writes each packet immediately, so the
+  # pcap is complete even under a hard kill.
+  # The unique pcap path makes the pkill match exactly this tcpdump.
+  sudo -E ip netns exec zpr-b timeout -s TERM --kill-after=3 30 \
+    tcpdump -i tun0 -n -U -w "$PWNED_PCAP" icmp6 2>/dev/null &
+  sleep 2
+
+  echo "TEST STARTING: ping zpr-a -> zpr-b"
+  # We do NOT check whether the ping succeeds: a correctly-rejected forgery just
+  # means no reply, which is the passing case.
+  sudo ip netns exec zpr-a ping -6 -q -c 5 -w 5 "$B_ZPR_ADDR" || true
+
+  sleep 2
+  # Stop the capture: SIGTERM first so tcpdump cleans up and restores the tty,
+  # then SIGKILL as a backstop if it's stuck idle. DON'T block on wait: the outer
+  # sudo wrapper does not reliably reap, which previously hung the whole script.
+  sudo pkill -TERM -f "tcpdump -i tun0 -n -U -w $PWNED_PCAP" 2>/dev/null || true
+  sleep 1
+  sudo pkill -KILL -f "tcpdump -i tun0 -n -U -w $PWNED_PCAP" 2>/dev/null || true
+  stty sane 2>/dev/null || true
+
+  #
+  # Verdict: any captured packet containing the injected string is a breach.
+  #
+  if grep -a -q "$PWNED_STRING" "$PWNED_PCAP" 2>/dev/null; then
+    echo "SECURITY FAILURE: mangled payload \"$PWNED_STRING\" reached zpr-b!"
+    PASS=1
+  else
+    echo "No mangled payload reached zpr-b (forgery rejected)."
+  fi
+fi
+
+# The pcap was written by root (tcpdump ran under sudo), so it is write-protected
+# for us. Remove it as root here so the trap cleanup's rm doesn't stop for an
+# interactive "remove write-protected file?" prompt.
+sudo rm -f "$PWNED_PCAP" 2>/dev/null || true
+
+#
+# Cleanup
+#
+
+for pid in $(get_descendants)
+do
+  echo
+  echo "Terminating $pid"
+  sleep 1
+  sudo kill -SIGINT "$pid"
+  sleep 1
+done
+
+stty sane || true
+
+#
+# Report status
+#
+
+echo
+if [[ "$PASS" == 0 ]]
+then echo "SUCCESS"
+else echo "FAILURE"
+fi
+
+exit "$PASS"


### PR DESCRIPTION
Security testing to demonstrate that the A2A keyed MICV actually protects forwarded traffic from a malicious node. The idea is to have a node try to tamper with a transit packet it's forwarding between two adapters and re-forge the MICV - a correct receiver rejects it, the old unkeyed hash does not. All of this is behind a Cargo feature + CLI flags so it can never ship on by accident.

Step 1
Added a Cargo feature enable-security-testing and three #[cfg]-gated flags

Step 2
Big warning banner at startup (main.rs) whenever the feature is compiled in

Step 3
The mangle itself in fastpath.rs. In forward()'s Node arm, if both ingress and egress links are adapters, call the new security_testing_mangle_ping(). It pulls the five-tuple, compression mode, and the egress adapter's A2A pubkey from the visa (get_egress_a2a_dh_pubkey()), confirms the packet is an ICMP echo request (v4 type 8 / v6 type 128), and overwrites the payload with "YOU HAVE BEEN PWNED" (bails if there's no room). To recompute the MICV it expands a throwaway copy so it hashes the same bytes the receiver will. The forged key is diffie_hellman(node_priv, adapter_pub) run through blake3::derive_key(ZDP_A2A_MICV_KEY_CONTEXT, ...) but the wrong shared secret since the node can't produce the real adapter-to-adapter one.

Step 4
--security-testing-unkeyed-a2a-micv forces the old unkeyed behavior. Added a guard arm at both MICV sites. The node's forge picks the unkeyed hash to match. Has to be set on the node and all adapters otherwise a keyed verifier stares at an unkeyed forgery and just rejects it normally.

Step 5
Integration test integration-test/a2a-pubkey-test.sh, copied from one-node-test. IPv6 (uses the existing v6 ping policy), 2 adapters + VS, node launched with the mangle flag, pings only zpr-a → zpr-b. tcpdump in the zpr-b namespace on tun0 (the decrypted overlay side, so only packets that passed the MICV land there) watches for the injected string and fails the test if it ever arrives. Does not check whether pings succeed.

Step 6
--security-testing-recompute-micvs (default true). With false the node mangles the payload but keeps the original MICV instead of re-forging it, so a receiver whose MICV covers the payload rejects it regardless of keying. 

Ran all three ways against the merged tree: keyed → PASS (forgery rejected), --unkeyed → FAIL (forgery accepted), --unkeyed --reuse → PASS.